### PR TITLE
test(audio): host-aware CoreML parity gates + complete AppleDouble-sidecar sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ hf download openai/whisper-tiny tokenizer.json tokenizer_config.json config.json
   --local-dir Models/tokenizers/whisper-tiny
 ```
 
-Each pipeline resolves its models root from its own env var (`WHISPERKIT_TEST_MODELS`, `ALIGNKIT_TEST_MODELS`, `SPEAKERKIT_TEST_MODELS`/`ARGMAX_TEST_MODELS`, `VADKIT_TEST_MODELS`), defaulting to `<repo>/Models/...` (gitignored). See each module's `tests/<kit>/model_io.rs` for the pinned repo id, revision, and per-file SHA-256, and the module docs for fetch commands.
+Each pipeline resolves its models root from its own env var (`WHISPERKIT_TEST_MODELS`, `ALIGNKIT_TEST_MODELS`, `SPEAKERKIT_TEST_MODELS`/`ARGMAX_TEST_MODELS`, `VADKIT_TEST_MODELS`), defaulting to `<repo>/Models/...` (gitignored). See each module's `tests/<kit>/model_io.rs` for the pinned repo id, revision, and per-file SHA-256, and the module docs for fetch commands. The model-gated suites load multi-hundred-MB CoreML models per test and libtest runs tests in one binary concurrently by default; on memory-constrained hosts (< 16 GB) append `--test-threads=1` after `--ignored` to run them serially.
 
 ## Examples & benches
 

--- a/crates/coremlit/tests/clap/common/mod.rs
+++ b/crates/coremlit/tests/clap/common/mod.rs
@@ -133,6 +133,47 @@ pub fn sha256_hex(path: &Path) -> String {
     .collect()
 }
 
+/// Recursively collects the forward-slash relative path of every FILE under
+/// `dir` (nested dirs such as `analytics/` and `weights/` are walked; only the
+/// files they contain become entries) into `out`. Pure path enumeration — no
+/// hashing — so it is hermetically testable without real model bytes; see
+/// `collect_files_rel_skips_sidecars_but_surfaces_real_extras` in
+/// `tests/clap/model_io.rs`. [`assert_exact_sha_manifest`] is the sole
+/// production caller.
+///
+/// OS-generated sidecars are skipped: AppleDouble `._*` files and `.DS_Store`.
+/// macOS materializes these inside bundles on non-native filesystems
+/// (exFAT/FAT/SMB); CoreML's loader never reads them, so excluding them from
+/// discovery cannot mask a functional artifact change — whereas NOT excluding
+/// them would false-fail [`assert_exact_sha_manifest`]'s exact-set gate as a
+/// phantom "unpinned extra" even though every pinned byte is untouched.
+#[allow(dead_code)]
+pub fn collect_files_rel(dir: &Path, prefix: &str, out: &mut Vec<String>) {
+  let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {dir:?}: {e}"));
+  for entry in entries {
+    let entry = entry.unwrap_or_else(|e| panic!("dir entry under {dir:?}: {e}"));
+    let name = entry.file_name().to_string_lossy().into_owned();
+    // Drop OS-generated sidecars (AppleDouble `._*`, `.DS_Store`) at every
+    // depth, before the file/dir split — see the doc comment above.
+    if name.starts_with("._") || name == ".DS_Store" {
+      continue;
+    }
+    let rel = if prefix.is_empty() {
+      name
+    } else {
+      format!("{prefix}/{name}")
+    };
+    let file_type = entry
+      .file_type()
+      .unwrap_or_else(|e| panic!("file_type {:?}: {e}", entry.path()));
+    if file_type.is_dir() {
+      collect_files_rel(&entry.path(), &rel, out);
+    } else {
+      out.push(rel);
+    }
+  }
+}
+
 /// Assert that the compiled-model bundle at `dir` matches an EXACT pinned
 /// manifest. `cases` is the pinned `(relative_path, sha256)` list.
 ///
@@ -149,32 +190,8 @@ pub fn sha256_hex(path: &Path) -> String {
 pub fn assert_exact_sha_manifest(dir: &Path, cases: &[(&str, &str)]) {
   use std::collections::BTreeSet;
 
-  // Recursively collect the forward-slash relative path of every FILE under
-  // `dir` (nested dirs such as `analytics/` and `weights/` are walked; only the
-  // files they contain become entries).
-  fn collect_files(dir: &Path, prefix: &str, out: &mut Vec<String>) {
-    let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {dir:?}: {e}"));
-    for entry in entries {
-      let entry = entry.unwrap_or_else(|e| panic!("dir entry under {dir:?}: {e}"));
-      let name = entry.file_name().to_string_lossy().into_owned();
-      let rel = if prefix.is_empty() {
-        name
-      } else {
-        format!("{prefix}/{name}")
-      };
-      let file_type = entry
-        .file_type()
-        .unwrap_or_else(|e| panic!("file_type {:?}: {e}", entry.path()));
-      if file_type.is_dir() {
-        collect_files(&entry.path(), &rel, out);
-      } else {
-        out.push(rel);
-      }
-    }
-  }
-
   let mut found = Vec::new();
-  collect_files(dir, "", &mut found);
+  collect_files_rel(dir, "", &mut found);
   let on_disk: BTreeSet<String> = found.into_iter().collect();
   let pinned: BTreeSet<String> = cases.iter().map(|(rel, _)| (*rel).to_owned()).collect();
 

--- a/crates/coremlit/tests/clap/model_io.rs
+++ b/crates/coremlit/tests/clap/model_io.rs
@@ -57,6 +57,8 @@
 
 mod common;
 
+use std::collections::BTreeSet;
+
 use coremlit::{
   ComputeUnits, DataType, Model,
   embeddings::clap::{
@@ -64,6 +66,62 @@ use coremlit::{
     embedding::EMBEDDING_DIM,
   },
 };
+
+/// Hermetic non-vacuity proof for [`common::collect_files_rel`]'s sidecar
+/// filter (no staged model needed). On exFAT/FAT/SMB volumes macOS
+/// materializes AppleDouble `._*` and `.DS_Store` sidecars inside `.mlmodelc`
+/// bundles; discovery must drop EXACTLY those, while every real file —
+/// crucially including an unpinned real extra — still reaches the exact-set
+/// gate [`common::assert_exact_sha_manifest`] builds on. This proves the
+/// filter fixes the false-failure WITHOUT blanket-suppressing genuine extras.
+#[test]
+fn collect_files_rel_skips_sidecars_but_surfaces_real_extras() {
+  let tmp = tempfile::tempdir().expect("create temp dir");
+  let bundle = tmp.path().join("clap_audio.mlmodelc");
+  std::fs::create_dir_all(bundle.join("weights")).expect("mkdir bundle weights/");
+
+  // Two real, pinned-style artifacts (one nested).
+  std::fs::write(bundle.join("model.mil"), b"mil").expect("write model.mil");
+  std::fs::write(bundle.join("weights/weight.bin"), b"w").expect("write weight.bin");
+  // OS-generated sidecars at two depths — every one must be skipped.
+  std::fs::write(bundle.join("._model.mil"), b"ad").expect("write ._model.mil");
+  std::fs::write(bundle.join(".DS_Store"), b"ds").expect("write .DS_Store");
+  std::fs::write(bundle.join("weights/._weight.bin"), b"ad").expect("write nested ._");
+  // A real, ordinary-named file that is NOT a sidecar and NOT pinned.
+  std::fs::write(bundle.join("rogue.bin"), b"x").expect("write rogue.bin");
+
+  let mut found = Vec::new();
+  common::collect_files_rel(&bundle, "", &mut found);
+  let discovered: BTreeSet<String> = found.into_iter().collect();
+
+  // Discovery keeps every real file and drops every sidecar (at both depths).
+  assert_eq!(
+    discovered,
+    BTreeSet::from([
+      "model.mil".to_string(),
+      "rogue.bin".to_string(),
+      "weights/weight.bin".to_string(),
+    ]),
+    "discovery must exclude `._*`/.DS_Store sidecars and keep every real file"
+  );
+
+  // The filter did NOT blanket-suppress extras: an ordinary unpinned file still
+  // breaks the exact-set equality `assert_exact_sha_manifest` performs, and
+  // shows up as the sole difference against a set listing only the two real
+  // artifacts.
+  let pinned: BTreeSet<String> =
+    BTreeSet::from(["model.mil".to_string(), "weights/weight.bin".to_string()]);
+  assert_ne!(
+    discovered, pinned,
+    "a real unpinned extra must still break the exact-set equality"
+  );
+  let extras: Vec<String> = discovered.difference(&pinned).cloned().collect();
+  assert_eq!(
+    extras,
+    vec!["rogue.bin".to_string()],
+    "the surviving extra must be exactly the real unpinned file, not a sidecar"
+  );
+}
 
 #[test]
 #[ignore = "requires local clapkit models (CLAPKIT_TEST_MODELS)"]

--- a/crates/coremlit/tests/granite/common/mod.rs
+++ b/crates/coremlit/tests/granite/common/mod.rs
@@ -134,16 +134,30 @@ pub fn cosine_checked(a: &[f32], b: &[f32]) -> f32 {
   (dot / (na.sqrt() * nb.sqrt())) as f32
 }
 
-/// Recursively collects every FILE under `dir` as a path relative to `root`,
-/// with `/` separators, into `out`. Used to enumerate a `.mlmodelc` bundle's
-/// actual tree so it can be set-compared against a pinned key manifest (no
-/// unpinned extras, none missing) BEFORE hashing — the #30 exact-enumerate
+/// Recursively collects every real FILE under `dir` as a path relative to
+/// `root`, with `/` separators, into `out`. Used to enumerate a `.mlmodelc`
+/// bundle's actual tree so it can be set-compared against a pinned key manifest
+/// (no unpinned extras, none missing) BEFORE hashing — the #30 exact-enumerate
 /// pattern.
+///
+/// OS-generated sidecars are skipped: AppleDouble `._*` files and `.DS_Store`.
+/// macOS materializes these inside bundles on non-native filesystems
+/// (exFAT/FAT/SMB); CoreML's loader never reads them, so excluding them from
+/// discovery cannot mask a functional artifact change — whereas NOT excluding
+/// them would false-fail the exact-set gate as a phantom "unpinned extra" even
+/// though every pinned byte is untouched.
 #[allow(dead_code)]
 pub fn collect_files_rel(root: &Path, dir: &Path, out: &mut std::collections::BTreeSet<String>) {
   for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()))
   {
     let entry = entry.expect("read dir entry");
+    // Drop OS-generated sidecars (AppleDouble `._*`, `.DS_Store`) at every
+    // depth, before the file/dir split — see the doc comment above.
+    let name = entry.file_name();
+    let name = name.to_string_lossy();
+    if name.starts_with("._") || name == ".DS_Store" {
+      continue;
+    }
     let path = entry.path();
     if entry.file_type().expect("file type").is_dir() {
       collect_files_rel(root, &path, out);

--- a/crates/coremlit/tests/granite/model_io.rs
+++ b/crates/coremlit/tests/granite/model_io.rs
@@ -139,3 +139,59 @@ fn granite_artifact_bytes_match_pinned_sha256() {
     );
   }
 }
+
+/// Hermetic non-vacuity proof for [`common::collect_files_rel`]'s sidecar
+/// filter (no staged model needed). On exFAT/FAT/SMB volumes macOS
+/// materializes AppleDouble `._*` and `.DS_Store` sidecars inside `.mlmodelc`
+/// bundles; discovery must drop EXACTLY those, while every real file —
+/// crucially including an unpinned real extra — still reaches the exact-set
+/// gate in [`granite_artifact_bytes_match_pinned_sha256`]. This proves the
+/// filter fixes the false-failure WITHOUT blanket-suppressing genuine extras.
+#[test]
+fn collect_files_rel_skips_sidecars_but_surfaces_real_extras() {
+  let tmp = tempfile::tempdir().expect("create temp dir");
+  let bundle = tmp.path().join("granite_97m_512.mlmodelc");
+  std::fs::create_dir_all(bundle.join("weights")).expect("mkdir bundle weights/");
+
+  // Two real, pinned-style artifacts (one nested).
+  std::fs::write(bundle.join("model.mil"), b"mil").expect("write model.mil");
+  std::fs::write(bundle.join("weights/weight.bin"), b"w").expect("write weight.bin");
+  // OS-generated sidecars at two depths — every one must be skipped.
+  std::fs::write(bundle.join("._model.mil"), b"ad").expect("write ._model.mil");
+  std::fs::write(bundle.join(".DS_Store"), b"ds").expect("write .DS_Store");
+  std::fs::write(bundle.join("weights/._weight.bin"), b"ad").expect("write nested ._");
+  // A real, ordinary-named file that is NOT a sidecar and NOT pinned.
+  std::fs::write(bundle.join("rogue.bin"), b"x").expect("write rogue.bin");
+
+  // Enumerate relative to the bundle root, exactly as
+  // `granite_artifact_bytes_match_pinned_sha256` does (`root == bundle`).
+  let mut discovered: BTreeSet<String> = BTreeSet::new();
+  common::collect_files_rel(&bundle, &bundle, &mut discovered);
+
+  // Discovery keeps every real file and drops every sidecar (at both depths).
+  assert_eq!(
+    discovered,
+    BTreeSet::from([
+      "model.mil".to_string(),
+      "rogue.bin".to_string(),
+      "weights/weight.bin".to_string(),
+    ]),
+    "discovery must exclude `._*`/.DS_Store sidecars and keep every real file"
+  );
+
+  // The filter did NOT blanket-suppress extras: an ordinary unpinned file still
+  // breaks the exact-set equality and shows up as the sole difference against a
+  // pin listing only the two real artifacts.
+  let pinned: BTreeSet<String> =
+    BTreeSet::from(["model.mil".to_string(), "weights/weight.bin".to_string()]);
+  assert_ne!(
+    discovered, pinned,
+    "a real unpinned extra must still break the exact-set equality"
+  );
+  let extras: Vec<String> = discovered.difference(&pinned).cloned().collect();
+  assert_eq!(
+    extras,
+    vec!["rogue.bin".to_string()],
+    "the surviving extra must be exactly the real unpinned file, not a sidecar"
+  );
+}

--- a/crates/coremlit/tests/speaker/argmax_model_io.rs
+++ b/crates/coremlit/tests/speaker/argmax_model_io.rs
@@ -208,14 +208,29 @@ fn artifact_path(rel: &str) -> PathBuf {
   common::argmax_models_dir().join(rel)
 }
 
-/// Recursively collects every FILE under `dir` as a path relative to `root`,
-/// inserting each into `out` with `/` separators to match [`ARTIFACT_SHA256`]'s
-/// keys. Used to enumerate a `.mlmodelc` bundle's actual tree so it can be
-/// checked against the pinned key set (no unpinned extras, none missing).
+/// Recursively collects every real FILE under `dir` as a path relative to
+/// `root`, inserting each into `out` with `/` separators to match
+/// [`ARTIFACT_SHA256`]'s keys. Used to enumerate a `.mlmodelc` bundle's actual
+/// tree so it can be checked against the pinned key set (no unpinned extras,
+/// none missing).
+///
+/// OS-generated sidecars are skipped: AppleDouble `._*` files and `.DS_Store`.
+/// macOS materializes these inside bundles on non-native filesystems
+/// (exFAT/FAT/SMB); CoreML's loader never reads them, so excluding them from
+/// discovery cannot mask a functional artifact change — whereas NOT excluding
+/// them would false-fail the exact-set gate below as a phantom "unpinned
+/// extra" even though every pinned byte is untouched.
 fn collect_files_rel(root: &Path, dir: &Path, out: &mut BTreeSet<String>) {
   for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()))
   {
     let entry = entry.expect("read dir entry");
+    // Drop OS-generated sidecars (AppleDouble `._*`, `.DS_Store`) at every
+    // depth, before the file/dir split — see the doc comment above.
+    let name = entry.file_name();
+    let name = name.to_string_lossy();
+    if name.starts_with("._") || name == ".DS_Store" {
+      continue;
+    }
     let path = entry.path();
     if entry.file_type().expect("file type").is_dir() {
       collect_files_rel(root, &path, out);
@@ -229,6 +244,63 @@ fn collect_files_rel(root: &Path, dir: &Path, out: &mut BTreeSet<String>) {
       out.insert(rel);
     }
   }
+}
+
+/// Hermetic non-vacuity proof for [`collect_files_rel`]'s sidecar filter (no
+/// staged model needed). On exFAT/FAT/SMB volumes macOS materializes
+/// AppleDouble `._*` and `.DS_Store` sidecars inside `.mlmodelc` bundles;
+/// discovery must drop EXACTLY those, while every real file — crucially
+/// including an unpinned real extra — still reaches the exact-set gate in
+/// [`argmax_artifact_bytes_match_pinned_sha256`]. This proves the filter fixes
+/// the false-failure WITHOUT blanket-suppressing genuine extras.
+#[test]
+fn collect_files_rel_skips_sidecars_but_surfaces_real_extras() {
+  let tmp = tempfile::tempdir().expect("create temp dir");
+  let root = tmp.path();
+  let bundle = root.join("Model.mlmodelc");
+  std::fs::create_dir_all(bundle.join("weights")).expect("mkdir bundle weights/");
+
+  // Two real, pinned-style artifacts (one nested).
+  std::fs::write(bundle.join("model.mil"), b"mil").expect("write model.mil");
+  std::fs::write(bundle.join("weights/weight.bin"), b"w").expect("write weight.bin");
+  // OS-generated sidecars at two depths — every one must be skipped.
+  std::fs::write(bundle.join("._model.mil"), b"ad").expect("write ._model.mil");
+  std::fs::write(bundle.join(".DS_Store"), b"ds").expect("write .DS_Store");
+  std::fs::write(bundle.join("weights/._weight.bin"), b"ad").expect("write nested ._");
+  // A real, ordinary-named file that is NOT a sidecar and NOT pinned.
+  std::fs::write(bundle.join("rogue.bin"), b"x").expect("write rogue.bin");
+
+  let mut discovered: BTreeSet<String> = BTreeSet::new();
+  collect_files_rel(root, &bundle, &mut discovered);
+
+  // Discovery keeps every real file and drops every sidecar (at both depths).
+  assert_eq!(
+    discovered,
+    BTreeSet::from([
+      "Model.mlmodelc/model.mil".to_string(),
+      "Model.mlmodelc/rogue.bin".to_string(),
+      "Model.mlmodelc/weights/weight.bin".to_string(),
+    ]),
+    "discovery must exclude `._*`/.DS_Store sidecars and keep every real file"
+  );
+
+  // The filter did NOT blanket-suppress extras: an ordinary unpinned file still
+  // breaks the exact-set equality and shows up as the sole difference against a
+  // pin listing only the two real artifacts.
+  let pinned: BTreeSet<String> = BTreeSet::from([
+    "Model.mlmodelc/model.mil".to_string(),
+    "Model.mlmodelc/weights/weight.bin".to_string(),
+  ]);
+  assert_ne!(
+    discovered, pinned,
+    "a real unpinned extra must still break the exact-set equality"
+  );
+  let extras: Vec<String> = discovered.difference(&pinned).cloned().collect();
+  assert_eq!(
+    extras,
+    vec!["Model.mlmodelc/rogue.bin".to_string()],
+    "the surviving extra must be exactly the real unpinned file, not a sidecar"
+  );
 }
 
 #[test]

--- a/crates/coremlit/tests/speaker/common/mod.rs
+++ b/crates/coremlit/tests/speaker/common/mod.rs
@@ -716,3 +716,192 @@ pub fn assert_golden_roster(golden: &Golden) -> usize {
   }
   total
 }
+
+// ── Host-class provenance for the committed-Swift-golden parity gate ────────
+//
+// CoreML `CpuOnly` kernels ship with the OS and are not contracted to produce
+// identical floats across macOS builds or chip generations (#36), so the parity
+// gate stamps each golden with the host-class it was generated on and enforces
+// its tight bound only against a matching host (see `check_host_class`). This
+// block is duplicated verbatim in the vad and speaker `common/mod.rs` — the
+// repo's self-contained-`common` convention, the same one that already
+// duplicates `fnv1a_f32`/`load_wav_16k_mono`; each suite's hermetic tests drive
+// its own copy, which is what guards the two copies against drift.
+
+/// The host-class identity that determines CoreML `CpuOnly` float
+/// reproducibility: macOS build (the OS binary set every CPU kernel ships
+/// in), chip (kernel dispatch varies by microarchitecture), process arch
+/// (Rosetta), plus the human-readable product version (fully determined by
+/// the build; carried for diagnostics). Deliberately NOT included: Xcode /
+/// Swift toolchain (compiles the dumper, not the runtime kernels — inputs
+/// are FNV-pinned and model bytes SHA-pinned), `hw.model` (same chip + build
+/// ⇒ same CPU floats), RAM/core counts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostClass {
+  pub os_build: String,
+  pub os_product_version: String,
+  pub chip: String,
+  pub arch: String,
+}
+
+impl HostClass {
+  /// The RUNNING host's class. Reads the sysctl keys the Swift dumpers read
+  /// (`kern.osversion`, `kern.osproductversion`, `machdep.cpu.brand_string`) by
+  /// shelling out to `/usr/sbin/sysctl`, and normalizes the process arch to the
+  /// `arm64`/`x86_64` spelling the dumpers record. Called only from model-gated
+  /// tests and the `running_host_class_is_well_formed` smoke test — hermetic
+  /// predicate tests use synthetic values.
+  ///
+  /// Production code (`src/audio/whisper/model/mod.rs::device_identifier`)
+  /// deliberately uses `libc::sysctlbyname`; this test-side reader deliberately
+  /// shells out instead — spawn cost is irrelevant in a model-gated test and it
+  /// keeps the test tree free of `unsafe`.
+  ///
+  /// # Panics
+  /// With a `host-class gate:` message if a sysctl read fails or is empty
+  /// (model-gated dev machines only — sysctl always exists on macOS).
+  pub fn running() -> Self {
+    HostClass {
+      os_build: sysctl_string("kern.osversion"),
+      os_product_version: sysctl_string("kern.osproductversion"),
+      chip: sysctl_string("machdep.cpu.brand_string"),
+      // The aarch64 -> arm64 normalization is load-bearing: without it every
+      // Apple-Silicon run would mismatch every golden (the dumpers record
+      // `arm64` via compile-time `#if arch(arm64)`, and compile-time arch IS
+      // the process arch that governs the in-process `CpuOnly` kernels).
+      arch: match std::env::consts::ARCH {
+        "aarch64" => "arm64".to_string(),
+        other => other.to_string(),
+      },
+    }
+  }
+
+  /// Reads the OPTIONAL `generationHost` object from a golden's JSON. Absent or
+  /// `null` → `Ok(None)` (a legacy golden, pre-host-provenance). Present → must
+  /// be an object whose `osBuild`/`osProductVersion`/`chip`/`arch` are all
+  /// non-empty strings; unknown extra keys inside the object are tolerated.
+  ///
+  /// FORM only — the host MATCH is [`check_host_class`]'s job, never the
+  /// parser's: the hermetic loader tests and the committed goldens must parse on
+  /// EVERY host (this one included).
+  ///
+  /// # Errors
+  /// If `generationHost` is present but not an object, or is missing any of the
+  /// four fields as a non-empty string. Every message contains `generationHost`.
+  pub fn from_golden(name: &str, v: &serde_json::Value) -> Result<Option<Self>, String> {
+    let host = match v.get("generationHost") {
+      None | Some(serde_json::Value::Null) => return Ok(None),
+      Some(serde_json::Value::Object(map)) => map,
+      Some(other) => {
+        return Err(format!(
+          "{name}: `generationHost` is {other} — expected an object with osBuild / \
+           osProductVersion / chip / arch string fields"
+        ));
+      }
+    };
+    let field = |key: &str| -> Result<String, String> {
+      host
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| format!("{name}: `generationHost.{key}` is missing, not a string, or empty"))
+    };
+    Ok(Some(HostClass {
+      os_build: field("osBuild")?,
+      os_product_version: field("osProductVersion")?,
+      chip: field("chip")?,
+      arch: field("arch")?,
+    }))
+  }
+}
+
+impl std::fmt::Display for HostClass {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(
+      f,
+      "macOS {} (build {}), {}, {}",
+      self.os_product_version, self.os_build, self.chip, self.arch
+    )
+  }
+}
+
+/// Reads one sysctl value as a trimmed string via `/usr/sbin/sysctl -n`
+/// (absolute path — PATH-independent).
+///
+/// # Panics
+/// With a `host-class gate:` message on spawn failure, a non-zero exit, or
+/// empty output.
+fn sysctl_string(key: &str) -> String {
+  let output = std::process::Command::new("/usr/sbin/sysctl")
+    .args(["-n", key])
+    .output()
+    .unwrap_or_else(|e| panic!("host-class gate: cannot spawn /usr/sbin/sysctl for `{key}`: {e}"));
+  assert!(
+    output.status.success(),
+    "host-class gate: `/usr/sbin/sysctl -n {key}` exited {}",
+    output.status
+  );
+  let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+  assert!(
+    !value.is_empty(),
+    "host-class gate: `/usr/sbin/sysctl -n {key}` produced empty output"
+  );
+  value
+}
+
+/// Verdict of the host-class gate for one golden.
+#[derive(Debug, PartialEq, Eq)]
+pub enum HostVerdict {
+  /// `generationHost` recorded and equal to the running host-class: the tight
+  /// parity bounds apply and a failure is cleanly attributable to the port.
+  Match,
+  /// The golden predates host provenance (no `generationHost`): the tight
+  /// bounds still apply (a PASS is sound evidence on any host — a port bug
+  /// exactly cancelling host drift under these bounds is not a real risk),
+  /// but a FAILURE is ambiguous between a port defect and host-CoreML drift —
+  /// append [`legacy_failure_note`] to fidelity failure messages.
+  LegacyUnknown,
+}
+
+/// THE host-class match predicate + mismatch diagnosis. Pure — no I/O — so the
+/// hermetic tests drive it with synthetic host-class values.
+///
+/// # Errors
+/// The full actionable diagnosis for a recorded-but-different host; the caller
+/// panics with it BEFORE any CoreML number is produced.
+pub fn check_host_class(
+  fixture: &str,
+  recorded: Option<&HostClass>,
+  running: &HostClass,
+  regen_script: &str,
+) -> Result<HostVerdict, String> {
+  match recorded {
+    None => Ok(HostVerdict::LegacyUnknown),
+    Some(r) if r == running => Ok(HostVerdict::Match),
+    Some(r) => Err(format!(
+      "{fixture}: committed golden was generated on a DIFFERENT host-class.\n  \
+       golden host : {r}\n  this host   : {running}\n\
+       CoreML CpuOnly floating point is not contracted portable across macOS builds or chips,\n\
+       so the tight parity bound would misattribute host float drift to the port. This failure\n\
+       is NOT evidence of a port defect. To test the port on this machine, regenerate a\n\
+       same-host oracle and re-run:\n  {regen_script}\n\
+       Do NOT widen the parity tolerances instead — the tight bounds are what catch real\n\
+       stitching/index-mapping regressions on a matching host."
+    )),
+  }
+}
+
+/// The ambiguity note appended to a fidelity failure when the golden predates
+/// host-class provenance (a [`HostVerdict::LegacyUnknown`] golden): the failure
+/// cannot be cleanly attributed to the port versus host-CoreML drift, and the
+/// fix is a same-host regeneration, never a widened tolerance.
+pub fn legacy_failure_note(regen_script: &str) -> String {
+  format!(
+    "\nNOTE: this golden predates host-class provenance (no `generationHost` field), so this\n\
+     failure is AMBIGUOUS between a port defect and host-CoreML CpuOnly float drift (CpuOnly\n\
+     floats are not contracted portable across macOS builds/chips). Regenerate a same-host\n\
+     oracle via {regen_script} to disambiguate — regeneration also stamps `generationHost`.\n\
+     Do NOT widen the tolerance."
+  )
+}

--- a/crates/coremlit/tests/speaker/model_io.rs
+++ b/crates/coremlit/tests/speaker/model_io.rs
@@ -116,10 +116,24 @@ use coremlit::{ComputeUnits, DataType, Model};
 /// Recursively collects every FILE under `dir` as a `/`-separated path relative
 /// to `root`. Used by `wespeaker_v2_and_wespeaker_int8_are_byte_identical` to
 /// compare two `.mlmodelc` bundle trees file-for-file.
+///
+/// OS-generated sidecars are skipped: AppleDouble `._*` files and `.DS_Store`.
+/// macOS materializes these inside bundles on non-native filesystems
+/// (exFAT/FAT/SMB); CoreML's loader never reads them, so excluding them from
+/// discovery cannot mask a functional artifact change — whereas NOT excluding
+/// them would false-fail the byte-identity comparison below as a phantom
+/// "unpinned extra" even though every real byte is untouched.
 fn collect_files_rel(root: &Path, dir: &Path, out: &mut BTreeSet<String>) {
   for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()))
   {
     let entry = entry.expect("read dir entry");
+    // Drop OS-generated sidecars (AppleDouble `._*`, `.DS_Store`) at every
+    // depth, before the file/dir split — see the doc comment above.
+    let name = entry.file_name();
+    let name = name.to_string_lossy();
+    if name.starts_with("._") || name == ".DS_Store" {
+      continue;
+    }
     let path = entry.path();
     if entry.file_type().expect("file type").is_dir() {
       collect_files_rel(root, &path, out);
@@ -134,6 +148,63 @@ fn collect_files_rel(root: &Path, dir: &Path, out: &mut BTreeSet<String>) {
       );
     }
   }
+}
+
+/// Hermetic non-vacuity proof for [`collect_files_rel`]'s sidecar filter (no
+/// staged model needed). On exFAT/FAT/SMB volumes macOS materializes
+/// AppleDouble `._*` and `.DS_Store` sidecars inside `.mlmodelc` bundles;
+/// discovery must drop EXACTLY those, while every real file — crucially
+/// including an unpinned real extra — still reaches the byte-identity gate in
+/// [`wespeaker_v2_and_wespeaker_int8_are_byte_identical`]. This proves the
+/// filter fixes the false-failure WITHOUT blanket-suppressing genuine extras.
+#[test]
+fn collect_files_rel_skips_sidecars_but_surfaces_real_extras() {
+  let tmp = tempfile::tempdir().expect("create temp dir");
+  let root = tmp.path();
+  let bundle = root.join("Model.mlmodelc");
+  std::fs::create_dir_all(bundle.join("weights")).expect("mkdir bundle weights/");
+
+  // Two real, pinned-style artifacts (one nested).
+  std::fs::write(bundle.join("model.mil"), b"mil").expect("write model.mil");
+  std::fs::write(bundle.join("weights/weight.bin"), b"w").expect("write weight.bin");
+  // OS-generated sidecars at two depths — every one must be skipped.
+  std::fs::write(bundle.join("._model.mil"), b"ad").expect("write ._model.mil");
+  std::fs::write(bundle.join(".DS_Store"), b"ds").expect("write .DS_Store");
+  std::fs::write(bundle.join("weights/._weight.bin"), b"ad").expect("write nested ._");
+  // A real, ordinary-named file that is NOT a sidecar and NOT pinned.
+  std::fs::write(bundle.join("rogue.bin"), b"x").expect("write rogue.bin");
+
+  let mut discovered: BTreeSet<String> = BTreeSet::new();
+  collect_files_rel(root, &bundle, &mut discovered);
+
+  // Discovery keeps every real file and drops every sidecar (at both depths).
+  assert_eq!(
+    discovered,
+    BTreeSet::from([
+      "Model.mlmodelc/model.mil".to_string(),
+      "Model.mlmodelc/rogue.bin".to_string(),
+      "Model.mlmodelc/weights/weight.bin".to_string(),
+    ]),
+    "discovery must exclude `._*`/.DS_Store sidecars and keep every real file"
+  );
+
+  // The filter did NOT blanket-suppress extras: an ordinary unpinned file still
+  // breaks the exact-set equality and shows up as the sole difference against a
+  // tree containing only the two real artifacts.
+  let pinned: BTreeSet<String> = BTreeSet::from([
+    "Model.mlmodelc/model.mil".to_string(),
+    "Model.mlmodelc/weights/weight.bin".to_string(),
+  ]);
+  assert_ne!(
+    discovered, pinned,
+    "a real unpinned extra must still break the exact-set equality"
+  );
+  let extras: Vec<String> = discovered.difference(&pinned).cloned().collect();
+  assert_eq!(
+    extras,
+    vec!["Model.mlmodelc/rogue.bin".to_string()],
+    "the surviving extra must be exactly the real unpinned file, not a sidecar"
+  );
 }
 
 #[test]

--- a/crates/coremlit/tests/speaker/parity_argmax_swift.rs
+++ b/crates/coremlit/tests/speaker/parity_argmax_swift.rs
@@ -43,6 +43,14 @@
 //!   its own [`ArgmaxComputeOptions`] matches what the golden was generated
 //!   with. Comparing a `.all`-placed Rust preprocessor against a `.cpuOnly`
 //!   Swift one would measure CoreML's scheduler and blame the port.
+//! - the golden records the `generationHost` (macOS build, chip, arch) it was
+//!   dumped on. CoreML `CpuOnly` floats are not contracted portable across macOS
+//!   builds/chips — the very drift the placement study acknowledges for `All` —
+//!   so the fidelity gate enforces its exact/1e-6 bounds only on a matching
+//!   host-class and fails a mismatched host toward `regen_goldens.sh` (same-host
+//!   regeneration IS the port test off the generation host). The tight bounds are
+//!   never widened. Goldens predating the field are enforced tightly with an
+//!   ambiguity note on failure.
 //!
 //! (As a free bonus the goldens record that WhisperKit's own AVFoundation
 //! loader — the one `DiarizeCLI` uses — decodes these WAVs to the *identical*
@@ -102,7 +110,10 @@
 //!
 //! `#[ignore]` (needs the gitignored `Models/argmax-speakerkit/` artifacts and
 //! the committed goldens); run via
-//! `ARGMAX_TEST_MODELS=… cargo test -p coremlit --features speaker -- --ignored`.
+//! `ARGMAX_TEST_MODELS=… cargo test -p coremlit --features speaker -- --ignored
+//! --test-threads=1` (serial recommended on memory-constrained hosts: several
+//! tests in this binary each load all three models, and libtest's default
+//! parallelism multiplies peak RSS).
 
 mod common;
 
@@ -133,7 +144,12 @@ use coremlit::{
 /// `MLMultiArray` for the segmenter's `.float16` `waveform` input and lets it
 /// convert), and both being IEEE round-to-nearest-even is a fact about the
 /// implementations rather than a contract. A value materially above zero is a
-/// FINDING (our mask or index mapping), never a tolerance to raise.
+/// FINDING — our mask or index mapping when the running host-class matches the
+/// golden's `generationHost`, or host-CoreML CpuOnly float drift when it does
+/// not (the same macOS/hardware sensitivity the `All`-placement study
+/// acknowledges; `CpuOnly` is not exempt across macOS builds/chips) — never a
+/// tolerance to raise. The host-aware gate fails a mismatched host toward
+/// same-host regeneration before this bound is ever consulted.
 const EMBED_MAX_ABS_TOL: f64 = 1e-6;
 
 /// Min cosine between our raw embedding and argmax's, per consumed
@@ -179,6 +195,12 @@ fn fixture_audio(name: &str) -> PathBuf {
 
 /// The fixture names, in golden order.
 const GATE_FIXTURES: &[&str] = &["02_pyannote_sample", "07_yuhewei_dongbei_english", "ted_60"];
+
+/// The regeneration script the host-aware gate points a mismatched (or legacy,
+/// unstamped) host at. Same-host regeneration IS the port-correctness test off
+/// the golden's generation host, so the fidelity gate names it rather than
+/// blaming the port or inviting a widened tolerance.
+const SPEAKER_REGEN_SCRIPT: &str = "crates/coremlit/tests/speaker/swift/regen_goldens.sh";
 
 // ─────────────────────────────────────────────────────────────────────────
 // The golden (written by tests/speaker/swift/Tests/ArgmaxTensorDump)
@@ -229,6 +251,11 @@ struct SwiftGolden {
   fresh_mask_alloc_all_zero: bool,
   chunks: Vec<SwiftChunk>,
   slots: Vec<SwiftSlot>,
+  /// The host-class the golden was generated on, or `None` for a legacy golden
+  /// that predates host provenance. FORM-validated by
+  /// [`common::HostClass::from_golden`]; the host MATCH is the model-gated
+  /// fidelity gate's job (`check_host_class` in [`measure`]), never the loader's.
+  generation_host: Option<common::HostClass>,
 }
 
 /// Decodes one slot's `activeFrames` bit string, hard-failing unless it is
@@ -339,6 +366,11 @@ fn load_swift_golden(name: &str) -> SwiftGolden {
       .expect("freshMaskAllocAllZero"),
     chunks,
     slots,
+    // FORM only — parses `generationHost` if present, tolerates its absence
+    // (legacy golden). This loader panics rather than returning Result, so keep
+    // that style; the host MATCH happens in the model-gated fidelity gate.
+    generation_host: common::HostClass::from_golden(name, &v)
+      .unwrap_or_else(|e| panic!("malformed golden: {e}")),
   }
 }
 
@@ -443,6 +475,13 @@ struct Fidelity {
   /// the embedding loop's `ours.contains(..)` filter silently shrinking
   /// coverage instead of failing — a bug that check would share with neither.
   golden_slots: usize,
+  /// Suffix for fidelity failure messages: empty when the golden's
+  /// `generationHost` matches the running host-class (or for the placement
+  /// study, which never consults the host gate); the ambiguity note when the
+  /// golden predates host provenance. A recorded-but-mismatched host has
+  /// already panicked with the regenerate diagnosis before any fidelity
+  /// number was produced.
+  host_failure_note: String,
 }
 
 /// Replays one fixture through [`ArgmaxSource`] at `compute` and measures it
@@ -470,7 +509,14 @@ fn measure(
   );
 
   // ── Placement-match proof: argmax's preprocessor is hardcoded .cpuOnly ──
-  if expect_golden_placement {
+  //
+  // The fidelity gate (`expect_golden_placement`) also runs the host-class gate
+  // here — the last precondition before the models load — producing the suffix
+  // appended to its fidelity failure messages. The placement STUDY
+  // (`expect_golden_placement == false`) sets the suffix empty and performs NO
+  // host check: it runs on `ComputeUnits::All` and its loose bounds absorb
+  // cross-host `CpuOnly` drift by design (see the placement-study doc).
+  let host_failure_note = if expect_golden_placement {
     let ours = [
       ("segmenter", compute.segmenter()),
       ("preprocessor", compute.preprocessor()),
@@ -491,7 +537,32 @@ fn measure(
         units.as_str()
       );
     }
-  }
+
+    // Host-class gate — after the placement proof, before any model loads.
+    let running = common::HostClass::running();
+    match common::check_host_class(
+      fixture,
+      golden.generation_host.as_ref(),
+      &running,
+      SPEAKER_REGEN_SCRIPT,
+    ) {
+      Ok(common::HostVerdict::Match) => {
+        println!("[host] {fixture}: golden generationHost matches this host: {running}");
+        String::new()
+      }
+      Ok(common::HostVerdict::LegacyUnknown) => {
+        println!(
+          "[host] {fixture}: golden has no generationHost (pre-host-provenance); tight \
+           bounds enforced — a failure would be ambiguous between port defect and host \
+           drift"
+        );
+        common::legacy_failure_note(SPEAKER_REGEN_SCRIPT)
+      }
+      Err(diagnosis) => panic!("{diagnosis}"),
+    }
+  } else {
+    String::new()
+  };
 
   // ── The pinned model contract the golden was dumped through ──
   assert_eq!(golden.windows_count, ARGMAX_WINDOWS_PER_CHUNK);
@@ -645,6 +716,7 @@ fn measure(
     exact_rows,
     compared_rows,
     golden_slots: golden.slots.len(),
+    host_failure_note,
   }
 }
 
@@ -660,6 +732,10 @@ fn measure(
 /// them (the mutation that used to make the segmentation comparison vacuous)
 /// fails HERE, without the model-gated fidelity run below. The model-gated
 /// gates additionally assert the realized compared-cell count in [`measure`].
+///
+/// It now also exercises [`common::HostClass::from_golden`] on every committed
+/// golden (each parses to legacy `None` today — the designated flip-site for
+/// the post-regen host-presence assert; see the owner-gated regen runbook).
 #[test]
 fn committed_goldens_load_through_the_strict_loader() {
   for fixture in GATE_FIXTURES {
@@ -710,6 +786,10 @@ fn argmax_execution_fidelity_vs_swift() {
 
   let (mut worst_abs, mut worst_cos) = (0.0f64, 1.0f64);
   let (mut exact_rows, mut compared_rows, mut seg_cells) = (0usize, 0usize, 0usize);
+  // The host-class suffix, captured from the per-fixture gate. All committed
+  // goldens share one provenance state (all matched, or all legacy-unstamped),
+  // so any fixture's note is the note for the aggregate bit-identity assert.
+  let mut host_failure_note = String::new();
   for fixture in GATE_FIXTURES {
     let f = measure(fixture, compute, true);
 
@@ -717,27 +797,32 @@ fn argmax_execution_fidelity_vs_swift() {
       f.only_ours.is_empty() && f.only_theirs.is_empty(),
       "{fixture}: the consumed (chunk, slot) set differs from argmax's.\n  only ours: {:?}\n  \
        only theirs: {:?}\nThe activity gate, the bounded() filter and Extraction's zero-column \
-       invariant all land here — this is a mapping bug.",
+       invariant all land here — on a matching host-class this is a mapping bug.{}",
       f.only_ours,
-      f.only_theirs
+      f.only_theirs,
+      f.host_failure_note
     );
     assert_eq!(
       f.seg_mismatches, 0,
       "{fixture}: {} of {} segmentation cells disagree with argmax's speaker_ids. Both sides read \
-       the SAME hard tensor, so this is an indexing bug, not a tolerance.",
-      f.seg_mismatches, f.seg_cells
+       the SAME hard tensor, so on a matching host-class this is an indexing bug, not a \
+       tolerance.{}",
+      f.seg_mismatches, f.seg_cells, f.host_failure_note
     );
     assert!(
       f.worst_abs <= EMBED_MAX_ABS_TOL,
       "{fixture}: embedding max|diff| {:.6e} exceeds {EMBED_MAX_ABS_TOL:e}. Placement is matched \
-       and the masks are provably identical (dia's fallback fires 0x), so this is OUR mask or \
-       index mapping — a FINDING, not a bound to raise.",
-      f.worst_abs
+       and the masks are provably identical (dia's fallback fires 0x), so on a matching \
+       host-class this is OUR mask or index mapping — a FINDING, not a bound to raise.{}",
+      f.worst_abs,
+      f.host_failure_note
     );
     assert!(
       f.worst_cos >= EMBED_COS_TOL,
-      "{fixture}: embedding cosine {:.9} below {EMBED_COS_TOL}. See above — this is a FINDING.",
-      f.worst_cos
+      "{fixture}: embedding cosine {:.9} below {EMBED_COS_TOL}. See above — on a matching \
+       host-class this is a FINDING.{}",
+      f.worst_cos,
+      f.host_failure_note
     );
 
     worst_abs = worst_abs.max(f.worst_abs);
@@ -745,6 +830,7 @@ fn argmax_execution_fidelity_vs_swift() {
     exact_rows += f.exact_rows;
     compared_rows += f.compared_rows;
     seg_cells += f.seg_cells;
+    host_failure_note = f.host_failure_note;
   }
 
   println!(
@@ -759,8 +845,9 @@ fn argmax_execution_fidelity_vs_swift() {
     compared_rows,
     "every consumed embedding row was bit-identical when this gate was written ({compared_rows} of \
      them); {} now differ within tolerance. Investigate before relaxing this: same models, same \
-     placement, same input and same mask should be bit-reproducible.",
-    compared_rows - exact_rows
+     placement, same input and same mask should be bit-reproducible.{}",
+    compared_rows - exact_rows,
+    host_failure_note
   );
 }
 
@@ -774,7 +861,11 @@ fn argmax_execution_fidelity_vs_swift() {
 /// loosened. argmax's own Swift is subject to the identical effect (its
 /// segmenter defaults to `.cpuOnly` but `PyannoteModelManager` places it
 /// wherever its `ModelInfo` says), so this is a property of the MODEL on this
-/// hardware, not of the port.
+/// hardware, not of the port. On a host-class differing from the golden's
+/// generationHost, the measured divergence additionally includes cross-host
+/// CpuOnly drift; the loose bounds absorb it by design — this study
+/// characterizes scheduling, it is not the fidelity gate and performs no host
+/// check.
 ///
 /// **What it measures (and it is not nothing):** ANE/GPU placement flips
 /// **66 of 72 447** hard `speaker_ids` cells (**0.0911%**) and moves EVERY
@@ -860,5 +951,142 @@ fn argmax_default_placement_vs_the_cpu_only_reference() {
     worst_cos >= PLACEMENT_COS_TOL,
     "ANE/GPU placement degrades an embedding to cosine {worst_cos:.9}, below the measured \
      {PLACEMENT_COS_TOL}. See above."
+  );
+}
+
+// ── Hermetic host-class gate tests (no model; drive THIS suite's common copy) ─
+
+/// A synthetic host-class for the pure-predicate tests below.
+fn synthetic_host() -> common::HostClass {
+  common::HostClass {
+    os_build: "24F74".to_string(),
+    os_product_version: "15.5".to_string(),
+    chip: "Apple M1".to_string(),
+    arch: "arm64".to_string(),
+  }
+}
+
+/// [`common::HostClass::from_golden`] is strict on a present `generationHost`
+/// but legacy-tolerant of its absence — driven directly with `serde_json::json!`
+/// values, independent of the full golden loader.
+#[test]
+fn generation_host_parse_is_strict_and_legacy_tolerant() {
+  // Absent → legacy (`None`), never an error: unstamped committed goldens must
+  // keep parsing on every host.
+  let absent = serde_json::json!({});
+  assert_eq!(
+    common::HostClass::from_golden("wf", &absent).expect("absent must be Ok"),
+    None
+  );
+
+  // Well-formed synthetic → `Some`, fields verified.
+  let ok = serde_json::json!({
+    "generationHost": {
+      "osBuild": "99Z999",
+      "osProductVersion": "99.9",
+      "chip": "Synthetic Chip",
+      "arch": "arm64"
+    }
+  });
+  assert_eq!(
+    common::HostClass::from_golden("wf", &ok).expect("well-formed must be Ok"),
+    Some(common::HostClass {
+      os_build: "99Z999".to_string(),
+      os_product_version: "99.9".to_string(),
+      chip: "Synthetic Chip".to_string(),
+      arch: "arm64".to_string(),
+    })
+  );
+
+  // Malformed (missing `arch`) → `Err` naming the field.
+  let bad = serde_json::json!({
+    "generationHost": {
+      "osBuild": "99Z999",
+      "osProductVersion": "99.9",
+      "chip": "Synthetic Chip"
+    }
+  });
+  assert!(
+    common::HostClass::from_golden("wf", &bad)
+      .unwrap_err()
+      .contains("generationHost")
+  );
+}
+
+#[test]
+fn host_gate_matches_identical_host_class() {
+  let h = synthetic_host();
+  assert_eq!(
+    common::check_host_class("wf", Some(&h), &h, SPEAKER_REGEN_SCRIPT),
+    Ok(common::HostVerdict::Match)
+  );
+}
+
+#[test]
+fn host_gate_mismatch_diagnoses_regeneration_not_port_defect() {
+  let base = synthetic_host();
+  // One pair differs in osBuild only; the other in chip only.
+  let other_build = common::HostClass {
+    os_build: "24G84".to_string(),
+    ..base.clone()
+  };
+  let other_chip = common::HostClass {
+    chip: "Apple M1 Pro".to_string(),
+    ..base.clone()
+  };
+  for (recorded, running) in [(&base, &other_build), (&base, &other_chip)] {
+    let diagnosis = common::check_host_class("wf", Some(recorded), running, SPEAKER_REGEN_SCRIPT)
+      .expect_err("a differing host-class must be diagnosed, not matched");
+    let golden_render = recorded.to_string();
+    let running_render = running.to_string();
+    assert!(
+      diagnosis.contains(golden_render.as_str()),
+      "diagnosis must name the golden host: {diagnosis}"
+    );
+    assert!(
+      diagnosis.contains(running_render.as_str()),
+      "diagnosis must name the running host: {diagnosis}"
+    );
+    assert!(
+      diagnosis.contains("regen_goldens.sh"),
+      "diagnosis must point at regeneration: {diagnosis}"
+    );
+    assert!(
+      diagnosis.contains("NOT evidence of a port defect"),
+      "diagnosis must not blame the port: {diagnosis}"
+    );
+  }
+}
+
+#[test]
+fn host_gate_treats_unstamped_golden_as_legacy_ambiguous() {
+  let running = synthetic_host();
+  assert_eq!(
+    common::check_host_class("wf", None, &running, SPEAKER_REGEN_SCRIPT),
+    Ok(common::HostVerdict::LegacyUnknown)
+  );
+  let note = common::legacy_failure_note(SPEAKER_REGEN_SCRIPT);
+  assert!(
+    note.contains("AMBIGUOUS"),
+    "legacy note must flag ambiguity"
+  );
+  assert!(
+    note.contains("regen_goldens.sh"),
+    "legacy note must point at regeneration"
+  );
+}
+
+#[test]
+fn running_host_class_is_well_formed() {
+  // The only hermetic test that shells out to sysctl; CI is macos-15 on every
+  // job, so this is safe and catches a sysctl-key typo without any model.
+  let h = common::HostClass::running();
+  assert!(!h.os_build.is_empty(), "osBuild empty");
+  assert!(!h.os_product_version.is_empty(), "osProductVersion empty");
+  assert!(!h.chip.is_empty(), "chip empty");
+  assert!(
+    h.arch == "arm64" || h.arch == "x86_64",
+    "arch {:?} is neither arm64 nor x86_64",
+    h.arch
   );
 }

--- a/crates/coremlit/tests/speaker/parity_argmax_swift.rs
+++ b/crates/coremlit/tests/speaker/parity_argmax_swift.rs
@@ -786,9 +786,17 @@ fn argmax_execution_fidelity_vs_swift() {
 
   let (mut worst_abs, mut worst_cos) = (0.0f64, 1.0f64);
   let (mut exact_rows, mut compared_rows, mut seg_cells) = (0usize, 0usize, 0usize);
-  // The host-class suffix, captured from the per-fixture gate. All committed
-  // goldens share one provenance state (all matched, or all legacy-unstamped),
-  // so any fixture's note is the note for the aggregate bit-identity assert.
+  // The host-class suffix for the aggregate bit-identity assert below. All
+  // committed goldens today share one provenance state (all matched, or all
+  // legacy-unstamped) -- and `measure` already fails eagerly on a real host
+  // MISMATCH -- so within a single run the only two notes reachable here are
+  // "" (matched) and the one shared legacy-ambiguity string; a non-empty note
+  // is therefore never fixture-specific content, just a flag that this run
+  // touched an unstamped golden. Keeping the first NON-EMPTY note (rather
+  // than unconditionally overwriting with the LAST fixture's) keeps this
+  // cause-neutral if a future golden set ever mixed stamped and legacy
+  // goldens, instead of silently attributing one fixture's host state to a
+  // divergence a different fixture caused.
   let mut host_failure_note = String::new();
   for fixture in GATE_FIXTURES {
     let f = measure(fixture, compute, true);
@@ -830,7 +838,12 @@ fn argmax_execution_fidelity_vs_swift() {
     exact_rows += f.exact_rows;
     compared_rows += f.compared_rows;
     seg_cells += f.seg_cells;
-    host_failure_note = f.host_failure_note;
+    // Cause-neutral: keep the note only if it is non-empty, rather than
+    // unconditionally overwriting with the LAST fixture's -- see the
+    // `host_failure_note` declaration above.
+    if !f.host_failure_note.is_empty() {
+      host_failure_note = f.host_failure_note;
+    }
   }
 
   println!(

--- a/crates/coremlit/tests/speaker/swift/Tests/ArgmaxTensorDump/DumpArgmaxTensors.swift
+++ b/crates/coremlit/tests/speaker/swift/Tests/ArgmaxTensorDump/DumpArgmaxTensors.swift
@@ -59,6 +59,18 @@ import XCTest
 
 // MARK: - Golden schema (mirrored by `parity_argmax_swift.rs`)
 
+/// The host-class the golden was generated on — the four sysctl-derived fields
+/// `coremlit`'s `HostClass` compares to gate the tight fidelity bounds. CoreML
+/// `CpuOnly` floats are not contracted portable across macOS builds or chips
+/// (#36), so a golden is trustworthy as a bit-exact oracle only on a matching
+/// host. Mirrored by `parity_argmax_swift.rs`.
+private struct GoldenHost: Encodable {
+  let osBuild: String
+  let osProductVersion: String
+  let chip: String
+  let arch: String
+}
+
 /// One consumed `(chunk, slot)`: exactly the pair of tensors `Extraction`
 /// carries for it, as argmax's own Swift read them.
 private struct GoldenSlot: Encodable {
@@ -117,6 +129,10 @@ private struct Golden: Encodable {
   let fixture: String
   let generator: String
   let argmaxSwiftRevision: String
+  /// The host-class this golden was generated on. `parity_argmax_swift.rs`'s
+  /// host-aware gate enforces the exact/1e-6 fidelity bounds only when the
+  /// running host matches this, and points a mismatch at regeneration.
+  let generationHost: GoldenHost
   /// argmax's baseline tier: `W32A32` segmenter + `W16A16` embedder pair —
   /// `ArgmaxVariant::Baseline`.
   let variant: String
@@ -178,6 +194,17 @@ final class DumpArgmaxTensors: XCTestCase {
     XCTAssertFalse(fixtures.isEmpty, "SPEAKERKIT_FIXTURES is empty")
 
     let pipeline = try await Pipeline(modelsRoot: modelsRoot)
+
+    // The host-class every golden in this run is stamped with. Read ONCE via
+    // the identical sysctl keys `parity_argmax_swift.rs` reads, so string
+    // equality is well-defined by construction; a read failure hard-fails the
+    // dump rather than stamping a fake host.
+    let generationHost = GoldenHost(
+      osBuild: try sysctlString("kern.osversion"),
+      osProductVersion: try sysctlString("kern.osproductversion"),
+      chip: try sysctlString("machdep.cpu.brand_string"),
+      arch: processArch
+    )
 
     for (index, fixture) in fixtures.enumerated() {
       let samples = try readPcm16Mono16k(URL(fileURLWithPath: fixture.path))
@@ -242,6 +269,7 @@ final class DumpArgmaxTensors: XCTestCase {
         fixture: fixture.name,
         generator: "crates/coremlit/tests/speaker/swift/Tests/ArgmaxTensorDump/DumpArgmaxTensors.swift",
         argmaxSwiftRevision: revision,
+        generationHost: generationHost,
         variant: "baseline",
         computeUnits: [
           "segmenter": "cpu_only",
@@ -272,7 +300,9 @@ final class DumpArgmaxTensors: XCTestCase {
       try encoder.encode(golden).write(to: path)
       print(
         "[dump] \(fixture.name): \(samples.count) samples, \(run.chunks.count) argmax chunk(s), "
-          + "\(slots.count) consumed (chunk, slot) pairs -> \(path.path)")
+          + "\(slots.count) consumed (chunk, slot) pairs, "
+          + "host \(generationHost.osProductVersion)/\(generationHost.osBuild)/"
+          + "\(generationHost.chip)/\(generationHost.arch) -> \(path.path)")
     }
   }
 }
@@ -405,6 +435,43 @@ private func multiArray(_ output: SpeakerSegmenterOutput, _ name: String) throws
     throw DumpError.badEnvironment("segmenter output '\(name)' is missing")
   }
   return value
+}
+
+// MARK: - Host
+
+/// Reads a sysctl string by name using the two-call protocol (size query, then
+/// read), NUL-terminated by `String(cString:)` and whitespace-trimmed. The Rust
+/// gate reads the IDENTICAL keys via `/usr/sbin/sysctl -n`, so the recorded
+/// strings compare by construction — do NOT substitute
+/// `ProcessInfo.operatingSystemVersion` (it formats "15.5.0" where
+/// `kern.osproductversion` is "15.5"). Throws rather than stamping a fake host.
+private func sysctlString(_ name: String) throws -> String {
+  var size = 0
+  guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else {
+    throw DumpError.badEnvironment("sysctl \(name): size query failed")
+  }
+  var buffer = [CChar](repeating: 0, count: size)
+  guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else {
+    throw DumpError.badEnvironment("sysctl \(name): read failed")
+  }
+  let value = String(cString: buffer).trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !value.isEmpty else {
+    throw DumpError.badEnvironment("sysctl \(name): empty value")
+  }
+  return value
+}
+
+/// The process architecture governing which CPU kernels run in-process, spelled
+/// as `coremlit`'s `HostClass` normalizes it (`arm64`/`x86_64`). Compile-time
+/// arch IS the process arch.
+private var processArch: String {
+  #if arch(arm64)
+    return "arm64"
+  #elseif arch(x86_64)
+    return "x86_64"
+  #else
+    #error("unsupported host architecture for golden generation")
+  #endif
 }
 
 // MARK: - Audio

--- a/crates/coremlit/tests/vad/common/mod.rs
+++ b/crates/coremlit/tests/vad/common/mod.rs
@@ -167,3 +167,192 @@ pub fn sha256_hex(path: &Path) -> String {
     .map(|b| format!("{b:02x}"))
     .collect()
 }
+
+// ── Host-class provenance for the committed-Swift-golden parity gate ────────
+//
+// CoreML `CpuOnly` kernels ship with the OS and are not contracted to produce
+// identical floats across macOS builds or chip generations (#36), so the parity
+// gate stamps each golden with the host-class it was generated on and enforces
+// its tight bound only against a matching host (see `check_host_class`). This
+// block is duplicated verbatim in the vad and speaker `common/mod.rs` — the
+// repo's self-contained-`common` convention, the same one that already
+// duplicates `fnv1a_f32`/`load_wav_16k_mono`; each suite's hermetic tests drive
+// its own copy, which is what guards the two copies against drift.
+
+/// The host-class identity that determines CoreML `CpuOnly` float
+/// reproducibility: macOS build (the OS binary set every CPU kernel ships
+/// in), chip (kernel dispatch varies by microarchitecture), process arch
+/// (Rosetta), plus the human-readable product version (fully determined by
+/// the build; carried for diagnostics). Deliberately NOT included: Xcode /
+/// Swift toolchain (compiles the dumper, not the runtime kernels — inputs
+/// are FNV-pinned and model bytes SHA-pinned), `hw.model` (same chip + build
+/// ⇒ same CPU floats), RAM/core counts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostClass {
+  pub os_build: String,
+  pub os_product_version: String,
+  pub chip: String,
+  pub arch: String,
+}
+
+impl HostClass {
+  /// The RUNNING host's class. Reads the sysctl keys the Swift dumpers read
+  /// (`kern.osversion`, `kern.osproductversion`, `machdep.cpu.brand_string`) by
+  /// shelling out to `/usr/sbin/sysctl`, and normalizes the process arch to the
+  /// `arm64`/`x86_64` spelling the dumpers record. Called only from model-gated
+  /// tests and the `running_host_class_is_well_formed` smoke test — hermetic
+  /// predicate tests use synthetic values.
+  ///
+  /// Production code (`src/audio/whisper/model/mod.rs::device_identifier`)
+  /// deliberately uses `libc::sysctlbyname`; this test-side reader deliberately
+  /// shells out instead — spawn cost is irrelevant in a model-gated test and it
+  /// keeps the test tree free of `unsafe`.
+  ///
+  /// # Panics
+  /// With a `host-class gate:` message if a sysctl read fails or is empty
+  /// (model-gated dev machines only — sysctl always exists on macOS).
+  pub fn running() -> Self {
+    HostClass {
+      os_build: sysctl_string("kern.osversion"),
+      os_product_version: sysctl_string("kern.osproductversion"),
+      chip: sysctl_string("machdep.cpu.brand_string"),
+      // The aarch64 -> arm64 normalization is load-bearing: without it every
+      // Apple-Silicon run would mismatch every golden (the dumpers record
+      // `arm64` via compile-time `#if arch(arm64)`, and compile-time arch IS
+      // the process arch that governs the in-process `CpuOnly` kernels).
+      arch: match std::env::consts::ARCH {
+        "aarch64" => "arm64".to_string(),
+        other => other.to_string(),
+      },
+    }
+  }
+
+  /// Reads the OPTIONAL `generationHost` object from a golden's JSON. Absent or
+  /// `null` → `Ok(None)` (a legacy golden, pre-host-provenance). Present → must
+  /// be an object whose `osBuild`/`osProductVersion`/`chip`/`arch` are all
+  /// non-empty strings; unknown extra keys inside the object are tolerated.
+  ///
+  /// FORM only — the host MATCH is [`check_host_class`]'s job, never the
+  /// parser's: the hermetic loader tests and the committed goldens must parse on
+  /// EVERY host (this one included).
+  ///
+  /// # Errors
+  /// If `generationHost` is present but not an object, or is missing any of the
+  /// four fields as a non-empty string. Every message contains `generationHost`.
+  pub fn from_golden(name: &str, v: &serde_json::Value) -> Result<Option<Self>, String> {
+    let host = match v.get("generationHost") {
+      None | Some(serde_json::Value::Null) => return Ok(None),
+      Some(serde_json::Value::Object(map)) => map,
+      Some(other) => {
+        return Err(format!(
+          "{name}: `generationHost` is {other} — expected an object with osBuild / \
+           osProductVersion / chip / arch string fields"
+        ));
+      }
+    };
+    let field = |key: &str| -> Result<String, String> {
+      host
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| format!("{name}: `generationHost.{key}` is missing, not a string, or empty"))
+    };
+    Ok(Some(HostClass {
+      os_build: field("osBuild")?,
+      os_product_version: field("osProductVersion")?,
+      chip: field("chip")?,
+      arch: field("arch")?,
+    }))
+  }
+}
+
+impl std::fmt::Display for HostClass {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(
+      f,
+      "macOS {} (build {}), {}, {}",
+      self.os_product_version, self.os_build, self.chip, self.arch
+    )
+  }
+}
+
+/// Reads one sysctl value as a trimmed string via `/usr/sbin/sysctl -n`
+/// (absolute path — PATH-independent).
+///
+/// # Panics
+/// With a `host-class gate:` message on spawn failure, a non-zero exit, or
+/// empty output.
+fn sysctl_string(key: &str) -> String {
+  let output = std::process::Command::new("/usr/sbin/sysctl")
+    .args(["-n", key])
+    .output()
+    .unwrap_or_else(|e| panic!("host-class gate: cannot spawn /usr/sbin/sysctl for `{key}`: {e}"));
+  assert!(
+    output.status.success(),
+    "host-class gate: `/usr/sbin/sysctl -n {key}` exited {}",
+    output.status
+  );
+  let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+  assert!(
+    !value.is_empty(),
+    "host-class gate: `/usr/sbin/sysctl -n {key}` produced empty output"
+  );
+  value
+}
+
+/// Verdict of the host-class gate for one golden.
+#[derive(Debug, PartialEq, Eq)]
+pub enum HostVerdict {
+  /// `generationHost` recorded and equal to the running host-class: the tight
+  /// parity bounds apply and a failure is cleanly attributable to the port.
+  Match,
+  /// The golden predates host provenance (no `generationHost`): the tight
+  /// bounds still apply (a PASS is sound evidence on any host — a port bug
+  /// exactly cancelling host drift under these bounds is not a real risk),
+  /// but a FAILURE is ambiguous between a port defect and host-CoreML drift —
+  /// append [`legacy_failure_note`] to fidelity failure messages.
+  LegacyUnknown,
+}
+
+/// THE host-class match predicate + mismatch diagnosis. Pure — no I/O — so the
+/// hermetic tests drive it with synthetic host-class values.
+///
+/// # Errors
+/// The full actionable diagnosis for a recorded-but-different host; the caller
+/// panics with it BEFORE any CoreML number is produced.
+pub fn check_host_class(
+  fixture: &str,
+  recorded: Option<&HostClass>,
+  running: &HostClass,
+  regen_script: &str,
+) -> Result<HostVerdict, String> {
+  match recorded {
+    None => Ok(HostVerdict::LegacyUnknown),
+    Some(r) if r == running => Ok(HostVerdict::Match),
+    Some(r) => Err(format!(
+      "{fixture}: committed golden was generated on a DIFFERENT host-class.\n  \
+       golden host : {r}\n  this host   : {running}\n\
+       CoreML CpuOnly floating point is not contracted portable across macOS builds or chips,\n\
+       so the tight parity bound would misattribute host float drift to the port. This failure\n\
+       is NOT evidence of a port defect. To test the port on this machine, regenerate a\n\
+       same-host oracle and re-run:\n  {regen_script}\n\
+       Do NOT widen the parity tolerances instead — the tight bounds are what catch real\n\
+       stitching/index-mapping regressions on a matching host."
+    )),
+  }
+}
+
+/// The ambiguity note appended to a fidelity failure when the golden predates
+/// host-class provenance (a [`HostVerdict::LegacyUnknown`] golden): the failure
+/// cannot be cleanly attributed to the port versus host-CoreML drift, and the
+/// fix is a same-host regeneration, never a widened tolerance.
+pub fn legacy_failure_note(regen_script: &str) -> String {
+  format!(
+    "\nNOTE: this golden predates host-class provenance (no `generationHost` field), so this\n\
+     failure is AMBIGUOUS between a port defect and host-CoreML CpuOnly float drift (CpuOnly\n\
+     floats are not contracted portable across macOS builds/chips). Regenerate a same-host\n\
+     oracle via {regen_script} to disambiguate — regeneration also stamps `generationHost`.\n\
+     Do NOT widen the tolerance."
+  )
+}

--- a/crates/coremlit/tests/vad/parity_swift.rs
+++ b/crates/coremlit/tests/vad/parity_swift.rs
@@ -18,6 +18,19 @@
 //! skew moving ~10 % of chunks by up to ~5e-3, an order above the bound). The
 //! `strict_loader_*` hermetic tests additionally prove a MALFORMED golden is
 //! rejected before a single fidelity number is read.
+//!
+//! # The bound is a SAME-HOST-CLASS bound (host-aware gate)
+//!
+//! CoreML `CpuOnly` kernels ship with the OS (BNNS/Accelerate/Espresso) and are
+//! not contracted to produce identical floats across macOS builds or chip
+//! generations — cross-host drift up to ~1.2e-2 has been measured on this very
+//! trace after LSTM recurrence amplification (#36). Each golden therefore records
+//! the `generationHost` it was dumped on; the gate enforces [`TRACE_TOL`]
+//! unchanged when the running host-class matches, and on a mismatch fails with a
+//! regenerate-a-same-host-oracle diagnosis instead of blaming the port. The bound
+//! itself is NEVER widened for cross-host runs — a wide band would blind the gate
+//! to the stitching regressions it exists to catch. Goldens predating the
+//! `generationHost` field get the tight bounds with an ambiguity note on failure.
 
 mod common;
 
@@ -43,7 +56,16 @@ const GATE_FIXTURES: &[&str] = &["02_pyannote_sample", "07_yuhewei_dongbei_engli
 /// order of magnitude below the ~5e-3 a one-sample context skew moves the
 /// output (`tests/model_state.rs`), and 10x below the ±1e-3 probability
 /// perturbation the trace-mutation gate injects, so neither can hide under it.
+/// The bound is enforced only against a same-host-class golden (see the module
+/// doc's host-aware-gate section); a host-class mismatch fails toward
+/// regeneration, never toward a wider tolerance.
 const TRACE_TOL: f64 = 1e-4;
+
+/// The regeneration script the host-aware gate points a mismatched (or legacy,
+/// unstamped) host at. Same-host regeneration IS the port-correctness test off
+/// the golden's generation host, so the diagnosis names it rather than blaming
+/// the port or inviting a widened tolerance.
+const VAD_REGEN_SCRIPT: &str = "crates/coremlit/tests/vad/swift/regen_goldens.sh";
 
 /// The pinned generator identity every committed golden must record: the Swift
 /// dumper that produced it (`DumpVadTraces.swift`). A golden whose `generator`
@@ -78,6 +100,11 @@ struct SwiftGolden {
   input_samples: usize,
   input_fnv1a: String,
   chunks: Vec<SwiftChunk>,
+  /// The host-class the golden was generated on, or `None` for a legacy golden
+  /// that predates host provenance. FORM-validated by
+  /// [`common::HostClass::from_golden`]; the host MATCH is the model-gated
+  /// gate's job (`check_host_class`), never the parser's.
+  generation_host: Option<common::HostClass>,
 }
 
 /// STRICTLY parses a Swift trace golden from its JSON, hard-erroring on ANY
@@ -216,6 +243,10 @@ fn parse_golden(name: &str, v: &serde_json::Value) -> Result<SwiftGolden, String
     input_samples: usize_field("inputSamples")?,
     input_fnv1a: str_field("inputFnv1a")?,
     chunks,
+    // FORM only — parses `generationHost` if present, tolerates its absence
+    // (legacy golden). The host MATCH happens in the model-gated gate, so the
+    // strict-loader and committed-golden hermetic tests parse on every host.
+    generation_host: common::HostClass::from_golden(name, v)?,
   })
 }
 
@@ -251,6 +282,9 @@ fn vad_probabilities_match_fluidaudio_swift_trace() {
   let mut overall_worst = 0.0f64;
   let mut total_chunks = 0usize;
 
+  // The running host-class, read once (all fixtures share this machine).
+  let running = common::HostClass::running();
+
   for &fixture in GATE_FIXTURES {
     let golden = load_swift_golden(fixture);
 
@@ -283,6 +317,35 @@ fn vad_probabilities_match_fluidaudio_swift_trace() {
       golden.input_fnv1a,
       "{fixture}: input FNV-1a mismatch — the gate and the oracle saw different audio"
     );
+
+    // Host-class gate — the LAST precondition before the first CoreML-produced
+    // number. The fixture/generator/revision/geometry/input guards above are
+    // host-independent harness-validity checks and must keep failing first (a
+    // harness bug must never be reported as a host mismatch); only once they
+    // pass does host-class attribution become the question. A recorded-but-
+    // different host panics here with the regenerate diagnosis before any
+    // probability is compared; a legacy (unstamped) golden yields the ambiguity
+    // note appended to the fidelity failure below.
+    let host_note = match common::check_host_class(
+      fixture,
+      golden.generation_host.as_ref(),
+      &running,
+      VAD_REGEN_SCRIPT,
+    ) {
+      Ok(common::HostVerdict::Match) => {
+        println!("[host] {fixture}: golden generationHost matches this host: {running}");
+        String::new()
+      }
+      Ok(common::HostVerdict::LegacyUnknown) => {
+        println!(
+          "[host] {fixture}: golden has no generationHost (pre-host-provenance); tight \
+           bounds enforced — a failure would be ambiguous between port defect and host \
+           drift"
+        );
+        common::legacy_failure_note(VAD_REGEN_SCRIPT)
+      }
+      Err(diagnosis) => panic!("{diagnosis}"),
+    };
 
     // Replay vadkit over the SAME 4096-stride chunking (the short final chunk
     // is included and padded inside predict_chunk, exactly as VadManager does).
@@ -317,7 +380,7 @@ fn vad_probabilities_match_fluidaudio_swift_trace() {
       assert!(
         delta <= TRACE_TOL,
         "{fixture}: chunk {}: |Δ| {delta:.3e} exceeds {TRACE_TOL:.0e} \
-         (vadkit={p_rust}, swift={})",
+         (vadkit={p_rust}, swift={}){host_note}",
         gold.chunk_index,
         gold.probability
       );
@@ -351,6 +414,15 @@ fn well_formed() -> serde_json::Value {
     "fixture": "wf",
     "generator": "crates/coremlit/tests/vad/swift/Tests/VadTraceDump/DumpVadTraces.swift",
     "fluidAudioRevision": "1a2da18",
+    // A deliberately UNREAL host: it can never equal a running host-class, so
+    // any accidental parse-time host enforcement would fail the hermetic suite
+    // on every machine (the D4 trap guard).
+    "generationHost": {
+      "osBuild": "99Z999",
+      "osProductVersion": "99.9",
+      "chip": "Synthetic Chip",
+      "arch": "arm64"
+    },
     "determinismVerified": true,
     "computeUnits": "cpu_only",
     "sampleRate": 16000,
@@ -374,6 +446,15 @@ fn strict_loader_accepts_a_well_formed_golden() {
   assert_eq!(g.chunks.len(), 2);
   assert_eq!(g.chunks[0].probability, 1.0);
   assert_eq!(g.chunks[1].unpadded_samples, 2805);
+  assert_eq!(
+    g.generation_host,
+    Some(common::HostClass {
+      os_build: "99Z999".to_string(),
+      os_product_version: "99.9".to_string(),
+      chip: "Synthetic Chip".to_string(),
+      arch: "arm64".to_string(),
+    })
+  );
 }
 
 #[test]
@@ -501,4 +582,166 @@ fn strict_loader_tolerates_absent_determinism_verified() {
     .unwrap()
     .remove("determinismVerified");
   parse_golden("wf", &missing).expect("missing determinismVerified must be tolerated");
+}
+
+#[test]
+fn strict_loader_tolerates_absent_generation_host() {
+  // Mirror the determinismVerified absent-tolerance: both an explicit `null`
+  // and a removed key parse to `generation_host == None` (a legacy golden), so
+  // committed unstamped goldens keep loading on every host.
+  let mut null = well_formed();
+  null["generationHost"] = serde_json::Value::Null;
+  assert_eq!(
+    parse_golden("wf", &null)
+      .expect("null generationHost must be tolerated")
+      .generation_host,
+    None
+  );
+
+  let mut missing = well_formed();
+  missing.as_object_mut().unwrap().remove("generationHost");
+  assert_eq!(
+    parse_golden("wf", &missing)
+      .expect("absent generationHost must be tolerated")
+      .generation_host,
+    None
+  );
+}
+
+#[test]
+fn strict_loader_rejects_malformed_generation_host() {
+  // A string, not an object.
+  let mut a_string = well_formed();
+  a_string["generationHost"] = serde_json::json!("Apple M1");
+  assert!(
+    parse_golden("wf", &a_string)
+      .unwrap_err()
+      .contains("generationHost")
+  );
+
+  // An object missing `chip`.
+  let mut missing_chip = well_formed();
+  missing_chip["generationHost"]
+    .as_object_mut()
+    .unwrap()
+    .remove("chip");
+  assert!(
+    parse_golden("wf", &missing_chip)
+      .unwrap_err()
+      .contains("generationHost")
+  );
+
+  // An object with an empty `osBuild`.
+  let mut empty_build = well_formed();
+  empty_build["generationHost"]["osBuild"] = serde_json::json!("");
+  assert!(
+    parse_golden("wf", &empty_build)
+      .unwrap_err()
+      .contains("generationHost")
+  );
+}
+
+// ── Hermetic host-class gate tests (no model; synthetic host-classes) ───────
+
+/// A synthetic host-class for the pure-predicate tests below.
+fn synthetic_host() -> common::HostClass {
+  common::HostClass {
+    os_build: "24F74".to_string(),
+    os_product_version: "15.5".to_string(),
+    chip: "Apple M1".to_string(),
+    arch: "arm64".to_string(),
+  }
+}
+
+#[test]
+fn host_gate_matches_identical_host_class() {
+  let h = synthetic_host();
+  assert_eq!(
+    common::check_host_class("wf", Some(&h), &h, VAD_REGEN_SCRIPT),
+    Ok(common::HostVerdict::Match)
+  );
+}
+
+#[test]
+fn host_gate_mismatch_diagnoses_regeneration_not_port_defect() {
+  let base = synthetic_host();
+  // One pair differs in osBuild only; the other in chip only.
+  let other_build = common::HostClass {
+    os_build: "24G84".to_string(),
+    ..base.clone()
+  };
+  let other_chip = common::HostClass {
+    chip: "Apple M1 Pro".to_string(),
+    ..base.clone()
+  };
+  for (recorded, running) in [(&base, &other_build), (&base, &other_chip)] {
+    let diagnosis = common::check_host_class("wf", Some(recorded), running, VAD_REGEN_SCRIPT)
+      .expect_err("a differing host-class must be diagnosed, not matched");
+    let golden_render = recorded.to_string();
+    let running_render = running.to_string();
+    assert!(
+      diagnosis.contains(golden_render.as_str()),
+      "diagnosis must name the golden host: {diagnosis}"
+    );
+    assert!(
+      diagnosis.contains(running_render.as_str()),
+      "diagnosis must name the running host: {diagnosis}"
+    );
+    assert!(
+      diagnosis.contains("regen_goldens.sh"),
+      "diagnosis must point at regeneration: {diagnosis}"
+    );
+    assert!(
+      diagnosis.contains("NOT evidence of a port defect"),
+      "diagnosis must not blame the port: {diagnosis}"
+    );
+  }
+}
+
+#[test]
+fn host_gate_treats_unstamped_golden_as_legacy_ambiguous() {
+  let running = synthetic_host();
+  assert_eq!(
+    common::check_host_class("wf", None, &running, VAD_REGEN_SCRIPT),
+    Ok(common::HostVerdict::LegacyUnknown)
+  );
+  let note = common::legacy_failure_note(VAD_REGEN_SCRIPT);
+  assert!(
+    note.contains("AMBIGUOUS"),
+    "legacy note must flag ambiguity"
+  );
+  assert!(
+    note.contains("regen_goldens.sh"),
+    "legacy note must point at regeneration"
+  );
+}
+
+#[test]
+fn running_host_class_is_well_formed() {
+  // The only hermetic test that shells out to sysctl; CI is macos-15 on every
+  // job, so this is safe and catches a sysctl-key typo without any model.
+  let h = common::HostClass::running();
+  assert!(!h.os_build.is_empty(), "osBuild empty");
+  assert!(!h.os_product_version.is_empty(), "osProductVersion empty");
+  assert!(!h.chip.is_empty(), "chip empty");
+  assert!(
+    h.arch == "arm64" || h.arch == "x86_64",
+    "arch {:?} is neither arm64 nor x86_64",
+    h.arch
+  );
+}
+
+/// Hermetic: every committed VAD golden parses through the strict
+/// [`load_swift_golden`] loader (reads committed JSON only, no model). Pins the
+/// interim legacy behavior — goldens without `generationHost` still load, on
+/// every host — and is the designated flip-site for the post-regen
+/// host-presence assert (the owner-gated regen runbook). It also gives this
+/// suite the committed-golden hermetic coverage the speaker suite already has.
+#[test]
+fn committed_goldens_parse_through_the_strict_loader() {
+  for &fixture in GATE_FIXTURES {
+    let golden = load_swift_golden(fixture);
+    assert_eq!(golden.chunk_size, CHUNK_SAMPLES, "{fixture}: chunk size");
+    assert!(!golden.chunks.is_empty(), "{fixture}: golden has no chunks");
+  }
 }

--- a/crates/coremlit/tests/vad/swift/Tests/VadTraceDump/DumpVadTraces.swift
+++ b/crates/coremlit/tests/vad/swift/Tests/VadTraceDump/DumpVadTraces.swift
@@ -38,6 +38,18 @@ import XCTest
 
 // MARK: - Golden schema (mirrored by `parity_swift.rs`)
 
+/// The host-class the golden was generated on — the four sysctl-derived fields
+/// `coremlit`'s `HostClass` compares to gate the tight parity bound. CoreML
+/// `CpuOnly` floats are not contracted portable across macOS builds or chips
+/// (#36), so a golden is trustworthy as a bit-exact oracle only on a matching
+/// host. Mirrored by `parity_swift.rs`.
+private struct GoldenHost: Encodable {
+  let osBuild: String
+  let osProductVersion: String
+  let chip: String
+  let arch: String
+}
+
 /// One 256 ms chunk: its index, the unpadded sample count fed for it (the
 /// final chunk is shorter and repeat-last-padded inside `VadManager`), and the
 /// speech probability `VadManager` produced.
@@ -51,6 +63,10 @@ private struct Golden: Encodable {
   let fixture: String
   let generator: String
   let fluidAudioRevision: String
+  /// The host-class this golden was generated on. `parity_swift.rs`'s
+  /// host-aware gate enforces the tight bound only when the running host
+  /// matches this, and points a mismatch at regeneration.
+  let generationHost: GoldenHost
   /// Placement of the VAD model, as `coremlit::ComputeUnits` spells it. The
   /// Rust gate asserts its own placement matches.
   let computeUnits: String
@@ -108,6 +124,17 @@ final class DumpVadTraces: XCTestCase {
       return VadManager(config: VadConfig(computeUnits: .cpuOnly), vadModel: model)
     }
 
+    // The host-class every golden in this run is stamped with. Read ONCE via
+    // the identical sysctl keys `parity_swift.rs` reads, so string equality is
+    // well-defined by construction; a read failure hard-fails the dump rather
+    // than stamping a fake host.
+    let generationHost = GoldenHost(
+      osBuild: try sysctlString("kern.osversion"),
+      osProductVersion: try sysctlString("kern.osproductversion"),
+      chip: try sysctlString("machdep.cpu.brand_string"),
+      arch: processArch
+    )
+
     for (index, fixture) in fixtures.enumerated() {
       let samples = try readPcm16Mono16k(URL(fileURLWithPath: fixture.path))
       XCTAssertFalse(samples.isEmpty, "\(fixture.name): decoded zero samples")
@@ -148,6 +175,7 @@ final class DumpVadTraces: XCTestCase {
         fixture: fixture.name,
         generator: "crates/coremlit/tests/vad/swift/Tests/VadTraceDump/DumpVadTraces.swift",
         fluidAudioRevision: revision,
+        generationHost: generationHost,
         computeUnits: "cpu_only",
         sampleRate: VadManager.sampleRate,
         chunkSize: chunkSize,
@@ -165,9 +193,49 @@ final class DumpVadTraces: XCTestCase {
       encoder.outputFormatting = [.sortedKeys]
       let path = outDir.appendingPathComponent("\(fixture.name).json")
       try encoder.encode(golden).write(to: path)
-      print("[dump] \(fixture.name): \(samples.count) samples, \(results.count) chunks -> \(path.path)")
+      print(
+        "[dump] \(fixture.name): \(samples.count) samples, \(results.count) chunks, "
+          + "host \(generationHost.osProductVersion)/\(generationHost.osBuild)/"
+          + "\(generationHost.chip)/\(generationHost.arch) -> \(path.path)")
     }
   }
+}
+
+// MARK: - Host
+
+/// Reads a sysctl string by name using the two-call protocol (size query, then
+/// read), NUL-terminated by `String(cString:)` and whitespace-trimmed. The Rust
+/// gate reads the IDENTICAL keys via `/usr/sbin/sysctl -n`, so the recorded
+/// strings compare by construction — do NOT substitute
+/// `ProcessInfo.operatingSystemVersion` (it formats "15.5.0" where
+/// `kern.osproductversion` is "15.5"). Throws rather than stamping a fake host.
+private func sysctlString(_ name: String) throws -> String {
+  var size = 0
+  guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else {
+    throw DumpError.badEnvironment("sysctl \(name): size query failed")
+  }
+  var buffer = [CChar](repeating: 0, count: size)
+  guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else {
+    throw DumpError.badEnvironment("sysctl \(name): read failed")
+  }
+  let value = String(cString: buffer).trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !value.isEmpty else {
+    throw DumpError.badEnvironment("sysctl \(name): empty value")
+  }
+  return value
+}
+
+/// The process architecture governing which CPU kernels run in-process, spelled
+/// as `coremlit`'s `HostClass` normalizes it (`arm64`/`x86_64`). Compile-time
+/// arch IS the process arch.
+private var processArch: String {
+  #if arch(arm64)
+    return "arm64"
+  #elseif arch(x86_64)
+    return "x86_64"
+  #else
+    #error("unsupported host architecture for golden generation")
+  #endif
 }
 
 // MARK: - Audio


### PR DESCRIPTION
Closes #36.

Makes the CoreML VAD + Argmax-speaker committed-golden parity gates host-aware, and completes the AppleDouble-sidecar remediation across the whole model-io tree. Three commits:

## #36.3 — AppleDouble/`.DS_Store` sidecar false-failures (`1a9e6ad` + `a0f9564`)

On exFAT/FAT/SMB-staged model trees macOS materializes `._*` and `.DS_Store` sidecars inside `.mlmodelc` bundles, and the exact-manifest walks counted them as unpinned extras → false failures with the pinned bytes untouched. The scoped skip (`file_name` starts with `._`, or `== ".DS_Store"`) is now applied at **all four** exact-manifest walk sites — argmax speaker, granite, clap `assert_exact_sha_manifest` (the #30→#35 int8 gate), and speakerkit wespeaker byte-identity — preserving the exact-set equality and its symmetric-difference diagnostic. Each site has a hermetic, model-free negative test proving sidecars are dropped while a real extra still fails.

## #36.1 / #36.2 — host-aware gates (`c51e63c`)

CoreML `CpuOnly` floats are not contracted portable across macOS builds/chips, so a correct port off the golden-generation host failed with a message that blamed the port. Each golden now records a `generationHost` (osBuild/osProductVersion/chip/arch). On a matching host-class the existing **tight bounds apply byte-unchanged** (`TRACE_TOL=1e-4`; seg-exact / `1e-6` / `0.999_999`); on a mismatch the gate fails with an actionable *regenerate-a-same-host-oracle* diagnosis instead of a port-defect message. **The tight bounds are never widened.** Goldens predating the field (`LegacyUnknown`) keep the tight bounds with an ambiguity note on failure — behavior-preserving on the generation host.

## #36.4 — serial/memory doc rider

`--test-threads=1` + per-suite memory guidance for constrained hosts (the model gates are local/dev-only; CI never runs them).

## Review

Fable 5 max-effort review: **SHIP-READY**. Tight bounds and the parser-vs-gate separation verified at the assert sites (the host comparison lives only in the model-gated path, never in the parsers, so hermetic suites pass on every host). Model-gated gates re-pass bit-exact on the generation host: VAD 217/217 chunks |Δ|=0; speaker 72,447 seg cells EXACT, 123/123 rows bit-identical.

## Owner-gated follow-up (NOT in this PR)

Run `crates/coremlit/tests/{vad,speaker}/swift/regen_goldens.sh` on the generation host (FluidAudio `1a2da18` / argmax `dcf3a00`) to stamp `generationHost` into the 5 committed goldens and flip on the two host-presence asserts. Full runbook is in the `c51e63c` commit body. Merge held for the owner.
