### PR TITLE
fix(whisperkit): allow single_use_lifetimes on fold — stable lint drift false positive

### DIFF
--- a/crates/whisperkit/src/task_facts/mod.rs
+++ b/crates/whisperkit/src/task_facts/mod.rs
@@ -793,6 +793,8 @@ impl TaskFacts {
   /// assert_eq!(TaskFacts::fold([&clean]), clean);
   /// ```
   #[must_use]
+  // `'a` can't be elided: `&Self` in impl-Trait position is an unstable anonymous lifetime (E0658).
+  #[allow(single_use_lifetimes)]
   pub fn fold<'a>(contributors: impl IntoIterator<Item = &'a Self>) -> Self {
     let mut accumulator = TaskFactsAccumulator::new();
     for contributor in contributors {


### PR DESCRIPTION
stable-1.96's `single_use_lifetimes` fires on `TaskFacts::fold`'s required named `'a`, but the elision it suggests is impossible — an anonymous lifetime in `impl Trait` argument position is unstable (E0658). This is a targeted `#[allow]` with a rationale comment on that one function only; no workspace-lint changes.
