### PR TITLE
fix(coremlit/clap): #30 remediation — fail-closed parity, int8 gates, exact SHA manifest, 43%-faster text placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Each pipeline resolves its models root from its own env var (`WHISPERKIT_TEST_MO
 | `cargo bench -p coremlit --features whisper --bench whisper_stages` | Hermetic criterion benches: logits filters, DTW, VAD chunking, compression ratio |
 | `cargo bench -p coremlit --features whisper --bench whisper_rtf` | End-to-end tokens/sec + real-time factor on the tiny model (skips without models) |
 | `cargo bench -p coremlit --features align --bench align_align` | Alignment encode / align_chunk RTF |
+| `cargo bench -p coremlit --features clap --bench clap_encode` | CLAP dual-tower encode phases (cold/cached load, first + warm inference) per tower × ComputeUnits, with output hash / cosine / RSS (skips without models; `CLAPKIT_BENCH_COLD=1` also measures cold specialization) |
 
 ## Feature flags
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Each pipeline resolves its models root from its own env var (`WHISPERKIT_TEST_MO
 | `cargo bench -p coremlit --features whisper --bench whisper_stages` | Hermetic criterion benches: logits filters, DTW, VAD chunking, compression ratio |
 | `cargo bench -p coremlit --features whisper --bench whisper_rtf` | End-to-end tokens/sec + real-time factor on the tiny model (skips without models) |
 | `cargo bench -p coremlit --features align --bench align_align` | Alignment encode / align_chunk RTF |
-| `cargo bench -p coremlit --features clap --bench clap_encode` | CLAP dual-tower encode phases (cold/cached load, first + warm inference) per tower × ComputeUnits, with output hash / cosine / RSS (skips without models; `CLAPKIT_BENCH_COLD=1` also measures cold specialization) |
+| `cargo bench -p coremlit --features clap --bench clap_encode` | CLAP dual-tower encode phases (first-observed / cached load, first + warm inference) per tower × ComputeUnits, with output hash / cosine / RSS (skips without models) |
 
 ## Feature flags
 

--- a/crates/coremlit/Cargo.toml
+++ b/crates/coremlit/Cargo.toml
@@ -230,6 +230,12 @@ tokenizers.workspace = true
 # `clap`) read committed librosa `.npy` mel oracles via `npyz` (former clapkit
 # dev-dep).
 npyz.workspace = true
+# The `clap_encode` bench reports process RSS via `task_info(MACH_TASK_BASIC_INFO)`
+# (the same query as `audio::whisper::log::resident_memory_bytes`, which rides the
+# `whisper` feature the bench does not enable). Dev-deps compile only for
+# tests/benches/examples, so this adds nothing to the library's feature graph.
+libc.workspace = true
+mach2.workspace = true
 # `tests/align/parity_words.rs` names `asry::Aligner` (the ONNX oracle) and
 # `asry::ort::api()` directly, so asry must appear as a dev-dep too. Cargo
 # unions its features with the optional runtime entry above; `align-oracle`
@@ -517,6 +523,16 @@ required-features = ["clap-oracle"]
 name = "clap_tokenizer_identity_textclap"
 path = "tests/clap/tokenizer_identity_textclap.rs"
 required-features = ["clap-oracle"]
+
+# Dual-tower encode harness: cold/cached load, first + warm inference per tower ×
+# ComputeUnits (model-gated; `harness = false` custom main — the load phases are
+# one-shot costs criterion's resampling cannot see). Mirrors the whisper/align
+# bench registrations above.
+[[bench]]
+name = "clap_encode"
+path = "benches/clap/encode.rs"
+harness = false
+required-features = ["clap"]
 
 [lints]
 workspace = true

--- a/crates/coremlit/Cargo.toml
+++ b/crates/coremlit/Cargo.toml
@@ -524,10 +524,10 @@ name = "clap_tokenizer_identity_textclap"
 path = "tests/clap/tokenizer_identity_textclap.rs"
 required-features = ["clap-oracle"]
 
-# Dual-tower encode harness: cold/cached load, first + warm inference per tower ×
-# ComputeUnits (model-gated; `harness = false` custom main — the load phases are
-# one-shot costs criterion's resampling cannot see). Mirrors the whisper/align
-# bench registrations above.
+# Dual-tower encode harness: first-observed/cached load, first + warm inference
+# per tower × ComputeUnits (model-gated; `harness = false` custom main — the load
+# phases are one-shot costs criterion's resampling cannot see). Mirrors the
+# whisper/align bench registrations above.
 [[bench]]
 name = "clap_encode"
 path = "benches/clap/encode.rs"

--- a/crates/coremlit/benches/clap/encode.rs
+++ b/crates/coremlit/benches/clap/encode.rs
@@ -5,19 +5,26 @@
 //! reproducible measurement. `harness = false` (a custom `main`, like
 //! `benches/whisper/rtf.rs`): the load phases are **one-shot** costs — criterion's
 //! statistical resampling would reload each model dozens of times, and every load
-//! after the first hits the OS specialization cache, so it cannot see a cold or a
-//! first-inference cost at all.
+//! after the first hits the OS specialization cache, so it cannot see a
+//! first-observed-load or first-inference cost at all.
 //!
-//! # The four phases (spec §; audit #30)
+//! # The phases (spec §; audit #30)
 //!
-//! - **cold specialization** — the first-ever load of a model the OS has not yet
-//!   specialized for this device. A **one-time OS cost**, distinct from a cached
-//!   load. Measured only in the opt-in, reversible cold mode (see below), because
-//!   on any host that has already run the clap tests the model is already
-//!   specialized and every load is a cache hit.
-//! - **cached load** — [`crate::Model::load`] when the specialized artifact
-//!   already exists in the OS cache. This is what every production process start
-//!   pays after the one-time cold specialization; it is the steady-state load.
+//! - **first-observed load** — the first [`crate::Model::load`] of a
+//!   `(tower, placement)` in THIS fresh process. On a host that has never
+//!   specialized this model for this device it folds in the **one-time OS
+//!   specialization** cost; on a host that already has (e.g. after running the
+//!   clap tests) it is already a cache hit. Either way it is the honest,
+//!   real-world first-load number — no shared system state is touched to force
+//!   it, so read it as an upper bound that still carries any not-yet-paid
+//!   specialization.
+//! - **cached load** — a second [`crate::Model::load`] in the SAME process, after
+//!   the first-observed load has populated the OS specialization cache. It
+//!   isolates the specialization-cache-HIT load path (any cache-MISS cost is paid
+//!   by the first-observed load above). Being a back-to-back in-process call it
+//!   also inherits process-local CoreML/framework init and warm allocator state
+//!   that a fresh process does NOT, so read it as a lower bound on — not a
+//!   measurement of — a later process's cached-start latency.
 //! - **first inference** — the first `embed` after a load (the prediction path's
 //!   own MPSGraph/ANE program specialization).
 //! - **warm inference** — median / p90 over [`WARM_RUNS`] (≥ 20) steady-state
@@ -27,34 +34,35 @@
 //! hash (an 8-hex SHA-256 prefix over the warm embedding's bytes — a perf change
 //! that alters numerics changes the hash) AND its cosine against the
 //! [`ComputeUnits::CpuOnly`] reference (the semantic drift check the placement
-//! gate uses), and the process resident-memory footprint.
+//! gate uses), and a current process resident-memory snapshot.
 //!
-//! # Cold mode (opt-in, reversible)
+//! # True cold specialization is NOT measured here
 //!
-//! The default run measures **cached load / first inference / warm** for the full
-//! 2 × 4 matrix — always safe, never touches state outside the target dir. To
-//! also measure genuine **cold specialization**, set `CLAPKIT_BENCH_COLD=1`: for
-//! `ComputeUnits::All` on each tower, the harness renames the on-device ANE
-//! specialization cache (`~/Library/Caches/com.apple.e5rt.e5bundlecache`) aside,
-//! times a cold [`crate::Model::load`], then **restores** it — a cache the OS
-//! rebuilds transparently, left byte-for-byte as it was. Caveat: clearing the
-//! e5rt cache yields a genuine cold number for the ANE-compiling **text** tower;
-//! the **audio** (HTSAT) tower falls back to GPU/CPU (`ANECCompile` fails — see
-//! `tests/clap/placement.rs`), whose MPSGraph specialization is cached partly
-//! elsewhere, so the audio cold figure here is a lower bound on the true
-//! first-ever specialization.
+//! Genuine cold specialization — the first-ever load of a model the OS has never
+//! specialized for this device — is a one-time OS cost. Measuring it reliably
+//! requires a CLEAN, disposable environment (a fresh user profile or VM whose ANE
+//! specialization cache, `~/Library/Caches/com.apple.e5rt.e5bundlecache`, has
+//! never seen this model), NOT evicting the shared on-device cache, which is a
+//! resource other CoreML processes on the host rely on. This harness therefore
+//! never touches that cache and does not force a cold load; run it once in a
+//! disposable profile if you need the cold number. The `first-observed load`
+//! column already captures the cold cost whenever the host running the bench has
+//! not previously specialized the model.
+//!
+//! Note on iteration order: the [`UNITS`] are measured in sequence, so a later
+//! placement's `first-observed load` can be partly warmed by an earlier one. OS
+//! specialization is per-model, so this cross-placement warming is limited, but
+//! the first-observed column should be read with the iteration order in mind.
 //!
 //! Run (model-gated — set `CLAPKIT_TEST_MODELS`, or place models at
 //! `Models/clapkit/`):
 //! `cargo bench -p coremlit --features clap --bench clap_encode`
-//! Add `CLAPKIT_BENCH_COLD=1` to also measure cold specialization.
 //!
 //! `criterion_group!`-style benches carry a crate-level `#![allow(missing_docs)]`
 //! because the macro expands to an undocumented `pub fn`; this custom-`main`
 //! bench has no such expansion and no external API, so it needs no such allow.
 
 use std::{
-  fs,
   hint::black_box,
   path::{Path, PathBuf},
   time::Instant,
@@ -100,34 +108,31 @@ fn main() {
     return;
   }
 
-  let cold = std::env::var_os("CLAPKIT_BENCH_COLD").is_some_and(|v| v == "1");
   println!(
     "# clap_encode — CLAP dual-tower encode phases (measured, never marketed)\n\
      # models: {}\n\
-     # warm runs: {WARM_RUNS}   cold mode: {}\n\
+     # warm runs: {WARM_RUNS}\n\
      # latency in ms; cos = cosine vs CpuOnly reference (same tower/input); \
-     rss = cumulative process resident MB\n",
+     rss = current process resident MB (a snapshot, not a peak)\n",
     models.display(),
-    if cold {
-      "ON (genuine cold specialization, e5rt cache reversibly cleared)"
-    } else {
-      "off (set CLAPKIT_BENCH_COLD=1 for cold specialization)"
-    },
   );
 
-  bench_audio(&audio_model, cold);
-  bench_text(&text_model, cold);
+  bench_audio(&audio_model);
+  bench_text(&text_model);
 
-  println!("\n# peak process resident memory: {:.1} MB", rss_mb());
+  println!("\n# current process resident memory: {:.1} MB", rss_mb());
   println!(
-    "# note: rss is cumulative — every configuration above is loaded in this one \
-     process, so each rss column is a running total, not that configuration's \
-     isolated footprint."
+    "# note: rss is a single current snapshot (task resident_size at the moment \
+     each row prints), NOT a peak and NOT a cumulative running total — encoders \
+     are dropped between configurations, so a row is neither monotonic nor that \
+     configuration's isolated footprint. A true peak would need sampling across \
+     load + inference."
   );
 }
 
-/// Audio tower: cold / cached load, first + warm `embed_window`, per unit.
-fn bench_audio(model: &Path, cold: bool) {
+/// Audio tower: first-observed + cached load, first + warm `embed_window`, per
+/// unit.
+fn bench_audio(model: &Path) {
   println!("## audio tower (HTSAT) — {}", model.display());
   print_header();
 
@@ -135,19 +140,24 @@ fn bench_audio(model: &Path, cold: bool) {
   let mut reference: Option<Embedding> = None;
 
   for unit in UNITS {
-    let cold_ms = (cold && unit == ComputeUnits::All)
-      .then(|| {
-        measure_cold(model, "audio", || {
-          AudioEncoder::from_file_with(model, AudioEncoderOptions::new().with_compute(unit))
-            .map(drop)
-        })
-      })
-      .flatten();
+    // First-observed load: the first load of this (tower, unit) in this fresh
+    // process — folds in the one-time OS specialization on a host that has not
+    // yet specialized this model. Dropped before the cached measurement.
+    let first_load_start = Instant::now();
+    let priming =
+      AudioEncoder::from_file_with(model, AudioEncoderOptions::new().with_compute(unit))
+        .unwrap_or_else(|e| panic!("first-observed load audio [{unit}]: {e}"));
+    let first_load_ms = ms(first_load_start);
+    drop(priming);
 
+    // Cached load: a second in-process load after the first populated the OS
+    // specialization cache — isolates the specialization-cache-hit path. Being
+    // back-to-back in-process, it is a lower bound on (not a measurement of) a
+    // fresh process's cached start.
     let load_start = Instant::now();
     let encoder =
       AudioEncoder::from_file_with(model, AudioEncoderOptions::new().with_compute(unit))
-        .unwrap_or_else(|e| panic!("load audio [{unit}]: {e}"));
+        .unwrap_or_else(|e| panic!("cached load audio [{unit}]: {e}"));
     let cached_load_ms = ms(load_start);
 
     let first_start = Instant::now();
@@ -171,7 +181,7 @@ fn bench_audio(model: &Path, cold: bool) {
     let cos = record_cosine(unit, &last, &mut reference);
     print_row(
       unit,
-      cold_ms,
+      first_load_ms,
       cached_load_ms,
       first_ms,
       &mut warm,
@@ -182,27 +192,32 @@ fn bench_audio(model: &Path, cold: bool) {
   println!();
 }
 
-/// Text tower: cold / cached load, first + warm `embed`, per unit.
-fn bench_text(model: &Path, cold: bool) {
+/// Text tower: first-observed + cached load, first + warm `embed`, per unit.
+fn bench_text(model: &Path) {
   println!("## text tower (RoBERTa) — {}", model.display());
   print_header();
 
   let mut reference: Option<Embedding> = None;
 
   for unit in UNITS {
-    let cold_ms = (cold && unit == ComputeUnits::All)
-      .then(|| {
-        measure_cold(model, "text", || {
-          TextEncoder::from_bundled_tokenizer(model, TextEncoderOptions::new().with_compute(unit))
-            .map(drop)
-        })
-      })
-      .flatten();
+    // First-observed load: the first load of this (tower, unit) in this fresh
+    // process — folds in the one-time OS specialization on a host that has not
+    // yet specialized this model. Dropped before the cached measurement.
+    let first_load_start = Instant::now();
+    let priming =
+      TextEncoder::from_bundled_tokenizer(model, TextEncoderOptions::new().with_compute(unit))
+        .unwrap_or_else(|e| panic!("first-observed load text [{unit}]: {e}"));
+    let first_load_ms = ms(first_load_start);
+    drop(priming);
 
+    // Cached load: a second in-process load after the first populated the OS
+    // specialization cache — isolates the specialization-cache-hit path. Being
+    // back-to-back in-process, it is a lower bound on (not a measurement of) a
+    // fresh process's cached start.
     let load_start = Instant::now();
     let encoder =
       TextEncoder::from_bundled_tokenizer(model, TextEncoderOptions::new().with_compute(unit))
-        .unwrap_or_else(|e| panic!("load text [{unit}]: {e}"));
+        .unwrap_or_else(|e| panic!("cached load text [{unit}]: {e}"));
     let cached_load_ms = ms(load_start);
 
     let first_start = Instant::now();
@@ -226,7 +241,7 @@ fn bench_text(model: &Path, cold: bool) {
     let cos = record_cosine(unit, &last, &mut reference);
     print_row(
       unit,
-      cold_ms,
+      first_load_ms,
       cached_load_ms,
       first_ms,
       &mut warm,
@@ -250,71 +265,11 @@ fn record_cosine(unit: ComputeUnits, emb: &Embedding, reference: &mut Option<Emb
     .map_or_else(|| emb.cosine(emb), |r| emb.cosine(r))
 }
 
-/// Times a cold [`crate::Model::load`] with the OS ANE specialization cache
-/// reversibly cleared, then restores the cache. Returns the cold load in ms, or
-/// `None` if the cache could not be safely moved aside (reported, never faked).
-fn measure_cold(
-  _model: &Path,
-  tower: &str,
-  load: impl Fn() -> Result<(), coremlit::embeddings::clap::Error>,
-) -> Option<f64> {
-  let cache = e5rt_cache_dir()?;
-  let backup = cache.with_extension(format!("clapbench-bak-{}", std::process::id()));
-
-  // Rename the specialization cache aside so the next load is genuinely cold.
-  // Atomic on the same filesystem; skip (report None) if it is absent or the
-  // move fails, rather than fabricate a cold number.
-  if !cache.exists() {
-    eprintln!(
-      "[cold] {tower}: no e5rt cache present — cannot force a cold load; reporting cached only"
-    );
-    return None;
-  }
-  if let Err(e) = fs::rename(&cache, &backup) {
-    eprintln!("[cold] {tower}: could not move e5rt cache aside ({e}); reporting cached only");
-    return None;
-  }
-
-  let start = Instant::now();
-  let result = load();
-  let elapsed = ms(start);
-
-  // Restore: discard whatever the cold load repopulated, then move the original
-  // cache back so the user's on-device cache is left exactly as it was.
-  let _ = fs::remove_dir_all(&cache);
-  if let Err(e) = fs::rename(&backup, &cache) {
-    eprintln!(
-      "[cold] {tower}: WARNING failed to restore e5rt cache from {} ({e}) — the OS will \
-       transparently rebuild it on next use",
-      backup.display()
-    );
-  }
-
-  match result {
-    Ok(()) => Some(elapsed),
-    Err(e) => {
-      eprintln!("[cold] {tower}: cold load failed: {e}");
-      None
-    }
-  }
-}
-
-/// `~/Library/Caches/com.apple.e5rt.e5bundlecache`, the on-device ANE
-/// specialization cache, if `HOME` is set.
-fn e5rt_cache_dir() -> Option<PathBuf> {
-  std::env::var_os("HOME").map(|home| {
-    PathBuf::from(home)
-      .join("Library")
-      .join("Caches")
-      .join("com.apple.e5rt.e5bundlecache")
-  })
-}
-
 fn print_header() {
   println!(
     "{:<26} {:>12} {:>11} {:>10} {:>11} {:>10} {:>12} {:>9} {:>10}",
     "unit",
-    "cold_load",
+    "first_load",
     "cached_load",
     "first_inf",
     "warm_median",
@@ -328,7 +283,7 @@ fn print_header() {
 #[allow(clippy::too_many_arguments)]
 fn print_row(
   unit: ComputeUnits,
-  cold_ms: Option<f64>,
+  first_load_ms: f64,
   cached_load_ms: f64,
   first_ms: f64,
   warm: &mut [f64],
@@ -336,11 +291,10 @@ fn print_row(
   emb: &Embedding,
 ) {
   let (median, p90) = median_p90(warm);
-  let cold = cold_ms.map_or_else(|| "—".to_string(), |v| format!("{v:.1}"));
   println!(
-    "{:<26} {:>12} {:>11.1} {:>10.2} {:>11.2} {:>10.2} {:>12.6} {:>9.1} {:>10}",
+    "{:<26} {:>12.1} {:>11.1} {:>10.2} {:>11.2} {:>10.2} {:>12.6} {:>9.1} {:>10}",
     unit.as_str(),
-    cold,
+    first_load_ms,
     cached_load_ms,
     first_ms,
     median,

--- a/crates/coremlit/benches/clap/encode.rs
+++ b/crates/coremlit/benches/clap/encode.rs
@@ -1,0 +1,446 @@
+//! CLAP dual-tower encode harness: the four cost phases the #30 audit called
+//! out, measured PER TOWER (audio, text) × PER [`ComputeUnits`], model-gated.
+//!
+//! This replaces the audit's ad-hoc one-off numbers with a committed,
+//! reproducible measurement. `harness = false` (a custom `main`, like
+//! `benches/whisper/rtf.rs`): the load phases are **one-shot** costs — criterion's
+//! statistical resampling would reload each model dozens of times, and every load
+//! after the first hits the OS specialization cache, so it cannot see a cold or a
+//! first-inference cost at all.
+//!
+//! # The four phases (spec §; audit #30)
+//!
+//! - **cold specialization** — the first-ever load of a model the OS has not yet
+//!   specialized for this device. A **one-time OS cost**, distinct from a cached
+//!   load. Measured only in the opt-in, reversible cold mode (see below), because
+//!   on any host that has already run the clap tests the model is already
+//!   specialized and every load is a cache hit.
+//! - **cached load** — [`crate::Model::load`] when the specialized artifact
+//!   already exists in the OS cache. This is what every production process start
+//!   pays after the one-time cold specialization; it is the steady-state load.
+//! - **first inference** — the first `embed` after a load (the prediction path's
+//!   own MPSGraph/ANE program specialization).
+//! - **warm inference** — median / p90 over [`WARM_RUNS`] (≥ 20) steady-state
+//!   `embed` calls.
+//!
+//! For each measured configuration it emits the latency, the output embedding's
+//! hash (an 8-hex SHA-256 prefix over the warm embedding's bytes — a perf change
+//! that alters numerics changes the hash) AND its cosine against the
+//! [`ComputeUnits::CpuOnly`] reference (the semantic drift check the placement
+//! gate uses), and the process resident-memory footprint.
+//!
+//! # Cold mode (opt-in, reversible)
+//!
+//! The default run measures **cached load / first inference / warm** for the full
+//! 2 × 4 matrix — always safe, never touches state outside the target dir. To
+//! also measure genuine **cold specialization**, set `CLAPKIT_BENCH_COLD=1`: for
+//! `ComputeUnits::All` on each tower, the harness renames the on-device ANE
+//! specialization cache (`~/Library/Caches/com.apple.e5rt.e5bundlecache`) aside,
+//! times a cold [`crate::Model::load`], then **restores** it — a cache the OS
+//! rebuilds transparently, left byte-for-byte as it was. Caveat: clearing the
+//! e5rt cache yields a genuine cold number for the ANE-compiling **text** tower;
+//! the **audio** (HTSAT) tower falls back to GPU/CPU (`ANECCompile` fails — see
+//! `tests/clap/placement.rs`), whose MPSGraph specialization is cached partly
+//! elsewhere, so the audio cold figure here is a lower bound on the true
+//! first-ever specialization.
+//!
+//! Run (model-gated — set `CLAPKIT_TEST_MODELS`, or place models at
+//! `Models/clapkit/`):
+//! `cargo bench -p coremlit --features clap --bench clap_encode`
+//! Add `CLAPKIT_BENCH_COLD=1` to also measure cold specialization.
+//!
+//! `criterion_group!`-style benches carry a crate-level `#![allow(missing_docs)]`
+//! because the macro expands to an undocumented `pub fn`; this custom-`main`
+//! bench has no such expansion and no external API, so it needs no such allow.
+
+use std::{
+  fs,
+  hint::black_box,
+  path::{Path, PathBuf},
+  time::Instant,
+};
+
+use coremlit::{
+  ComputeUnits,
+  embeddings::clap::{
+    AudioEncoder, AudioEncoderOptions, Embedding, TextEncoder, TextEncoderOptions,
+    audio::TARGET_SAMPLES,
+  },
+};
+
+/// Steady-state `embed` calls timed for the warm median / p90 (≥ 20 per the
+/// spec; 25 for a stable p90 index).
+const WARM_RUNS: usize = 25;
+
+/// The public compute matrix both towers are measured over — the same four units
+/// as `tests/clap/placement.rs`, but **`CpuOnly` first**: it is the cosine
+/// reference, so measuring it first lets every other unit (`All` included) report
+/// a real cross-placement cosine against it rather than a self-reference.
+const UNITS: [ComputeUnits; 4] = [
+  ComputeUnits::CpuOnly,
+  ComputeUnits::All,
+  ComputeUnits::CpuAndGpu,
+  ComputeUnits::CpuAndNeuralEngine,
+];
+
+/// A representative text query (the placement gate's prompt).
+const TEXT_PROMPT: &str = "a violin playing a slow melody in a concert hall";
+
+fn main() {
+  let models = models_dir();
+  let audio_model = models.join("clap_audio.mlmodelc");
+  let text_model = models.join("clap_text.mlmodelc");
+  if !audio_model.is_dir() || !text_model.is_dir() {
+    eprintln!(
+      "clap_encode bench skipped: clapkit models not found under {} \
+       (set CLAPKIT_TEST_MODELS, or fetch to Models/clapkit — see the crate README). \
+       MEASURED NOTHING.",
+      models.display()
+    );
+    return;
+  }
+
+  let cold = std::env::var_os("CLAPKIT_BENCH_COLD").is_some_and(|v| v == "1");
+  println!(
+    "# clap_encode — CLAP dual-tower encode phases (measured, never marketed)\n\
+     # models: {}\n\
+     # warm runs: {WARM_RUNS}   cold mode: {}\n\
+     # latency in ms; cos = cosine vs CpuOnly reference (same tower/input); \
+     rss = cumulative process resident MB\n",
+    models.display(),
+    if cold {
+      "ON (genuine cold specialization, e5rt cache reversibly cleared)"
+    } else {
+      "off (set CLAPKIT_BENCH_COLD=1 for cold specialization)"
+    },
+  );
+
+  bench_audio(&audio_model, cold);
+  bench_text(&text_model, cold);
+
+  println!("\n# peak process resident memory: {:.1} MB", rss_mb());
+  println!(
+    "# note: rss is cumulative — every configuration above is loaded in this one \
+     process, so each rss column is a running total, not that configuration's \
+     isolated footprint."
+  );
+}
+
+/// Audio tower: cold / cached load, first + warm `embed_window`, per unit.
+fn bench_audio(model: &Path, cold: bool) {
+  println!("## audio tower (HTSAT) — {}", model.display());
+  print_header();
+
+  let samples = deterministic_window(TARGET_SAMPLES);
+  let mut reference: Option<Embedding> = None;
+
+  for unit in UNITS {
+    let cold_ms = (cold && unit == ComputeUnits::All)
+      .then(|| {
+        measure_cold(model, "audio", || {
+          AudioEncoder::from_file_with(model, AudioEncoderOptions::new().with_compute(unit))
+            .map(drop)
+        })
+      })
+      .flatten();
+
+    let load_start = Instant::now();
+    let encoder =
+      AudioEncoder::from_file_with(model, AudioEncoderOptions::new().with_compute(unit))
+        .unwrap_or_else(|e| panic!("load audio [{unit}]: {e}"));
+    let cached_load_ms = ms(load_start);
+
+    let first_start = Instant::now();
+    let first = encoder
+      .embed_window(&samples)
+      .unwrap_or_else(|e| panic!("first audio embed [{unit}]: {e}"));
+    let first_ms = ms(first_start);
+
+    let mut warm = Vec::with_capacity(WARM_RUNS);
+    let mut last = first;
+    for _ in 0..WARM_RUNS {
+      let t = Instant::now();
+      last = black_box(
+        encoder
+          .embed_window(black_box(&samples))
+          .unwrap_or_else(|e| panic!("warm audio embed [{unit}]: {e}")),
+      );
+      warm.push(ms(t));
+    }
+
+    let cos = record_cosine(unit, &last, &mut reference);
+    print_row(
+      unit,
+      cold_ms,
+      cached_load_ms,
+      first_ms,
+      &mut warm,
+      cos,
+      &last,
+    );
+  }
+  println!();
+}
+
+/// Text tower: cold / cached load, first + warm `embed`, per unit.
+fn bench_text(model: &Path, cold: bool) {
+  println!("## text tower (RoBERTa) — {}", model.display());
+  print_header();
+
+  let mut reference: Option<Embedding> = None;
+
+  for unit in UNITS {
+    let cold_ms = (cold && unit == ComputeUnits::All)
+      .then(|| {
+        measure_cold(model, "text", || {
+          TextEncoder::from_bundled_tokenizer(model, TextEncoderOptions::new().with_compute(unit))
+            .map(drop)
+        })
+      })
+      .flatten();
+
+    let load_start = Instant::now();
+    let encoder =
+      TextEncoder::from_bundled_tokenizer(model, TextEncoderOptions::new().with_compute(unit))
+        .unwrap_or_else(|e| panic!("load text [{unit}]: {e}"));
+    let cached_load_ms = ms(load_start);
+
+    let first_start = Instant::now();
+    let first = encoder
+      .embed(TEXT_PROMPT)
+      .unwrap_or_else(|e| panic!("first text embed [{unit}]: {e}"));
+    let first_ms = ms(first_start);
+
+    let mut warm = Vec::with_capacity(WARM_RUNS);
+    let mut last = first;
+    for _ in 0..WARM_RUNS {
+      let t = Instant::now();
+      last = black_box(
+        encoder
+          .embed(black_box(TEXT_PROMPT))
+          .unwrap_or_else(|e| panic!("warm text embed [{unit}]: {e}")),
+      );
+      warm.push(ms(t));
+    }
+
+    let cos = record_cosine(unit, &last, &mut reference);
+    print_row(
+      unit,
+      cold_ms,
+      cached_load_ms,
+      first_ms,
+      &mut warm,
+      cos,
+      &last,
+    );
+  }
+  println!();
+}
+
+/// Cosine of `emb` against the `CpuOnly` reference for this tower. `CpuOnly` is
+/// measured first in [`UNITS`] and seeds the reference (self-scoring to 1.0);
+/// every subsequent unit is scored against it — the same drift check
+/// `tests/clap/placement.rs` pins.
+fn record_cosine(unit: ComputeUnits, emb: &Embedding, reference: &mut Option<Embedding>) -> f32 {
+  if unit == ComputeUnits::CpuOnly {
+    *reference = Some(emb.clone());
+  }
+  reference
+    .as_ref()
+    .map_or_else(|| emb.cosine(emb), |r| emb.cosine(r))
+}
+
+/// Times a cold [`crate::Model::load`] with the OS ANE specialization cache
+/// reversibly cleared, then restores the cache. Returns the cold load in ms, or
+/// `None` if the cache could not be safely moved aside (reported, never faked).
+fn measure_cold(
+  _model: &Path,
+  tower: &str,
+  load: impl Fn() -> Result<(), coremlit::embeddings::clap::Error>,
+) -> Option<f64> {
+  let cache = e5rt_cache_dir()?;
+  let backup = cache.with_extension(format!("clapbench-bak-{}", std::process::id()));
+
+  // Rename the specialization cache aside so the next load is genuinely cold.
+  // Atomic on the same filesystem; skip (report None) if it is absent or the
+  // move fails, rather than fabricate a cold number.
+  if !cache.exists() {
+    eprintln!(
+      "[cold] {tower}: no e5rt cache present — cannot force a cold load; reporting cached only"
+    );
+    return None;
+  }
+  if let Err(e) = fs::rename(&cache, &backup) {
+    eprintln!("[cold] {tower}: could not move e5rt cache aside ({e}); reporting cached only");
+    return None;
+  }
+
+  let start = Instant::now();
+  let result = load();
+  let elapsed = ms(start);
+
+  // Restore: discard whatever the cold load repopulated, then move the original
+  // cache back so the user's on-device cache is left exactly as it was.
+  let _ = fs::remove_dir_all(&cache);
+  if let Err(e) = fs::rename(&backup, &cache) {
+    eprintln!(
+      "[cold] {tower}: WARNING failed to restore e5rt cache from {} ({e}) — the OS will \
+       transparently rebuild it on next use",
+      backup.display()
+    );
+  }
+
+  match result {
+    Ok(()) => Some(elapsed),
+    Err(e) => {
+      eprintln!("[cold] {tower}: cold load failed: {e}");
+      None
+    }
+  }
+}
+
+/// `~/Library/Caches/com.apple.e5rt.e5bundlecache`, the on-device ANE
+/// specialization cache, if `HOME` is set.
+fn e5rt_cache_dir() -> Option<PathBuf> {
+  std::env::var_os("HOME").map(|home| {
+    PathBuf::from(home)
+      .join("Library")
+      .join("Caches")
+      .join("com.apple.e5rt.e5bundlecache")
+  })
+}
+
+fn print_header() {
+  println!(
+    "{:<26} {:>12} {:>11} {:>10} {:>11} {:>10} {:>12} {:>9} {:>10}",
+    "unit",
+    "cold_load",
+    "cached_load",
+    "first_inf",
+    "warm_median",
+    "warm_p90",
+    "cos_vs_cpu",
+    "rss_MB",
+    "emb_hash"
+  );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_row(
+  unit: ComputeUnits,
+  cold_ms: Option<f64>,
+  cached_load_ms: f64,
+  first_ms: f64,
+  warm: &mut [f64],
+  cos: f32,
+  emb: &Embedding,
+) {
+  let (median, p90) = median_p90(warm);
+  let cold = cold_ms.map_or_else(|| "—".to_string(), |v| format!("{v:.1}"));
+  println!(
+    "{:<26} {:>12} {:>11.1} {:>10.2} {:>11.2} {:>10.2} {:>12.6} {:>9.1} {:>10}",
+    unit.as_str(),
+    cold,
+    cached_load_ms,
+    first_ms,
+    median,
+    p90,
+    cos,
+    rss_mb(),
+    hash8(emb),
+  );
+}
+
+/// Milliseconds elapsed since `start`.
+fn ms(start: Instant) -> f64 {
+  start.elapsed().as_secs_f64() * 1e3
+}
+
+/// Median and p90 of `samples` (sorted in place). p90 = the `ceil(0.9·n)-1`
+/// order statistic (nearest-rank), matching a small-sample percentile.
+fn median_p90(samples: &mut [f64]) -> (f64, f64) {
+  samples.sort_by(f64::total_cmp);
+  let n = samples.len();
+  let median = samples[n / 2];
+  let p90_idx = ((n as f64 * 0.9).ceil() as usize)
+    .saturating_sub(1)
+    .min(n - 1);
+  (median, samples[p90_idx])
+}
+
+/// First 8 hex of the SHA-256 over the embedding's raw f32 little-endian bytes —
+/// a stable fingerprint of the numeric output (any drift changes it).
+fn hash8(emb: &Embedding) -> String {
+  use sha2::{Digest, Sha256};
+  let mut hasher = Sha256::new();
+  for &v in emb.as_slice() {
+    hasher.update(v.to_le_bytes());
+  }
+  hasher
+    .finalize()
+    .iter()
+    .take(4)
+    .map(|b| format!("{b:02x}"))
+    .collect()
+}
+
+/// This process's resident memory footprint, in MB. Replicates
+/// `coremlit::audio::whisper::log::resident_memory_bytes` (that helper rides the
+/// `whisper` feature, which a `clap` bench does not enable) via the `libc` /
+/// `mach2` dev-deps.
+fn rss_mb() -> f64 {
+  // SAFETY: `mach_task_basic_info` is plain-old-data; the all-zero bit pattern
+  // is a valid value for every field.
+  let mut info: libc::mach_task_basic_info = unsafe { core::mem::zeroed() };
+  let mut count = (core::mem::size_of::<libc::mach_task_basic_info>()
+    / core::mem::size_of::<libc::natural_t>()) as libc::mach_msg_type_number_t;
+  // SAFETY: `mach_task_self()` names the current task; `info` is a zeroed,
+  // properly sized/aligned MACH_TASK_BASIC_INFO out-struct and `count` carries
+  // its capacity in words per the in-out contract, so the kernel writes only
+  // within `info`. The result code is checked before `info` is read.
+  let result = unsafe {
+    libc::task_info(
+      mach2::traps::mach_task_self(),
+      libc::MACH_TASK_BASIC_INFO,
+      (&raw mut info).cast(),
+      &mut count,
+    )
+  };
+  if result == libc::KERN_SUCCESS {
+    info.resident_size as f64 / (1024.0 * 1024.0)
+  } else {
+    f64::NAN
+  }
+}
+
+/// The clapkit model directory: `CLAPKIT_TEST_MODELS`, else
+/// `<workspace>/Models/clapkit` — mirrors `tests/clap/common::models_dir`. A
+/// bench target is its own crate and cannot reach a `tests/` module, so this is
+/// duplicated (as the align bench duplicates its constants for the same reason).
+fn models_dir() -> PathBuf {
+  std::env::var_os("CLAPKIT_TEST_MODELS").map_or_else(
+    || {
+      PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("Models")
+        .join("clapkit")
+    },
+    PathBuf::from,
+  )
+}
+
+/// A deterministic 48 kHz mono window: a sum of a few fixed sinusoids (no RNG),
+/// giving both towers a stable, non-trivial input. Mirrors
+/// `tests/clap/common::deterministic_window` (unreachable from a bench crate).
+fn deterministic_window(len: usize) -> Vec<f32> {
+  const SR: f32 = 48_000.0;
+  (0..len)
+    .map(|i| {
+      let t = i as f32 / SR;
+      let two_pi = std::f32::consts::TAU;
+      0.5 * (two_pi * 220.0 * t).sin()
+        + 0.3 * (two_pi * 440.0 * t).sin()
+        + 0.2 * (two_pi * 1760.0 * t).sin()
+    })
+    .collect()
+}

--- a/crates/coremlit/conversion/clap/README.md
+++ b/crates/coremlit/conversion/clap/README.md
@@ -11,8 +11,18 @@ scratchpad locations and must be adapted to re-run.
   `8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a`.
 - **Distributed CoreML artifacts:**
   [`FinDIT-Studio/clapkit-coreml`](https://huggingface.co/FinDIT-Studio/clapkit-coreml),
-  revision `97d631f3814e1e46b798a8e88c9aa2e2202fdf67` (fp16). Pinned in
-  `tests/clap/model_io.rs` / `tests/clap/text_model_io.rs` (SHA-256 + shapes).
+  revision `02a99c6a8be21da1e9a947499ea503a10c80c4f1` — ships both the **fp16**
+  tier (byte-identical to the original fp16-only publication
+  `97d631f3814e1e46b798a8e88c9aa2e2202fdf67`) and the 2×-smaller **int8** tier
+  (`clap_{audio,text}_int8.mlmodelc`). Fetch at the immutable revision (never
+  mutable `main`):
+  ```sh
+  hf download FinDIT-Studio/clapkit-coreml \
+    --revision 02a99c6a8be21da1e9a947499ea503a10c80c4f1 \
+    --local-dir Models/clapkit
+  ```
+  Every artifact file's SHA-256 (both tiers) + I/O shapes are pinned in
+  `tests/clap/model_io.rs` / `tests/clap/text_model_io.rs`.
 - **Toolchain (pinned):** coremltools 9.0 · torch 2.5.1 · transformers 5.14.0 ·
   numpy 1.26.4 · python 3.11.15.
 

--- a/crates/coremlit/src/embeddings/clap/audio/mod.rs
+++ b/crates/coremlit/src/embeddings/clap/audio/mod.rs
@@ -30,6 +30,23 @@ mod names {
 /// CoreML falls back to GPU/CPU (fp16-clean there); the text graph does compile
 /// for the ANE. `All` is the honest default — it never *asserts* ANE residency,
 /// which `tests/clap/placement.rs` characterizes rather than claims.
+///
+/// The issue #30 perf pass (the `clap_encode` bench) measured every placement and
+/// **kept** `All` here — unlike the text tower, no non-`All` unit clears the
+/// meaningful-speedup bar. Warm-median latency (Apple M1 Max, macOS 26.5 25F71,
+/// fp16, 25 runs × 3 sweeps): `CpuAndGpu` ~44.2 ms, `All` ~48.6 ms, `CpuOnly`
+/// ~47.8 ms, `CpuAndNeuralEngine` ~120.6 ms. `CpuAndGpu` is only ~9 % faster than
+/// `All` (below the ~15 % threshold a default change would need), `All`/`CpuOnly`
+/// are within noise, and naming the ANE is ~2.5× *slower* (the HTSAT `ANECCompile`
+/// fallback thrash). So `All` stays the default.
+///
+/// One honest caveat the bench also surfaced: because `All` names the ANE, every
+/// *load* re-attempts the HTSAT `ANECCompile` (which fails and falls back), a
+/// ~1.5–2 s cost `CpuAndGpu` skips entirely (it loads in ~0.1 s). Since the crate
+/// mandates construct-once / reuse / prewarm, that load is paid once and does not
+/// touch per-request latency — but a load-latency-sensitive caller can pin
+/// [`AudioEncoderOptions::with_compute`]`(ComputeUnits::CpuAndGpu)` for the faster
+/// load (and ~9 % warm win) at identical parity.
 pub const DEFAULT_AUDIO_COMPUTE: ComputeUnits = ComputeUnits::All;
 
 #[cfg(feature = "serde")]
@@ -260,6 +277,38 @@ impl AudioEncoder {
       out.push(WindowEmbedding::new(embedding, span));
     }
     Ok(out)
+  }
+
+  /// Runs one throwaway [`Self::embed_window`] to fully specialize the prediction
+  /// path, so the first user-facing request is warm.
+  ///
+  /// Construction ([`Self::from_file`] &c.) already pays the model *load* /
+  /// device specialization; what it does **not** pay is the first prediction's
+  /// own graph specialization. The `clap_encode` bench measures that first
+  /// inference at several times the warm latency (e.g. ~200 ms first vs ~48 ms
+  /// warm on `All`), so calling `prewarm` once — after construction, before
+  /// serving — moves that one-time cost off the first real clip. Then **reuse**
+  /// this same encoder for every request (it is `&self`, so it stays resident and
+  /// there is nothing to reconstruct).
+  ///
+  /// This is the whole prewarm delta over the construct-once-and-reuse pattern:
+  /// the load is the constructor's job, and this is deliberately *only* the dummy
+  /// inference the reuse pattern otherwise leaves for the first live request. The
+  /// warm-up runs a fixed synthetic 1 s tone (`repeatpad`ed to the fixed window),
+  /// so it neither reads caller audio nor allocates a full-window buffer up front.
+  ///
+  /// # Errors
+  /// As [`Self::embed_window`]; a failure here surfaces a broken model at prewarm
+  /// time rather than on the first request.
+  pub fn prewarm(&self) -> Result<()> {
+    const SR: f32 = 48_000.0;
+    // 1 s of a fixed 440 Hz tone: a valid, non-silent window (avoids the
+    // zero-magnitude path) that `embed_window` `repeatpad`s to the full window.
+    let signal: Vec<f32> = (0..48_000)
+      .map(|i| 0.5 * (std::f32::consts::TAU * 440.0 * (i as f32 / SR)).sin())
+      .collect();
+    self.embed_window(&signal)?;
+    Ok(())
   }
 }
 

--- a/crates/coremlit/src/embeddings/clap/mod.rs
+++ b/crates/coremlit/src/embeddings/clap/mod.rs
@@ -60,8 +60,69 @@
 //! Placement is characterized, not asserted (`tests/clap/placement.rs`). As converted
 //! (T1), the **audio** (HTSAT Swin) graph does **not** compile for the ANE and
 //! falls back to GPU/CPU; the **text** (RoBERTa) graph does compile for the ANE.
-//! [`crate::ComputeUnits::All`] lets CoreML schedule either way; the crate
-//! never claims ANE residency for the audio tower.
+//! The crate never claims ANE residency for the audio tower.
+//!
+//! The per-tower **defaults are measure-then-pin** (the `clap_encode` bench, issue
+//! #30): the **audio** default is [`crate::ComputeUnits::All`] (no non-`All` unit
+//! is meaningfully faster — see [`audio::DEFAULT_AUDIO_COMPUTE`]); the **text**
+//! default is [`crate::ComputeUnits::CpuAndGpu`], ~43 % faster warm than `All`
+//! because the tiny text graph pays ANE-dispatch overhead on `All` (see
+//! [`text::DEFAULT_TEXT_COMPUTE`]). Both stay overridable per encoder via
+//! `with_compute` / `set_compute`; the full latency × placement table lives in
+//! `tests/clap/placement.rs` and is reproduced by the bench.
+//!
+//! # Performance: construct once, reuse, prewarm (measured, never marketed)
+//!
+//! The committed `clap_encode` bench (`benches/clap/encode.rs`) separates the four
+//! cost phases per tower × placement, model-gated. Regenerate with
+//! `CLAPKIT_TEST_MODELS=… cargo bench -p coremlit --features clap --bench clap_encode`
+//! (the numbers below are Apple M1 Max / macOS 26.5, fp16 — the bench is the
+//! reproducible source of truth, not this prose).
+//!
+//! **Construct each encoder once and reuse it.** An [`AudioEncoder`] /
+//! [`TextEncoder`] loads its CoreML model at construction and reuses that one
+//! resident [`crate::Model`] across every `embed*` call (`&self` inference, no
+//! per-call load). Reconstructing per request would re-pay the whole load below —
+//! don't.
+//!
+//! **Prewarm before the first user-facing request.** Construction pays the model
+//! *load* / device specialization, but the *first* `embed` still pays the
+//! prediction path's own graph specialization — measured at several × the warm
+//! latency (audio ~200 ms first vs ~48 ms warm; text ~120 ms first vs ~17 ms
+//! warm). [`AudioEncoder::prewarm`] / [`TextEncoder::prewarm`] run one throwaway
+//! inference to absorb that up front, so the first real request is warm. The
+//! recipe:
+//!
+//! ```no_run
+//! # use coremlit::embeddings::clap::{AudioEncoder, TextEncoder};
+//! # fn demo(audio_path: &str, text_path: &str) -> Result<(), coremlit::embeddings::clap::Error> {
+//! let audio = AudioEncoder::from_file(audio_path)?; // load (one-time)
+//! let text = TextEncoder::from_file(text_path)?;
+//! audio.prewarm()?; // absorb first-inference specialization before serving
+//! text.prewarm()?;
+//! // …reuse `audio` / `text` for every request from here on.
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! **Cold vs cached load (the one-time specialization).** The first-ever load of
+//! these graphs on a given device pays a large **one-time** OS specialization cost
+//! (the #30 audit measured ~24.2 s audio / ~7.25 s text on `All`, vs sub-second
+//! for the ONNX reference). It is cached thereafter: on an already-specialized
+//! host every later process start is fast (measured cached loads: text ~0.3–0.7 s,
+//! audio ~0.05–0.16 s on `CpuOnly`/`CpuAndGpu`), and the specialization survives
+//! process restarts — clearing the ANE (`e5rt`) cache barely moved load time
+//! (audio-`All` 2.0 s → 2.3 s, text-`All` 0.28 s → 0.34 s), so the bulk of it is
+//! cached outside that ANE cache and persists. Net: budget the one-time
+//! specialization at install/first-run, and prewarm at process start so the
+//! steady-state cached-load + warm-inference path is what users actually hit.
+//! (The audio tower's ANE-naming placements re-attempt the failing HTSAT
+//! `ANECCompile` on *every* load — see [`audio::DEFAULT_AUDIO_COMPUTE`] — an
+//! `All`-only load cost, not a per-request one.)
+//!
+//! **int8 is a size tier, not a speed tier.** Its weight-only quantization keeps
+//! the fp16 activations, so it is not faster (the audit measured text ~21 %
+//! *slower*); use it to halve on-disk / weight memory, not to cut latency.
 //!
 //! # Long-audio pipeline
 //!

--- a/crates/coremlit/src/embeddings/clap/mod.rs
+++ b/crates/coremlit/src/embeddings/clap/mod.rs
@@ -19,12 +19,30 @@
 //!
 //! # Model artifacts
 //!
-//! The two CoreML graphs are distributed on the Hugging Face Hub at
+//! The CoreML graphs are distributed on the Hugging Face Hub at
 //! [`FinDIT-Studio/clapkit-coreml`](https://huggingface.co/FinDIT-Studio/clapkit-coreml),
-//! revision `97d631f3814e1e46b798a8e88c9aa2e2202fdf67` (fp16, converted from
+//! revision `02a99c6a8be21da1e9a947499ea503a10c80c4f1` (converted from
 //! `laion/clap-htsat-unfused` — **CC-BY-4.0**, attribution required; see the
-//! crate `NOTICE`). They are gitignored dev-time downloads under
-//! `Models/clapkit/`; their SHA-256 and I/O contracts are pinned by
+//! crate `NOTICE`). That revision ships **two tiers**, both loaded through the
+//! same encoders (identical I/O contract; pick per tower at load time):
+//!
+//! - **fp16** (`clap_audio.mlmodelc` / `clap_text.mlmodelc`) — the validated,
+//!   shipped default; every parity / placement / e2e gate runs on it.
+//! - **int8** (`clap_audio_int8.mlmodelc` / `clap_text_int8.mlmodelc`) — a
+//!   2×-smaller **opt-in** tier, measured-parity-clean per the int8 gates in
+//!   `tests/clap/`. (The per-tower production default is the owner's decision;
+//!   this crate records only that fp16 is validated and int8 is opt-in.)
+//!
+//! They are gitignored dev-time downloads under `Models/clapkit/`, fetched at the
+//! immutable revision (never mutable `main`):
+//!
+//! ```text
+//! hf download FinDIT-Studio/clapkit-coreml \
+//!   --revision 02a99c6a8be21da1e9a947499ea503a10c80c4f1 \
+//!   --local-dir Models/clapkit
+//! ```
+//!
+//! Every artifact file's SHA-256 and the I/O contracts are pinned by
 //! `tests/clap/model_io.rs` / `tests/clap/text_model_io.rs`.
 //!
 //! # Encoder split: Rust front-ends around fp16 CoreML graphs

--- a/crates/coremlit/src/embeddings/clap/text/mod.rs
+++ b/crates/coremlit/src/embeddings/clap/text/mod.rs
@@ -26,10 +26,30 @@ mod names {
 /// so they can never index past the position table.
 pub const TEXT_MAX_TOKENS: usize = 512;
 
-/// Default [`TextEncoderOptions::compute`]. [`ComputeUnits::All`]. As converted
-/// (T1), the RoBERTa text graph **does** compile for the ANE (unlike the audio
-/// graph); placement is still characterized, not asserted (`tests/clap/placement.rs`).
-pub const DEFAULT_TEXT_COMPUTE: ComputeUnits = ComputeUnits::All;
+/// Default [`TextEncoderOptions::compute`]: [`ComputeUnits::CpuAndGpu`] — a
+/// **measure-then-pin** default, moved off `All` by the issue #30 perf pass (the
+/// committed `clap_encode` bench, `benches/clap/encode.rs`).
+///
+/// The RoBERTa text graph is tiny (a fixed `[1, 512]` window). On `All`, CoreML
+/// pulls the ANE into the schedule, and for a graph this small the per-dispatch
+/// coordination cost dominates the actual compute — so `All` is *slower* than
+/// scheduling on the GPU alone. Measured **warm-median** latency (Apple M1 Max,
+/// macOS 26.5 25F71, fp16, 25 runs, consistent across 3 sweeps):
+///
+/// | unit                      | warm median | cosine vs `CpuOnly` |
+/// |---------------------------|-------------|---------------------|
+/// | `CpuAndGpu` (new default) | ~16.8 ms    | 0.999956            |
+/// | `CpuAndNeuralEngine`      | ~28.6 ms    | 0.999950            |
+/// | `All` (former default)    | ~29.7 ms    | 0.999947            |
+/// | `CpuOnly`                 | ~42.1 ms    | 1.000000 (ref)      |
+///
+/// `CpuAndGpu` is ~43 % faster than the former `All` default and holds the
+/// cross-placement parity floor the `tests/clap/placement.rs` gate pins (0.9999).
+/// Only the *default* moves — every unit stays selectable via
+/// [`TextEncoderOptions::with_compute`] / [`TextEncoderOptions::set_compute`]
+/// (`All` and `CpuOnly` remain parity-clean). The text graph **does** compile for
+/// the ANE (unlike the audio graph); placement is characterized, not asserted.
+pub const DEFAULT_TEXT_COMPUTE: ComputeUnits = ComputeUnits::CpuAndGpu;
 
 #[cfg(feature = "serde")]
 fn default_text_compute() -> ComputeUnits {
@@ -279,6 +299,31 @@ impl TextEncoder {
     // (`NonFiniteEmbedding`).
     check_finite_output(&row)?;
     Embedding::from_slice_normalizing(&row)
+  }
+
+  /// Runs one throwaway [`Self::embed`] to fully specialize the prediction path,
+  /// so the first user-facing request is warm.
+  ///
+  /// Construction ([`Self::from_file`] &c.) already pays the model *load* /
+  /// device specialization; what it does **not** pay is the first prediction's
+  /// own graph specialization. The `clap_encode` bench measures that first
+  /// inference at several times the warm latency (e.g. ~120 ms first vs ~17 ms
+  /// warm on `CpuAndGpu`), so calling `prewarm` once — after construction, before
+  /// serving — moves that one-time cost off the first real query. Then **reuse**
+  /// this same encoder for every request (it is `&self`, so it stays resident and
+  /// there is nothing to reconstruct).
+  ///
+  /// This is the whole prewarm delta over the construct-once-and-reuse pattern:
+  /// the load is the constructor's job, and this is deliberately *only* the dummy
+  /// inference the reuse pattern otherwise leaves for the first live request.
+  ///
+  /// # Errors
+  /// As [`Self::embed`] (the warm-up query is a fixed non-empty string, so the
+  /// empty-text path cannot fire); a failure here surfaces a broken model at
+  /// prewarm time rather than on the first request.
+  pub fn prewarm(&self) -> Result<()> {
+    self.embed("warmup")?;
+    Ok(())
   }
 }
 

--- a/crates/coremlit/src/embeddings/clap/text/tests.rs
+++ b/crates/coremlit/src/embeddings/clap/text/tests.rs
@@ -6,7 +6,11 @@ use super::*;
 fn options_default_equals_new() {
   assert_eq!(TextEncoderOptions::default(), TextEncoderOptions::new());
   assert_eq!(TextEncoderOptions::new().compute(), DEFAULT_TEXT_COMPUTE);
-  assert_eq!(DEFAULT_TEXT_COMPUTE, ComputeUnits::All);
+  // Measure-then-pin default: moved off `All` to `CpuAndGpu` by the #30 perf pass
+  // (the tiny RoBERTa graph pays ANE dispatch overhead on `All`; `CpuAndGpu` is
+  // ~43% faster warm and holds the placement parity floor — see the const's docs
+  // and `benches/clap/encode.rs`).
+  assert_eq!(DEFAULT_TEXT_COMPUTE, ComputeUnits::CpuAndGpu);
 }
 
 #[test]

--- a/crates/coremlit/tests/clap/common/mod.rs
+++ b/crates/coremlit/tests/clap/common/mod.rs
@@ -1,9 +1,10 @@
 //! Shared helpers for clapkit's model-gated integration tests.
 //!
-//! The CoreML artifacts (`clap_audio.mlmodelc` / `clap_text.mlmodelc`) are
-//! gitignored dev-time downloads from `FinDIT-Studio/clapkit-coreml`
-//! (revision `97d631f3814e1e46b798a8e88c9aa2e2202fdf67`). Model-gated tests are
-//! `#[ignore]` by default and run only when the tree is present.
+//! The CoreML artifacts (fp16 `clap_{audio,text}.mlmodelc` + int8
+//! `clap_{audio,text}_int8.mlmodelc`) are gitignored dev-time downloads from
+//! `FinDIT-Studio/clapkit-coreml` (revision
+//! `02a99c6a8be21da1e9a947499ea503a10c80c4f1`). Model-gated tests are `#[ignore]`
+//! by default and run only when the tree is present.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/coremlit/tests/clap/common/mod.rs
+++ b/crates/coremlit/tests/clap/common/mod.rs
@@ -133,6 +133,72 @@ pub fn sha256_hex(path: &Path) -> String {
     .collect()
 }
 
+/// Assert that the compiled-model bundle at `dir` matches an EXACT pinned
+/// manifest. `cases` is the pinned `(relative_path, sha256)` list.
+///
+/// Two gates, both of which must hold:
+/// 1. **Exact membership** — the set of relative paths of every FILE under `dir`
+///    (recursively) must equal the set of `cases` keys, so a **missing** artifact
+///    AND an **added** one both red (hashing a fixed named list alone would let a
+///    newly-added file slip through unnoticed — the gap this closes).
+/// 2. **Content** — each file's SHA-256 must equal its pinned value.
+///
+/// Uses a `std`-only recursive walk (no `walkdir` dependency); relative paths are
+/// forward-slash joined to match the pinned keys (e.g. `weights/weight.bin`).
+#[allow(dead_code)]
+pub fn assert_exact_sha_manifest(dir: &Path, cases: &[(&str, &str)]) {
+  use std::collections::BTreeSet;
+
+  // Recursively collect the forward-slash relative path of every FILE under
+  // `dir` (nested dirs such as `analytics/` and `weights/` are walked; only the
+  // files they contain become entries).
+  fn collect_files(dir: &Path, prefix: &str, out: &mut Vec<String>) {
+    let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {dir:?}: {e}"));
+    for entry in entries {
+      let entry = entry.unwrap_or_else(|e| panic!("dir entry under {dir:?}: {e}"));
+      let name = entry.file_name().to_string_lossy().into_owned();
+      let rel = if prefix.is_empty() {
+        name
+      } else {
+        format!("{prefix}/{name}")
+      };
+      let file_type = entry
+        .file_type()
+        .unwrap_or_else(|e| panic!("file_type {:?}: {e}", entry.path()));
+      if file_type.is_dir() {
+        collect_files(&entry.path(), &rel, out);
+      } else {
+        out.push(rel);
+      }
+    }
+  }
+
+  let mut found = Vec::new();
+  collect_files(dir, "", &mut found);
+  let on_disk: BTreeSet<String> = found.into_iter().collect();
+  let pinned: BTreeSet<String> = cases.iter().map(|(rel, _)| (*rel).to_owned()).collect();
+
+  if on_disk != pinned {
+    let missing: Vec<&String> = pinned.difference(&on_disk).collect();
+    let extra: Vec<&String> = on_disk.difference(&pinned).collect();
+    panic!(
+      "artifact manifest mismatch under {dir:?}:\n  \
+       missing (pinned but not on disk): {missing:?}\n  \
+       extra (on disk but not pinned): {extra:?}\n  \
+       if the bundle changed intentionally, update the pinned `cases` list AND \
+       the doc SHA table"
+    );
+  }
+
+  for (relative, expected) in cases {
+    let actual = sha256_hex(&dir.join(relative));
+    assert_eq!(
+      &actual, expected,
+      "sha256 drift on artifact {relative} under {dir:?}"
+    );
+  }
+}
+
 /// A deterministic 48 kHz mono window of `len` samples: a sum of a few fixed
 /// sinusoids (no RNG dependency), for placement/agreement tests that only need a
 /// stable, non-trivial input to compare across compute units.

--- a/crates/coremlit/tests/clap/e2e.rs
+++ b/crates/coremlit/tests/clap/e2e.rs
@@ -125,6 +125,39 @@ fn multi_minute_pipeline_int8_pins_top_label() {
   run_pipeline_and_pin(&audio, &text, "int8", TOP_SCORE_INT8_LO, TOP_SCORE_INT8_HI);
 }
 
+/// The documented prewarm/reuse path (issue #30 perf pass): constructing an
+/// encoder pays the load, [`AudioEncoder::prewarm`] / [`TextEncoder::prewarm`]
+/// absorb the first-inference specialization, and the SAME encoder is then reused
+/// for real requests. Pins that prewarm succeeds on both towers and leaves each
+/// encoder fully usable (a real `embed*` after prewarm returns a valid unit
+/// embedding).
+#[test]
+#[ignore = "requires clapkit models (CLAPKIT_TEST_MODELS)"]
+fn prewarm_then_reuse_both_towers() {
+  let audio = AudioEncoder::from_file(common::audio_model_path()).unwrap();
+  let text = TextEncoder::from_file(common::text_model_path()).unwrap();
+
+  audio.prewarm().expect("audio prewarm");
+  text.prewarm().expect("text prewarm");
+
+  // Reuse after prewarm: both encoders still produce valid unit-norm embeddings.
+  let window = common::deterministic_window(coremlit::embeddings::clap::audio::TARGET_SAMPLES);
+  let a = audio
+    .embed_window(&window)
+    .expect("audio embed after prewarm");
+  let t = text
+    .embed("a violin playing a slow melody")
+    .expect("text embed after prewarm");
+  assert!(
+    (a.cosine(&a) - 1.0).abs() <= 1e-5,
+    "audio embedding is unit-norm after prewarm"
+  );
+  assert!(
+    (t.cosine(&t) - 1.0).abs() <= 1e-5,
+    "text embedding is unit-norm after prewarm"
+  );
+}
+
 /// Drive the full long-audio pipeline for one tier and pin the geometry, the
 /// aggregate self-consistency, the top zero-shot label, and the top logit band.
 fn run_pipeline_and_pin(

--- a/crates/coremlit/tests/clap/e2e.rs
+++ b/crates/coremlit/tests/clap/e2e.rs
@@ -32,6 +32,14 @@ const TOP_SCORE_LO: f32 = 8.3;
 const TOP_SCORE_HI: f32 = 9.3;
 const AGG_SELF_COSINE_LO: f32 = 0.97;
 
+// int8 tier (opt-in): same DECISION (top label unchanged), top logit pinned in an
+// int8-specific two-sided band around the measured 8.880292 (measured LOCALLY
+// 2026-07-19 on artifact `clapkit-coreml@02a99c6a`; matches issue #30's 8.885357).
+// The window geometry and aggregate self-consistency are tier-agnostic and reuse
+// the fp16 pins above.
+const TOP_SCORE_INT8_LO: f32 = 8.4;
+const TOP_SCORE_INT8_HI: f32 = 9.4;
+
 // The canonical CLAP zero-shot prompt template ("This is a sound of {label}",
 // used by LAION/HF's own zero-shot-audio-classification examples). With bare
 // nouns the audio↔text cosines are tiny and speech/music rank ambiguously; the
@@ -53,8 +61,49 @@ fn tiled_speech_clip() -> Vec<f32> {
   clip
 }
 
+/// Cosine of two unit-norm embeddings (== dot product), **fail-closed**: a
+/// length mismatch (`zip` would silently truncate) or any non-finite input/output
+/// panics rather than returning a wrong-but-finite / NaN value that a downstream
+/// comparison could pass blindly. Same guard as the parity reducer
+/// (`tests/clap/parity_textclap.rs`); the inputs are L2-normalized embeddings so
+/// cosine == the raw dot product — that contract is unchanged.
 fn cosine(a: &[f32], b: &[f32]) -> f32 {
-  a.iter().zip(b).map(|(x, y)| x * y).sum()
+  assert_eq!(
+    a.len(),
+    b.len(),
+    "cosine operands differ in length: {} vs {}",
+    a.len(),
+    b.len()
+  );
+  assert!(
+    a.iter().chain(b).all(|v| v.is_finite()),
+    "cosine operand contains a non-finite value (NaN/inf) — the reducer must fail closed"
+  );
+  let c: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+  assert!(c.is_finite(), "cosine produced a non-finite value: {c}");
+  c
+}
+
+/// Fail-closed proof (HERMETIC — no model, runs in the default `cargo test` under
+/// the `clap` feature): a `NaN` operand must PANIC, not slip through the
+/// self-consistency check. Removing the finite guard reds this test.
+#[test]
+#[should_panic(expected = "non-finite")]
+fn cosine_rejects_non_finite_operand() {
+  let a = [f32::NAN, 0.0, 0.0];
+  let b = [1.0, 0.0, 0.0];
+  let _ = cosine(&a, &b);
+}
+
+/// Fail-closed proof (HERMETIC): mismatched operand lengths must PANIC rather
+/// than let `zip` truncate to the shorter side. Removing the length assertion
+/// reds this test.
+#[test]
+#[should_panic(expected = "differ in length")]
+fn cosine_rejects_length_mismatch() {
+  let a = [1.0, 0.0, 0.0];
+  let b = [1.0, 0.0];
+  let _ = cosine(&a, &b);
 }
 
 #[test]
@@ -62,13 +111,36 @@ fn cosine(a: &[f32], b: &[f32]) -> f32 {
 fn multi_minute_pipeline_pins_windows_aggregate_and_top_label() {
   let audio = AudioEncoder::from_file(common::audio_model_path()).unwrap();
   let text = TextEncoder::from_file(common::text_model_path()).unwrap();
+  run_pipeline_and_pin(&audio, &text, "fp16", TOP_SCORE_LO, TOP_SCORE_HI);
+}
+
+/// int8 tier (opt-in): the SAME multi-minute pipeline with the int8 encoders. The
+/// DECISION (top zero-shot label) must be unchanged and the top logit lands in the
+/// int8-specific band; window geometry / aggregate coherence are tier-agnostic.
+#[test]
+#[ignore = "requires clapkit int8 models (CLAPKIT_TEST_MODELS)"]
+fn multi_minute_pipeline_int8_pins_top_label() {
+  let audio = AudioEncoder::from_file(common::audio_model_int8_path()).unwrap();
+  let text = TextEncoder::from_file(common::text_model_int8_path()).unwrap();
+  run_pipeline_and_pin(&audio, &text, "int8", TOP_SCORE_INT8_LO, TOP_SCORE_INT8_HI);
+}
+
+/// Drive the full long-audio pipeline for one tier and pin the geometry, the
+/// aggregate self-consistency, the top zero-shot label, and the top logit band.
+fn run_pipeline_and_pin(
+  audio: &AudioEncoder,
+  text: &TextEncoder,
+  tier: &str,
+  top_score_lo: f32,
+  top_score_hi: f32,
+) {
   let clip = tiled_speech_clip();
 
   // 1. Plan → 2. per-window embeddings (always exposed to the caller).
   let plan = WindowPlan::new(); // no overlap, keep the padded tail
   let windows = audio.embed_windows(&clip, &plan).unwrap();
   println!(
-    "[e2e] {} windows over {} samples",
+    "[e2e/{tier}] {} windows over {} samples",
     windows.len(),
     clip.len()
   );
@@ -93,7 +165,7 @@ fn multi_minute_pipeline_pins_windows_aggregate_and_top_label() {
   let norm_sq: f32 = clip_embedding.as_slice().iter().map(|x| x * x).sum();
   assert!((norm_sq - 1.0).abs() < 1e-5, "aggregate not unit-norm");
   let self_cos = cosine(clip_embedding.as_slice(), windows[0].embedding().as_slice());
-  println!("[e2e] aggregate↔window[0] cosine = {self_cos:.6}");
+  println!("[e2e/{tier}] aggregate↔window[0] cosine = {self_cos:.6}");
   assert!(
     self_cos >= AGG_SELF_COSINE_LO,
     "aggregate {self_cos:.6} diverged from its windows (below {AGG_SELF_COSINE_LO})"
@@ -112,14 +184,14 @@ fn multi_minute_pipeline_pins_windows_aggregate_and_top_label() {
     .collect();
   let ranked = score(&clip_embedding, &anchors, ScoreMode::LogitScaled);
   for r in &ranked {
-    println!("[e2e] {:<30} logit = {:.6}", r.label(), r.score());
+    println!("[e2e/{tier}] {:<30} logit = {:.6}", r.label(), r.score());
   }
 
   assert_eq!(ranked[0].label(), TOP_LABEL, "top zero-shot label drifted");
   let top = ranked[0].score();
   assert!(
-    (TOP_SCORE_LO..=TOP_SCORE_HI).contains(&top),
-    "top logit {top:.6} outside pinned band [{TOP_SCORE_LO}, {TOP_SCORE_HI}]"
+    (top_score_lo..=top_score_hi).contains(&top),
+    "top logit {top:.6} outside pinned band [{top_score_lo}, {top_score_hi}]"
   );
   // The decision is unambiguous: the speech anchor beats the runner-up.
   assert!(

--- a/crates/coremlit/tests/clap/model_io.rs
+++ b/crates/coremlit/tests/clap/model_io.rs
@@ -6,10 +6,12 @@
 //! # Artifact
 //!
 //! Source: [`FinDIT-Studio/clapkit-coreml`](https://huggingface.co/FinDIT-Studio/clapkit-coreml),
-//! revision (commit SHA) `97d631f3814e1e46b798a8e88c9aa2e2202fdf67`, converted
-//! by T1 from `laion/clap-htsat-unfused`
-//! (`@ 8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a`, fp16). Gitignored, fetched
-//! dev-time under `Models/clapkit/` (`CLAPKIT_TEST_MODELS`).
+//! revision (commit SHA) `02a99c6a8be21da1e9a947499ea503a10c80c4f1` — the current
+//! revision, which ships BOTH tiers: the **fp16** tier (converted by T1 from
+//! `laion/clap-htsat-unfused` `@ 8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a`,
+//! byte-identical to the original fp16-only publication
+//! `97d631f3814e1e46b798a8e88c9aa2e2202fdf67`) and the 2×-smaller **int8** tier.
+//! Gitignored, fetched dev-time under `Models/clapkit/` (`CLAPKIT_TEST_MODELS`).
 //!
 //! # License (load-bearing; owner to reconcile before the branch PR)
 //!
@@ -20,22 +22,32 @@
 //! source repo satisfies both, and reconciling the front-matter is an owner
 //! decision recorded here, not this crate's to make.
 //!
-//! # Per-file SHA-256 (pinned; `CHECKSUMS.sha256` on the HF revision)
+//! # Per-file SHA-256 (pinned; EVERY file in each `.mlmodelc`, from
+//! `CHECKSUMS.sha256` at revision `02a99c6a8be21da1e9a947499ea503a10c80c4f1`)
 //!
-//! fp16 (revision `97d631f3814e1e46b798a8e88c9aa2e2202fdf67`):
+//! Both tiers pin all five compiled-model files, so drift in ANY committed
+//! artifact byte (not just `model.mil` / `weight.bin`) reds. The fp16 bytes are
+//! unchanged from the original `97d631f3…` publication.
 //!
-//! | File | SHA-256 |
-//! |---|---|
-//! | `clap_audio.mlmodelc/model.mil` | `1ecf76edf7846153623485a98c0a3d047e660cc68ee10a6d21a39664d309db52` |
-//! | `clap_audio.mlmodelc/weights/weight.bin` | `723fe6aab7c4af1c671a210a35c289c67763bc6a7532b9df155a0c3fc0c3c9d7` |
-//!
-//! int8 (the quantized variant shipped at revision `02a99c6a`; same I/O
-//! contract, compressed weights):
+//! fp16 (`clap_audio.mlmodelc`):
 //!
 //! | File | SHA-256 |
 //! |---|---|
-//! | `clap_audio_int8.mlmodelc/model.mil` | `1cdbbcc0911e9a9d427119e182dc3efa93d90b7159a614d372d397aff7861bb1` |
-//! | `clap_audio_int8.mlmodelc/weights/weight.bin` | `b3a37ec5550dcdd6932b314b830275ebcba013748421e1a517760b9afeabafb8` |
+//! | `analytics/coremldata.bin` | `29fbf161ab063c891080f328de0ee4ed80fdbaef4b5d36c4086c38da582aa7c4` |
+//! | `coremldata.bin` | `652c4652d19b4a7e926468e14582442f047389145576827068f6ae47f97ebb3e` |
+//! | `metadata.json` | `44ea8733243b41a005a6aa25144fbde165c5e3f80ede79889f2d039da6a65ec4` |
+//! | `model.mil` | `1ecf76edf7846153623485a98c0a3d047e660cc68ee10a6d21a39664d309db52` |
+//! | `weights/weight.bin` | `723fe6aab7c4af1c671a210a35c289c67763bc6a7532b9df155a0c3fc0c3c9d7` |
+//!
+//! int8 (`clap_audio_int8.mlmodelc`; the 2×-smaller variant, same I/O contract):
+//!
+//! | File | SHA-256 |
+//! |---|---|
+//! | `analytics/coremldata.bin` | `4455479a6d65004fe95d582246675cc9167c0b8fb6e0e673ad9db4009c0443de` |
+//! | `coremldata.bin` | `4bee9628bdf8821a391b32a7d23967c3c6712ae72088a318266583f35743ac33` |
+//! | `metadata.json` | `c5c466395cfb5a58ae9ed6f44e208492c59c6a1a245919928d08d87a8ffcf964` |
+//! | `model.mil` | `1cdbbcc0911e9a9d427119e182dc3efa93d90b7159a614d372d397aff7861bb1` |
+//! | `weights/weight.bin` | `b3a37ec5550dcdd6932b314b830275ebcba013748421e1a517760b9afeabafb8` |
 //!
 //! # Contract (matches the spec table and T1's I/O record)
 //!
@@ -76,7 +88,21 @@ fn clap_audio_io_matches_spec() {
 #[ignore = "requires local clapkit models (CLAPKIT_TEST_MODELS)"]
 fn clap_audio_artifacts_match_pinned_sha256() {
   let dir = common::audio_model_path();
+  // EVERY file in the `.mlmodelc` (per `CHECKSUMS.sha256` @ 02a99c6a), not just
+  // model.mil + weight.bin — drift in any committed byte reds.
   let cases = [
+    (
+      "analytics/coremldata.bin",
+      "29fbf161ab063c891080f328de0ee4ed80fdbaef4b5d36c4086c38da582aa7c4",
+    ),
+    (
+      "coremldata.bin",
+      "652c4652d19b4a7e926468e14582442f047389145576827068f6ae47f97ebb3e",
+    ),
+    (
+      "metadata.json",
+      "44ea8733243b41a005a6aa25144fbde165c5e3f80ede79889f2d039da6a65ec4",
+    ),
     (
       "model.mil",
       "1ecf76edf7846153623485a98c0a3d047e660cc68ee10a6d21a39664d309db52",
@@ -118,7 +144,20 @@ fn clap_audio_int8_io_matches_spec() {
 #[ignore = "requires local clapkit int8 models (CLAPKIT_TEST_MODELS)"]
 fn clap_audio_int8_artifacts_match_pinned_sha256() {
   let dir = common::audio_model_int8_path();
+  // EVERY file in the int8 `.mlmodelc` (per `CHECKSUMS.sha256` @ 02a99c6a).
   let cases = [
+    (
+      "analytics/coremldata.bin",
+      "4455479a6d65004fe95d582246675cc9167c0b8fb6e0e673ad9db4009c0443de",
+    ),
+    (
+      "coremldata.bin",
+      "4bee9628bdf8821a391b32a7d23967c3c6712ae72088a318266583f35743ac33",
+    ),
+    (
+      "metadata.json",
+      "c5c466395cfb5a58ae9ed6f44e208492c59c6a1a245919928d08d87a8ffcf964",
+    ),
     (
       "model.mil",
       "1cdbbcc0911e9a9d427119e182dc3efa93d90b7159a614d372d397aff7861bb1",

--- a/crates/coremlit/tests/clap/model_io.rs
+++ b/crates/coremlit/tests/clap/model_io.rs
@@ -88,8 +88,10 @@ fn clap_audio_io_matches_spec() {
 #[ignore = "requires local clapkit models (CLAPKIT_TEST_MODELS)"]
 fn clap_audio_artifacts_match_pinned_sha256() {
   let dir = common::audio_model_path();
-  // EVERY file in the `.mlmodelc` (per `CHECKSUMS.sha256` @ 02a99c6a), not just
-  // model.mil + weight.bin — drift in any committed byte reds.
+  // The EXACT pinned manifest: every file in the `.mlmodelc` (per
+  // `CHECKSUMS.sha256` @ 02a99c6a), not just model.mil + weight.bin. The helper
+  // enumerates the bundle and set-compares against these keys before hashing, so
+  // an ADDED or REMOVED artifact reds as well as any byte drift.
   let cases = [
     (
       "analytics/coremldata.bin",
@@ -112,13 +114,7 @@ fn clap_audio_artifacts_match_pinned_sha256() {
       "723fe6aab7c4af1c671a210a35c289c67763bc6a7532b9df155a0c3fc0c3c9d7",
     ),
   ];
-  for (relative, expected) in cases {
-    let actual = common::sha256_hex(&dir.join(relative));
-    assert_eq!(
-      actual, expected,
-      "sha256 drift on audio artifact {relative}"
-    );
-  }
+  common::assert_exact_sha_manifest(&dir, &cases);
 }
 
 #[test]
@@ -144,7 +140,9 @@ fn clap_audio_int8_io_matches_spec() {
 #[ignore = "requires local clapkit int8 models (CLAPKIT_TEST_MODELS)"]
 fn clap_audio_int8_artifacts_match_pinned_sha256() {
   let dir = common::audio_model_int8_path();
-  // EVERY file in the int8 `.mlmodelc` (per `CHECKSUMS.sha256` @ 02a99c6a).
+  // The EXACT pinned manifest for the int8 `.mlmodelc` (per `CHECKSUMS.sha256` @
+  // 02a99c6a); the helper enumerates + set-compares before hashing, so a
+  // missing/added artifact reds too.
   let cases = [
     (
       "analytics/coremldata.bin",
@@ -167,11 +165,5 @@ fn clap_audio_int8_artifacts_match_pinned_sha256() {
       "b3a37ec5550dcdd6932b314b830275ebcba013748421e1a517760b9afeabafb8",
     ),
   ];
-  for (relative, expected) in cases {
-    let actual = common::sha256_hex(&dir.join(relative));
-    assert_eq!(
-      actual, expected,
-      "sha256 drift on audio int8 artifact {relative}"
-    );
-  }
+  common::assert_exact_sha_manifest(&dir, &cases);
 }

--- a/crates/coremlit/tests/clap/parity_textclap.rs
+++ b/crates/coremlit/tests/clap/parity_textclap.rs
@@ -29,6 +29,8 @@
 
 mod common;
 
+use std::path::Path;
+
 use coremlit::embeddings::clap::{AudioEncoder, TextEncoder};
 use textclap::{
   AudioEncoder as TcAudioEncoder, Options as TcOptions, TextEncoder as TcTextEncoder,
@@ -56,9 +58,77 @@ const AUDIO_FP32_HI: f32 = 1.0 + 1e-4;
 const TEXT_FP32_LO: f32 = 0.9998; // measured worst 0.99994940
 const TEXT_FP32_HI: f32 = 1.0 + 1e-4;
 
-/// Cosine of two unit-norm embeddings (== dot product).
+// ── int8 (2×-smaller opt-in tier) two-sided bands, same convention as the fp16
+//    bands above: pinned to clear the measured worst by ≥10× the ~1e-4 CoreML
+//    placement drift for the loose "quant" bands, and to sit just below the
+//    near-1.0 fp32-control worst for the "fp32" bands (HI = 1.0 + 1e-4). The int8
+//    CLAP encoder is compared to the SAME textclap ONNX oracles (quant + fp32) as
+//    fp16. Measured LOCALLY 2026-07-19 on artifact `clapkit-coreml@02a99c6a`
+//    (worst over the same windows/prompts); audio matches issue #30 exactly, text
+//    is within ~5e-4 of #30 (CoreML placement variance). A shift in EITHER
+//    direction is a finding — re-measure, do not just widen. ──
+const AUDIO_INT8_QUANT_LO: f32 = 0.9965; // measured worst 0.99801934 (#30: 0.99801934)
+const AUDIO_INT8_QUANT_HI: f32 = 0.9990;
+const TEXT_INT8_QUANT_LO: f32 = 0.9640; // measured worst 0.96874338 (CJK; #30: 0.96927553)
+const TEXT_INT8_QUANT_HI: f32 = 0.9745;
+const AUDIO_INT8_FP32_LO: f32 = 0.9997; // measured worst 0.99991775 (#30: 0.99991775)
+const AUDIO_INT8_FP32_HI: f32 = 1.0 + 1e-4;
+const TEXT_INT8_FP32_LO: f32 = 0.9990; // measured worst 0.99923772 (#30: 0.99924403)
+const TEXT_INT8_FP32_HI: f32 = 1.0 + 1e-4;
+
+/// Cosine of two unit-norm embeddings (== dot product), **fail-closed**.
+///
+/// The parity reducer folds these with `worst = worst.min(cos)` from `1.0`, and
+/// `f32::min` returns the *finite* operand when the other is `NaN` — so a single
+/// `NaN` cosine would leave `worst == 1.0` and silently GREEN a pinned band (the
+/// campaign's signature false-green). Likewise a bare `zip` silently truncates to
+/// the shorter operand, yielding a wrong-but-finite cosine. This guards both:
+///
+/// - equal length (no `zip` truncation),
+/// - every input element finite,
+/// - the result finite,
+///
+/// panicking otherwise. The inputs are L2-normalized embeddings, so cosine is the
+/// raw dot product — that contract is unchanged; only the guards are added.
 fn cosine(a: &[f32], b: &[f32]) -> f32 {
-  a.iter().zip(b).map(|(x, y)| x * y).sum()
+  assert_eq!(
+    a.len(),
+    b.len(),
+    "cosine operands differ in length: {} vs {}",
+    a.len(),
+    b.len()
+  );
+  assert!(
+    a.iter().chain(b).all(|v| v.is_finite()),
+    "cosine operand contains a non-finite value (NaN/inf) — the reducer must fail \
+     closed, not let `min` return the finite side and green a pinned band"
+  );
+  let c: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+  assert!(c.is_finite(), "cosine produced a non-finite value: {c}");
+  c
+}
+
+/// Fail-closed proof (HERMETIC — no model, runs in the default `cargo test`): a
+/// `NaN` operand must PANIC the reducer, not slip through. Guards the exact
+/// false-green above: without the finite check the `NaN` `cos` folds away under
+/// `worst.min(cos)` and the pinned band passes. Removing the guard reds this test.
+#[test]
+#[should_panic(expected = "non-finite")]
+fn cosine_rejects_non_finite_operand() {
+  let a = [f32::NAN, 0.0, 0.0];
+  let b = [1.0, 0.0, 0.0];
+  let _ = cosine(&a, &b);
+}
+
+/// Fail-closed proof (HERMETIC): mismatched operand lengths must PANIC rather
+/// than let `zip` truncate to the shorter side and return a wrong-but-finite
+/// cosine. Removing the length assertion reds this test.
+#[test]
+#[should_panic(expected = "differ in length")]
+fn cosine_rejects_length_mismatch() {
+  let a = [1.0, 0.0, 0.0];
+  let b = [1.0, 0.0];
+  let _ = cosine(&a, &b);
 }
 
 /// The audio windows fed to both crates: the whole JFK clip and two halves — all
@@ -92,8 +162,8 @@ fn textclap_onnx(file: &str) -> std::path::PathBuf {
 
 /// Run the audio per-window comparison against `onnx_file`, returning the worst
 /// (min) cosine over the windows. Prints each so the measurement is visible.
-fn audio_parity_worst(onnx_file: &str, tier: &str) -> f32 {
-  let clap = AudioEncoder::from_file(common::audio_model_path()).expect("load clapkit audio");
+fn audio_parity_worst(clap_model: &Path, onnx_file: &str, tier: &str) -> f32 {
+  let clap = AudioEncoder::from_file(clap_model).expect("load clapkit audio");
   let mut tc = TcAudioEncoder::from_file(textclap_onnx(onnx_file), TcOptions::new())
     .expect("load textclap audio ONNX");
   let samples = jfk_samples();
@@ -110,8 +180,8 @@ fn audio_parity_worst(onnx_file: &str, tier: &str) -> f32 {
 }
 
 /// Run the text comparison against `onnx_file`, returning the worst cosine.
-fn text_parity_worst(onnx_file: &str, tier: &str) -> f32 {
-  let clap = TextEncoder::from_file(common::text_model_path()).expect("load clapkit text");
+fn text_parity_worst(clap_model: &Path, onnx_file: &str, tier: &str) -> f32 {
+  let clap = TextEncoder::from_file(clap_model).expect("load clapkit text");
   let mut tc = TcTextEncoder::from_onnx_file(textclap_onnx(onnx_file), TcOptions::new())
     .expect("load textclap text ONNX");
   let mut worst = 1.0f32;
@@ -129,7 +199,11 @@ fn text_parity_worst(onnx_file: &str, tier: &str) -> f32 {
 #[test]
 #[ignore = "requires clapkit models (CLAPKIT_TEST_MODELS) + textclap quantized ONNX (CLAPKIT_TEXTCLAP_ONNX)"]
 fn audio_per_window_parity_vs_textclap_quantized() {
-  let worst = audio_parity_worst("audio_model_quantized.onnx", "quant");
+  let worst = audio_parity_worst(
+    &common::audio_model_path(),
+    "audio_model_quantized.onnx",
+    "fp16/quant",
+  );
   assert!(
     (AUDIO_QUANT_LO..=AUDIO_QUANT_HI).contains(&worst),
     "audio quantized-parity worst cosine {worst:.8} outside pinned band [{AUDIO_QUANT_LO}, {AUDIO_QUANT_HI}] \
@@ -140,7 +214,11 @@ fn audio_per_window_parity_vs_textclap_quantized() {
 #[test]
 #[ignore = "requires clapkit models (CLAPKIT_TEST_MODELS) + textclap quantized ONNX (CLAPKIT_TEXTCLAP_ONNX)"]
 fn text_parity_vs_textclap_quantized() {
-  let worst = text_parity_worst("text_model_quantized.onnx", "quant");
+  let worst = text_parity_worst(
+    &common::text_model_path(),
+    "text_model_quantized.onnx",
+    "fp16/quant",
+  );
   assert!(
     (TEXT_QUANT_LO..=TEXT_QUANT_HI).contains(&worst),
     "text quantized-parity worst cosine {worst:.8} outside pinned band [{TEXT_QUANT_LO}, {TEXT_QUANT_HI}]"
@@ -157,8 +235,12 @@ fn audio_parity_vs_textclap_fp32_control() {
      unquantized Xenova ONNX (README 'Test models') or don't force this #[ignore]d test.",
     common::textclap_onnx_dir()
   );
-  let fp32 = audio_parity_worst("audio_model.onnx", "fp32");
-  let quant = audio_parity_worst("audio_model_quantized.onnx", "quant");
+  let fp32 = audio_parity_worst(&common::audio_model_path(), "audio_model.onnx", "fp16/fp32");
+  let quant = audio_parity_worst(
+    &common::audio_model_path(),
+    "audio_model_quantized.onnx",
+    "fp16/quant",
+  );
   // The de-quantized oracle must agree at least as well as the quantized one:
   // removing quantization can only reduce the gap. The delta is the measured
   // quantization contribution.
@@ -186,8 +268,12 @@ fn text_parity_vs_textclap_fp32_control() {
      unquantized Xenova ONNX (README 'Test models') or don't force this #[ignore]d test.",
     common::textclap_onnx_dir()
   );
-  let fp32 = text_parity_worst("text_model.onnx", "fp32");
-  let quant = text_parity_worst("text_model_quantized.onnx", "quant");
+  let fp32 = text_parity_worst(&common::text_model_path(), "text_model.onnx", "fp16/fp32");
+  let quant = text_parity_worst(
+    &common::text_model_path(),
+    "text_model_quantized.onnx",
+    "fp16/quant",
+  );
   println!(
     "[text] quantization contribution ≈ {:.8} (fp32 {fp32:.8} − quant {quant:.8})",
     fp32 - quant
@@ -195,6 +281,112 @@ fn text_parity_vs_textclap_fp32_control() {
   assert!(
     (TEXT_FP32_LO..=TEXT_FP32_HI).contains(&fp32),
     "text fp32-control worst cosine {fp32:.8} outside pinned band [{TEXT_FP32_LO}, {TEXT_FP32_HI}]"
+  );
+  assert!(
+    fp32 + 1e-4 >= quant,
+    "fp32 control ({fp32:.8}) should agree at least as well as quantized ({quant:.8})"
+  );
+}
+
+// ── int8 tier (opt-in): the SAME per-window/prompt comparison against the SAME
+//    textclap ONNX oracles, but loading the int8 CLAP encoders. Bands are
+//    int8-specific (compression widens the gap vs fp32 slightly); reuses the
+//    now-fail-closed `cosine` + the model-parameterized `*_parity_worst`. ──
+
+#[test]
+#[ignore = "requires clapkit int8 models (CLAPKIT_TEST_MODELS) + textclap quantized ONNX (CLAPKIT_TEXTCLAP_ONNX)"]
+fn audio_per_window_parity_vs_textclap_quantized_int8() {
+  let worst = audio_parity_worst(
+    &common::audio_model_int8_path(),
+    "audio_model_quantized.onnx",
+    "int8/quant",
+  );
+  assert!(
+    (AUDIO_INT8_QUANT_LO..=AUDIO_INT8_QUANT_HI).contains(&worst),
+    "audio int8 quantized-parity worst cosine {worst:.8} outside pinned band \
+     [{AUDIO_INT8_QUANT_LO}, {AUDIO_INT8_QUANT_HI}] — a shift in EITHER direction is a finding \
+     (re-measure, do not just widen)"
+  );
+}
+
+#[test]
+#[ignore = "requires clapkit int8 models (CLAPKIT_TEST_MODELS) + textclap quantized ONNX (CLAPKIT_TEXTCLAP_ONNX)"]
+fn text_parity_vs_textclap_quantized_int8() {
+  let worst = text_parity_worst(
+    &common::text_model_int8_path(),
+    "text_model_quantized.onnx",
+    "int8/quant",
+  );
+  assert!(
+    (TEXT_INT8_QUANT_LO..=TEXT_INT8_QUANT_HI).contains(&worst),
+    "text int8 quantized-parity worst cosine {worst:.8} outside pinned band \
+     [{TEXT_INT8_QUANT_LO}, {TEXT_INT8_QUANT_HI}]"
+  );
+}
+
+#[test]
+#[ignore = "requires clapkit int8 models + textclap UNQUANTIZED fp32 ONNX (unquantized fp32 control)"]
+fn audio_parity_vs_textclap_fp32_control_int8() {
+  assert!(
+    textclap_onnx("audio_model.onnx").exists(),
+    "fp32-control oracle `audio_model.onnx` absent under CLAPKIT_TEXTCLAP_ONNX ({:?}). The README \
+     marks the fp32 control load-bearing, so a FORCED run must not green-skip it — fetch the \
+     unquantized Xenova ONNX (README 'Test models') or don't force this #[ignore]d test.",
+    common::textclap_onnx_dir()
+  );
+  let fp32 = audio_parity_worst(
+    &common::audio_model_int8_path(),
+    "audio_model.onnx",
+    "int8/fp32",
+  );
+  let quant = audio_parity_worst(
+    &common::audio_model_int8_path(),
+    "audio_model_quantized.onnx",
+    "int8/quant",
+  );
+  println!(
+    "[audio/int8] quantization contribution ≈ {:.8} (fp32 {fp32:.8} − quant {quant:.8})",
+    fp32 - quant
+  );
+  assert!(
+    (AUDIO_INT8_FP32_LO..=AUDIO_INT8_FP32_HI).contains(&fp32),
+    "audio int8 fp32-control worst cosine {fp32:.8} outside pinned band \
+     [{AUDIO_INT8_FP32_LO}, {AUDIO_INT8_FP32_HI}]"
+  );
+  assert!(
+    fp32 + 1e-4 >= quant,
+    "fp32 control ({fp32:.8}) should agree at least as well as quantized ({quant:.8})"
+  );
+}
+
+#[test]
+#[ignore = "requires clapkit int8 models + textclap UNQUANTIZED fp32 ONNX (unquantized fp32 control)"]
+fn text_parity_vs_textclap_fp32_control_int8() {
+  assert!(
+    textclap_onnx("text_model.onnx").exists(),
+    "fp32-control oracle `text_model.onnx` absent under CLAPKIT_TEXTCLAP_ONNX ({:?}). The README \
+     marks the fp32 control load-bearing, so a FORCED run must not green-skip it — fetch the \
+     unquantized Xenova ONNX (README 'Test models') or don't force this #[ignore]d test.",
+    common::textclap_onnx_dir()
+  );
+  let fp32 = text_parity_worst(
+    &common::text_model_int8_path(),
+    "text_model.onnx",
+    "int8/fp32",
+  );
+  let quant = text_parity_worst(
+    &common::text_model_int8_path(),
+    "text_model_quantized.onnx",
+    "int8/quant",
+  );
+  println!(
+    "[text/int8] quantization contribution ≈ {:.8} (fp32 {fp32:.8} − quant {quant:.8})",
+    fp32 - quant
+  );
+  assert!(
+    (TEXT_INT8_FP32_LO..=TEXT_INT8_FP32_HI).contains(&fp32),
+    "text int8 fp32-control worst cosine {fp32:.8} outside pinned band \
+     [{TEXT_INT8_FP32_LO}, {TEXT_INT8_FP32_HI}]"
   );
   assert!(
     fp32 + 1e-4 >= quant,

--- a/crates/coremlit/tests/clap/placement.rs
+++ b/crates/coremlit/tests/clap/placement.rs
@@ -41,6 +41,18 @@ const AUDIO_MIN_COSINE: f32 = 0.9999;
 /// for the ANE); pinned at 0.9999.
 const TEXT_MIN_COSINE: f32 = 0.9999;
 
+/// Lower bound on the **int8** audio tower's cross-placement cosine over the same
+/// public matrix. Same characterization as fp16 (HTSAT still falls back off the
+/// ANE — `ANECCompile()` fails at int8 too, confirmed at run time — so all units
+/// agree to compression tolerance). MEASURED worst = 0.99998385 (locally
+/// 2026-07-19 on `clapkit-coreml@02a99c6a`; matches issue #30's 0.99998385);
+/// pinned at 0.9999. A drop below is a finding, not a threshold to loosen.
+const AUDIO_INT8_MIN_COSINE: f32 = 0.9999;
+/// Lower bound on the **int8** text tower's cross-placement cosine. MEASURED
+/// worst = 0.99993771 (locally 2026-07-19 on `clapkit-coreml@02a99c6a`; matches
+/// issue #30's 0.99993682); pinned at 0.9999.
+const TEXT_INT8_MIN_COSINE: f32 = 0.9999;
+
 const AUDIO_UNITS: &[ComputeUnits] = &[
   ComputeUnits::All,
   // The public ANE-naming variant MUST be exercised: the doc claims every ANE
@@ -117,4 +129,60 @@ fn text_placement_agreement_characterized() {
   }
   assert!((reference.cosine(&reference) - 1.0).abs() <= 1e-5);
   eprintln!("[placement] text worst cross-unit cosine = {worst:.8}");
+}
+
+// ── int8 tier (opt-in): the SAME placement characterization on the int8 encoders.
+//    The audio int8 graph still falls back off the ANE (same as fp16); the text
+//    int8 graph compiles for the ANE. Never asserts ANE residency for audio. ──
+
+#[test]
+#[ignore = "requires local clapkit int8 models (CLAPKIT_TEST_MODELS)"]
+fn audio_int8_placement_agreement_characterized() {
+  let samples = common::deterministic_window(coremlit::embeddings::clap::audio::TARGET_SAMPLES);
+
+  let embed = |unit: ComputeUnits| -> Embedding {
+    AudioEncoder::from_file_with(
+      common::audio_model_int8_path(),
+      AudioEncoderOptions::new().with_compute(unit),
+    )
+    .unwrap_or_else(|e| panic!("load audio int8 [{}]: {e}", unit.as_str()))
+    .embed_window(&samples)
+    .unwrap_or_else(|e| panic!("embed audio int8 [{}]: {e}", unit.as_str()))
+  };
+
+  let reference = embed(ComputeUnits::CpuOnly);
+  let mut worst = 1.0f32;
+  for &unit in AUDIO_UNITS {
+    let cos = embed(unit).cosine(&reference);
+    worst = worst.min(cos);
+    assert_band("audio int8", unit, cos, AUDIO_INT8_MIN_COSINE);
+  }
+  assert!((reference.cosine(&reference) - 1.0).abs() <= 1e-5);
+  eprintln!("[placement] audio int8 worst cross-unit cosine = {worst:.8}");
+}
+
+#[test]
+#[ignore = "requires local clapkit int8 models (CLAPKIT_TEST_MODELS)"]
+fn text_int8_placement_agreement_characterized() {
+  const PROMPT: &str = "a violin playing a slow melody in a concert hall";
+
+  let embed = |unit: ComputeUnits| -> Embedding {
+    TextEncoder::from_bundled_tokenizer(
+      common::text_model_int8_path(),
+      TextEncoderOptions::new().with_compute(unit),
+    )
+    .unwrap_or_else(|e| panic!("load text int8 [{}]: {e}", unit.as_str()))
+    .embed(PROMPT)
+    .unwrap_or_else(|e| panic!("embed text int8 [{}]: {e}", unit.as_str()))
+  };
+
+  let reference = embed(ComputeUnits::CpuOnly);
+  let mut worst = 1.0f32;
+  for &unit in TEXT_UNITS {
+    let cos = embed(unit).cosine(&reference);
+    worst = worst.min(cos);
+    assert_band("text int8", unit, cos, TEXT_INT8_MIN_COSINE);
+  }
+  assert!((reference.cosine(&reference) - 1.0).abs() <= 1e-5);
+  eprintln!("[placement] text int8 worst cross-unit cosine = {worst:.8}");
 }

--- a/crates/coremlit/tests/clap/placement.rs
+++ b/crates/coremlit/tests/clap/placement.rs
@@ -11,6 +11,34 @@
 //!   runs on the ANE.
 //! - **Text (RoBERTa).** Compiles for the ANE.
 //!
+//! # Measured warm latency & the placement defaults (issue #30 perf pass)
+//!
+//! This test pins numeric *agreement* across placements; the committed
+//! `clap_encode` bench (`benches/clap/encode.rs`) measures the *latency* of each,
+//! and the two towers' defaults are set from that measured table
+//! (measure-then-pin). Warm-median `embed` latency and the cross-placement cosine,
+//! on **Apple M1 Max / macOS 26.5 (25F71)**, fp16, 25 runs × 3 sweeps:
+//!
+//! | tower | `CpuOnly` | `All` | `CpuAndGpu` | `CpuAndNeuralEngine` |
+//! |-------|-----------|-------|-------------|----------------------|
+//! | audio | ~47.8 ms (ref) | ~48.6 ms · 0.999983 | ~44.2 ms · 0.999983 | ~120.6 ms · 0.999987 |
+//! | text  | ~42.1 ms (ref) | ~29.7 ms · 0.999947 | **~16.8 ms · 0.999956** | ~28.6 ms · 0.999950 |
+//!
+//! - **Text → [`ComputeUnits::CpuAndGpu`]** (changed from `All`). The tiny `[1,
+//!   512]` RoBERTa graph pays ANE-dispatch overhead on `All`; `CpuAndGpu` is ~43 %
+//!   faster warm and holds the parity floor below (0.9999). See
+//!   [`coremlit::embeddings::clap::text::DEFAULT_TEXT_COMPUTE`].
+//! - **Audio → [`ComputeUnits::All`]** (kept). `CpuAndGpu` is only ~9 % faster
+//!   (below the ~15 % bar a default change needs); `All`/`CpuOnly` are within
+//!   noise, and the ANE selection is ~2.5× slower (HTSAT `ANECCompile` fallback).
+//!   See [`coremlit::embeddings::clap::audio::DEFAULT_AUDIO_COMPUTE`].
+//!
+//! Regenerate the numbers with
+//! `CLAPKIT_TEST_MODELS=… cargo bench -p coremlit --features clap --bench clap_encode`.
+//! int8 is a **size** tier, not a speed tier: weight-only quantization leaves the
+//! fp16 activations, so it is measured no faster (the audit saw text ~21 % slower);
+//! the defaults above are tower-level and apply to both tiers.
+//!
 //! # What is pinned
 //!
 //! For each encoder, one deterministic input is embedded under every placement

--- a/crates/coremlit/tests/clap/text_model_io.rs
+++ b/crates/coremlit/tests/clap/text_model_io.rs
@@ -3,22 +3,32 @@
 //! `.mlmodelc`; every SHA comes from the downloaded bytes. See
 //! `tests/clap/model_io.rs` for the shared artifact/license/revision record.
 //!
-//! # Per-file SHA-256 (pinned; `CHECKSUMS.sha256` on the HF revision)
+//! # Per-file SHA-256 (pinned; EVERY file in each `.mlmodelc`, from
+//! `CHECKSUMS.sha256` at revision `02a99c6a8be21da1e9a947499ea503a10c80c4f1`)
 //!
-//! fp16 (revision `97d631f3814e1e46b798a8e88c9aa2e2202fdf67`):
+//! Both tiers pin all five compiled-model files, so drift in ANY committed
+//! artifact byte reds. The fp16 bytes are unchanged from the original `97d631f3…`
+//! publication.
 //!
-//! | File | SHA-256 |
-//! |---|---|
-//! | `clap_text.mlmodelc/model.mil` | `0ec4d567c8d26a1aac4e161b1bdea6f9cd36441ec9e1da51fa5d28d79c22b744` |
-//! | `clap_text.mlmodelc/weights/weight.bin` | `7f4e15e9ccb0ffbc2341eec286e9d9934d3d3d8d6465dfddebed248bddc0e3dd` |
-//!
-//! int8 (the quantized variant shipped at revision `02a99c6a`; same I/O
-//! contract, compressed weights):
+//! fp16 (`clap_text.mlmodelc`):
 //!
 //! | File | SHA-256 |
 //! |---|---|
-//! | `clap_text_int8.mlmodelc/model.mil` | `0cc3ccdcf48e622a4701fa44e4c2096f0bead887461cb400e2b4af4e5641c2ee` |
-//! | `clap_text_int8.mlmodelc/weights/weight.bin` | `f181a595cefce402335499c32ea2f9727ef334afea9c592a2eabebb4172350a0` |
+//! | `analytics/coremldata.bin` | `6ce0a63b5bf13fc8f60fb1b8956373a2317d0a7349a0b6899ce5030eb9f8aef6` |
+//! | `coremldata.bin` | `edbf40e51518ad8f65a1d070f4c0e9b87fea644e6d69eb9eb55652e9fc697885` |
+//! | `metadata.json` | `8592b665a1e5a2d9b9078917b3dc9aedb0eb3fa8b8b4ae4630ee78b953082a7c` |
+//! | `model.mil` | `0ec4d567c8d26a1aac4e161b1bdea6f9cd36441ec9e1da51fa5d28d79c22b744` |
+//! | `weights/weight.bin` | `7f4e15e9ccb0ffbc2341eec286e9d9934d3d3d8d6465dfddebed248bddc0e3dd` |
+//!
+//! int8 (`clap_text_int8.mlmodelc`; the 2×-smaller variant, same I/O contract):
+//!
+//! | File | SHA-256 |
+//! |---|---|
+//! | `analytics/coremldata.bin` | `b914a93d50ae8336aad0977e28c4c1f84dccc39f7845fcd1660c43d565ca6fb7` |
+//! | `coremldata.bin` | `95bc733c2b0d3d2fa64edf548f77a50f344c020cce382a0b96c46477ad4a0b84` |
+//! | `metadata.json` | `0ed552101f045f5864c9d7212bffe09b478a2c1e8c39ec1d2732f95d206ee1df` |
+//! | `model.mil` | `0cc3ccdcf48e622a4701fa44e4c2096f0bead887461cb400e2b4af4e5641c2ee` |
+//! | `weights/weight.bin` | `f181a595cefce402335499c32ea2f9727ef334afea9c592a2eabebb4172350a0` |
 //!
 //! # Contract (matches the spec table and T1's I/O record)
 //!
@@ -60,7 +70,20 @@ fn clap_text_io_matches_spec() {
 #[ignore = "requires local clapkit models (CLAPKIT_TEST_MODELS)"]
 fn clap_text_artifacts_match_pinned_sha256() {
   let dir = common::text_model_path();
+  // EVERY file in the `.mlmodelc` (per `CHECKSUMS.sha256` @ 02a99c6a).
   let cases = [
+    (
+      "analytics/coremldata.bin",
+      "6ce0a63b5bf13fc8f60fb1b8956373a2317d0a7349a0b6899ce5030eb9f8aef6",
+    ),
+    (
+      "coremldata.bin",
+      "edbf40e51518ad8f65a1d070f4c0e9b87fea644e6d69eb9eb55652e9fc697885",
+    ),
+    (
+      "metadata.json",
+      "8592b665a1e5a2d9b9078917b3dc9aedb0eb3fa8b8b4ae4630ee78b953082a7c",
+    ),
     (
       "model.mil",
       "0ec4d567c8d26a1aac4e161b1bdea6f9cd36441ec9e1da51fa5d28d79c22b744",
@@ -101,7 +124,20 @@ fn clap_text_int8_io_matches_spec() {
 #[ignore = "requires local clapkit int8 models (CLAPKIT_TEST_MODELS)"]
 fn clap_text_int8_artifacts_match_pinned_sha256() {
   let dir = common::text_model_int8_path();
+  // EVERY file in the int8 `.mlmodelc` (per `CHECKSUMS.sha256` @ 02a99c6a).
   let cases = [
+    (
+      "analytics/coremldata.bin",
+      "b914a93d50ae8336aad0977e28c4c1f84dccc39f7845fcd1660c43d565ca6fb7",
+    ),
+    (
+      "coremldata.bin",
+      "95bc733c2b0d3d2fa64edf548f77a50f344c020cce382a0b96c46477ad4a0b84",
+    ),
+    (
+      "metadata.json",
+      "0ed552101f045f5864c9d7212bffe09b478a2c1e8c39ec1d2732f95d206ee1df",
+    ),
     (
       "model.mil",
       "0cc3ccdcf48e622a4701fa44e4c2096f0bead887461cb400e2b4af4e5641c2ee",

--- a/crates/coremlit/tests/clap/text_model_io.rs
+++ b/crates/coremlit/tests/clap/text_model_io.rs
@@ -70,7 +70,9 @@ fn clap_text_io_matches_spec() {
 #[ignore = "requires local clapkit models (CLAPKIT_TEST_MODELS)"]
 fn clap_text_artifacts_match_pinned_sha256() {
   let dir = common::text_model_path();
-  // EVERY file in the `.mlmodelc` (per `CHECKSUMS.sha256` @ 02a99c6a).
+  // The EXACT pinned manifest: every file in the `.mlmodelc` (per
+  // `CHECKSUMS.sha256` @ 02a99c6a). The helper enumerates + set-compares against
+  // these keys before hashing, so an added/removed artifact reds too.
   let cases = [
     (
       "analytics/coremldata.bin",
@@ -93,10 +95,7 @@ fn clap_text_artifacts_match_pinned_sha256() {
       "7f4e15e9ccb0ffbc2341eec286e9d9934d3d3d8d6465dfddebed248bddc0e3dd",
     ),
   ];
-  for (relative, expected) in cases {
-    let actual = common::sha256_hex(&dir.join(relative));
-    assert_eq!(actual, expected, "sha256 drift on text artifact {relative}");
-  }
+  common::assert_exact_sha_manifest(&dir, &cases);
 }
 
 #[test]
@@ -124,7 +123,9 @@ fn clap_text_int8_io_matches_spec() {
 #[ignore = "requires local clapkit int8 models (CLAPKIT_TEST_MODELS)"]
 fn clap_text_int8_artifacts_match_pinned_sha256() {
   let dir = common::text_model_int8_path();
-  // EVERY file in the int8 `.mlmodelc` (per `CHECKSUMS.sha256` @ 02a99c6a).
+  // The EXACT pinned manifest for the int8 `.mlmodelc` (per `CHECKSUMS.sha256` @
+  // 02a99c6a); the helper enumerates + set-compares before hashing, so a
+  // missing/added artifact reds too.
   let cases = [
     (
       "analytics/coremldata.bin",
@@ -147,11 +148,5 @@ fn clap_text_int8_artifacts_match_pinned_sha256() {
       "f181a595cefce402335499c32ea2f9727ef334afea9c592a2eabebb4172350a0",
     ),
   ];
-  for (relative, expected) in cases {
-    let actual = common::sha256_hex(&dir.join(relative));
-    assert_eq!(
-      actual, expected,
-      "sha256 drift on text int8 artifact {relative}"
-    );
-  }
+  common::assert_exact_sha_manifest(&dir, &cases);
 }


### PR DESCRIPTION
## Scope

Remediate GitHub issue #30 (a third-party clapkit audit) on `coremlit::embeddings::clap`: correctness /
test-hygiene bug fixes plus a data-backed performance pass. Rebased onto current `main` (post the
clustering-port merge).

### Bugs
- **Fail-closed parity reducer** — the cosine reducer was NaN-blind (`worst.min(cos)` returns the finite
  operand, so a NaN passed the band). Now asserts equal length + all-finite inputs + finite result, with
  **hermetic `#[should_panic]` tests that red if the guard is removed** (a sibling in `e2e.rs` fixed the
  same way).
- **First-class int8 gates** — placement / parity / e2e added (model-gated), measure-then-pinned from
  live runs against the staged int8 artifacts.
- **Exact SHA manifest** — the SHA tests now *enumerate* each `.mlmodelc` and set-compare paths against
  the pinned manifest before hashing (an added *or* removed file reds), across all four fp16/int8
  bundles. Extended from 2 pinned files to the complete bundle.
- **Revision-locked download** + provenance updated to the int8-inclusive HF revision.

### Performance
- **Text placement default `All` → `CpuAndGpu`** — measured **~43% faster** warm (16.8 vs 29.7 ms) with
  the parity floor held (cosine vs CpuOnly 0.999956); resolves the audit's "text tower slower than ONNX"
  finding. Audio default kept `All` (the 15% bar not met). `with_compute`/`set_compute` intact.
- **Committed benchmark harness** (`benches/clap/encode.rs`) — first-observed / cached load, first + warm
  inference, per tower × ComputeUnits, with output hash + cosine + RSS; model-gated. An earlier
  destructive cold-cache-eviction mode was removed (it could strand/delete a developer's shared CoreML
  cache).
- **Prewarm** methods on both encoders; int8 documented as a size tier, not a speed tier.

## Verification

`fmt=0 clippy=0 (-D warnings) test=0 (clap-oracle) featmap=0 bench=0 doc=0`. int8 gates + exact-manifest
tests run green against the staged models; the manifest gate is mutation-proven (extra/removed file → red).

## Review

Codex adversarial review: **APPROVE** on the substance (correctness fixes, int8 gates, placement default,
prewarm, pinned hashes); the one HIGH it raised (destructive benchmark cache mode) was removed, and the
follow-up benchmark-labeling nits corrected. Merge held for the owner. Addresses issue #30.
