### PR TITLE
feat(whisperkit): issue-9 follow-ups — verified findings fixed, contracts pinned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ objc2-core-ml = { version = "0.3", features = ["block2", "objc2-core-video"] }
 objc2-foundation = "0.3"
 objc2-core-video = "0.3"
 objc2-core-foundation = "0.3"
+objc2-natural-language = { version = "0.3", default-features = false, features = [
+  "std",
+  "NLLanguage",
+  "NLLanguageRecognizer",
+] }
 block2 = "0.6"
 half = "2.7"
 thiserror = "2"

--- a/crates/whisperkit/Cargo.toml
+++ b/crates/whisperkit/Cargo.toml
@@ -29,6 +29,7 @@ unicode_categories.workspace = true
 
 serde = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
+objc2 = { workspace = true, optional = true }
 objc2-foundation = { workspace = true, optional = true }
 objc2-natural-language = { workspace = true, optional = true }
 
@@ -41,7 +42,7 @@ tracing = ["dep:tracing"]
 # truth for language stays the decoder's own `<|lang|>` token (see
 # `WhisperTokenizer::split_to_word_tokens`'s doc) -- this feature only
 # exposes the redetection helper for callers who want a second opinion.
-nl-recognizer = ["dep:objc2-foundation", "dep:objc2-natural-language"]
+nl-recognizer = ["dep:objc2", "dep:objc2-foundation", "dep:objc2-natural-language"]
 
 [dev-dependencies]
 cpal.workspace = true

--- a/crates/whisperkit/Cargo.toml
+++ b/crates/whisperkit/Cargo.toml
@@ -29,10 +29,19 @@ unicode_categories.workspace = true
 
 serde = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
+objc2-foundation = { workspace = true, optional = true }
+objc2-natural-language = { workspace = true, optional = true }
 
 [features]
 serde = ["dep:serde"]
 tracing = ["dep:tracing"]
+# Optional transcript-based language redetection for word splitting
+# (`tokenizer::nl_recognizer::redetect_language`), via Apple's
+# `NLLanguageRecognizer`. Off by default: the pipeline's one source of
+# truth for language stays the decoder's own `<|lang|>` token (see
+# `WhisperTokenizer::split_to_word_tokens`'s doc) -- this feature only
+# exposes the redetection helper for callers who want a second opinion.
+nl-recognizer = ["dep:objc2-foundation", "dep:objc2-natural-language"]
 
 [dev-dependencies]
 cpal.workspace = true

--- a/crates/whisperkit/src/audio/chunker/mod.rs
+++ b/crates/whisperkit/src/audio/chunker/mod.rs
@@ -187,7 +187,7 @@ impl VadChunker {
     clip_ranges: &[(usize, usize)],
   ) -> Vec<AudioChunk>
   where
-    V: VoiceActivityDetector,
+    V: VoiceActivityDetector + ?Sized,
   {
     if samples.len() <= max_len {
       return vec![AudioChunk::new(0, samples)];
@@ -234,7 +234,7 @@ impl VadChunker {
     end: usize,
   ) -> usize
   where
-    V: VoiceActivityDetector,
+    V: VoiceActivityDetector + ?Sized,
   {
     let mid = start + (end - start) / 2;
     let activity = vad.voice_activity(&samples[mid..end]);

--- a/crates/whisperkit/src/audio/vad/mod.rs
+++ b/crates/whisperkit/src/audio/vad/mod.rs
@@ -20,7 +20,12 @@ pub const DEFAULT_ENERGY_THRESHOLD: f32 = 0.02;
 ///
 /// Implementors supply per-frame activity; the provided methods port the
 /// frame/segment utilities every detector shares
-/// (`VoiceActivityDetector.swift`).
+/// (`VoiceActivityDetector.swift`). Every method takes `&self` and returns
+/// a concrete, owned or borrowed value — no generics, no `Self`-sized
+/// return — so this trait is dyn-compatible; that is what lets
+/// [`crate::transcribe::WhisperKit`] hold one behind
+/// `Box<dyn VoiceActivityDetector + Send + Sync>` and swap it at runtime
+/// via [`crate::transcribe::WhisperKit::set_vad_detector`].
 pub trait VoiceActivityDetector {
   /// One activity flag per [`Self::frame_length_samples`]-sized frame
   /// (final partial frame included).

--- a/crates/whisperkit/src/constants/mod.rs
+++ b/crates/whisperkit/src/constants/mod.rs
@@ -38,10 +38,27 @@ pub const APPEND_PUNCTUATION: &str = "\"'.。,，!！?？:：”)]}、";
 /// [`TranscriptionResult`](crate::result::TranscriptionResult)/
 /// [`TranscriptionSegment`](crate::result::TranscriptionSegment) text —
 /// product layers that don't want `[BLANK_AUDIO]` polluting search or
-/// timeline results must filter or model it themselves, e.g. by comparing
-/// [`TranscriptionResult::text`](crate::result::TranscriptionResult::text)/
+/// timeline results must filter or model it themselves.
+///
+/// **Result-level equality is the validated contract.** The pinned
+/// silence golden asserts
+/// [`TranscriptionResult::text`](crate::result::TranscriptionResult::text)
+/// exactly equal to this constant. Segment text is a different shape:
+/// under that same validated configuration (default
+/// `skip_special_tokens == false`),
 /// [`TranscriptionSegment::text`](crate::result::TranscriptionSegment::text)
-/// against this constant.
+/// is the undecorated per-segment decode and still carries its
+/// special/timestamp tokens
+/// (`<|startoftranscript|><|en|><|transcribe|><|0.00|> [BLANK_AUDIO]<|10.00|><|endoftext|>`
+/// for that golden) — comparing it against this constant with equality
+/// will not match there. Setting `skip_special_tokens` filters those
+/// tokens out of segment text too (see
+/// [`segment::find_seek_point_and_segments`](crate::segment::find_seek_point_and_segments)),
+/// which narrows the gap, but that combination isn't itself pinned by a
+/// golden here: treat a segment-level check as `contains`, not
+/// equality, or filter/model on
+/// [`TranscriptionResult::text`](crate::result::TranscriptionResult::text)
+/// instead.
 pub const BLANK_AUDIO_MARKER: &str = "[BLANK_AUDIO]";
 
 /// Whisper language table: `(english_name, iso_code)`, 112 entries.

--- a/crates/whisperkit/src/constants/mod.rs
+++ b/crates/whisperkit/src/constants/mod.rs
@@ -21,6 +21,29 @@ pub const PREPEND_PUNCTUATION: &str = "\"'“¡¿([{-";
 /// `defaultAppendPunctuations`, Models.swift:1460).
 pub const APPEND_PUNCTUATION: &str = "\"'.。,，!！?？:：”)]}、";
 
+/// Upstream-compatible marker some Whisper models emit as decoded text for
+/// silent or near-silent audio. This is a training-data artifact baked
+/// into the model's learned output, not a tokenizer special token or a
+/// control code this crate inserts: the decoder literally samples the BPE
+/// tokens that spell this string out, the same as it would any other
+/// text, and this crate decodes and reports it faithfully rather than
+/// intercepting it.
+///
+/// Matches Swift's own observed output for the same input bit-for-bit
+/// (coremlit issue #9, "Silence output should be filtered or explicitly
+/// modeled": both runtimes produced exactly `[BLANK_AUDIO]`, one segment,
+/// for 5 s of silence under matched VAD/prefill settings). Because this is
+/// upstream-compatible model behavior rather than a bug, this crate does
+/// not filter it out of
+/// [`TranscriptionResult`](crate::result::TranscriptionResult)/
+/// [`TranscriptionSegment`](crate::result::TranscriptionSegment) text —
+/// product layers that don't want `[BLANK_AUDIO]` polluting search or
+/// timeline results must filter or model it themselves, e.g. by comparing
+/// [`TranscriptionResult::text`](crate::result::TranscriptionResult::text)/
+/// [`TranscriptionSegment::text`](crate::result::TranscriptionSegment::text)
+/// against this constant.
+pub const BLANK_AUDIO_MARKER: &str = "[BLANK_AUDIO]";
+
 /// Whisper language table: `(english_name, iso_code)`, 112 entries.
 ///
 /// Extracted verbatim from `Models.swift` `Constants.languages`.

--- a/crates/whisperkit/src/constants/tests.rs
+++ b/crates/whisperkit/src/constants/tests.rs
@@ -38,3 +38,11 @@ fn punctuation_contains_load_bearing_members() {
   assert!(APPEND_PUNCTUATION.contains(','));
   assert!(APPEND_PUNCTUATION.contains('.'));
 }
+
+#[test]
+fn blank_audio_marker_matches_upstream_literal() {
+  // Pins the exact literal (coremlit issue #9): both runtimes decoded
+  // silence to this same text bit-for-bit, so this crate must not
+  // normalize/trim/alter it into some other shape.
+  assert_eq!(BLANK_AUDIO_MARKER, "[BLANK_AUDIO]");
+}

--- a/crates/whisperkit/src/lib.rs
+++ b/crates/whisperkit/src/lib.rs
@@ -150,11 +150,14 @@
 //!   matches). Never compare outputs across compute units as if
 //!   equivalent: fix one unit for regression baselines, or keep a
 //!   separate baseline per unit.
-//! - **Silence decodes to a marker, not to empty text.** Silent windows
-//!   come back as
+//! - **Silence can decode to a marker, not to empty text.** Confirmed
+//!   under the validated configuration coremlit issue #9 pinned (tiny
+//!   model, matched VAD/prefill options, 5 s of digital silence): the
+//!   window decodes to exactly
 //!   [`BLANK_AUDIO_MARKER`](constants::BLANK_AUDIO_MARKER) — see that
-//!   constant's doc; product layers filter or model it rather than
-//!   indexing it as transcript text.
+//!   constant's doc for the general, model/config-dependent shape of
+//!   this behavior. When this marker is emitted, product layers should
+//!   filter or model it rather than indexing it as transcript text.
 //! - **Sampling above temperature 0 is non-reproducible by design, on
 //!   both runtimes.** Whenever the fallback ladder retries at
 //!   `temperature > 0`, upstream Swift draws from an unseeded RNG

--- a/crates/whisperkit/src/lib.rs
+++ b/crates/whisperkit/src/lib.rs
@@ -141,7 +141,7 @@
 //! cheapest faithful record is to serialize the exact option values used
 //! and store that snapshot with the transcript.
 //!
-//! Two provenance-adjacent behaviors to plan for:
+//! Provenance-adjacent behaviors to plan for:
 //!
 //! - **Compute units affect output.** The same model/audio/options can
 //!   yield different transcripts across `cpuOnly`/`cpuAndGPU`/
@@ -155,6 +155,31 @@
 //!   [`BLANK_AUDIO_MARKER`](constants::BLANK_AUDIO_MARKER) — see that
 //!   constant's doc; product layers filter or model it rather than
 //!   indexing it as transcript text.
+//! - **Sampling above temperature 0 is non-reproducible by design, on
+//!   both runtimes.** Whenever the fallback ladder retries at
+//!   `temperature > 0`, upstream Swift draws from an unseeded RNG
+//!   (`Float.random`, `TokenSampler.swift:169`) and this port's default
+//!   deliberately matches that non-determinism
+//!   ([`GreedyTokenSampler::new`](decode::sampler::GreedyTokenSampler::new)
+//!   seeds from the OS via `StdRng::from_os_rng`). Two identical runs
+//!   that fall back can therefore legitimately differ. Consumers that
+//!   need reproducible fallback output should build their sampler with
+//!   [`GreedyTokenSampler::with_seed`](decode::sampler::GreedyTokenSampler::with_seed)
+//!   — a determinism knob Swift has no equivalent for — and should record
+//!   the effective temperature (the initial value plus any fallback
+//!   increments actually taken) in provenance, since it marks exactly
+//!   which outputs carry sampling randomness.
+//! - **Swift CLI comparison pitfall: `--language` forces prefill on.**
+//!   The upstream Swift CLI resolves
+//!   `usePrefillPrompt: arguments.usePrefillPrompt || arguments.language
+//!   != nil || task == .translate` (`TranscribeCLIUtils.swift:56`), so
+//!   passing `--language` to it silently turns prefill ON regardless of
+//!   the flag under test. A parity or benchmark harness that sets
+//!   `--language` while intending a no-prefill configuration is
+//!   comparing mismatched configurations — pin the language through
+//!   [`DecodingOptions::language`](options::DecodingOptions::language)
+//!   on this side and double-check what the Swift side actually resolved
+//!   before attributing any divergence to the ports.
 //!
 //! # Examples
 //!

--- a/crates/whisperkit/src/lib.rs
+++ b/crates/whisperkit/src/lib.rs
@@ -99,6 +99,63 @@
 //!   [`local_agreement_transcriber`](transcribe::WhisperKit::local_agreement_transcriber)).
 //! - [`log`] — leveled logging with a replacing callback.
 //!
+//! # Reproducibility and provenance
+//!
+//! The same audio through the same model can produce different text,
+//! tokens, and segments when decode options drift — coremlit issue #9's
+//! round-1–4 validation found exact Rust/Swift parity under one pinned
+//! configuration and observable divergence when single knobs moved (e.g.
+//! VAD-chunked with prefill was parity-pass; the same run without prefill
+//! was not). Consumers that index, snapshot, or regression-test
+//! transcripts should therefore set the decode policy **explicitly**
+//! rather than relying on defaults, and record the full configuration
+//! alongside every stored transcript or benchmark artifact:
+//!
+//! - model folder identity and revision (e.g. the Hugging Face repo id +
+//!   revision the `.mlmodelc` folder came from — this crate loads local
+//!   folders and does not know their provenance;
+//!   [`Options::model_folder`](options::Options::model_folder) is only
+//!   the path)
+//! - tokenizer identity and revision (same caveat;
+//!   [`Options::tokenizer_folder`](options::Options::tokenizer_folder))
+//! - compute units, per stage
+//!   ([`ComputeOptions`](options::ComputeOptions))
+//! - chunking strategy
+//!   ([`DecodingOptions::chunking_strategy`](options::DecodingOptions::chunking_strategy))
+//! - language, when known
+//!   ([`DecodingOptions::language`](options::DecodingOptions::language) —
+//!   set it explicitly instead of leaving auto-detection to pick one)
+//! - prefill
+//!   ([`DecodingOptions::use_prefill_prompt`](options::DecodingOptions::use_prefill_prompt))
+//! - special-token skipping
+//!   ([`DecodingOptions::skip_special_tokens`](options::DecodingOptions::skip_special_tokens))
+//! - word timestamps
+//!   ([`DecodingOptions::word_timestamps`](options::DecodingOptions::word_timestamps))
+//! - VAD strategy (the detector driving VAD chunking —
+//!   [`EnergyVad`](audio::vad::EnergyVad) by default, swappable via
+//!   [`WhisperKit::set_vad_detector`](transcribe::WhisperKit::set_vad_detector))
+//!
+//! Under the `serde` feature, [`DecodingOptions`](options::DecodingOptions),
+//! [`ComputeOptions`](options::ComputeOptions), and
+//! [`Options`](options::Options) are all serde-serializable, so the
+//! cheapest faithful record is to serialize the exact option values used
+//! and store that snapshot with the transcript.
+//!
+//! Two provenance-adjacent behaviors to plan for:
+//!
+//! - **Compute units affect output.** The same model/audio/options can
+//!   yield different transcripts across `cpuOnly`/`cpuAndGPU`/
+//!   `cpuAndNeuralEngine`/`all` — CoreML backend numeric drift, not a bug
+//!   in this port (Rust and Swift match each other when the unit
+//!   matches). Never compare outputs across compute units as if
+//!   equivalent: fix one unit for regression baselines, or keep a
+//!   separate baseline per unit.
+//! - **Silence decodes to a marker, not to empty text.** Silent windows
+//!   come back as
+//!   [`BLANK_AUDIO_MARKER`](constants::BLANK_AUDIO_MARKER) — see that
+//!   constant's doc; product layers filter or model it rather than
+//!   indexing it as transcript text.
+//!
 //! # Examples
 //!
 //! ```no_run

--- a/crates/whisperkit/src/lib.rs
+++ b/crates/whisperkit/src/lib.rs
@@ -165,11 +165,21 @@
 //!   deliberately matches that non-determinism
 //!   ([`GreedyTokenSampler::new`](decode::sampler::GreedyTokenSampler::new)
 //!   seeds from the OS via `StdRng::from_os_rng`). Two identical runs
-//!   that fall back can therefore legitimately differ. Consumers that
-//!   need reproducible fallback output should build their sampler with
+//!   that fall back can therefore legitimately differ. The full
+//!   [`WhisperKit::transcribe`](transcribe::WhisperKit::transcribe)/
+//!   [`transcribe_all`](transcribe::WhisperKit::transcribe_all) pipeline
+//!   builds this sampler internally, fresh per attempt, and takes no
+//!   sampler of its own — so at this level there is no seed-injection
+//!   path today, and output stays non-deterministic at `temperature >
+//!   0` by design, exactly like Swift, with no workaround available
+//!   here. Direct callers of [`decode::decode_text`]/
+//!   [`decode::detect_language`] (this crate's own tests included) sit
+//!   one layer lower and do supply their own sampler, so they can build
+//!   it with
 //!   [`GreedyTokenSampler::with_seed`](decode::sampler::GreedyTokenSampler::with_seed)
-//!   — a determinism knob Swift has no equivalent for — and should record
-//!   the effective temperature (the initial value plus any fallback
+//!   — a determinism knob Swift has no equivalent for — for
+//!   reproducible output at that layer. Either way, record the
+//!   effective temperature (the initial value plus any fallback
 //!   increments actually taken) in provenance, since it marks exactly
 //!   which outputs carry sampling randomness.
 //! - **Swift CLI comparison pitfall: `--language` forces prefill on.**

--- a/crates/whisperkit/src/options/mod.rs
+++ b/crates/whisperkit/src/options/mod.rs
@@ -244,9 +244,16 @@ pub struct DecodingOptions {
   /// model choose them.
   #[cfg_attr(feature = "serde", serde(default = "default_use_prefill_prompt"))]
   use_prefill_prompt: bool,
-  /// Detect the spoken language instead of using `language`.
-  #[cfg_attr(feature = "serde", serde(default))]
-  detect_language: bool,
+  /// Detect the spoken language instead of using `language`. Tri-state:
+  /// `None` means the caller never chose, and the value resolves against
+  /// `use_prefill_prompt` at read time — see [`Self::detect_language`]
+  /// (the getter is the single resolution point) for the Swift rule this
+  /// ports (`Configurations.swift:222`).
+  #[cfg_attr(
+    feature = "serde",
+    serde(default, skip_serializing_if = "Option::is_none")
+  )]
+  detect_language: Option<bool>,
   /// Omit special tokens (e.g. `<|endoftext|>`) from decoded text.
   #[cfg_attr(feature = "serde", serde(default))]
   skip_special_tokens: bool,
@@ -375,7 +382,7 @@ impl DecodingOptions {
       sample_length: DEFAULT_SAMPLE_LENGTH,
       top_k: DEFAULT_TOP_K,
       use_prefill_prompt: DEFAULT_USE_PREFILL_PROMPT,
-      detect_language: false,
+      detect_language: None,
       skip_special_tokens: false,
       without_timestamps: false,
       word_timestamps: false,
@@ -589,11 +596,27 @@ impl DecodingOptions {
     self
   }
 
-  // -- detect_language (bool) --------------------------------------------
-  /// Detect the spoken language instead of using `language`.
+  // -- detect_language (tri-state bool) ------------------------------------
+  /// Detect the spoken language instead of using `language`, resolved:
+  /// when the caller never set it, it defaults to `!use_prefill_prompt` —
+  /// detection kicks in by default exactly when prefill is off. Ports
+  /// Swift's constructor resolution `detectLanguage ?? !usePrefillPrompt`
+  /// (`Configurations.swift:222`, "If prefill is false, detect language
+  /// by default"); this port resolves at read time instead of
+  /// construction time only because Rust builders mutate after
+  /// construction — the observable rule is identical, and an explicit
+  /// [`Self::set_detect_language`]/[`Self::clear_detect_language`]/
+  /// [`Self::update_detect_language`] always wins over the coupling, in
+  /// either direction, regardless of mutation order.
+  ///
+  /// This getter is the single resolution point: every pipeline consumer
+  /// reads the coupled value through it.
   #[inline(always)]
   pub const fn detect_language(&self) -> bool {
-    self.detect_language
+    match self.detect_language {
+      Some(explicit) => explicit,
+      None => !self.use_prefill_prompt,
+    }
   }
   /// Builder form of [`Self::set_detect_language`].
   #[must_use]
@@ -602,10 +625,11 @@ impl DecodingOptions {
     self.set_detect_language();
     self
   }
-  /// Sets [`Self::detect_language`] to `true`.
+  /// Sets [`Self::detect_language`] explicitly to `true` (an explicit
+  /// value always beats the `!use_prefill_prompt` default coupling).
   #[inline(always)]
   pub const fn set_detect_language(&mut self) -> &mut Self {
-    self.detect_language = true;
+    self.detect_language = Some(true);
     self
   }
   /// Builder form of [`Self::update_detect_language`].
@@ -615,16 +639,19 @@ impl DecodingOptions {
     self.update_detect_language(detect_language);
     self
   }
-  /// Assigns [`Self::detect_language`] directly.
+  /// Assigns [`Self::detect_language`] explicitly (an explicit value
+  /// always beats the `!use_prefill_prompt` default coupling).
   #[inline(always)]
   pub const fn update_detect_language(&mut self, detect_language: bool) -> &mut Self {
-    self.detect_language = detect_language;
+    self.detect_language = Some(detect_language);
     self
   }
-  /// Sets [`Self::detect_language`] to `false`.
+  /// Sets [`Self::detect_language`] explicitly to `false` (an explicit
+  /// value always beats the `!use_prefill_prompt` default coupling — this
+  /// is how a no-prefill caller opts back out of detection).
   #[inline(always)]
   pub const fn clear_detect_language(&mut self) -> &mut Self {
-    self.detect_language = false;
+    self.detect_language = Some(false);
     self
   }
 

--- a/crates/whisperkit/src/options/mod.rs
+++ b/crates/whisperkit/src/options/mod.rs
@@ -602,12 +602,52 @@ impl DecodingOptions {
   /// detection kicks in by default exactly when prefill is off. Ports
   /// Swift's constructor resolution `detectLanguage ?? !usePrefillPrompt`
   /// (`Configurations.swift:222`, "If prefill is false, detect language
-  /// by default"); this port resolves at read time instead of
-  /// construction time only because Rust builders mutate after
-  /// construction — the observable rule is identical, and an explicit
-  /// [`Self::set_detect_language`]/[`Self::clear_detect_language`]/
-  /// [`Self::update_detect_language`] always wins over the coupling, in
-  /// either direction, regardless of mutation order.
+  /// by default"). An explicit [`Self::set_detect_language`]/
+  /// [`Self::clear_detect_language`]/[`Self::update_detect_language`]
+  /// always wins over the coupling, in either direction, regardless of
+  /// mutation order.
+  ///
+  /// **Construction is Swift-identical.** Build with the chained
+  /// `with_*`/`maybe_*` form and this getter returns exactly what
+  /// Swift's memberwise initializer would have stored for the same
+  /// `(detect_language, use_prefill_prompt)` pair: e.g.
+  /// `DecodingOptions::new().maybe_use_prefill_prompt(false)` resolves
+  /// `true` here, same as Swift's `DecodingOptions(usePrefillPrompt:
+  /// false)`, because both sides apply the identical `?? !usePrefillPrompt`
+  /// formula to the same final inputs.
+  ///
+  /// **Pinned deviation: in-place mutation of `use_prefill_prompt` after
+  /// construction, while `detect_language` is still unset.** Swift's
+  /// `detectLanguage` is a plain stored `Bool` — resolved once inside
+  /// `init`, then frozen; reassigning the `var usePrefillPrompt`
+  /// property afterward never touches it again. This getter has no such
+  /// freeze point and re-resolves on every call against whatever
+  /// `use_prefill_prompt` currently holds. Concretely:
+  /// `DecodingOptions::new()` (prefill ON, the default) followed by the
+  /// in-place mutator [`Self::clear_use_prefill_prompt`] resolves `true`
+  /// here — but Swift's equivalent, `var o = DecodingOptions()`
+  /// (`detectLanguage` already frozen `false`) followed by
+  /// `o.usePrefillPrompt = false`, leaves `detectLanguage` at the
+  /// `false` its initializer committed to. At a nonzero temperature
+  /// this changes whether a language-detection probe runs at all, which
+  /// consumes the attempt's sampler RNG draw and can shift both the
+  /// sampled tokens that follow and the word-level language split.
+  ///
+  /// This is a deliberate, accepted deviation, not a defect to fix:
+  /// eagerly freezing the resolution — inside `new()` or every mutator
+  /// that touches `use_prefill_prompt` — would have to materialize
+  /// `Some(false)` immediately, destroying the `None` ("caller never
+  /// chose") tri-state this field exists to represent, and with it
+  /// `serde`'s absent-on-unset round trip
+  /// (`skip_serializing_if = "Option::is_none"`) and the explicit-wins
+  /// guarantee above — both depend on telling "never set" apart from
+  /// "set to whatever the coupling currently says." A caller who wants
+  /// Swift's frozen-at-construction behavior after mutating
+  /// `use_prefill_prompt` in place sets `detect_language` explicitly
+  /// first (one call to [`Self::set_detect_language`]/
+  /// [`Self::clear_detect_language`]/[`Self::update_detect_language`]
+  /// before the mutation) — an explicit choice always wins over the
+  /// coupling.
   ///
   /// This getter is the single resolution point: every pipeline consumer
   /// reads the coupled value through it.

--- a/crates/whisperkit/src/options/tests.rs
+++ b/crates/whisperkit/src/options/tests.rs
@@ -106,7 +106,13 @@ fn detect_language_default_couples_to_prefill() {
   assert!(!unset.detect_language());
   assert_eq!(unset.detect_language, None, "constructed unset, not false");
 
-  // Unset + prefill OFF: resolves true — the Swift-matching coupling.
+  // Unset + prefill OFF, reached by an in-place mutator on an
+  // already-constructed value: resolves true, this port's own
+  // live-resolution rule — not Swift-identical. See
+  // `DecodingOptions::detect_language`'s doc ("Pinned deviation") and
+  // `detect_language_pinned_construction_vs_mutation_histories` below
+  // for the construction-vs-mutation distinction Swift parity actually
+  // depends on here.
   let mut no_prefill = DecodingOptions::new();
   no_prefill.clear_use_prefill_prompt();
   assert!(no_prefill.detect_language());
@@ -136,6 +142,46 @@ fn detect_language_default_couples_to_prefill() {
     .maybe_use_prefill_prompt(false)
     .maybe_detect_language(false);
   assert!(!via_update.detect_language());
+}
+
+#[test]
+fn detect_language_pinned_construction_vs_mutation_histories() {
+  // `DecodingOptions::detect_language`'s doc names two histories for an
+  // unset `detect_language` ending with `use_prefill_prompt == false`.
+  // Both resolve to the SAME Rust value (`true`) — what differs is
+  // which Swift call each history actually corresponds to.
+
+  // (i) Construction: chain `with_*`/`maybe_*` from `new()`, never
+  // mutate again. Swift-identical — matches
+  // `DecodingOptions(usePrefillPrompt: false)`, whose initializer
+  // computes `detectLanguage = nil ?? !false = true` directly from the
+  // argument: same formula, same final inputs, same value.
+  let constructed = DecodingOptions::new().maybe_use_prefill_prompt(false);
+  assert_eq!(constructed.detect_language, None, "still unset");
+  assert!(constructed.detect_language());
+
+  // (ii) In-place mutation of an already-constructed value: the pinned
+  // deviation. Also resolves `true` here, but Swift's equivalent is
+  // `var o = DecodingOptions()` — `usePrefillPrompt` defaults `true`,
+  // so `detectLanguage` freezes `!true == false` right there in `init`
+  // — followed by the LATER, separate mutation `o.usePrefillPrompt =
+  // false`, which cannot reach back and change the already-frozen
+  // `detectLanguage`. Swift stays `false`; this port resolves `true`.
+  // Kept deliberately (see the doc's tri-state/serde argument), not
+  // "fixed" to match.
+  let mut mutated = DecodingOptions::new();
+  assert!(mutated.use_prefill_prompt()); // prefill ON — Swift's default init
+  mutated.clear_use_prefill_prompt(); // separate, later mutation: Swift's `o.usePrefillPrompt = false`
+  assert_eq!(mutated.detect_language, None, "still unset");
+  assert!(
+    mutated.detect_language(),
+    "pinned deviation: Swift's equivalent history stays false here"
+  );
+
+  // Both histories land on the identical Rust value, which is exactly
+  // why this is a getter-shape (Swift-comparison-point) deviation
+  // rather than a value bug reachable from a single Rust run.
+  assert_eq!(constructed.detect_language(), mutated.detect_language());
 }
 
 #[cfg(feature = "serde")]

--- a/crates/whisperkit/src/options/tests.rs
+++ b/crates/whisperkit/src/options/tests.rs
@@ -92,6 +92,98 @@ fn serde_round_trips_and_fills_defaults() {
 }
 
 #[test]
+fn detect_language_default_couples_to_prefill() {
+  // Ports Swift's `detectLanguage ?? !usePrefillPrompt`
+  // (Configurations.swift:222): unset detection defaults ON exactly when
+  // prefill is OFF, and an explicit choice always wins (coremlit
+  // issue #9 follow-up — this was the one genuine defaults gap between
+  // the ports).
+
+  // Unset + prefill ON (both defaults): resolves false — the pre-coupling
+  // default path, byte-unchanged.
+  let unset = DecodingOptions::new();
+  assert!(unset.use_prefill_prompt());
+  assert!(!unset.detect_language());
+  assert_eq!(unset.detect_language, None, "constructed unset, not false");
+
+  // Unset + prefill OFF: resolves true — the Swift-matching coupling.
+  let mut no_prefill = DecodingOptions::new();
+  no_prefill.clear_use_prefill_prompt();
+  assert!(no_prefill.detect_language());
+
+  // Explicit false beats the coupling even with prefill off...
+  let mut explicit_false = DecodingOptions::new();
+  explicit_false
+    .clear_use_prefill_prompt()
+    .clear_detect_language();
+  assert!(!explicit_false.detect_language());
+
+  // ...and mutation ORDER does not matter: the coupling is resolved at
+  // read time, so flipping prefill after the explicit choice cannot
+  // overwrite it (the construction-time-resolution failure mode).
+  let mut late_prefill = DecodingOptions::new();
+  late_prefill.clear_detect_language();
+  late_prefill.clear_use_prefill_prompt();
+  assert!(!late_prefill.detect_language());
+
+  // Explicit true with prefill ON (coupling would say false).
+  let explicit_true = DecodingOptions::new().with_detect_language();
+  assert!(explicit_true.use_prefill_prompt());
+  assert!(explicit_true.detect_language());
+
+  // maybe_/update_ record an explicit choice too.
+  let via_update = DecodingOptions::new()
+    .maybe_use_prefill_prompt(false)
+    .maybe_detect_language(false);
+  assert!(!via_update.detect_language());
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn detect_language_serde_tristate() {
+  // (d) of the coupling contract: unset serializes ABSENT and a missing
+  // field deserializes as unset (still coupled), while explicit values
+  // round-trip and win.
+
+  // Unset -> key absent (also covered by the exact-key test above).
+  let json = serde_json::to_string(&DecodingOptions::new()).unwrap();
+  let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+  assert!(!value.as_object().unwrap().contains_key("detect_language"));
+
+  // Missing field -> unset, not Some(false): with prefill also absent
+  // (default ON) it resolves false...
+  let missing: DecodingOptions = serde_json::from_str("{}").unwrap();
+  assert_eq!(missing.detect_language, None);
+  assert!(!missing.detect_language());
+  // ...and with prefill explicitly OFF in the config, the still-unset
+  // field resolves true — a partial config gets the Swift coupling.
+  let coupled: DecodingOptions = serde_json::from_str(r#"{"use_prefill_prompt":false}"#).unwrap();
+  assert_eq!(coupled.detect_language, None);
+  assert!(coupled.detect_language());
+
+  // Explicit false survives the round trip and beats the coupling.
+  let explicit_false: DecodingOptions =
+    serde_json::from_str(r#"{"use_prefill_prompt":false,"detect_language":false}"#).unwrap();
+  assert_eq!(explicit_false.detect_language, Some(false));
+  assert!(!explicit_false.detect_language());
+  let json = serde_json::to_string(&explicit_false).unwrap();
+  assert!(json.contains("\"detect_language\":false"));
+  assert_eq!(
+    serde_json::from_str::<DecodingOptions>(&json).unwrap(),
+    explicit_false
+  );
+
+  // Explicit true round-trips as a present key.
+  let explicit_true = DecodingOptions::new().with_detect_language();
+  let json = serde_json::to_string(&explicit_true).unwrap();
+  assert!(json.contains("\"detect_language\":true"));
+  assert_eq!(
+    serde_json::from_str::<DecodingOptions>(&json).unwrap(),
+    explicit_true
+  );
+}
+
+#[test]
 fn compute_defaults_match_swift_model_compute_options() {
   let c = ComputeOptions::new();
   assert_eq!(c.mel(), coremlit::ComputeUnits::CpuAndGpu);
@@ -237,15 +329,17 @@ fn decoding_options_empty_collections_skip_serializing() {
   let json = serde_json::to_string(&DecodingOptions::new()).unwrap();
   let value: serde_json::Value = serde_json::from_str(&json).unwrap();
   let object = value.as_object().unwrap();
-  // Exact-key checks: `detect_language` (always serialized) contains the
-  // substring "language", so a substring match on the JSON text would be a
-  // false negative for the `language` field specifically.
+  // Exact-key checks: an explicitly-set `detect_language` key contains
+  // the substring "language", so a substring match on the JSON text would
+  // be a false negative for the `language` field specifically.
   assert!(!object.contains_key("language"));
   assert!(!object.contains_key("clip_timestamps"));
   assert!(!object.contains_key("prompt_tokens"));
   assert!(!object.contains_key("prefix_tokens"));
   assert!(!object.contains_key("suppress_tokens"));
-  assert!(object.contains_key("detect_language"));
+  // Unset tri-state `detect_language` is skipped like the `None` floats
+  // (see `detect_language_serde_tristate` for the full presence matrix).
+  assert!(!object.contains_key("detect_language"));
   assert_eq!(
     serde_json::from_str::<DecodingOptions>(&json).unwrap(),
     DecodingOptions::new()

--- a/crates/whisperkit/src/tokenizer/mod.rs
+++ b/crates/whisperkit/src/tokenizer/mod.rs
@@ -17,6 +17,9 @@ use unicode_categories::UnicodeCategories;
 
 use crate::{constants, error::TokenizerError};
 
+#[cfg(feature = "nl-recognizer")]
+pub mod nl_recognizer;
+
 // ---------------------------------------------------------------------
 // SpecialTokens
 // ---------------------------------------------------------------------
@@ -405,6 +408,26 @@ impl WhisperTokenizer {
   /// `NLLanguageRecognizer.dominantLanguage` detection (spec §5.3) — the
   /// caller supplies it directly (e.g. from the decoded `<|lang|>` prompt
   /// token) instead of re-detecting it from the decoded text.
+  ///
+  /// # Overriding or pre-normalizing `language_code`
+  /// `language_code` is an ordinary argument, not something this method
+  /// derives itself — this crate's pipeline callers pass the decoder's own
+  /// `<|lang|>` prompt token by default, and that stays the one source of
+  /// truth (see the paragraph above). A caller that instead wants Swift's
+  /// original text-based re-detection — e.g. for code-switched audio,
+  /// where the decoder's single per-window language token can be a poor
+  /// fit — can compute its own replacement code and pass that here. The
+  /// optional `nl-recognizer` feature (off by default) ships exactly that
+  /// as `tokenizer::nl_recognizer::redetect_language`, a thin wrapper over
+  /// `NLLanguageRecognizer` that additionally normalizes its raw BCP-47
+  /// result to a bare base code (`zh-Hant`/`zh-Hans`/`zh-*` all become
+  /// `zh`) before returning — the exact normalization step Swift's own
+  /// call site skips (`Models.swift:1297`), which is why a `zh-Hant`
+  /// transcript falls through to space-based splitting there instead of
+  /// landing on the CJK arm above (coremlit issue #9). See that
+  /// function's doc for the full trade-off: a text-based second opinion
+  /// can help, but it is still a second, independently-fallible signal,
+  /// which is exactly why this crate does not call it automatically.
   ///
   /// `tokens` is **not** filtered before splitting, even though Swift's
   /// language-detection preamble filters its own (separate, ephemeral)

--- a/crates/whisperkit/src/tokenizer/mod.rs
+++ b/crates/whisperkit/src/tokenizer/mod.rs
@@ -422,7 +422,7 @@ impl WhisperTokenizer {
   /// `NLLanguageRecognizer` that additionally normalizes its raw BCP-47
   /// result to a bare base code (`zh-Hant`/`zh-Hans`/`zh-*` all become
   /// `zh`) before returning — the exact normalization step Swift's own
-  /// call site skips (`Models.swift:1297`), which is why a `zh-Hant`
+  /// call site skips (`Models.swift:1301`), which is why a `zh-Hant`
   /// transcript falls through to space-based splitting there instead of
   /// landing on the CJK arm above (coremlit issue #9). See that
   /// function's doc for the full trade-off: a text-based second opinion

--- a/crates/whisperkit/src/tokenizer/nl_recognizer/mod.rs
+++ b/crates/whisperkit/src/tokenizer/nl_recognizer/mod.rs
@@ -39,7 +39,7 @@ mod tests;
 /// a bare base code: for Traditional Chinese text it returns `zh-Hant`,
 /// not `zh` (verified empirically against this exact crate version).
 /// Swift's WhisperKit passes that raw tag straight into its own CJK
-/// allowlist check (`Models.swift:1297`), which only matches the bare
+/// allowlist check (`Models.swift:1301`), which only matches the bare
 /// codes `zh`/`ja`/`th`/`lo`/`my`/`yue` — so `zh-Hant` misses the list and
 /// Swift falls through to space-based (phrase-blob) splitting for
 /// Traditional Chinese (coremlit issue #9's root-caused finding). This

--- a/crates/whisperkit/src/tokenizer/nl_recognizer/mod.rs
+++ b/crates/whisperkit/src/tokenizer/nl_recognizer/mod.rs
@@ -5,6 +5,7 @@
 //! [`super::WhisperTokenizer::split_to_word_tokens`]'s doc for why the
 //! pipeline itself never calls this automatically (coremlit issue #9).
 
+use objc2::rc::autoreleasepool;
 use objc2_foundation::NSString;
 use objc2_natural_language::NLLanguageRecognizer;
 
@@ -13,8 +14,8 @@ mod tests;
 
 /// Redetects `text`'s dominant language from its own decoded content via
 /// `NLLanguageRecognizer` — the same class Swift's WhisperKit uses
-/// internally (`Models.swift:1294`) — normalizing the raw BCP-47 result to
-/// a Whisper base language code before returning it.
+/// internally (`Models.swift:1297-1299`) — normalizing the raw BCP-47
+/// result to a Whisper base language code before returning it.
 ///
 /// # Why this exists
 /// [`super::WhisperTokenizer::split_to_word_tokens`] always splits words
@@ -52,17 +53,37 @@ mod tests;
 ///
 /// Returns `None` when `NLLanguageRecognizer` cannot determine a dominant
 /// language (notably: empty or extremely short input).
+///
+/// # Thread safety
+/// This function establishes its own autorelease pool
+/// ([`autoreleasepool`]) around the complete operation — including the
+/// final owned-`String` conversion — so it is safe to call from any
+/// thread, including a bare `std::thread` with no surrounding Cocoa/
+/// AppKit run-loop pool. The pool is required, not optional: objc2's own
+/// documented contract is that any Objective-C method may autorelease
+/// internally (`objc2` 0.6.4 `src/rc/autorelease.rs:316`,
+/// [`autoreleasepool`]'s own doc), and the final `NSString` -> `String`
+/// conversion below specifically goes through `objc2-foundation`'s
+/// `autoreleasepool_leaking` (`objc2-foundation` 0.3.2 `src/util.rs:46`),
+/// which — per its own SAFETY comment (`objc2`
+/// `src/rc/autorelease.rs:524-533`) — *assumes* a real pool exists
+/// further up the call stack rather than establishing one itself. Without
+/// the pool this function pushes, every temporary autoreleased while
+/// redetecting a language would leak instead of draining on a thread
+/// with no pool above it.
 pub fn redetect_language(text: &str) -> Option<String> {
-  // SAFETY: fresh, unshared recognizer instance; `new` has no
-  // preconditions beyond ordinary Objective-C allocation.
-  let recognizer = unsafe { NLLanguageRecognizer::new() };
-  let ns_text = NSString::from_str(text);
-  // SAFETY: `recognizer` and `ns_text` are both live for the call, and
-  // the recognizer is not shared across threads.
-  unsafe { recognizer.processString(&ns_text) };
-  // SAFETY: accessor send on the same live recognizer.
-  let language = unsafe { recognizer.dominantLanguage() }?;
-  Some(normalize_bcp47(&language.to_string()))
+  autoreleasepool(|_| {
+    // SAFETY: fresh, unshared recognizer instance; `new` has no
+    // preconditions beyond ordinary Objective-C allocation.
+    let recognizer = unsafe { NLLanguageRecognizer::new() };
+    let ns_text = NSString::from_str(text);
+    // SAFETY: `recognizer` and `ns_text` are both live for the call, and
+    // the recognizer is not shared across threads.
+    unsafe { recognizer.processString(&ns_text) };
+    // SAFETY: accessor send on the same live recognizer.
+    let language = unsafe { recognizer.dominantLanguage() }?;
+    Some(normalize_bcp47(&language.to_string()))
+  })
 }
 
 /// Reduces a BCP-47 language tag to the primary subtag Whisper's

--- a/crates/whisperkit/src/tokenizer/nl_recognizer/mod.rs
+++ b/crates/whisperkit/src/tokenizer/nl_recognizer/mod.rs
@@ -1,0 +1,82 @@
+//! Optional transcript-based language redetection via Apple's
+//! `NLLanguageRecognizer`, gated behind the `nl-recognizer` feature (off
+//! by default). See [`redetect_language`]'s doc for the trade-off this
+//! exists to offer callers, and
+//! [`super::WhisperTokenizer::split_to_word_tokens`]'s doc for why the
+//! pipeline itself never calls this automatically (coremlit issue #9).
+
+use objc2_foundation::NSString;
+use objc2_natural_language::NLLanguageRecognizer;
+
+#[cfg(test)]
+mod tests;
+
+/// Redetects `text`'s dominant language from its own decoded content via
+/// `NLLanguageRecognizer` — the same class Swift's WhisperKit uses
+/// internally (`Models.swift:1294`) — normalizing the raw BCP-47 result to
+/// a Whisper base language code before returning it.
+///
+/// # Why this exists
+/// [`super::WhisperTokenizer::split_to_word_tokens`] always splits words
+/// using the language the Whisper *decoder* already committed to (its
+/// `<|lang|>` prompt token), not a second opinion from the decoded text —
+/// that stays the pipeline's one source of truth (see that method's doc).
+/// That default is right for single-language audio, but code-switched
+/// audio (a clip whose dominant spoken language drifts mid-utterance) can
+/// benefit from re-checking the language against what actually got
+/// transcribed. This function is that opt-in second opinion: a caller who
+/// wants it computes its own replacement language code and passes that
+/// into `split_to_word_tokens` instead of the decoder's token. The
+/// library does not wire this in by default, for two reasons: a
+/// text-based re-detection can be wrong in ways the decoder's own
+/// language token isn't (short strings, mixed-script strings, and proper
+/// nouns are all documented `NLLanguageRecognizer` failure modes), and
+/// doing it unconditionally would silently reintroduce a second,
+/// competing language signal into every call.
+///
+/// # The normalization Swift's own call site lacks
+/// `NLLanguageRecognizer.dominantLanguage` returns a full BCP-47 tag, not
+/// a bare base code: for Traditional Chinese text it returns `zh-Hant`,
+/// not `zh` (verified empirically against this exact crate version).
+/// Swift's WhisperKit passes that raw tag straight into its own CJK
+/// allowlist check (`Models.swift:1297`), which only matches the bare
+/// codes `zh`/`ja`/`th`/`lo`/`my`/`yue` — so `zh-Hant` misses the list and
+/// Swift falls through to space-based (phrase-blob) splitting for
+/// Traditional Chinese (coremlit issue #9's root-caused finding). This
+/// function normalizes before returning specifically so it cannot
+/// reproduce that gap: every result is reduced to its primary BCP-47
+/// subtag (`zh-Hant`/`zh-Hans`/`zh-*` all become `zh`), with ISO 639-2's
+/// `cmn` additionally mapped to `zh` (Whisper's vocabulary has no separate
+/// `cmn` token; `NLLanguageRecognizer` has not been observed to emit it,
+/// but the mapping costs nothing).
+///
+/// Returns `None` when `NLLanguageRecognizer` cannot determine a dominant
+/// language (notably: empty or extremely short input).
+pub fn redetect_language(text: &str) -> Option<String> {
+  // SAFETY: fresh, unshared recognizer instance; `new` has no
+  // preconditions beyond ordinary Objective-C allocation.
+  let recognizer = unsafe { NLLanguageRecognizer::new() };
+  let ns_text = NSString::from_str(text);
+  // SAFETY: `recognizer` and `ns_text` are both live for the call, and
+  // the recognizer is not shared across threads.
+  unsafe { recognizer.processString(&ns_text) };
+  // SAFETY: accessor send on the same live recognizer.
+  let language = unsafe { recognizer.dominantLanguage() }?;
+  Some(normalize_bcp47(&language.to_string()))
+}
+
+/// Reduces a BCP-47 language tag to the primary subtag Whisper's
+/// `<|lang|>` vocabulary and
+/// [`super::WhisperTokenizer::split_to_word_tokens`] expect: text before
+/// the first `-`, lowercased (`zh-Hant` -> `zh`, `zh-Hans` -> `zh`,
+/// `pt-BR` -> `pt`, a bare `en` -> `en` unchanged), with ISO 639-2's `cmn`
+/// (Mandarin) additionally mapped to `zh` since the primary-subtag rule
+/// alone does not reduce it.
+fn normalize_bcp47(tag: &str) -> String {
+  let primary = tag.split('-').next().unwrap_or(tag).to_ascii_lowercase();
+  if primary == "cmn" {
+    "zh".to_string()
+  } else {
+    primary
+  }
+}

--- a/crates/whisperkit/src/tokenizer/nl_recognizer/tests.rs
+++ b/crates/whisperkit/src/tokenizer/nl_recognizer/tests.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+// No `WHISPERKIT_TEST_MODELS` gating needed here, unlike the tokenizer's
+// own fixture-driven tests: `NLLanguageRecognizer` is an Apple system
+// framework always present on macOS, not a downloaded model asset.
+
+#[test]
+fn redetects_english() {
+  assert_eq!(
+    redetect_language("This is a plain English sentence for language detection.").as_deref(),
+    Some("en")
+  );
+}
+
+#[test]
+fn redetects_traditional_chinese_and_normalizes_to_zh() {
+  // issue #9's own repro string: `NLLanguageRecognizer`'s raw output for
+  // this text is `zh-Hant`, not `zh` (verified empirically against this
+  // crate version) -- collapsing that down to `zh` is the entire point of
+  // this wrapper existing instead of callers using the class directly.
+  let detected = redetect_language("你上學也不也不說普通話全是東北話").unwrap();
+  assert_eq!(detected, "zh");
+}
+
+#[test]
+fn empty_input_is_undetermined() {
+  assert_eq!(redetect_language(""), None);
+}
+
+#[test]
+fn normalize_bcp47_strips_script_and_region_subtags() {
+  assert_eq!(normalize_bcp47("zh-Hant"), "zh");
+  assert_eq!(normalize_bcp47("zh-Hans"), "zh");
+  assert_eq!(normalize_bcp47("zh-CN"), "zh");
+  assert_eq!(normalize_bcp47("pt-BR"), "pt");
+  assert_eq!(normalize_bcp47("en"), "en");
+}
+
+#[test]
+fn normalize_bcp47_maps_cmn_to_zh() {
+  assert_eq!(normalize_bcp47("cmn"), "zh");
+  assert_eq!(normalize_bcp47("cmn-Hant"), "zh");
+}

--- a/crates/whisperkit/src/tokenizer/nl_recognizer/tests.rs
+++ b/crates/whisperkit/src/tokenizer/nl_recognizer/tests.rs
@@ -41,3 +41,28 @@ fn normalize_bcp47_maps_cmn_to_zh() {
   assert_eq!(normalize_bcp47("cmn"), "zh");
   assert_eq!(normalize_bcp47("cmn-Hant"), "zh");
 }
+
+#[test]
+fn redetect_language_is_stable_across_repeated_calls_on_a_bare_thread() {
+  // Regression coverage for `redetect_language`'s autorelease-pool wrap:
+  // a bare `std::thread` (unlike a Cocoa/AppKit run loop) never has a
+  // pool already on the stack, so this exercises exactly the thread
+  // shape that would leak without the function establishing its own
+  // pool. Fifty repeated calls returning a stable, correct result is
+  // evidence the pool-wrapped path is correct and repeatable from such a
+  // thread; it is NOT proof that nothing leaks -- that would need a
+  // subprocess harness driven with `OBJC_DEBUG_MISSING_POOLS=YES`,
+  // deliberately not built here (recorded as a known limitation in the
+  // fixes report instead).
+  let handle = std::thread::spawn(|| {
+    for _ in 0..50 {
+      assert_eq!(
+        redetect_language("This is a plain English sentence for language detection.").as_deref(),
+        Some("en")
+      );
+    }
+  });
+  handle
+    .join()
+    .expect("redetect_language must not panic on a bare thread");
+}

--- a/crates/whisperkit/src/tokenizer/tests.rs
+++ b/crates/whisperkit/src/tokenizer/tests.rs
@@ -171,6 +171,59 @@ fn split_to_word_tokens_empty_input_is_empty() {
 
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn cjk_languages_split_into_fine_grained_words() {
+  // Pins a deliberate, chosen DIVERGENCE from Swift (coremlit issue #9,
+  // "Chinese word timestamp grouping needs a product policy"): Swift's
+  // `NLLanguageRecognizer` reports `zh-Hant` for Traditional Chinese text,
+  // but Swift's own CJK allowlist in `splitToWordTokens` is exactly
+  // `zh`/`ja`/`th`/`lo`/`my`/`yue` (`Models.swift:1293-1306`) --
+  // `zh-Hant` misses that list and falls through to the space-based
+  // splitter, which (Chinese has no spaces) groups a whole utterance into
+  // one coarse phrase blob instead of timing each character. This crate
+  // never reproduces that gap: the language code driving the split always
+  // comes from the decoder's own `<|lang|>` prompt token (see
+  // [`WhisperTokenizer::split_to_word_tokens`]'s doc), which is a bare
+  // base code (`zh`, never `zh-Hant`) by construction, so it always lands
+  // on the CJK arm below. The sample string and its expected
+  // per-character split are copied verbatim from issue #9's own
+  // Rust/Swift comparison run (its "Representative output" section). If a
+  // future change ever "fixes" this by routing decoder language codes
+  // through Swift's raw, un-normalized recognizer output, this test
+  // catches the regression back to phrase-blob grouping.
+  let t = tiny();
+  let text = "你上學也不也不說普通話";
+  let expected_words = vec![
+    "你", "上", "學", "也", "不", "也", "不", "說", "普", "通", "話",
+  ];
+  assert_eq!(expected_words.len(), text.chars().count());
+
+  for lang in ["zh", "ja", "yue"] {
+    let ids = t.encode(text).unwrap();
+    let words = t.split_to_word_tokens(&ids, lang).unwrap();
+    let texts: Vec<&str> = words.iter().map(|(w, _)| w.as_str()).collect();
+    assert_eq!(texts, expected_words, "language {lang}");
+    assert_eq!(
+      words.len(),
+      text.chars().count(),
+      "language {lang}: word count must equal char count"
+    );
+  }
+
+  // Contrast: a non-CJK language code routes the exact same tokens to the
+  // space-based splitter instead -- since the sample has no spaces, the
+  // whole utterance collapses into a single coarse "word". This is the
+  // failure mode the CJK arm above exists to avoid.
+  let ids = t.encode(text).unwrap();
+  let en_words = t.split_to_word_tokens(&ids, "en").unwrap();
+  assert_eq!(
+    en_words.len(),
+    1,
+    "non-CJK routing must not split per character"
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn split_to_word_tokens_preserves_token_coverage_and_text() {
   // Structural invariants that must hold regardless of split strategy:
   // every input token is covered by exactly one word, in original order;

--- a/crates/whisperkit/src/transcribe/mod.rs
+++ b/crates/whisperkit/src/transcribe/mod.rs
@@ -861,7 +861,40 @@ impl<B> WhisperKit<B> {
   /// drives — the seam matching Swift's injectable `voiceActivityDetector`
   /// field (`WhisperKit.swift:880`). [`audio::vad::EnergyVad`] (this
   /// pipeline's default) is one valid detector to construct here; any
-  /// other [`audio::vad::VoiceActivityDetector`] implementation works too.
+  /// type implementing [`audio::vad::VoiceActivityDetector`] works too,
+  /// provided it also satisfies this parameter's actual bounds —
+  /// `Send + Sync + 'static` (the `'static` is implicit: the default
+  /// object-lifetime bound for a `Box<dyn Trait + Send + Sync>` with no
+  /// lifetime written out) — because the boxed detector is stored on
+  /// `self` for the pipeline's full lifetime and must be safe to
+  /// send/share across threads along with it.
+  ///
+  /// # Examples
+  ///
+  /// A detector holding non-`Send` state is rejected at compile time
+  /// (this example is intentionally `compile_fail`):
+  ///
+  /// ```compile_fail
+  /// use std::{cell::Cell, rc::Rc};
+  /// use whisperkit::audio::vad::VoiceActivityDetector;
+  /// use whisperkit::transcribe::WhisperKit;
+  ///
+  /// struct NotSendVad(Rc<Cell<u32>>);
+  ///
+  /// impl VoiceActivityDetector for NotSendVad {
+  ///   fn voice_activity(&self, samples: &[f32]) -> Vec<bool> {
+  ///     vec![false; samples.len()]
+  ///   }
+  ///   fn frame_length_samples(&self) -> usize {
+  ///     160
+  ///   }
+  /// }
+  ///
+  /// fn reject<B>(kit: &mut WhisperKit<B>) {
+  ///   // error[E0277]: `Rc<Cell<u32>>` cannot be sent between threads safely
+  ///   kit.set_vad_detector(Box::new(NotSendVad(Rc::new(Cell::new(0)))));
+  /// }
+  /// ```
   #[inline(always)]
   pub fn set_vad_detector(
     &mut self,

--- a/crates/whisperkit/src/transcribe/mod.rs
+++ b/crates/whisperkit/src/transcribe/mod.rs
@@ -725,6 +725,14 @@ pub struct WhisperKit<B> {
   backend: B,
   tokenizer: WhisperTokenizer,
   variant: Option<ModelVariant>,
+  /// VAD detector [`Self::transcribe`]'s VAD-chunked branch drives.
+  /// Defaults to [`audio::vad::EnergyVad`] — Swift's own default for its
+  /// counterpart `voiceActivityDetector` field (`WhisperKit.swift:880`) —
+  /// and is swappable via [`Self::with_vad_detector`]/
+  /// [`Self::set_vad_detector`] (coremlit issue #9: "Make VAD strategy
+  /// pluggable or configurable rather than locking product behavior to
+  /// the default energy VAD").
+  vad_detector: Box<dyn audio::vad::VoiceActivityDetector + Send + Sync>,
 }
 
 impl WhisperKit<CoreMlBackend> {
@@ -782,6 +790,7 @@ impl WhisperKit<CoreMlBackend> {
       backend,
       tokenizer,
       variant,
+      vad_detector: Box::new(audio::vad::EnergyVad::new()),
     })
   }
 }
@@ -804,6 +813,7 @@ impl<B> WhisperKit<B> {
       backend,
       tokenizer,
       variant: None,
+      vad_detector: Box::new(audio::vad::EnergyVad::new()),
     }
   }
 
@@ -826,6 +836,39 @@ impl<B> WhisperKit<B> {
   #[inline(always)]
   pub const fn variant(&self) -> Option<ModelVariant> {
     self.variant
+  }
+
+  /// The VAD detector [`Self::transcribe`]'s VAD-chunked branch drives.
+  /// Defaults to [`audio::vad::EnergyVad`]; see [`Self::with_vad_detector`]/
+  /// [`Self::set_vad_detector`] to swap it.
+  #[inline(always)]
+  pub fn vad_detector(&self) -> &(dyn audio::vad::VoiceActivityDetector + Send + Sync) {
+    self.vad_detector.as_ref()
+  }
+
+  /// Builder form of [`Self::set_vad_detector`].
+  #[must_use]
+  #[inline(always)]
+  pub fn with_vad_detector(
+    mut self,
+    detector: Box<dyn audio::vad::VoiceActivityDetector + Send + Sync>,
+  ) -> Self {
+    self.set_vad_detector(detector);
+    self
+  }
+
+  /// Replaces the VAD detector [`Self::transcribe`]'s VAD-chunked branch
+  /// drives — the seam matching Swift's injectable `voiceActivityDetector`
+  /// field (`WhisperKit.swift:880`). [`audio::vad::EnergyVad`] (this
+  /// pipeline's default) is one valid detector to construct here; any
+  /// other [`audio::vad::VoiceActivityDetector`] implementation works too.
+  #[inline(always)]
+  pub fn set_vad_detector(
+    &mut self,
+    detector: Box<dyn audio::vad::VoiceActivityDetector + Send + Sync>,
+  ) -> &mut Self {
+    self.vad_detector = detector;
+    self
   }
 
   /// Builds an [`AudioStreamTranscriber`] over this pipeline's own
@@ -898,13 +941,14 @@ where
   /// [`ChunkingStrategy::Vad`](crate::options::ChunkingStrategy::Vad)
   /// **and** `audio.len()` exceeds the backend's
   /// [`ModelDims::window_samples`](crate::backend::ModelDims::window_samples)
-  /// (:876-878): [`audio::vad::EnergyVad`] +
-  /// [`chunker::VadChunker::chunk_all`] split `audio` along silence
-  /// boundaries (:880-886 — Swift's injectable `voiceActivityDetector ??
-  /// EnergyVAD()` field, :880, has no seam here yet: the energy VAD is
-  /// the only detector this port ships, so it is constructed directly),
-  /// with `clip_timestamps` cleared per chunk since chunking already
-  /// consumed them (:892-894); each chunk runs its own
+  /// (:876-878): [`Self::vad_detector`] + [`chunker::VadChunker::chunk_all`]
+  /// split `audio` along silence boundaries (:880-886 — Swift's injectable
+  /// `voiceActivityDetector ?? EnergyVAD()` field, :880, is
+  /// [`Self::vad_detector`]'s own counterpart: it defaults to
+  /// [`audio::vad::EnergyVad`], same as Swift, and
+  /// [`Self::with_vad_detector`]/[`Self::set_vad_detector`] are the seam
+  /// that swaps it), with `clip_timestamps` cleared per chunk since
+  /// chunking already consumed them (:892-894); each chunk runs its own
   /// [`TranscribeTask::run`], window-id-offset by its position in the
   /// chunk list (Swift's `audioIndex + batchIndex * batchSize`, :750 —
   /// which collapses to a flat running index here, see the deviation note
@@ -957,10 +1001,14 @@ where
   ) -> Result<TranscriptionResult, TranscribeError> {
     let window_samples = self.backend.dims().window_samples();
     if options.chunking_strategy().is_vad() && audio.len() > window_samples {
-      let vad = audio::vad::EnergyVad::new();
       let vad_chunker = chunker::VadChunker::new();
       let clip_ranges = chunker::prepare_seek_clips(options.clip_timestamps_slice(), audio.len())?;
-      let chunks = vad_chunker.chunk_all(&vad, audio, window_samples, &clip_ranges);
+      let chunks = vad_chunker.chunk_all(
+        self.vad_detector.as_ref(),
+        audio,
+        window_samples,
+        &clip_ranges,
+      );
       let chunk_options = options.clone().with_clip_timestamps(Vec::new());
 
       let mut chunk_results = Vec::with_capacity(chunks.len());

--- a/crates/whisperkit/src/transcribe/tests.rs
+++ b/crates/whisperkit/src/transcribe/tests.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use super::*;
 use crate::{
+  audio::vad::VoiceActivityDetector,
   backend::{ModelDims, mock::MockBackend},
   error::SegmentError,
   options::{ChunkingStrategy, DecodingOptions},
@@ -303,6 +304,52 @@ fn vad_chunked_transcribe_reanchors_and_merges() {
     (starts[2] - 4.1).abs() < 1e-3,
     "chunk 3 re-anchored, got {}",
     starts[2]
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn vad_detector_swap_changes_chunk_boundaries() {
+  // coremlit issue #9 ("Make VAD strategy pluggable or configurable
+  // rather than locking product behavior to the default energy VAD"):
+  // reuses `vad_chunked_transcribe_reanchors_and_merges`'s exact audio
+  // (two silent stretches inside 96_000 samples, 48_000-sample windows)
+  // but swaps in a detector that never reports silence. With no silence
+  // to split on, `split_on_middle_of_longest_silence` falls through to
+  // its `None => end` arm every time instead of cutting at a silence
+  // midpoint, so chunking lands on whole-window boundaries (2 chunks of
+  // 48_000 samples each, second chunk starting at exactly 3.0 s) instead
+  // of the default `EnergyVad`'s silence-cut boundaries (3 chunks,
+  // starting at 0 / 2.1 / 4.1 s, pinned above) -- an observable chunking
+  // difference driven purely by which detector is plugged in.
+  struct AlwaysActiveVad;
+  impl VoiceActivityDetector for AlwaysActiveVad {
+    fn voice_activity(&self, samples: &[f32]) -> Vec<bool> {
+      vec![true; samples.len().div_ceil(self.frame_length_samples())]
+    }
+    fn frame_length_samples(&self) -> usize {
+      crate::audio::vad::DEFAULT_FRAME_LENGTH_SAMPLES
+    }
+  }
+
+  let t = tiny_tokenizer();
+  let mut mock = MockBackend::new().with_dims(ModelDims::new().with_window_samples(48_000));
+  let hello = t.encode(" Hello").unwrap()[0];
+  script_clean_window(&mut mock, hello);
+  let kit = WhisperKit::with_backend(mock, t).with_vad_detector(Box::new(AlwaysActiveVad));
+  let mut audio = vec![0.1f32; 96_000];
+  audio[32_000..35_200].fill(0.0);
+  audio[64_000..67_200].fill(0.0);
+  let options = DecodingOptions::new().with_chunking_strategy(ChunkingStrategy::Vad);
+  let result = kit.transcribe(&audio, &options).unwrap();
+  assert_eq!(result.text(), "Hello Hello", "2 whole-window chunks, not 3");
+  let segments = result.segments_slice();
+  assert_eq!(segments.len(), 2);
+  assert!((segments[0].start() - 0.0).abs() < 1e-3);
+  assert!(
+    (segments[1].start() - 3.0).abs() < 1e-3,
+    "chunk 2 starts at the whole-window boundary (48_000 / 16_000), got {}",
+    segments[1].start()
   );
 }
 

--- a/crates/whisperkit/src/transcribe/tests.rs
+++ b/crates/whisperkit/src/transcribe/tests.rs
@@ -322,6 +322,13 @@ fn vad_detector_swap_changes_chunk_boundaries() {
   // of the default `EnergyVad`'s silence-cut boundaries (3 chunks,
   // starting at 0 / 2.1 / 4.1 s, pinned above) -- an observable chunking
   // difference driven purely by which detector is plugged in.
+  //
+  // Unit struct: no fields, so it is trivially `Send + Sync + 'static`
+  // (auto traits with nothing in the type to violate them) -- it
+  // satisfies `set_vad_detector`'s actual bounds, and compiling below is
+  // the positive-case proof of that, complementing that method's
+  // `compile_fail` doctest, which rejects a detector holding non-`Send`
+  // state.
   struct AlwaysActiveVad;
   impl VoiceActivityDetector for AlwaysActiveVad {
     fn voice_activity(&self, samples: &[f32]) -> Vec<bool> {

--- a/crates/whisperkit/src/transcribe/tests.rs
+++ b/crates/whisperkit/src/transcribe/tests.rs
@@ -243,6 +243,83 @@ fn failed_probe_rederives_language_from_that_attempts_decode() {
 
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn detect_language_pinned_deviation_actually_runs_the_probe() {
+  // Closes the loop on `DecodingOptions::detect_language`'s pinned
+  // deviation (also pinned at the options-getter level by
+  // `options::tests::detect_language_pinned_construction_vs_mutation_histories`):
+  // an unset `detect_language` with `use_prefill_prompt` mutated to
+  // `false` in place resolves `true` on this port (Swift's equivalent
+  // history stays `false`). This test proves that resolution is not
+  // just a getter-level curiosity — it actually gates whether
+  // `TranscribeTask::run` invokes the language-detection probe against
+  // the backend, observed via `MockCounters` deltas between two
+  // otherwise-identical runs.
+  let t = tiny_tokenizer();
+  let hello = t.encode(" Hello").unwrap()[0];
+
+  // Shared recipe: prefill OFF (so `initial_prompt == [SOT]` on both
+  // sides — one token, no task token anywhere in `current_tokens`,
+  // which keeps `TimestampRulesFilter` a no-op for a multilingual model
+  // per its own `effective_sample_begin` doc, so the scripted logits
+  // reach the sampler unmodified), one fallback attempt
+  // (`temperature_fallback_count(0)`), and the same first-token-logprob
+  // trick `failed_probe_rederives_language_from_that_attempts_decode`
+  // above uses: an unmasked one-hot step samples with logprob ~-1.21
+  // against this tiny vocab's softmax denominator, comfortably below
+  // -0.5, so `decode_text` breaks after exactly one `decode_step` call.
+  // One scripted step serves either run: the probe (if it runs) and the
+  // main decode both read script index 0 — the probe's own
+  // unconditional reset rewinds the mock's script cursor before the
+  // main decode starts (`decode::detect_language`'s own doc).
+  let base_options = || {
+    DecodingOptions::new()
+      .maybe_use_prefill_prompt(false)
+      .with_temperature_fallback_count(0)
+      .maybe_first_token_logprob_threshold(Some(-0.5))
+      .maybe_logprob_threshold(None)
+  };
+
+  // Probe disabled: explicit `false` beats the coupling even with
+  // prefill off.
+  let mut no_probe = MockBackend::new().with_dims(ModelDims::new().with_window_samples(16_000));
+  no_probe.push_token_step(hello);
+  let options_no_probe = base_options().maybe_detect_language(false);
+  assert!(!options_no_probe.detect_language());
+  TranscribeTask::new(&no_probe, &t)
+    .run(&vec![0.1; 32_000], &options_no_probe)
+    .unwrap();
+
+  // Probe enabled: `detect_language` left unset, resolving `true` via
+  // the pinned deviation — Swift's equivalent history
+  // (`DecodingOptions()` then `usePrefillPrompt = false`) would stay
+  // `false` and never run this probe at all.
+  let mut with_probe = MockBackend::new().with_dims(ModelDims::new().with_window_samples(16_000));
+  with_probe.push_token_step(hello);
+  let options_with_probe = base_options();
+  assert!(options_with_probe.detect_language());
+  TranscribeTask::new(&with_probe, &t)
+    .run(&vec![0.1; 32_000], &options_with_probe)
+    .unwrap();
+
+  // The delta IS the probe: one extra `decode_step` (the probe's own
+  // one-shot draw) and one extra `reset_decoder_state`
+  // (`decode::detect_language`'s own unconditional reset).
+  let base = no_probe.counters();
+  let probed = with_probe.counters();
+  assert_eq!(
+    probed.decode_steps(),
+    base.decode_steps() + 1,
+    "probe adds exactly one decode_step call"
+  );
+  assert_eq!(
+    probed.resets(),
+    base.resets() + 1,
+    "probe adds exactly one reset_decoder_state call"
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn transcribe_all_preserves_order_across_scoped_threads() {
   let t = tiny_tokenizer();
   // The mock's script cursor lives in each worker's OWN MockDecoderState

--- a/crates/whisperkit/tests/pipeline.rs
+++ b/crates/whisperkit/tests/pipeline.rs
@@ -11,7 +11,7 @@ use coremlit::{ComputeUnits, Model};
 use whisperkit::{
   backend::{InferenceBackend, coreml::CoreMlBackend},
   model::{ModelState, manager::ModelManager},
-  options::{ComputeOptions, DecodingOptions, Options},
+  options::{ChunkingStrategy, ComputeOptions, DecodingOptions, Options},
   transcribe::WhisperKit,
 };
 
@@ -316,4 +316,49 @@ fn detect_language_on_es_and_ja_clips() {
   assert_eq!(kit.detect_language(&es).unwrap().language(), "es");
   let ja = common::load_wav_mono_f32(&common::fixtures_dir().join("audio/ja_test_clip.wav"));
   assert_eq!(kit.detect_language(&ja).unwrap().language(), "ja");
+}
+
+#[test]
+#[ignore = "requires local tiny model (WHISPERKIT_TEST_MODELS)"]
+fn silence_transcribes_to_the_blank_audio_marker() {
+  // Pins coremlit issue #9's silence edge case: 5 s of digital silence,
+  // VAD off / prefill on, decoded to exactly `[BLANK_AUDIO]`, one segment,
+  // on both Rust and Swift in the issue's own validation run --
+  // upstream-compatible model behavior, not a Rust-only quirk.
+  // `use_prefill_prompt`/`chunking_strategy` are set explicitly rather
+  // than left to their (already-matching) defaults, per the issue's own
+  // P1 policy recommendation to pin decode options rather than rely on
+  // them silently.
+  let kit = WhisperKit::new(&tiny_options()).unwrap();
+  let audio = vec![0.0f32; 5 * whisperkit::constants::SAMPLE_RATE as usize];
+  let options = DecodingOptions::new()
+    .with_use_prefill_prompt()
+    .with_chunking_strategy(ChunkingStrategy::Disabled);
+  let result = kit.transcribe(&audio, &options).unwrap();
+  assert!(
+    result
+      .text()
+      .contains(whisperkit::constants::BLANK_AUDIO_MARKER),
+    "got: {:?}",
+    result.text()
+  );
+  assert_eq!(result.segments_slice().len(), 1);
+}
+
+#[test]
+#[ignore = "requires local tiny model (WHISPERKIT_TEST_MODELS)"]
+fn half_second_clip_yields_no_segments() {
+  // Pins coremlit issue #9's other validated edge case: a clip too short
+  // to form a segment decodes to empty text with zero segments on both
+  // runtimes -- distinct from the silence case above (real speech
+  // content, just too little of it: the first 0.5 s of `jfk.wav`).
+  let kit = WhisperKit::new(&tiny_options()).unwrap();
+  let mut audio = common::load_wav_mono_f32(&common::fixtures_dir().join("audio/jfk.wav"));
+  audio.truncate(whisperkit::constants::SAMPLE_RATE as usize / 2); // 0.5 s
+  let options = DecodingOptions::new()
+    .with_use_prefill_prompt()
+    .with_chunking_strategy(ChunkingStrategy::Disabled);
+  let result = kit.transcribe(&audio, &options).unwrap();
+  assert_eq!(result.text(), "", "got: {:?}", result.text());
+  assert!(result.segments_slice().is_empty());
 }

--- a/crates/whisperkit/tests/pipeline.rs
+++ b/crates/whisperkit/tests/pipeline.rs
@@ -329,20 +329,38 @@ fn silence_transcribes_to_the_blank_audio_marker() {
   // than left to their (already-matching) defaults, per the issue's own
   // P1 policy recommendation to pin decode options rather than rely on
   // them silently.
+  //
+  // All three assertions below are byte-exact pins captured empirically
+  // against this exact tiny-model/option combination (`cargo test -p
+  // whisperkit --test pipeline -- --ignored --nocapture
+  // silence_transcribes_to_the_blank_audio_marker`), not derived from a
+  // spec: `result.text()` is exactly the marker, with no surrounding
+  // whitespace. The sole segment's raw `text()` retains its special/
+  // timestamp tokens because this test leaves `skip_special_tokens` at
+  // its default (`false`, unset here) -- segment text is the
+  // undecorated decode, `TranscriptionResult::text()` is the cleaned
+  // aggregate view assembled from it, so the two having different
+  // shapes is expected, not a bug in either.
   let kit = WhisperKit::new(&tiny_options()).unwrap();
   let audio = vec![0.0f32; 5 * whisperkit::constants::SAMPLE_RATE as usize];
   let options = DecodingOptions::new()
     .with_use_prefill_prompt()
     .with_chunking_strategy(ChunkingStrategy::Disabled);
   let result = kit.transcribe(&audio, &options).unwrap();
-  assert!(
-    result
-      .text()
-      .contains(whisperkit::constants::BLANK_AUDIO_MARKER),
+  assert_eq!(
+    result.text(),
+    whisperkit::constants::BLANK_AUDIO_MARKER,
     "got: {:?}",
     result.text()
   );
-  assert_eq!(result.segments_slice().len(), 1);
+  let segments = result.segments_slice();
+  assert_eq!(segments.len(), 1, "got: {segments:?}");
+  assert_eq!(
+    segments[0].text(),
+    "<|startoftranscript|><|en|><|transcribe|><|0.00|> [BLANK_AUDIO]<|10.00|><|endoftext|>",
+    "got: {:?}",
+    segments[0].text()
+  );
 }
 
 #[test]

--- a/crates/whisperkit/tests/pipeline.rs
+++ b/crates/whisperkit/tests/pipeline.rs
@@ -330,9 +330,9 @@ fn silence_transcribes_to_the_blank_audio_marker() {
   // P1 policy recommendation to pin decode options rather than rely on
   // them silently.
   //
-  // All three assertions below are byte-exact pins captured empirically
-  // against this exact tiny-model/option combination (`cargo test -p
-  // whisperkit --test pipeline -- --ignored --nocapture
+  // The byte-exact strings below are pins captured empirically against
+  // this exact tiny-model/option combination (`cargo test -p whisperkit
+  // --test pipeline -- --ignored --nocapture
   // silence_transcribes_to_the_blank_audio_marker`), not derived from a
   // spec: `result.text()` is exactly the marker, with no surrounding
   // whitespace. The sole segment's raw `text()` retains its special/
@@ -340,7 +340,11 @@ fn silence_transcribes_to_the_blank_audio_marker() {
   // its default (`false`, unset here) -- segment text is the
   // undecorated decode, `TranscriptionResult::text()` is the cleaned
   // aggregate view assembled from it, so the two having different
-  // shapes is expected, not a bug in either.
+  // shapes is expected, not a bug in either. The representation
+  // invariant that falls out of this -- result-level equality against
+  // the marker holds, segment-level equality never does under this
+  // configuration (`BLANK_AUDIO_MARKER`'s own doc) -- is asserted
+  // explicitly below, not left for a reader to infer from the strings.
   let kit = WhisperKit::new(&tiny_options()).unwrap();
   let audio = vec![0.0f32; 5 * whisperkit::constants::SAMPLE_RATE as usize];
   let options = DecodingOptions::new()
@@ -360,6 +364,11 @@ fn silence_transcribes_to_the_blank_audio_marker() {
     "<|startoftranscript|><|en|><|transcribe|><|0.00|> [BLANK_AUDIO]<|10.00|><|endoftext|>",
     "got: {:?}",
     segments[0].text()
+  );
+  assert_ne!(
+    segments[0].text(),
+    whisperkit::constants::BLANK_AUDIO_MARKER,
+    "segment text must retain its special/timestamp tokens here, unlike result.text()"
   );
 }
 


### PR DESCRIPTION
Closes the library-side portion of #9 after adversarially verifying each finding. Full verification results are posted as a comment on #9; this PR carries the fixes and contract pins.

## What's here (10 commits)

**Behavioral (one deliberate parity fix):**
- `detect_language` default now couples to prefill, matching Swift's `detectLanguage ?? !usePrefillPrompt` (`Configurations.swift:222`): the option is an unset-able tri-state (`Option<bool>`); unset + prefill-on resolves `false` (default path byte-unchanged — goldens untouched), unset + prefill-off resolves `true` (the Swift-matching change), explicit set always wins. One documented residual deviation: Swift snapshots the resolution at init; we resolve live at read, observable only when `use_prefill_prompt` is mutated in place with detection unset — argued in the rustdoc (a snapshot would destroy the unset state's serde absent round-trip) and pinned by tests for both histories, including a MockBackend pipeline test proving the probe runs (+1 decode step, +1 decoder reset).

**New opt-in capability:**
- `nl-recognizer` cargo feature (off by default): `tokenizer::nl_recognizer::redetect_language`, an `NLLanguageRecognizer` wrapper that normalizes BCP-47 tags to bare base codes before returning — the normalization Swift's own call site lacks (`Models.swift:1301`), so it structurally cannot reproduce the `zh-Hant` phrase-blob fallthrough from #9. Full ObjC interaction runs inside its own autorelease pool (safe from bare threads); the decoder token remains the pipeline's single source of truth (this helper is never called automatically).

**API:**
- Pluggable VAD: `Box<dyn VoiceActivityDetector + Send + Sync>` setter; `EnergyVad` default byte-unchanged (boundary test pins it); swap test proves observable chunking difference.

**Contract pins (regression tests against the real tiny model):**
- CJK fine-grained word splitting pinned for `zh`/`ja`/`yue` — prevents a future "restore Swift parity" regression to phrase-blobs.
- Silence: `BLANK_AUDIO_MARKER` const; 5 s silence pinned byte-exact (result text `[BLANK_AUDIO]`, exactly 1 segment, raw segment text retains special tokens — asserted unequal to the bare marker); 0.5 s clip → empty text, 0 segments.
- Docs: provenance/reproducibility guidance (what to record per #9; serde snapshotting; temp>0 non-reproducibility on both runtimes by design; the Swift CLI `--language`-forces-prefill harness pitfall).

## Verification

- Whole-branch adversarial review (opus): APPROVE — goldens confirmed executed and untouched (jfk 30/30, es), every Swift citation verified against oracle `dcf3a00`.
- Codex adversarial loop: rounds 1–2 findings (autorelease pool, silence-contract precision, VAD doc bounds, citation lines; detect_language mutation-history divergence, BLANK_AUDIO segment-level guidance, seed-injection doc) all repaired with regression tests; round 3: **APPROVE, no material findings**. One non-blocking cosmetic note recorded (a test's setup style vs its prose narrative; the covered behavior is separately pinned).
- Gates per commit and on the final tree, each exit code captured individually: fmt, clippy `-D warnings` (default + `nl-recognizer`), workspace tests, model-gated `--ignored` (goldens green), `cargo hack --each-feature` (5 combos), rustdoc `-D warnings`, `--doc --all-features`.