### PR TITLE
fix(whisperkit): fully close issue #9 — fallback-trigger parity + reproducible fallback

### DIFF
--- a/crates/whisperkit/Cargo.toml
+++ b/crates/whisperkit/Cargo.toml
@@ -18,9 +18,16 @@ targets = ["aarch64-apple-darwin"]
 [dependencies]
 coremlit.workspace = true
 derive_more.workspace = true
-flate2.workspace = true
 libc.workspace = true
 mach2.workspace = true
+# `objc2` + `objc2-foundation` are CORE (non-optional): the compression-ratio
+# fallback signal (`text::compression_ratio_of_*`) calls Apple's
+# `NSData.compressed(using: .zlib)` on every fallback decision, so it must be
+# present in every feature configuration of this macOS-only crate, not just
+# under `nl-recognizer`. `nl-recognizer` still gates its own extra dep
+# (`objc2-natural-language`) below.
+objc2.workspace = true
+objc2-foundation.workspace = true
 rand.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -29,8 +36,6 @@ unicode_categories.workspace = true
 
 serde = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
-objc2 = { workspace = true, optional = true }
-objc2-foundation = { workspace = true, optional = true }
 objc2-natural-language = { workspace = true, optional = true }
 
 [features]
@@ -42,7 +47,7 @@ tracing = ["dep:tracing"]
 # truth for language stays the decoder's own `<|lang|>` token (see
 # `WhisperTokenizer::split_to_word_tokens`'s doc) -- this feature only
 # exposes the redetection helper for callers who want a second opinion.
-nl-recognizer = ["dep:objc2", "dep:objc2-foundation", "dep:objc2-natural-language"]
+nl-recognizer = ["dep:objc2-natural-language"]
 
 [dev-dependencies]
 cpal.workspace = true

--- a/crates/whisperkit/src/decode/sampler/mod.rs
+++ b/crates/whisperkit/src/decode/sampler/mod.rs
@@ -23,6 +23,14 @@
 //! every method it defines is an unconditional `fatalError`, including
 //! its own initializer on an invalid beam size/patience, so there is no
 //! real behavior to port — a spec non-goal.
+//!
+//! **Rust-only addition, no Swift equivalent:** [`derive_attempt_seed`]
+//! turns one caller-chosen [`DecodingOptions::seed`] into a distinct
+//! [`GreedyTokenSampler::with_seed`] seed per (window, attempt), so
+//! [`crate::transcribe::TranscribeTask`]'s temperature-fallback ladder can
+//! be both reproducible end to end and free of correlated draws across
+//! windows/attempts — see that function's own doc for the exact mixing
+//! function and contract (coremlit issue #9).
 
 use std::num::NonZeroUsize;
 
@@ -100,7 +108,11 @@ impl GreedyTokenSampler {
   /// `NonZeroUsize::MIN`). Seeds its RNG from the OS
   /// (`StdRng::from_os_rng`) — `temperature == 0.0` never consults the
   /// RNG, so this only matters for reproducibility at `temperature !=
-  /// 0.0`; see [`Self::with_seed`] for the deterministic alternative.
+  /// 0.0`; see [`Self::with_seed`] for the deterministic alternative,
+  /// which [`crate::transcribe::TranscribeTask`]'s fallback ladder now
+  /// calls automatically (via [`derive_attempt_seed`]) whenever
+  /// [`DecodingOptions::seed`] is set — this constructor's OS-seeded
+  /// behavior is exactly what running with `seed` left `None` still gets.
   pub fn new(temperature: f32, eot_token: u32, options: &DecodingOptions) -> Self {
     Self {
       temperature,
@@ -117,7 +129,10 @@ impl GreedyTokenSampler {
   /// 0..<sum)` unseeded (`TokenSampler.swift:169`); [`Self::new`]'s
   /// OS-seeded default matches that non-determinism, and this builder
   /// adds a reproducibility knob Swift has no equivalent for, so
-  /// `temperature != 0.0` callers (e.g. tests) can assert an exact draw.
+  /// `temperature != 0.0` callers (e.g. tests, and — via
+  /// [`derive_attempt_seed`] — [`crate::transcribe::TranscribeTask`]'s
+  /// own fallback ladder when [`DecodingOptions::seed`] is set) can
+  /// assert or reproduce an exact draw.
   #[must_use]
   #[inline(always)]
   pub fn with_seed(mut self, seed: u64) -> Self {
@@ -244,6 +259,61 @@ impl GreedyTokenSampler {
       logprobs.push(0.0);
     }
   }
+}
+
+// ---------------------------------------------------------------------
+// Seed derivation
+// ---------------------------------------------------------------------
+
+/// SplitMix64's avalanche finalizer (Steele, Lea & Flood, *Fast Splittable
+/// Pseudorandom Number Generators*, OOPSLA 2014): two multiply-xorshift
+/// rounds that turn a single-bit input difference into an unrelated
+/// (on average half-flipped) 64-bit output. The same finalizer backs
+/// `java.util.SplittableRandom`'s stream splitting; [`derive_attempt_seed`]
+/// below chains two rounds of it to fold extra coordinates into a base
+/// seed.
+const fn splitmix64(x: u64) -> u64 {
+  let mut z = x;
+  z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+  z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+  z ^ (z >> 31)
+}
+
+/// Deterministically derives a per-(window, attempt) sampler seed from a
+/// caller-chosen base `seed` ([`DecodingOptions::seed`]).
+///
+/// Reusing `seed` verbatim for every [`GreedyTokenSampler`] the
+/// temperature-fallback ladder builds would make every window/attempt draw
+/// the exact same RNG stream — wrong the moment two of them share a logits
+/// shape, since they would then sample identical sequences. Instead
+/// `window_index` and `attempt_index` are folded into `seed` through two
+/// rounds of `splitmix64`'s avalanche (this module's private SplitMix64
+/// finalizer, above): the first round mixes in `window_index`, the second
+/// mixes `attempt_index` into that already-avalanched state — so any
+/// `(seed, window_index, attempt_index)` triple that differs in even one
+/// coordinate produces an unrelated 64-bit result, while the identical
+/// triple always reproduces the identical result. That is what lets
+/// [`DecodingOptions::seed`] be, at once, (a) sufficient on its own to
+/// reproduce a whole transcription's sampled tokens bit-for-bit across
+/// separate runs, and (b) safe to reuse across every window and fallback
+/// attempt in that transcription without correlating their draws.
+///
+/// [`crate::transcribe::TranscribeTask`]'s fallback ladder calls this with
+/// `window_index` a strictly monotonic per-`run` window counter — offset by
+/// the task's own `window_id_offset` (see
+/// [`TranscribeTask::set_window_id_offset`](crate::transcribe::TranscribeTask::set_window_id_offset)'s
+/// doc) so sequential VAD chunks and concurrent batch workers don't reuse
+/// each other's window indices either — and `attempt_index` the fallback
+/// loop's own `0..=temperature_fallback_count` counter. The function itself
+/// has no dependency on that caller: it is a pure, public mixing primitive,
+/// so a direct [`decode_text`](crate::decode::decode_text)/
+/// [`detect_language`](crate::decode::detect_language) caller that wants to
+/// replicate (or deliberately diverge from) the pipeline's exact seed
+/// schedule can call it exactly the same way.
+#[must_use]
+pub const fn derive_attempt_seed(seed: u64, window_index: u64, attempt_index: u64) -> u64 {
+  let with_window = splitmix64(seed ^ window_index);
+  splitmix64(with_window ^ attempt_index)
 }
 
 /// Index of the largest entry in `logits`, comparing with `f32::total_cmp`

--- a/crates/whisperkit/src/decode/sampler/mod.rs
+++ b/crates/whisperkit/src/decode/sampler/mod.rs
@@ -302,8 +302,12 @@ const fn splitmix64(x: u64) -> u64 {
 /// `window_index` a strictly monotonic per-`run` window counter — offset by
 /// the task's own `window_id_offset` (see
 /// [`TranscribeTask::set_window_id_offset`](crate::transcribe::TranscribeTask::set_window_id_offset)'s
-/// doc) so sequential VAD chunks and concurrent batch workers don't reuse
-/// each other's window indices either — and `attempt_index` the fallback
+/// doc) to bias distinct chunks/workers toward distinct seed streams (note
+/// this is a decorrelation *nudge*, not a guarantee: per-chunk offsets
+/// increment by 1 while a chunk consumes as many window indices as it has
+/// windows, so `offset + window_index` ranges can overlap across chunks —
+/// harmless, because distinct audio yields distinct logits and thus
+/// distinct draws regardless of the seed) — and `attempt_index` the fallback
 /// loop's own `0..=temperature_fallback_count` counter. The function itself
 /// has no dependency on that caller: it is a pure, public mixing primitive,
 /// so a direct [`decode_text`](crate::decode::decode_text)/

--- a/crates/whisperkit/src/decode/sampler/mod.rs
+++ b/crates/whisperkit/src/decode/sampler/mod.rs
@@ -270,8 +270,8 @@ impl GreedyTokenSampler {
 /// rounds that turn a single-bit input difference into an unrelated
 /// (on average half-flipped) 64-bit output. The same finalizer backs
 /// `java.util.SplittableRandom`'s stream splitting; [`derive_attempt_seed`]
-/// below chains two rounds of it to fold extra coordinates into a base
-/// seed.
+/// below chains one round of it per coordinate (base seed, worker, window,
+/// attempt) to fold all four into a single sub-seed.
 const fn splitmix64(x: u64) -> u64 {
   let mut z = x;
   z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
@@ -279,45 +279,100 @@ const fn splitmix64(x: u64) -> u64 {
   z ^ (z >> 31)
 }
 
-/// Deterministically derives a per-(window, attempt) sampler seed from a
-/// caller-chosen base `seed` ([`DecodingOptions::seed`]).
+/// Distinct, nonzero *odd* multipliers — one per coordinate — that spread a
+/// coordinate across the full 64-bit width before it is XORed into the
+/// running `splitmix64` state in [`derive_attempt_seed`]. Oddness makes
+/// `coord.wrapping_mul(GAMMA)` a bijection on `u64` (odd values are units
+/// modulo 2^64), so distinct coordinate values never collapse to the same
+/// contribution; using a *different* constant per coordinate — applied at a
+/// *different* mixing round — is what stops two coordinates from aliasing
+/// when their raw values are swapped. `GAMMA_SEED` is SplitMix64's
+/// golden-ratio increment; the other three are the MurmurHash3 / SplitMix64
+/// finalizer multipliers — all well-known full-period mixing constants.
+const GAMMA_SEED: u64 = 0x9E37_79B9_7F4A_7C15;
+const GAMMA_WORKER: u64 = 0xD1B5_4A32_D192_ED03;
+const GAMMA_WINDOW: u64 = 0xFF51_AFD7_ED55_8CCD;
+const GAMMA_ATTEMPT: u64 = 0xC4CE_B9FE_1A85_EC53;
+
+/// Deterministically derives a per-(worker, window, attempt) sampler
+/// sub-seed from a caller-chosen base `seed` ([`DecodingOptions::seed`]).
 ///
 /// Reusing `seed` verbatim for every [`GreedyTokenSampler`] the
 /// temperature-fallback ladder builds would make every window/attempt draw
 /// the exact same RNG stream — wrong the moment two of them share a logits
-/// shape, since they would then sample identical sequences. Instead
-/// `window_index` and `attempt_index` are folded into `seed` through two
-/// rounds of `splitmix64`'s avalanche (this module's private SplitMix64
-/// finalizer, above): the first round mixes in `window_index`, the second
-/// mixes `attempt_index` into that already-avalanched state — so any
-/// `(seed, window_index, attempt_index)` triple that differs in even one
-/// coordinate produces an unrelated 64-bit result, while the identical
-/// triple always reproduces the identical result. That is what lets
-/// [`DecodingOptions::seed`] be, at once, (a) sufficient on its own to
-/// reproduce a whole transcription's sampled tokens bit-for-bit across
-/// separate runs, and (b) safe to reuse across every window and fallback
-/// attempt in that transcription without correlating their draws.
+/// shape, since they would then sample identical sequences. Instead the
+/// three coordinates are *domain-separated*: each is folded into the running
+/// state in its own `splitmix64` round (this module's private SplitMix64
+/// finalizer, above), after an initial round that mixes the base seed with a
+/// nonzero constant. With `s` the running state:
+///
+/// ```text
+/// s = splitmix64(seed           ^ GAMMA_SEED)
+/// s = splitmix64(s ^ worker_index .wrapping_mul(GAMMA_WORKER))
+/// s = splitmix64(s ^ window_index .wrapping_mul(GAMMA_WINDOW))
+/// s = splitmix64(s ^ attempt_index.wrapping_mul(GAMMA_ATTEMPT))
+/// ```
+///
+/// The coordinates are **never summed or otherwise collapsed into one
+/// number**: `worker_index` and `window_index` enter at *different* rounds
+/// through *different* multipliers, so `(worker = 0, window = 1)` and
+/// `(worker = 1, window = 0)` derive unrelated sub-seeds — the earlier
+/// `offset + window_index` sum aliased exactly that pair. And because the
+/// first round mixes `seed` with a nonzero constant, `seed = 0` does not
+/// collapse to `0`, so cross-seed pairs the earlier XOR mixer folded onto a
+/// single value (`(seed = 0, window = 0)` and `(seed = 1, window = 1)` both
+/// became `0` under `splitmix64(seed ^ window)`, since `splitmix64(0) == 0`)
+/// now differ too.
+///
+/// Two guaranteed properties:
+///
+/// * **Reproducible.** This is a pure function of its four arguments, so an
+///   identical `(seed, worker_index, window_index, attempt_index)` tuple
+///   always reproduces the identical result — which is what lets
+///   [`DecodingOptions::seed`] alone reproduce a whole transcription's
+///   sampled tokens bit-for-bit across separate runs.
+/// * **No single-coordinate collapse.** Changing *exactly one* coordinate
+///   (holding the others fixed) is *guaranteed* to change the output, never
+///   merely usually: each `splitmix64` round is a bijection, and a
+///   coordinate reaches its round through an odd-constant multiply then an
+///   XOR — both bijections — so the map from that coordinate to the
+///   post-round state is injective and every later round preserves the
+///   difference. No coordinate (the base seed included) has a value that
+///   aliases another, and none collapses at zero.
+///
+/// A `u64` result cannot be globally injective over the full four-`u64`
+/// input space (pigeonhole), so "collision-free" here means the
+/// per-single-coordinate injectivity above plus being empirically
+/// collision-free across the realistic worker/window/attempt ranges a
+/// transcription reaches — see this module's `derive_attempt_seed` collision
+/// test.
 ///
 /// [`crate::transcribe::TranscribeTask`]'s fallback ladder calls this with
-/// `window_index` a strictly monotonic per-`run` window counter — offset by
-/// the task's own `window_id_offset` (see
-/// [`TranscribeTask::set_window_id_offset`](crate::transcribe::TranscribeTask::set_window_id_offset)'s
-/// doc) to bias distinct chunks/workers toward distinct seed streams (note
-/// this is a decorrelation *nudge*, not a guarantee: per-chunk offsets
-/// increment by 1 while a chunk consumes as many window indices as it has
-/// windows, so `offset + window_index` ranges can overlap across chunks —
-/// harmless, because distinct audio yields distinct logits and thus
-/// distinct draws regardless of the seed) — and `attempt_index` the fallback
-/// loop's own `0..=temperature_fallback_count` counter. The function itself
-/// has no dependency on that caller: it is a pure, public mixing primitive,
-/// so a direct [`decode_text`](crate::decode::decode_text)/
+/// `worker_index` the task's own
+/// [`window_id_offset`](crate::transcribe::TranscribeTask::set_window_id_offset)
+/// (a genuinely unique per-chunk / per-audio / per-worker id, so distinct
+/// chunks and concurrently-running workers now get distinct seed streams as
+/// a real guarantee rather than the pre-fix *nudge*), `window_index` a
+/// strictly monotonic per-`run` window counter *local* to that task (reset
+/// to 0 for every task — precisely why it must be a coordinate separate from
+/// `worker_index`), and `attempt_index` the fallback loop's own
+/// `0..=temperature_fallback_count` counter. The function itself has no
+/// dependency on that caller: it is a pure, public mixing primitive, so a
+/// direct [`decode_text`](crate::decode::decode_text)/
 /// [`detect_language`](crate::decode::detect_language) caller that wants to
 /// replicate (or deliberately diverge from) the pipeline's exact seed
-/// schedule can call it exactly the same way.
+/// schedule can call it the same way.
 #[must_use]
-pub const fn derive_attempt_seed(seed: u64, window_index: u64, attempt_index: u64) -> u64 {
-  let with_window = splitmix64(seed ^ window_index);
-  splitmix64(with_window ^ attempt_index)
+pub const fn derive_attempt_seed(
+  seed: u64,
+  worker_index: u64,
+  window_index: u64,
+  attempt_index: u64,
+) -> u64 {
+  let mut state = splitmix64(seed ^ GAMMA_SEED);
+  state = splitmix64(state ^ worker_index.wrapping_mul(GAMMA_WORKER));
+  state = splitmix64(state ^ window_index.wrapping_mul(GAMMA_WINDOW));
+  splitmix64(state ^ attempt_index.wrapping_mul(GAMMA_ATTEMPT))
 }
 
 /// Index of the largest entry in `logits`, comparing with `f32::total_cmp`

--- a/crates/whisperkit/src/decode/sampler/tests.rs
+++ b/crates/whisperkit/src/decode/sampler/tests.rs
@@ -97,3 +97,116 @@ fn finalize_appends_eot_once() {
   sampler.finalize(&mut tokens, &mut logprobs); // idempotent: already ends in EOT
   assert_eq!(tokens.len(), 3);
 }
+
+// ---------------------------------------------------------------------
+// derive_attempt_seed
+// ---------------------------------------------------------------------
+
+#[test]
+fn derive_attempt_seed_is_pure_and_deterministic() {
+  // Same triple, same result -- every time, no hidden state.
+  assert_eq!(
+    derive_attempt_seed(1, 2, 3),
+    derive_attempt_seed(1, 2, 3),
+    "pure function: identical inputs must reproduce identical output"
+  );
+  // Each coordinate independently changes the result.
+  assert_ne!(
+    derive_attempt_seed(1, 2, 3),
+    derive_attempt_seed(1, 2, 4),
+    "attempt_index must change the derived seed"
+  );
+  assert_ne!(
+    derive_attempt_seed(1, 2, 3),
+    derive_attempt_seed(1, 3, 3),
+    "window_index must change the derived seed"
+  );
+  assert_ne!(
+    derive_attempt_seed(1, 2, 3),
+    derive_attempt_seed(2, 2, 3),
+    "the base seed must change the derived seed"
+  );
+}
+
+#[test]
+fn derive_attempt_seed_has_no_collisions_over_realistic_ranges() {
+  // Statistical decorrelation check over a generous window/attempt range
+  // (temperature_fallback_count defaults to 5, so 0..=8 already exceeds
+  // any default configuration; 0..64 windows covers long-form audio's
+  // window count many times over). A broken derivation that ignored (or
+  // truncated) either coordinate would collide immediately here.
+  let mut seen = std::collections::HashSet::new();
+  for window in 0..64u64 {
+    for attempt in 0..=8u64 {
+      let derived = derive_attempt_seed(0xABCD_1234_5678_9ABC, window, attempt);
+      assert!(
+        seen.insert(derived),
+        "collision at window={window} attempt={attempt}"
+      );
+    }
+  }
+}
+
+/// A seeded, non-degenerate (multi-candidate) sampler at `temperature =
+/// 0.7` -- top_k defaults to 5, so this is a genuine multinomial draw
+/// among several candidates, not a coin flip between two or a foregone
+/// argmax.
+fn seeded_sampler(seed: u64) -> GreedyTokenSampler {
+  GreedyTokenSampler::new(0.7, 999, &DecodingOptions::new()).with_seed(seed)
+}
+
+fn draw_sequence(sampler: &mut GreedyTokenSampler, logits: &[f32], n: usize) -> Vec<u32> {
+  (0..n).map(|_| sampler.sample(logits).token()).collect()
+}
+
+#[test]
+fn attempt_seed_derivation_changes_sampled_draws_across_attempts() {
+  // Proves the (window, attempt) sub-seed derivation is actually wired
+  // into distinct SAMPLING streams, not just distinct numbers in the
+  // abstract: two samplers seeded from adjacent attempt indices at the
+  // same window draw different sequences from the exact same logits.
+  //
+  // Mutation check performed by hand (not left in the tree): temporarily
+  // making `derive_attempt_seed` ignore `attempt_index` (returning the
+  // same sub-seed for every attempt at a fixed window) made this
+  // `assert_ne!` fail, confirming the test is sensitive to exactly the
+  // bug class it exists to catch.
+  let seed = 0xC0FFEE_u64;
+  let window = 3u64;
+  let logits: Vec<f32> = (0..32).map(|i| i as f32 * 0.1 - 1.6).collect();
+
+  let mut attempt0 = seeded_sampler(derive_attempt_seed(seed, window, 0));
+  let mut attempt1 = seeded_sampler(derive_attempt_seed(seed, window, 1));
+  let draws0 = draw_sequence(&mut attempt0, &logits, 20);
+  let draws1 = draw_sequence(&mut attempt1, &logits, 20);
+  assert_ne!(
+    draws0, draws1,
+    "different attempt_index must decorrelate the sampled stream"
+  );
+
+  // Reproducibility half: the identical (window, attempt) pair always
+  // replays the identical stream (this is what makes a whole
+  // transcription reproducible from one base seed).
+  let mut replay0 = seeded_sampler(derive_attempt_seed(seed, window, 0));
+  let replay_draws0 = draw_sequence(&mut replay0, &logits, 20);
+  assert_eq!(draws0, replay_draws0);
+}
+
+#[test]
+fn attempt_seed_derivation_changes_sampled_draws_across_windows() {
+  // Same proof as above, along the window_index coordinate instead of
+  // attempt_index: two different windows at the same attempt must not
+  // share a draw stream either.
+  let seed = 0xC0FFEE_u64;
+  let attempt = 1u64;
+  let logits: Vec<f32> = (0..32).map(|i| i as f32 * 0.1 - 1.6).collect();
+
+  let mut window0 = seeded_sampler(derive_attempt_seed(seed, 0, attempt));
+  let mut window1 = seeded_sampler(derive_attempt_seed(seed, 1, attempt));
+  let draws0 = draw_sequence(&mut window0, &logits, 20);
+  let draws1 = draw_sequence(&mut window1, &logits, 20);
+  assert_ne!(
+    draws0, draws1,
+    "different window_index must decorrelate the sampled stream"
+  );
+}

--- a/crates/whisperkit/src/decode/sampler/tests.rs
+++ b/crates/whisperkit/src/decode/sampler/tests.rs
@@ -104,45 +104,103 @@ fn finalize_appends_eot_once() {
 
 #[test]
 fn derive_attempt_seed_is_pure_and_deterministic() {
-  // Same triple, same result -- every time, no hidden state.
+  // Same tuple, same result -- every time, no hidden state.
   assert_eq!(
-    derive_attempt_seed(1, 2, 3),
-    derive_attempt_seed(1, 2, 3),
+    derive_attempt_seed(1, 2, 3, 4),
+    derive_attempt_seed(1, 2, 3, 4),
     "pure function: identical inputs must reproduce identical output"
   );
-  // Each coordinate independently changes the result.
+  // Each of the four coordinates independently changes the result: the
+  // mixer folds every one into its own bijective `splitmix64` round, so
+  // changing exactly one is *guaranteed* to change the output (see
+  // `derive_attempt_seed`'s doc), not merely likely to.
   assert_ne!(
-    derive_attempt_seed(1, 2, 3),
-    derive_attempt_seed(1, 2, 4),
-    "attempt_index must change the derived seed"
+    derive_attempt_seed(1, 2, 3, 4),
+    derive_attempt_seed(2, 2, 3, 4),
+    "the base seed must change the derived seed"
   );
   assert_ne!(
-    derive_attempt_seed(1, 2, 3),
-    derive_attempt_seed(1, 3, 3),
+    derive_attempt_seed(1, 2, 3, 4),
+    derive_attempt_seed(1, 9, 3, 4),
+    "worker_index must change the derived seed"
+  );
+  assert_ne!(
+    derive_attempt_seed(1, 2, 3, 4),
+    derive_attempt_seed(1, 2, 9, 4),
     "window_index must change the derived seed"
   );
   assert_ne!(
-    derive_attempt_seed(1, 2, 3),
-    derive_attempt_seed(2, 2, 3),
-    "the base seed must change the derived seed"
+    derive_attempt_seed(1, 2, 3, 4),
+    derive_attempt_seed(1, 2, 3, 9),
+    "attempt_index must change the derived seed"
+  );
+}
+
+#[test]
+fn derive_attempt_seed_domain_separates_worker_and_window() {
+  // Regression for the caller-side `offset + window_index` SUM alias
+  // (coremlit#13): `transcribe_all` feeds each audio's global index as the
+  // worker id while every task resets its window counter to 0, so
+  // audio-0/window-1 (0 + 1) and audio-1/window-0 (1 + 0) summed to the
+  // same coordinate `1` and shared one StdRng stream -- identical draws on
+  // any shared logits shape (silent/repeated windows, or the MockBackend
+  // that ignores encoder output). Passed as SEPARATE coordinates they must
+  // derive different sub-seeds.
+  for seed in [0u64, 1, 7, u64::MAX] {
+    for attempt in 0..=5u64 {
+      assert_ne!(
+        derive_attempt_seed(seed, 0, 1, attempt),
+        derive_attempt_seed(seed, 1, 0, attempt),
+        "(worker=0, window=1) must not alias (worker=1, window=0) \
+         [seed={seed} attempt={attempt}]"
+      );
+    }
+  }
+}
+
+#[test]
+fn derive_attempt_seed_has_no_zero_collapse_across_base_seeds() {
+  // Regression for the mixer's XOR/zero alias (coremlit#13): the old
+  // `splitmix64(seed ^ window)` mixer folded distinct coordinates together
+  // because `splitmix64(0) == 0`. `(seed=0, window=0)` and
+  // `(seed=1, window=1)` both derived 0, and `(seed=0, window=1)` aliased
+  // `(seed=1, window=0)`. None of these may alias now, and the all-zero
+  // tuple must not derive 0.
+  assert_ne!(
+    derive_attempt_seed(0, 0, 0, 0),
+    0,
+    "the all-zero tuple must not collapse to 0"
+  );
+  assert_ne!(
+    derive_attempt_seed(0, 0, 0, 0),
+    derive_attempt_seed(1, 0, 1, 0),
+    "(seed=0, window=0) must not alias (seed=1, window=1)"
+  );
+  assert_ne!(
+    derive_attempt_seed(0, 0, 1, 0),
+    derive_attempt_seed(1, 0, 0, 0),
+    "(seed=0, window=1) must not alias (seed=1, window=0)"
   );
 }
 
 #[test]
 fn derive_attempt_seed_has_no_collisions_over_realistic_ranges() {
-  // Statistical decorrelation check over a generous window/attempt range
-  // (temperature_fallback_count defaults to 5, so 0..=8 already exceeds
-  // any default configuration; 0..64 windows covers long-form audio's
-  // window count many times over). A broken derivation that ignored (or
-  // truncated) either coordinate would collide immediately here.
+  // Statistical decorrelation check over a generous worker/window/attempt
+  // range (temperature_fallback_count defaults to 5, so 0..=8 already
+  // exceeds any default configuration; 0..64 windows covers long-form
+  // audio's window count many times over; 0..64 workers covers a large
+  // concurrent batch or VAD-chunk count). A broken derivation that ignored,
+  // truncated, or summed any coordinate would collide immediately here.
   let mut seen = std::collections::HashSet::new();
-  for window in 0..64u64 {
-    for attempt in 0..=8u64 {
-      let derived = derive_attempt_seed(0xABCD_1234_5678_9ABC, window, attempt);
-      assert!(
-        seen.insert(derived),
-        "collision at window={window} attempt={attempt}"
-      );
+  for worker in 0..64u64 {
+    for window in 0..64u64 {
+      for attempt in 0..=8u64 {
+        let derived = derive_attempt_seed(0xABCD_1234_5678_9ABC, worker, window, attempt);
+        assert!(
+          seen.insert(derived),
+          "collision at worker={worker} window={window} attempt={attempt}"
+        );
+      }
     }
   }
 }
@@ -161,10 +219,10 @@ fn draw_sequence(sampler: &mut GreedyTokenSampler, logits: &[f32], n: usize) -> 
 
 #[test]
 fn attempt_seed_derivation_changes_sampled_draws_across_attempts() {
-  // Proves the (window, attempt) sub-seed derivation is actually wired
-  // into distinct SAMPLING streams, not just distinct numbers in the
-  // abstract: two samplers seeded from adjacent attempt indices at the
-  // same window draw different sequences from the exact same logits.
+  // Proves the sub-seed derivation is actually wired into distinct SAMPLING
+  // streams, not just distinct numbers in the abstract: two samplers seeded
+  // from adjacent attempt indices at the same (worker, window) draw
+  // different sequences from the exact same logits.
   //
   // Mutation check performed by hand (not left in the tree): temporarily
   // making `derive_attempt_seed` ignore `attempt_index` (returning the
@@ -172,11 +230,12 @@ fn attempt_seed_derivation_changes_sampled_draws_across_attempts() {
   // `assert_ne!` fail, confirming the test is sensitive to exactly the
   // bug class it exists to catch.
   let seed = 0xC0FFEE_u64;
+  let worker = 2u64;
   let window = 3u64;
   let logits: Vec<f32> = (0..32).map(|i| i as f32 * 0.1 - 1.6).collect();
 
-  let mut attempt0 = seeded_sampler(derive_attempt_seed(seed, window, 0));
-  let mut attempt1 = seeded_sampler(derive_attempt_seed(seed, window, 1));
+  let mut attempt0 = seeded_sampler(derive_attempt_seed(seed, worker, window, 0));
+  let mut attempt1 = seeded_sampler(derive_attempt_seed(seed, worker, window, 1));
   let draws0 = draw_sequence(&mut attempt0, &logits, 20);
   let draws1 = draw_sequence(&mut attempt1, &logits, 20);
   assert_ne!(
@@ -184,29 +243,50 @@ fn attempt_seed_derivation_changes_sampled_draws_across_attempts() {
     "different attempt_index must decorrelate the sampled stream"
   );
 
-  // Reproducibility half: the identical (window, attempt) pair always
-  // replays the identical stream (this is what makes a whole
-  // transcription reproducible from one base seed).
-  let mut replay0 = seeded_sampler(derive_attempt_seed(seed, window, 0));
+  // Reproducibility half: the identical tuple always replays the identical
+  // stream (this is what makes a whole transcription reproducible from one
+  // base seed).
+  let mut replay0 = seeded_sampler(derive_attempt_seed(seed, worker, window, 0));
   let replay_draws0 = draw_sequence(&mut replay0, &logits, 20);
   assert_eq!(draws0, replay_draws0);
 }
 
 #[test]
 fn attempt_seed_derivation_changes_sampled_draws_across_windows() {
-  // Same proof as above, along the window_index coordinate instead of
-  // attempt_index: two different windows at the same attempt must not
-  // share a draw stream either.
+  // Same proof as above, along the window_index coordinate: two different
+  // windows at the same (worker, attempt) must not share a draw stream.
   let seed = 0xC0FFEE_u64;
+  let worker = 2u64;
   let attempt = 1u64;
   let logits: Vec<f32> = (0..32).map(|i| i as f32 * 0.1 - 1.6).collect();
 
-  let mut window0 = seeded_sampler(derive_attempt_seed(seed, 0, attempt));
-  let mut window1 = seeded_sampler(derive_attempt_seed(seed, 1, attempt));
+  let mut window0 = seeded_sampler(derive_attempt_seed(seed, worker, 0, attempt));
+  let mut window1 = seeded_sampler(derive_attempt_seed(seed, worker, 1, attempt));
   let draws0 = draw_sequence(&mut window0, &logits, 20);
   let draws1 = draw_sequence(&mut window1, &logits, 20);
   assert_ne!(
     draws0, draws1,
     "different window_index must decorrelate the sampled stream"
+  );
+}
+
+#[test]
+fn attempt_seed_derivation_changes_sampled_draws_across_workers() {
+  // The Class-A alias (coremlit#13) at the SAMPLED-STREAM level: the two
+  // (worker, window) pairs the old `offset + window_index` sum collapsed --
+  // (worker=0, window=1) and (worker=1, window=0) -- must now draw
+  // different sequences from identical logits, exactly as two real
+  // transcription windows sharing a logits shape would need.
+  let seed = 0xC0FFEE_u64;
+  let attempt = 0u64;
+  let logits: Vec<f32> = (0..32).map(|i| i as f32 * 0.1 - 1.6).collect();
+
+  let mut worker0_window1 = seeded_sampler(derive_attempt_seed(seed, 0, 1, attempt));
+  let mut worker1_window0 = seeded_sampler(derive_attempt_seed(seed, 1, 0, attempt));
+  let draws_a = draw_sequence(&mut worker0_window1, &logits, 20);
+  let draws_b = draw_sequence(&mut worker1_window0, &logits, 20);
+  assert_ne!(
+    draws_a, draws_b,
+    "(worker=0, window=1) and (worker=1, window=0) must not share a stream"
   );
 }

--- a/crates/whisperkit/src/lib.rs
+++ b/crates/whisperkit/src/lib.rs
@@ -174,7 +174,7 @@
 //!   [`transcribe_all`](transcribe::WhisperKit::transcribe_all) pipeline
 //!   **bit-reproducible across runs, with the fallback ladder still fully
 //!   enabled**: [`transcribe::TranscribeTask`] derives an independent
-//!   per-(window, attempt) sub-seed from the base seed
+//!   per-(worker, window, attempt) sub-seed from the base seed
 //!   ([`decode::sampler::derive_attempt_seed`] — see its doc for the exact
 //!   mixing function and why one seed can't just be reused verbatim
 //!   everywhere), so the same audio/options/seed always samples the same

--- a/crates/whisperkit/src/lib.rs
+++ b/crates/whisperkit/src/lib.rs
@@ -158,30 +158,44 @@
 //!   constant's doc for the general, model/config-dependent shape of
 //!   this behavior. When this marker is emitted, product layers should
 //!   filter or model it rather than indexing it as transcript text.
-//! - **Sampling above temperature 0 is non-reproducible by design, on
-//!   both runtimes.** Whenever the fallback ladder retries at
+//! - **Sampling above temperature 0 is non-reproducible by default, on
+//!   both runtimes — set [`DecodingOptions::seed`](options::DecodingOptions::seed) to make it
+//!   reproducible on this side.** Whenever the fallback ladder retries at
 //!   `temperature > 0`, upstream Swift draws from an unseeded RNG
-//!   (`Float.random`, `TokenSampler.swift:169`) and this port's default
-//!   deliberately matches that non-determinism
+//!   (`Float.random`, `TokenSampler.swift:169`), and with
+//!   [`DecodingOptions::seed`](options::DecodingOptions::seed) left `None` (the default) this port's
+//!   sampler matches that non-determinism
 //!   ([`GreedyTokenSampler::new`](decode::sampler::GreedyTokenSampler::new)
-//!   seeds from the OS via `StdRng::from_os_rng`). Two identical runs
-//!   that fall back can therefore legitimately differ. The full
+//!   seeds from the OS via `StdRng::from_os_rng`) — two identical unseeded
+//!   runs that fall back can legitimately differ, by design, exactly like
+//!   Swift, and this is the byte-unchanged default path. Setting
+//!   [`DecodingOptions::seed`](options::DecodingOptions::seed) to `Some(_)` makes the full
 //!   [`WhisperKit::transcribe`](transcribe::WhisperKit::transcribe)/
 //!   [`transcribe_all`](transcribe::WhisperKit::transcribe_all) pipeline
-//!   builds this sampler internally, fresh per attempt, and takes no
-//!   sampler of its own — so at this level there is no seed-injection
-//!   path today, and output stays non-deterministic at `temperature >
-//!   0` by design, exactly like Swift, with no workaround available
-//!   here. Direct callers of [`decode::decode_text`]/
-//!   [`decode::detect_language`] (this crate's own tests included) sit
-//!   one layer lower and do supply their own sampler, so they can build
-//!   it with
+//!   **bit-reproducible across runs, with the fallback ladder still fully
+//!   enabled**: [`transcribe::TranscribeTask`] derives an independent
+//!   per-(window, attempt) sub-seed from the base seed
+//!   ([`decode::sampler::derive_attempt_seed`] — see its doc for the exact
+//!   mixing function and why one seed can't just be reused verbatim
+//!   everywhere), so the same audio/options/seed always samples the same
+//!   tokens end to end, while different windows and different fallback
+//!   attempts still draw distinct, uncorrelated streams. A seed makes
+//!   **this port's own** output reproducible; it does not, and cannot,
+//!   make that output match Swift's draws — Swift has no seed knob at
+//!   all, and its sampling stays unseeded regardless of anything set on
+//!   this side. Direct callers of [`decode::decode_text`]/
+//!   [`decode::detect_language`] (this crate's own tests included) sit one
+//!   layer below the pipeline and supply their own sampler; they can call
 //!   [`GreedyTokenSampler::with_seed`](decode::sampler::GreedyTokenSampler::with_seed)
-//!   — a determinism knob Swift has no equivalent for — for
-//!   reproducible output at that layer. Either way, record the
-//!   effective temperature (the initial value plus any fallback
-//!   increments actually taken) in provenance, since it marks exactly
-//!   which outputs carry sampling randomness.
+//!   directly (optionally through
+//!   [`decode::sampler::derive_attempt_seed`] too, to replicate the
+//!   pipeline's own seed schedule) for the same reproducibility at that
+//!   layer. Either way, seeded or not, record the effective temperature
+//!   (the initial value plus any fallback increments actually taken) in
+//!   provenance — already carried per window by
+//!   [`TranscriptionSegment::temperature`](result::TranscriptionSegment::temperature)/
+//!   [`DecodingResult::temperature`](result::DecodingResult::temperature) —
+//!   since it marks exactly which outputs carry sampling randomness.
 //! - **Swift CLI comparison pitfall: `--language` forces prefill on.**
 //!   The upstream Swift CLI resolves
 //!   `usePrefillPrompt: arguments.usePrefillPrompt || arguments.language

--- a/crates/whisperkit/src/options/mod.rs
+++ b/crates/whisperkit/src/options/mod.rs
@@ -580,7 +580,7 @@ impl DecodingOptions {
   ///
   /// `Some(seed)` makes the whole transcription reproducible instead:
   /// [`crate::transcribe::TranscribeTask`]'s fallback ladder derives an
-  /// independent per-(window, attempt) sub-seed from it via
+  /// independent per-(worker, window, attempt) sub-seed from it via
   /// [`derive_attempt_seed`](crate::decode::sampler::derive_attempt_seed)
   /// rather than reusing `seed` verbatim everywhere (see that function's
   /// doc for why, and for the exact mixing function) — so re-running the

--- a/crates/whisperkit/src/options/mod.rs
+++ b/crates/whisperkit/src/options/mod.rs
@@ -1,9 +1,9 @@
 //! Configuration types for the WhisperKit pipeline (spec §5.3, §6.2): the
-//! full 27-knob decode-time surface ([`DecodingOptions`]), per-stage compute
-//! unit selection ([`ComputeOptions`]), and construction config
-//! ([`Options`]). Ports `Configurations.swift` `DecodingOptions`/
-//! `WhisperKitConfig` and `Models.swift`
-//! `DecodingTask`/`ChunkingStrategy`/`ModelComputeOptions`.
+//! 27-knob decode-time surface Swift exposes, plus one Rust-only
+//! reproducibility addition ([`DecodingOptions`]), per-stage compute unit
+//! selection ([`ComputeOptions`]), and construction config ([`Options`]).
+//! Ports `Configurations.swift` `DecodingOptions`/`WhisperKitConfig` and
+//! `Models.swift` `DecodingTask`/`ChunkingStrategy`/`ModelComputeOptions`.
 //!
 //! Reference implementation of rust-options-pattern for this workspace:
 //! `DEFAULT_*` consts are the single source of truth; `new()` is `const`
@@ -203,9 +203,12 @@ fn default_use_prefill_prompt() -> bool {
   DEFAULT_USE_PREFILL_PROMPT
 }
 
-/// Decode-time configuration: the full 27-knob surface Swift exposes as
-/// `DecodingOptions` (spec §6.2). `new()`/`Default` apply Swift's defaults
-/// verbatim.
+/// Decode-time configuration: Swift's 27-knob `DecodingOptions` surface
+/// (spec §6.2), plus one Rust-only addition — [`Self::seed`], for
+/// reproducible temperature-fallback sampling (coremlit issue #9; see the
+/// crate root's "Reproducibility and provenance" docs). `new()`/`Default`
+/// apply Swift's defaults verbatim for every ported knob; `seed` defaults
+/// unset (`None`), matching today's OS-seeded behavior exactly.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DecodingOptions {
@@ -240,6 +243,14 @@ pub struct DecodingOptions {
   /// Candidate count for non-zero-temperature sampling.
   #[cfg_attr(feature = "serde", serde(default = "default_top_k"))]
   top_k: usize,
+  /// Base seed for reproducible temperature-fallback sampling. `None`
+  /// (the default) leaves sampling OS-seeded. See [`Self::seed`] for the
+  /// full contract.
+  #[cfg_attr(
+    feature = "serde",
+    serde(default, skip_serializing_if = "Option::is_none")
+  )]
+  seed: Option<u64>,
   /// Force the prefill tokens from `task`/`language` rather than let the
   /// model choose them.
   #[cfg_attr(feature = "serde", serde(default = "default_use_prefill_prompt"))]
@@ -381,6 +392,7 @@ impl DecodingOptions {
       temperature_fallback_count: DEFAULT_TEMPERATURE_FALLBACK_COUNT,
       sample_length: DEFAULT_SAMPLE_LENGTH,
       top_k: DEFAULT_TOP_K,
+      seed: None,
       use_prefill_prompt: DEFAULT_USE_PREFILL_PROMPT,
       detect_language: None,
       skip_special_tokens: false,
@@ -553,6 +565,66 @@ impl DecodingOptions {
   #[inline(always)]
   pub const fn set_top_k(&mut self, top_k: usize) -> &mut Self {
     self.top_k = top_k;
+    self
+  }
+
+  // -- seed (Option<u64>) ---------------------------------------------------
+  /// Base seed for reproducible temperature-fallback sampling.
+  ///
+  /// `None` (the default) leaves every attempt's
+  /// [`GreedyTokenSampler`](crate::decode::sampler::GreedyTokenSampler)
+  /// OS-seeded, matching Swift's own unseeded `Float.random`
+  /// (`TokenSampler.swift:169`) — nondeterministic at `temperature > 0`,
+  /// by design, on both runtimes; this is the byte-unchanged default
+  /// path.
+  ///
+  /// `Some(seed)` makes the whole transcription reproducible instead:
+  /// [`crate::transcribe::TranscribeTask`]'s fallback ladder derives an
+  /// independent per-(window, attempt) sub-seed from it via
+  /// [`derive_attempt_seed`](crate::decode::sampler::derive_attempt_seed)
+  /// rather than reusing `seed` verbatim everywhere (see that function's
+  /// doc for why, and for the exact mixing function) — so re-running the
+  /// same audio through the same options and `seed` always samples the
+  /// identical tokens, with the fallback ladder still fully enabled. A
+  /// seed makes this port's *own* output reproducible; it cannot make
+  /// that output match Swift's, which has no seed knob of its own and
+  /// always draws unseeded — record the effective temperature in
+  /// provenance either way
+  /// ([`TranscriptionSegment::temperature`](crate::result::TranscriptionSegment::temperature)).
+  #[inline(always)]
+  pub const fn seed(&self) -> Option<u64> {
+    self.seed
+  }
+  /// Builder form of [`Self::set_seed`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn with_seed(mut self, seed: u64) -> Self {
+    self.set_seed(seed);
+    self
+  }
+  /// Sets [`Self::seed`] to `Some(seed)`.
+  #[inline(always)]
+  pub const fn set_seed(&mut self, seed: u64) -> &mut Self {
+    self.seed = Some(seed);
+    self
+  }
+  /// Builder form of [`Self::update_seed`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn maybe_seed(mut self, seed: Option<u64>) -> Self {
+    self.update_seed(seed);
+    self
+  }
+  /// Assigns [`Self::seed`] directly.
+  #[inline(always)]
+  pub const fn update_seed(&mut self, seed: Option<u64>) -> &mut Self {
+    self.seed = seed;
+    self
+  }
+  /// Sets [`Self::seed`] to `None`.
+  #[inline(always)]
+  pub const fn clear_seed(&mut self) -> &mut Self {
+    self.seed = None;
     self
   }
 

--- a/crates/whisperkit/src/options/tests.rs
+++ b/crates/whisperkit/src/options/tests.rs
@@ -13,6 +13,7 @@ fn decoding_defaults_match_swift() {
   assert_eq!(o.temperature_fallback_count(), 5);
   assert_eq!(o.sample_length(), 224);
   assert_eq!(o.top_k(), 5);
+  assert_eq!(o.seed(), None); // Rust-only addition (coremlit issue #9): unset by default
   assert!(o.use_prefill_prompt());
   assert_eq!(o.use_prefill_prompt(), DEFAULT_USE_PREFILL_PROMPT); // pin to const
   assert!(!o.detect_language());
@@ -43,18 +44,28 @@ fn builder_and_mutator_vocabulary() {
     .with_temperature(0.4)
     .with_no_speech_threshold(0.9) // set_ = present value
     .maybe_logprob_threshold(None) // maybe_ = raw Option
-    .with_without_timestamps(); // bool with_ takes no arg
+    .with_without_timestamps() // bool with_ takes no arg
+    .with_seed(7);
   assert_eq!(o.temperature(), 0.4);
   assert_eq!(o.no_speech_threshold(), Some(0.9));
   assert_eq!(o.logprob_threshold(), None);
   assert!(o.without_timestamps());
+  assert_eq!(o.seed(), Some(7));
   let mut m = DecodingOptions::new();
   m.set_top_k(10)
     .clear_compression_ratio_threshold()
-    .set_detect_language();
+    .set_detect_language()
+    .set_seed(11);
   assert_eq!(m.top_k(), 10);
   assert_eq!(m.compression_ratio_threshold(), None);
   assert!(m.detect_language());
+  assert_eq!(m.seed(), Some(11));
+  m.update_seed(Some(12));
+  assert_eq!(m.seed(), Some(12));
+  m.clear_seed();
+  assert_eq!(m.seed(), None);
+  let via_maybe = DecodingOptions::new().maybe_seed(Some(13));
+  assert_eq!(via_maybe.seed(), Some(13));
 }
 
 #[test]
@@ -386,10 +397,46 @@ fn decoding_options_empty_collections_skip_serializing() {
   // Unset tri-state `detect_language` is skipped like the `None` floats
   // (see `detect_language_serde_tristate` for the full presence matrix).
   assert!(!object.contains_key("detect_language"));
+  // Unset `seed` (coremlit issue #9) follows the identical
+  // `Option<Copy>` presence rule as `max_initial_timestamp`/
+  // `max_window_seek` (see `seed_serde_absent_when_unset_round_trips_when_set`).
+  assert!(!object.contains_key("seed"));
   assert_eq!(
     serde_json::from_str::<DecodingOptions>(&json).unwrap(),
     DecodingOptions::new()
   );
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn seed_serde_absent_when_unset_round_trips_when_set() {
+  // Unset -> key absent (also covered by the exact-key test above).
+  let json = serde_json::to_string(&DecodingOptions::new()).unwrap();
+  let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+  assert!(!value.as_object().unwrap().contains_key("seed"));
+  assert_eq!(
+    serde_json::from_str::<DecodingOptions>(&json)
+      .unwrap()
+      .seed(),
+    None
+  );
+
+  // Missing field -> None, not some sentinel value.
+  let missing: DecodingOptions = serde_json::from_str("{}").unwrap();
+  assert_eq!(missing.seed(), None);
+
+  // Explicit value round-trips exactly, including through the full
+  // u64 range (serde_json represents u64 natively, no float-precision
+  // loss to worry about like it would for e.g. an f64 seed).
+  for seed in [0u64, 1, 42, u64::MAX] {
+    let explicit = DecodingOptions::new().with_seed(seed);
+    let json = serde_json::to_string(&explicit).unwrap();
+    assert!(json.contains(&format!("\"seed\":{seed}")));
+    assert_eq!(
+      serde_json::from_str::<DecodingOptions>(&json).unwrap(),
+      explicit
+    );
+  }
 }
 
 #[cfg(feature = "serde")]

--- a/crates/whisperkit/src/result/tests.rs
+++ b/crates/whisperkit/src/result/tests.rs
@@ -202,6 +202,33 @@ fn fallback_thresholds_use_strict_inequality() {
 }
 
 #[test]
+fn empty_word_tokens_do_not_trigger_compression_fallback() {
+  // PARITY (coremlit issue #9), decision level. An empty word-token window
+  // (decode/mod.rs feeds `compression_ratio_of_tokens(&word_tokens)`, and
+  // `word_tokens` can be empty) yields a compression ratio of 0.0 — Swift's
+  // value, since its tokens overload has no empty guard (see
+  // `text::tests::compression_ratio_of_tokens_empty_is_zero_matching_swift`).
+  // Threaded through `needs_fallback` at the DEFAULT threshold (Some(2.4)),
+  // `0.0 > 2.4` is false, so the compression check does not fire and no
+  // repetition fallback is requested — matching Swift. Before this fix the
+  // ratio was f32::INFINITY, `INFINITY > 2.4` was true, and this same empty
+  // window would have (wrongly) forced a fallback: the exact parity bug this
+  // guards against.
+  let empty_ratio = crate::text::compression_ratio_of_tokens(&[]);
+  assert_eq!(empty_ratio, 0.0);
+  // Other signals kept clean so the compression branch is the one under
+  // test: no_speech below its 0.6 default, avg_logprob above its -1.0
+  // default, first-token flag false.
+  let opts = DecodingOptions::new();
+  let r = result_with(-0.2, 0.1, empty_ratio, 0.0);
+  assert_ne!(
+    needs_fallback(false, &r, &opts),
+    Some(FallbackReason::CompressionRatioThreshold)
+  );
+  assert_eq!(needs_fallback(false, &r, &opts), None);
+}
+
+#[test]
 fn fallback_first_token_check_ignores_empty_token_log_probs() {
   // A `DecodingResult` with no token_log_probs at all still requires the
   // caller to compute first_token_log_prob_too_low from the loop-local

--- a/crates/whisperkit/src/text/mod.rs
+++ b/crates/whisperkit/src/text/mod.rs
@@ -12,23 +12,48 @@
 //! `slice::chunks` directly wherever batching is needed, and this sync,
 //! single-threaded port has no concurrent-worker fan-out to batch for.
 
-use std::io::Write;
-
-use flate2::{Compression, write::ZlibEncoder};
+use objc2::rc::autoreleasepool;
+use objc2_foundation::{NSData, NSDataCompressionAlgorithm};
 use unicode_categories::UnicodeCategories;
 
 use crate::result::WordTiming;
 
-/// zlib-compresses `bytes` at [`Compression::default`], returning the
-/// compressed byte length. `Err` only if the in-memory `Vec<u8>` sink's
-/// `Write` impl fails, which does not happen in practice — kept
-/// `Result`-typed so callers can fall back to [`f32::INFINITY`] the same
-/// way Swift's `catch` does, rather than `unwrap`-panicking on a
-/// theoretical error.
-fn zlib_compressed_len(bytes: &[u8]) -> std::io::Result<usize> {
-  let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
-  encoder.write_all(bytes)?;
-  Ok(encoder.finish()?.len())
+/// zlib-compresses `bytes` with Apple's libcompression — the exact
+/// `NSData.compressed(using: .zlib)` API Swift WhisperKit's
+/// `TextUtilities.compressionRatio` calls
+/// (`Utilities/TextUtilities.swift:14-28,33-53`) — and returns the
+/// compressed byte length. `None` mirrors Swift's `catch { return
+/// .infinity }`: on a genuine OS compression error the caller substitutes
+/// [`f32::INFINITY`] rather than `unwrap`-panicking.
+///
+/// # Why Apple's compressor, not `flate2`/`miniz_oxide`
+/// This length feeds the temperature-fallback repetition signal
+/// ([`compression_ratio_of_tokens`] -> `decode::finalize_decoding_result`),
+/// whose fallback *decision* must match Swift byte-for-byte (coremlit
+/// issue #9). Apple's `.zlib` algorithm emits **raw DEFLATE (RFC 1951)** —
+/// no zlib wrapper (its output begins e.g. `db c3 …`, not `78 …`) — and
+/// compresses markedly harder than `miniz_oxide` on repetitive input.
+/// `flate2::write::ZlibEncoder` emits RFC 1950 (a 2-byte header + 4-byte
+/// Adler-32 trailer, +6 bytes) and saturates at a weaker ratio; both gaps
+/// push our ratio *below* Swift's, flipping the fallback decision at
+/// realistic thresholds. No `flate2` compression level reproduces Apple's
+/// lengths, so this crate calls the identical Foundation API to get a
+/// ratio equal to Swift's by construction. This is a safe `objc2` call —
+/// `objc2` owns the FFI.
+///
+/// The [`autoreleasepool`] matches
+/// [`crate::tokenizer::nl_recognizer::redetect_language`]'s rationale: any
+/// Objective-C method may autorelease internally, so a pool must sit on the
+/// stack or temporaries leak on a thread with no Cocoa run-loop pool above
+/// it. Callers guard empty input before reaching here (Swift's zero-length
+/// `Data` compression throws, landing in the same `catch`).
+fn zlib_compressed_len(bytes: &[u8]) -> Option<usize> {
+  autoreleasepool(|_| {
+    NSData::with_bytes(bytes)
+      .compressedDataUsingAlgorithm_error(NSDataCompressionAlgorithm::Zlib)
+      .ok()
+      .map(|compressed| compressed.len())
+  })
 }
 
 /// Compression ratio (`raw_bytes / compressed_bytes`) of `tokens`, encoded
@@ -43,11 +68,12 @@ fn zlib_compressed_len(bytes: &[u8]) -> std::io::Result<usize> {
 /// `catch` block) or on a genuine compression error (mirrors Swift's
 /// `catch { return .infinity }`).
 ///
-/// Uses [`Compression::default`] (zlib level 6). Apple's
-/// `NSData.compressed(using: .zlib)` compression level is fixed by the OS
-/// and undocumented; if the golden-parity harness (Plan 3) shows
-/// threshold-crossing differences against real WhisperKit output, revisit
-/// the level there — not here.
+/// The compression itself goes through the private `zlib_compressed_len`,
+/// which calls the same Apple `NSData.compressed(using: .zlib)` API as
+/// Swift — see that function for why the codec, not just the byte
+/// encoding, must match Swift (coremlit issue #9). The `i32`-LE token
+/// encoding below is unchanged: it already matched Apple; only the
+/// compressor differed.
 pub fn compression_ratio_of_tokens(tokens: &[u32]) -> f32 {
   if tokens.is_empty() {
     return f32::INFINITY;
@@ -67,8 +93,8 @@ pub fn compression_ratio_of_tokens(tokens: &[u32]) -> f32 {
 /// also guards a fallible `text.data(using: .utf8)` (lines 39-42); that
 /// path is unreachable here since a Rust `&str` is always valid UTF-8.
 ///
-/// See [`compression_ratio_of_tokens`] for the zlib-compression-level
-/// caveat.
+/// Compresses via the private `zlib_compressed_len` (Apple's `.zlib` = raw
+/// DEFLATE), identical to Swift; see [`compression_ratio_of_tokens`].
 pub fn compression_ratio_of_text(text: &str) -> f32 {
   if text.is_empty() {
     return f32::INFINITY;

--- a/crates/whisperkit/src/text/mod.rs
+++ b/crates/whisperkit/src/text/mod.rs
@@ -45,8 +45,11 @@ use crate::result::WordTiming;
 /// [`crate::tokenizer::nl_recognizer::redetect_language`]'s rationale: any
 /// Objective-C method may autorelease internally, so a pool must sit on the
 /// stack or temporaries leak on a thread with no Cocoa run-loop pool above
-/// it. Callers guard empty input before reaching here (Swift's zero-length
-/// `Data` compression throws, landing in the same `catch`).
+/// it. Empty input needs no special-casing: Apple's libcompression
+/// compresses a zero-length buffer to a small non-empty result (2 bytes,
+/// per the issue-9 objc2 probe), never throwing, so this returns `Some(2)`
+/// for `&[]`. `None` is reserved for a genuine OS compression error — the
+/// only case Swift's `catch` actually handles.
 fn zlib_compressed_len(bytes: &[u8]) -> Option<usize> {
   autoreleasepool(|_| {
     NSData::with_bytes(bytes)
@@ -63,10 +66,15 @@ fn zlib_compressed_len(bytes: &[u8]) -> Option<usize> {
 /// into a `Data` buffer (platform-native byte order, little-endian on
 /// every Apple target), then `(data as NSData).compressed(using: .zlib)`.
 ///
-/// Returns [`f32::INFINITY`] for an empty `tokens` slice (Swift's
-/// zero-length `Data` compression attempt fails there, landing in its
-/// `catch` block) or on a genuine compression error (mirrors Swift's
-/// `catch { return .infinity }`).
+/// An empty `tokens` slice returns **`0.0`**, matching Swift's tokens
+/// overload exactly: that overload has **no empty guard**
+/// (`Utilities/TextUtilities.swift:14-28`), so it compresses an empty
+/// `Data()`, which Apple's libcompression turns into 2 bytes (not an
+/// error) — giving `0 / 2 == 0.0`. (Contrast [`compression_ratio_of_text`],
+/// which Swift *does* guard.) Only a genuine OS compression error yields
+/// [`f32::INFINITY`] here, mirroring Swift's `catch { return .infinity }` —
+/// and Swift's tokens overload would land in that identical `catch` on the
+/// same error, so the error path matches on both sides too.
 ///
 /// The compression itself goes through the private `zlib_compressed_len`,
 /// which calls the same Apple `NSData.compressed(using: .zlib)` API as
@@ -75,9 +83,6 @@ fn zlib_compressed_len(bytes: &[u8]) -> Option<usize> {
 /// encoding below is unchanged: it already matched Apple; only the
 /// compressor differed.
 pub fn compression_ratio_of_tokens(tokens: &[u32]) -> f32 {
-  if tokens.is_empty() {
-    return f32::INFINITY;
-  }
   let bytes: Vec<u8> = tokens
     .iter()
     .flat_map(|t| (*t as i32).to_le_bytes())
@@ -88,10 +93,18 @@ pub fn compression_ratio_of_tokens(tokens: &[u32]) -> f32 {
 /// Compression ratio (`raw_bytes / compressed_bytes`) of `text`'s UTF-8
 /// bytes — ports Swift `TextUtilities.compressionRatio(of text: String)`
 /// (`Utilities/TextUtilities.swift:33-53`). Returns [`f32::INFINITY`] for
-/// empty text (Swift's explicit `if text.isEmpty` guard, lines 34-36) or
-/// on a genuine compression error (Swift's `catch`, lines 49-51). Swift
-/// also guards a fallible `text.data(using: .utf8)` (lines 39-42); that
-/// path is unreachable here since a Rust `&str` is always valid UTF-8.
+/// empty text via Swift's explicit `if text.isEmpty { return .infinity }`
+/// guard (lines 34-36), or on a genuine compression error (Swift's
+/// `catch`, lines 49-51). Swift also guards a fallible `text.data(using:
+/// .utf8)` (lines 39-42); that path is unreachable here since a Rust
+/// `&str` is always valid UTF-8.
+///
+/// **Empty-input asymmetry (deliberate, matches Swift).** Unlike
+/// [`compression_ratio_of_tokens`] — whose Swift overload has *no* empty
+/// guard and so returns `0.0` for empty input — this text overload *does*
+/// guard empty and returns infinity. The two Swift overloads diverge here
+/// on purpose (`:34-36` guards text; `:14-28` does not guard tokens); keep
+/// this guard.
 ///
 /// Compresses via the private `zlib_compressed_len` (Apple's `.zlib` = raw
 /// DEFLATE), identical to Swift; see [`compression_ratio_of_tokens`].

--- a/crates/whisperkit/src/text/tests.rs
+++ b/crates/whisperkit/src/text/tests.rs
@@ -4,28 +4,59 @@ use super::*;
 // compression_ratio_of_tokens / compression_ratio_of_text
 // ---------------------------------------------------------------------
 
+// Recover the codec's compressed byte length from the public ratio
+// (`ratio == raw_len / compressed_len`), so the GOLDEN tests below can pin
+// Apple libcompression's ACTUAL output length — the true oracle — with a
+// clear integer failure message. `.round()` absorbs f32 division noise
+// (each captured length round-trips exactly; a wrong codec lands on a
+// different integer). Raw length is the i32-LE byte count (4 bytes/token)
+// for tokens and the UTF-8 byte count for text.
+fn compressed_len_of_tokens(tokens: &[u32]) -> usize {
+  (tokens.len() as f32 * 4.0 / compression_ratio_of_tokens(tokens)).round() as usize
+}
+fn compressed_len_of_text(text: &str) -> usize {
+  (text.len() as f32 / compression_ratio_of_text(text)).round() as usize
+}
+
 #[test]
 fn compression_ratio_detects_repetition() {
   let unique: Vec<u32> = (0..200).collect();
   let repeated = vec![42u32; 200];
   assert!(compression_ratio_of_tokens(&repeated) > compression_ratio_of_tokens(&unique));
   assert!(compression_ratio_of_tokens(&repeated) > 2.4); // crosses the fallback threshold
+  // Exact Apple oracle for the repeated case (see the golden test): 800
+  // raw i32-LE bytes compress to 13. flate2/miniz_oxide gave 27 — still
+  // > 2.4, which is precisely why the `> 2.4` check alone cannot guard the
+  // codec choice, but this length pin can.
+  assert_eq!(compressed_len_of_tokens(&repeated), 13);
   assert_eq!(compression_ratio_of_tokens(&[]), f32::INFINITY);
 }
 
 #[test]
-fn compression_ratio_uses_i32_le_bytes() {
-  // Byte-format parity: ratio == raw_len / zlib_len computed over i32-LE bytes.
-  let tokens = [1u32, 2, 3, 4];
-  let bytes: Vec<u8> = tokens
-    .iter()
-    .flat_map(|t| (*t as i32).to_le_bytes())
-    .collect();
-  let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
-  std::io::Write::write_all(&mut enc, &bytes).unwrap();
-  let compressed = enc.finish().unwrap();
-  let expected = bytes.len() as f32 / compressed.len() as f32;
-  assert_eq!(compression_ratio_of_tokens(&tokens), expected);
+fn compression_ratio_of_tokens_matches_apple_libcompression_golden() {
+  // GOLDEN / DIFFERENTIAL (coremlit issue #9). The pinned lengths are
+  // Apple libcompression's ACTUAL `.zlib` output — the exact
+  // `NSData.compressed(using: .zlib)` bytes Swift WhisperKit's
+  // `TextUtilities.compressionRatio` produces — captured with an
+  // independent oracle (NOT this crate's own encoder) and verified to
+  // inflate as raw DEFLATE / RFC 1951 (see
+  // `.superpowers/sdd/issue9-compression-fix-report.md`). Because they are
+  // not self-referential, they FAIL if the codec regresses to
+  // flate2/miniz_oxide (RFC-1950 zlib-wrapped, +6 bytes of wrapper, and a
+  // weaker body); each case notes what flate2 would emit instead.
+  //
+  // The findings doc's byte-level anchor: `[1212,318,257,1332,13]` x2 →
+  // Apple emits 24 bytes beginning `db c3 c2 c0` (raw DEFLATE); flate2
+  // would emit 30. This case simultaneously pins the i32-LE token encoding
+  // (the input) and the Apple codec (the length).
+  let doc_example: Vec<u32> = [1212, 318, 257, 1332, 13].repeat(2);
+  assert_eq!(doc_example.len(), 10, "40 raw i32-LE bytes");
+  assert_eq!(compressed_len_of_tokens(&doc_example), 24); // flate2: 30
+
+  // The same 5-token phrase x8 → Apple plateaus at 24 bytes (its harder
+  // compression on repetition); flate2 would emit 37. 160 raw bytes.
+  let phrase_x8: Vec<u32> = [1212, 318, 257, 1332, 13].repeat(8);
+  assert_eq!(compressed_len_of_tokens(&phrase_x8), 24); // flate2: 37
 }
 
 #[test]
@@ -36,18 +67,18 @@ fn compression_ratio_of_text_empty_is_infinite() {
 }
 
 #[test]
-fn compression_ratio_of_text_matches_hand_computed_zlib_ratio() {
-  // Same ratio formula as compression_ratio_of_tokens, different byte
-  // source (UTF-8 vs. i32-LE): sanity-checks the formula against a
-  // hand-rolled zlib pass over the string's own UTF-8 bytes, at the same
-  // Compression::default() level.
-  let text = "the quick brown fox jumps over the lazy dog ".repeat(5);
-  let bytes = text.as_bytes();
-  let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
-  std::io::Write::write_all(&mut enc, bytes).unwrap();
-  let compressed = enc.finish().unwrap();
-  let expected = bytes.len() as f32 / compressed.len() as f32;
-  assert_eq!(compression_ratio_of_text(&text), expected);
+fn compression_ratio_of_text_matches_apple_libcompression_golden() {
+  // GOLDEN (see the tokens golden above for provenance): Apple `.zlib`
+  // UTF-8 output lengths, independently captured and raw-DEFLATE-verified;
+  // they fail under a flate2 regression (flate2 lengths, noted, are
+  // larger).
+  let the_x20 = "the the the the the the the the the the the the the the the the the the the the";
+  assert_eq!(the_x20.len(), 79);
+  assert_eq!(compressed_len_of_text(the_x20), 9); // flate2: 28
+
+  let fox_x5 = "the quick brown fox jumps over the lazy dog ".repeat(5);
+  assert_eq!(fox_x5.len(), 220);
+  assert_eq!(compressed_len_of_text(&fox_x5), 48); // flate2: 58
 }
 
 #[test]

--- a/crates/whisperkit/src/text/tests.rs
+++ b/crates/whisperkit/src/text/tests.rs
@@ -29,7 +29,6 @@ fn compression_ratio_detects_repetition() {
   // > 2.4, which is precisely why the `> 2.4` check alone cannot guard the
   // codec choice, but this length pin can.
   assert_eq!(compressed_len_of_tokens(&repeated), 13);
-  assert_eq!(compression_ratio_of_tokens(&[]), f32::INFINITY);
 }
 
 #[test]
@@ -57,6 +56,24 @@ fn compression_ratio_of_tokens_matches_apple_libcompression_golden() {
   // compression on repetition); flate2 would emit 37. 160 raw bytes.
   let phrase_x8: Vec<u32> = [1212, 318, 257, 1332, 13].repeat(8);
   assert_eq!(compressed_len_of_tokens(&phrase_x8), 24); // flate2: 37
+}
+
+#[test]
+fn compression_ratio_of_tokens_empty_is_zero_matching_swift() {
+  // PARITY (coremlit issue #9). Swift's TOKENS overload
+  // (Utilities/TextUtilities.swift:14-28) has NO empty guard: it compresses
+  // an empty `Data()`, and Apple's libcompression turns a zero-length
+  // buffer into 2 bytes (it does NOT throw — proven by the issue-9 objc2
+  // probe), so Swift returns `0 / 2 == 0.0`, not infinity. This value is
+  // pinned to Swift's proven result, not a re-run of our own encoder.
+  //
+  // Decision-level consequence: in `needs_fallback`, `0.0 > threshold`
+  // (default 2.4) is false, so an empty word-token window does NOT force a
+  // repetition fallback — matching Swift. INFINITY (the pre-fix value)
+  // would have flipped that to a wrongful fallback. The end-to-end check
+  // lives in
+  // `result::tests::empty_word_tokens_do_not_trigger_compression_fallback`.
+  assert_eq!(compression_ratio_of_tokens(&[]), 0.0);
 }
 
 #[test]

--- a/crates/whisperkit/src/text/tests.rs
+++ b/crates/whisperkit/src/text/tests.rs
@@ -38,13 +38,12 @@ fn compression_ratio_of_tokens_matches_apple_libcompression_golden() {
   // `NSData.compressed(using: .zlib)` bytes Swift WhisperKit's
   // `TextUtilities.compressionRatio` produces — captured with an
   // independent oracle (NOT this crate's own encoder) and verified to
-  // inflate as raw DEFLATE / RFC 1951 (see
-  // `.superpowers/sdd/issue9-compression-fix-report.md`). Because they are
+  // inflate as raw DEFLATE / RFC 1951. Because they are
   // not self-referential, they FAIL if the codec regresses to
   // flate2/miniz_oxide (RFC-1950 zlib-wrapped, +6 bytes of wrapper, and a
   // weaker body); each case notes what flate2 would emit instead.
   //
-  // The findings doc's byte-level anchor: `[1212,318,257,1332,13]` x2 →
+  // Byte-level anchor: `[1212,318,257,1332,13]` x2 →
   // Apple emits 24 bytes beginning `db c3 c2 c0` (raw DEFLATE); flate2
   // would emit 30. This case simultaneously pins the i32-LE token encoding
   // (the input) and the Apple codec (the length).

--- a/crates/whisperkit/src/transcribe/mod.rs
+++ b/crates/whisperkit/src/transcribe/mod.rs
@@ -76,7 +76,10 @@ use crate::{
   audio::{self, chunker},
   backend::{AlignmentMatrix, InferenceBackend, coreml::CoreMlBackend},
   constants::{APPEND_PUNCTUATION, DEFAULT_LANGUAGE_CODE, PREPEND_PUNCTUATION, SAMPLE_RATE},
-  decode::{self, TranscriptionProgressCallback, sampler::GreedyTokenSampler},
+  decode::{
+    self, TranscriptionProgressCallback,
+    sampler::{self, GreedyTokenSampler},
+  },
   error::{DecodeError, ModelError, TranscribeError},
   model::{ModelVariant, detect_variant, manager::ModelManager},
   options::{DecodingOptions, Options},
@@ -281,6 +284,16 @@ where
     let window_padding = (options.window_clip_time() * SAMPLE_RATE as f32) as usize;
     let window_samples = self.backend.dims().window_samples();
 
+    // Strictly monotonic, 0-based count of windows this `run` call has
+    // attempted so far (incremented once per `decode_with_fallback` call,
+    // below) — the seed-derivation input `sampler::derive_attempt_seed`'s
+    // doc calls `window_index`. Deliberately NOT the `window_id` computed
+    // inside `decode_with_fallback` for progress-callback attribution:
+    // that value is derived from `timings` counters a prior window's
+    // fallback can leave in a stale state (see its own doc), so it is not
+    // guaranteed distinct across windows the way seed derivation needs.
+    let mut window_index: u64 = 0;
+
     let decode_loop_start = Instant::now();
     for (seek_clip_start, seek_clip_end) in seek_clips {
       // :116 — Swift's signed `seek < seekClipEnd - windowPadding` is
@@ -351,7 +364,9 @@ where
           &mut detected_language,
           options,
           &mut timings,
+          window_index,
         )?;
+        window_index += 1;
 
         // :178-194.
         let windowing_start = Instant::now();
@@ -529,6 +544,16 @@ where
   /// fallback and again before the caller's next window (see
   /// [`AlignmentMatrix`]'s own doc). `None` when `options.word_timestamps()`
   /// is `false` or the backend has no alignment data for this window.
+  ///
+  /// **Rust-only addition, no Swift equivalent:** each attempt's sampler is
+  /// seeded from `options.seed()` when set, via
+  /// [`sampler::derive_attempt_seed`] applied to `window_index` (this
+  /// call's own position in [`Self::run`]'s strictly monotonic per-window
+  /// counter, combined with `self.window_id_offset`) and the loop's own
+  /// `attempt` index — see that function's doc for the full mixing
+  /// contract. `options.seed()` unset takes the exact same
+  /// [`GreedyTokenSampler::new`] OS-seeded path as before this knob
+  /// existed: the default is byte-unchanged.
   #[allow(clippy::too_many_arguments)] // Mirrors Swift's decodeWithFallback argument
   // surface (mirroring decode_text's own precedent for this exact lint, per
   // its doc comment); no natural subset of these forms a cohesive struct
@@ -541,6 +566,7 @@ where
     detected_language: &mut Option<String>,
     options: &DecodingOptions,
     timings: &mut TranscriptionTimings,
+    window_index: u64,
   ) -> Result<(DecodingResult, Option<AlignmentMatrix>), TranscribeError> {
     let special = *self.tokenizer.special_tokens();
 
@@ -572,6 +598,20 @@ where
       let temperature =
         options.temperature() + attempt as f32 * options.temperature_increment_on_fallback();
       let mut sampler = GreedyTokenSampler::new(temperature, special.end_token(), options);
+      // `options.seed()` unset (the default): no-op, leaving `sampler`'s
+      // OS-seeded RNG exactly as `GreedyTokenSampler::new` just built it —
+      // byte-identical to the pre-seed-knob behavior. Set: reseed with
+      // this (window, attempt) pair's own derived sub-seed, so the whole
+      // transcription reproduces bit-for-bit across runs while every
+      // window/attempt still draws an independent stream (see
+      // `sampler::derive_attempt_seed`'s doc for the full contract).
+      if let Some(seed) = options.seed() {
+        sampler = sampler.with_seed(sampler::derive_attempt_seed(
+          seed,
+          self.window_id_offset as u64 + window_index,
+          attempt as u64,
+        ));
+      }
       // A FRESH early-stop latch per attempt: Swift initializes a new
       // early-stop entry for every decodeText invocation
       // (TextDecoder.swift:570), so a callback-stopped attempt whose

--- a/crates/whisperkit/src/transcribe/mod.rs
+++ b/crates/whisperkit/src/transcribe/mod.rs
@@ -196,7 +196,11 @@ impl<'ctx, B> TranscribeTask<'ctx, B> {
   /// Sets the chunk-worker id [`TranscriptionProgress::window_id`] updates
   /// are offset by — lets a caller running several [`TranscribeTask`]s
   /// concurrently over different audio chunks keep each worker's window ids
-  /// distinct.
+  /// distinct. It doubles as the `worker_index` coordinate of the seeded
+  /// fallback ladder's sub-seed derivation (see
+  /// [`sampler::derive_attempt_seed`]), which is what keeps distinct
+  /// chunks/workers on distinct RNG streams even where their task-local
+  /// window indices coincide.
   #[inline(always)]
   pub const fn set_window_id_offset(&mut self, window_id_offset: usize) -> &mut Self {
     self.window_id_offset = window_id_offset;
@@ -547,13 +551,14 @@ where
   ///
   /// **Rust-only addition, no Swift equivalent:** each attempt's sampler is
   /// seeded from `options.seed()` when set, via
-  /// [`sampler::derive_attempt_seed`] applied to `window_index` (this
-  /// call's own position in [`Self::run`]'s strictly monotonic per-window
-  /// counter, combined with `self.window_id_offset`) and the loop's own
-  /// `attempt` index — see that function's doc for the full mixing
-  /// contract. `options.seed()` unset takes the exact same
-  /// [`GreedyTokenSampler::new`] OS-seeded path as before this knob
-  /// existed: the default is byte-unchanged.
+  /// [`sampler::derive_attempt_seed`] over three domain-separated
+  /// coordinates — `self.window_id_offset` (this task's per-chunk/worker
+  /// id), `window_index` (this call's own position in [`Self::run`]'s
+  /// strictly monotonic per-`run` window counter, local to the task), and
+  /// the loop's own `attempt` index — passed distinctly, never summed; see
+  /// that function's doc for the full mixing contract. `options.seed()`
+  /// unset takes the exact same [`GreedyTokenSampler::new`] OS-seeded path
+  /// as before this knob existed: the default is byte-unchanged.
   #[allow(clippy::too_many_arguments)] // Mirrors Swift's decodeWithFallback argument
   // surface (mirroring decode_text's own precedent for this exact lint, per
   // its doc comment); no natural subset of these forms a cohesive struct
@@ -600,15 +605,16 @@ where
       let mut sampler = GreedyTokenSampler::new(temperature, special.end_token(), options);
       // `options.seed()` unset (the default): no-op, leaving `sampler`'s
       // OS-seeded RNG exactly as `GreedyTokenSampler::new` just built it —
-      // byte-identical to the pre-seed-knob behavior. Set: reseed with
-      // this (window, attempt) pair's own derived sub-seed, so the whole
-      // transcription reproduces bit-for-bit across runs while every
+      // byte-identical to the pre-seed-knob behavior. Set: reseed with this
+      // (worker, window, attempt) triple's own derived sub-seed, so the
+      // whole transcription reproduces bit-for-bit across runs while every
       // window/attempt still draws an independent stream (see
       // `sampler::derive_attempt_seed`'s doc for the full contract).
       if let Some(seed) = options.seed() {
         sampler = sampler.with_seed(sampler::derive_attempt_seed(
           seed,
-          self.window_id_offset as u64 + window_index,
+          self.window_id_offset as u64,
+          window_index,
           attempt as u64,
         ));
       }
@@ -697,6 +703,12 @@ where
             timings.decoding_fallback() + attempt_start.elapsed().as_secs_f64(),
           );
           self.backend.reset_decoder_state(state);
+          // Records the ZERO-BASED `attempt` index of the latest fallback:
+          // the first fallback writes 0.0, which is also this counter's init
+          // value, so it alone cannot tell "never fell back" from "one
+          // fallback at attempt 0" (a true fallback count would be
+          // `attempt + 1`). Kept as-is: the field is public and summed
+          // across merged results, so re-defining it is out of scope here.
           timings.set_total_decoding_fallbacks(attempt as f64);
         }
         None => break,

--- a/crates/whisperkit/src/transcribe/tests.rs
+++ b/crates/whisperkit/src/transcribe/tests.rs
@@ -170,6 +170,124 @@ fn fallback_ladder_retries_with_rising_temperature_then_accepts() {
   );
 }
 
+/// Scripts the exact catastrophic-avg-logprob window
+/// `fallback_ladder_retries_with_rising_temperature_then_accepts` uses to
+/// force the fallback ladder to exhaust all 3 attempts regardless of
+/// temperature (see that test's own comments for the avg-logprob
+/// derivation). Reused here because it is a PROVEN fallback-forcing
+/// script, and because its 4 "flat" (all-zero-but-EOT) steps per attempt
+/// are genuine top-k multinomial draws at temperature > 0: the sampled
+/// TOKEN is RNG-dependent even though the STEP COUNT is not, which is
+/// exactly the observable coremlit issue #9's seed-reproducibility
+/// contract needs.
+fn script_exhausting_fallback_window(mock: &mut MockBackend, end_token: u32) {
+  for _ in 0..3 {
+    for _ in 0..4 {
+      let mut flat = vec![0.0f32; 51865];
+      flat[end_token as usize] = -20.0;
+      mock.push_step(flat);
+    }
+    mock.push_token_step(end_token);
+  }
+}
+
+/// The fallback-exhausting options recipe, with a nonzero base
+/// `temperature` (so even ATTEMPT 0 draws from the RNG — attempt 0 at the
+/// crate's default `temperature() == 0.0` would sample by argmax alone,
+/// never touching the seed) and `seed` set from the given value.
+fn exhausting_fallback_options(seed: Option<u64>) -> DecodingOptions {
+  DecodingOptions::new()
+    .with_temperature(0.3)
+    .with_without_timestamps()
+    .maybe_first_token_logprob_threshold(None)
+    .maybe_compression_ratio_threshold(None)
+    .with_temperature_fallback_count(2) // 3 attempts total
+    .maybe_seed(seed)
+}
+
+/// Runs the exhausting-fallback scenario end to end against a freshly
+/// built [`MockBackend`]/[`TranscribeTask`] pair, so repeated calls are
+/// fully independent runs (no shared mutable state whatsoever) — the
+/// same shape a real caller re-invoking [`WhisperKit::transcribe`] twice
+/// would see.
+fn run_exhausting_fallback(t: &WhisperTokenizer, seed: Option<u64>) -> TranscriptionResult {
+  let mut mock = MockBackend::new().with_dims(ModelDims::new().with_window_samples(16_000));
+  script_exhausting_fallback_window(&mut mock, special().end_token());
+  let task = TranscribeTask::new(&mock, t);
+  let audio = vec![0.1f32; 32_000];
+  task
+    .run(&audio, &exhausting_fallback_options(seed))
+    .unwrap()
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn seeded_fallback_ladder_is_bit_reproducible_across_runs() {
+  // Closes coremlit issue #9's final open item: with a seed set, the
+  // fallback ladder can stay fully enabled AND be bit-reproducible.
+  // N (here 4) entirely independent runs (fresh backend/task every time)
+  // at the same seed, each forcing the SAME 3-attempt exhausting ladder,
+  // must all sample byte-identical tokens.
+  let t = tiny_tokenizer();
+  let runs: Vec<TranscriptionResult> = (0..4)
+    .map(|_| run_exhausting_fallback(&t, Some(7)))
+    .collect();
+  let reference = &runs[0];
+  assert_eq!(reference.segments_slice().len(), 1);
+  let reference_tokens = reference.segments_slice()[0].tokens_slice();
+  for (index, run) in runs.iter().enumerate().skip(1) {
+    assert_eq!(run.segments_slice().len(), 1);
+    assert_eq!(
+      run.segments_slice()[0].tokens_slice(),
+      reference_tokens,
+      "run {index} diverged from run 0: same seed, same fallback ladder -> byte-identical sampled tokens"
+    );
+    assert_eq!(run.text(), reference.text(), "run {index} text diverged");
+  }
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn seeded_fallback_ladder_differs_across_seeds() {
+  // Proves the seed is actually threaded into the pipeline's sampler
+  // construction, not silently ignored: a DIFFERENT base seed over the
+  // identical scripted scenario must sample different tokens. (If this
+  // ever flakes because two specific seed literals happen to coincide,
+  // that is a signal to pick different literals, not to delete the
+  // property -- verified empirically for the literals below before
+  // trusting them.)
+  let t = tiny_tokenizer();
+  let a = run_exhausting_fallback(&t, Some(7));
+  let b = run_exhausting_fallback(&t, Some(99));
+  assert_ne!(
+    a.segments_slice()[0].tokens_slice(),
+    b.segments_slice()[0].tokens_slice(),
+    "different seeds must not sample the same tokens"
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn unseeded_fallback_ladder_still_runs_without_threading_a_seed() {
+  // `seed = None` (the default): the fallback ladder must still run to
+  // completion exactly as it did before this knob existed. Deliberately
+  // NOT asserting any determinism/nondeterminism property here (an
+  // OS-seeded run could coincidentally repeat) -- only that this code
+  // path is exercised successfully. `options.seed()` returning `None`
+  // means `decode_with_fallback`'s `if let Some(seed) = ...` body never
+  // runs, so no seed is threaded into the sampler at all; that skip is a
+  // structural (code-path) guarantee, not something this test can
+  // observe from the outside without breaking the "don't assert
+  // (non)determinism" rule above.
+  let t = tiny_tokenizer();
+  let result = run_exhausting_fallback(&t, None);
+  assert_eq!(result.segments_slice().len(), 1, "lump branch, as scripted");
+  assert!(
+    (result.segments_slice()[0].temperature() - (0.3 + 2.0 * 0.2)).abs() < 1e-3,
+    "ladder still exhausts to the final (highest-temperature) attempt"
+  );
+}
+
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn segment_discovery_callback_fires_per_window() {


### PR DESCRIPTION
Fully closes #9. After PR #11 landed the library-side follow-ups, an adversarial re-check of the ONE remaining "expected nondeterminism" item found a **real deterministic port bug** underneath it. This PR fixes that bug and dissolves the reproducibility tradeoff the reporter was left holding.

## The bug the retest and our own earlier analysis both explained away

The remaining #9 failure ("EN VAD no-prefill, fallback enabled") was dismissed as "expected nondeterministic fallback sampling." That explains what happens **after** fallback fires — not whether we **decide** to fall back at the same points as Swift. The fallback decision is **deterministic** (computed from the temperature-0 attempt's `avg_logprob` + `compression_ratio`, before any RNG). Comparing those trigger inputs against Swift on the same attempt:

- `avg_logprob`: equivalent (~1.5e-4).
- **`compression_ratio`: DIVERGED.** Swift computes it via Apple libcompression (`NSData.compressed(using: .zlib)` = raw DEFLATE); we used `flate2` (miniz_oxide, RFC-1950 zlib-wrapped +6 bytes, weaker compression). Our ratio ran systematically low → **we fell back less often than Swift**, deterministically. `ted_60` window `[366400..]`, threshold 1.7: Swift 1.8407 (falls back) vs Rust 1.6124 (accepts). 8/40 hallucination-loop sequences flip even at the default 2.4.

It stayed hidden because the default-threshold fixture happens to land same-side both ways, and because the crate's own compression tests computed their "expected" value **with flate2 itself** (self-referential — structurally unable to catch it).

## What's in this PR (4 commits, 3 logically-independent fixes)

1. **`compression_ratio` parity** — now uses Apple libcompression via `objc2-foundation`'s `NSData.compressedDataUsingAlgorithm(.zlib)` — the exact API Swift calls, **zero `unsafe`** (objc2 owns the FFI). Byte-identical to Swift by construction. `objc2`/`objc2-foundation` become core deps; `flate2` dropped. The self-referential tests are replaced with goldens pinned to Apple's actual output (verified with an independent objc2 probe: 24/24/13/9/48 bytes, `db c3 c2 c0` signature).
2. **Empty-tokens parity** — empty tokens now yield `0.0` (matching Swift's guard-less tokens overload), not `INFINITY`; the text overload keeps its empty→`.infinity` guard (matching Swift's asymmetry). Without this, an empty-transcript window would fall back where Swift wouldn't.
3. **Seeded reproducible fallback** — `DecodingOptions.seed: Option<u64>`. With a seed, the fallback ladder is **bit-reproducible across runs** while remaining enabled (per-window/attempt sub-seed derivation); unset, behavior is byte-identical to before. This dissolves the reporter's "reproducibility XOR fallback quality" tradeoff — no need to disable the ladder to get determinism. `TranscriptionSegment::temperature` already records effective decode temperature for provenance.

## Verification

- **Fallback trigger now matches Swift across the input domain** (whole-branch review, vs oracle `dcf3a00`): non-empty via the identical Apple API + i32-LE encoding; empty → 0.0; single-token/large/multibyte all flow the same path — no residual divergence class.
- **The three fixes compose cleanly** on orthogonal axes (seed = draw within an attempt; compression + empty-tokens = the fallback decision). The empty-tokens fix *strengthens* coherence (removes a spurious edge that consumed extra seeded attempts). `seeded_fallback_ladder_is_bit_reproducible_across_runs` passes on the combined tree.
- **Goldens unchanged, confirmed by name:** `jfk_tiny_matches_golden_tokens_and_segments` and `es_tiny_matches_golden_tokens_and_segments` both pass (both assert zero fallbacks, so the ratio can't affect them).
- Reviews: seed injection reviewed; compression fix got a full independent review + delta-review (both APPROVE, independent objc2 oracle probe); whole-branch review APPROVE-grade (only comment-only nits, fixed).
- Gates green on the combined tree: fmt, clippy `-D warnings`, workspace tests, model-gated `--ignored` (goldens by name), `cargo hack --each-feature` (5/5, incl. the objc2 dep move), rustdoc `-D warnings`, `--doc --all-features`.

## Remaining #9 items are product policy, not port bugs

Fallback-ladder on/off, `[BLANK_AUDIO]` filtering, and provenance recording are consumer decisions (documented). The CJK 85-vs-24 word-grouping is the intended product-correct behavior, test-pinned in #11.