### PR TITLE
fix(whisper): wire load/specialization timings; correct fallback-count and audio_processing docs

### DIFF
--- a/crates/coremlit/src/audio/whisper/model/manager/mod.rs
+++ b/crates/coremlit/src/audio/whisper/model/manager/mod.rs
@@ -87,7 +87,7 @@ impl LoadedModels {
 /// [`ModelManager::into_loaded`] for a `WhisperKit` to fold into its
 /// per-run [`crate::audio::whisper::result::TranscriptionTimings`]. Mirrors
 /// the split Swift's `WhisperKit.loadModels(prewarmMode:)` records into
-/// `currentTimings` (`WhisperKit.swift:396-422`): the **prewarm** pass's
+/// `currentTimings` (`WhisperKit.swift:396-423`): the **prewarm** pass's
 /// per-model load elapsed is the *specialization* time (the one-time
 /// ANE/graph specialization the throwaway prewarm load pays up front), and
 /// the **real** load pass's per-model elapsed is the *load* time. The two

--- a/crates/coremlit/src/audio/whisper/model/manager/mod.rs
+++ b/crates/coremlit/src/audio/whisper/model/manager/mod.rs
@@ -12,7 +12,10 @@
 //! Swift's `LoadModelsCoordinator` actor (`ModelManager.swift:73-86`,
 //! `:214-232`) with plain `&mut self` serialization.
 
-use std::path::PathBuf;
+use std::{
+  path::PathBuf,
+  time::{Duration, Instant},
+};
 
 use crate::audio::whisper::{
   error::ModelError,
@@ -76,6 +79,63 @@ impl LoadedModels {
 }
 
 // ---------------------------------------------------------------------
+// ModelLoadTimings
+// ---------------------------------------------------------------------
+
+/// Per-model load/specialization durations a [`ModelManager`] observes while
+/// bringing the encoder and decoder up, handed off by
+/// [`ModelManager::into_loaded`] for a `WhisperKit` to fold into its
+/// per-run [`crate::audio::whisper::result::TranscriptionTimings`]. Mirrors
+/// the split Swift's `WhisperKit.loadModels(prewarmMode:)` records into
+/// `currentTimings` (`WhisperKit.swift:396-422`): the **prewarm** pass's
+/// per-model load elapsed is the *specialization* time (the one-time
+/// ANE/graph specialization the throwaway prewarm load pays up front), and
+/// the **real** load pass's per-model elapsed is the *load* time. The two
+/// `*_specialization` durations therefore stay [`Duration::ZERO`] whenever
+/// no prewarm pass ran ([`ModelManager::prewarm`] was not called), exactly
+/// as Swift leaves them unset without a `prewarmMode` load.
+///
+/// The mel feature-extractor's own load is not split out here (Swift records
+/// no per-mel field either); it is captured only in the whole-pass totals a
+/// `WhisperKit` measures around [`ModelManager::prewarm`]/
+/// [`ModelManager::into_loaded`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ModelLoadTimings {
+  encoder_load: Duration,
+  decoder_load: Duration,
+  encoder_specialization: Duration,
+  decoder_specialization: Duration,
+}
+
+impl ModelLoadTimings {
+  /// Time the real (non-prewarm) load pass spent loading the audio encoder.
+  #[inline(always)]
+  pub const fn encoder_load(&self) -> Duration {
+    self.encoder_load
+  }
+
+  /// Time the real (non-prewarm) load pass spent loading the text decoder.
+  #[inline(always)]
+  pub const fn decoder_load(&self) -> Duration {
+    self.decoder_load
+  }
+
+  /// Time the prewarm pass spent loading (specializing) the audio encoder;
+  /// [`Duration::ZERO`] when no prewarm pass ran.
+  #[inline(always)]
+  pub const fn encoder_specialization(&self) -> Duration {
+    self.encoder_specialization
+  }
+
+  /// Time the prewarm pass spent loading (specializing) the text decoder;
+  /// [`Duration::ZERO`] when no prewarm pass ran.
+  #[inline(always)]
+  pub const fn decoder_specialization(&self) -> Duration {
+    self.decoder_specialization
+  }
+}
+
+// ---------------------------------------------------------------------
 // ModelManager
 // ---------------------------------------------------------------------
 
@@ -87,6 +147,7 @@ pub struct ModelManager {
   state: ModelState,
   callback: Option<StateCallback>,
   models: Option<LoadedModels>,
+  timings: ModelLoadTimings,
 }
 
 impl std::fmt::Debug for ModelManager {
@@ -97,6 +158,7 @@ impl std::fmt::Debug for ModelManager {
       .field("state", &self.state)
       .field("callback", &self.callback.as_ref().map(|_| "<installed>"))
       .field("models", &self.models)
+      .field("timings", &self.timings)
       .finish()
   }
 }
@@ -113,6 +175,7 @@ impl ModelManager {
       state: ModelState::Unloaded,
       callback: None,
       models: None,
+      timings: ModelLoadTimings::default(),
     }
   }
 
@@ -189,11 +252,20 @@ impl ModelManager {
     }
   }
 
-  fn resolve_and_prewarm(&self) -> Result<(), ModelError> {
+  fn resolve_and_prewarm(&mut self) -> Result<(), ModelError> {
     let resolved = LocalModelLoader::new().resolve(&self.folder)?;
     crate::Model::prewarm(resolved.mel_ref(), self.compute.mel())?;
+    // The prewarm-pass per-model load is Swift's `*SpecializationTime`
+    // (`WhisperKit.swift:401-403,420-422`): the throwaway load-then-drop
+    // pays the one-time ANE/graph specialization so the real load below is
+    // fast. `resolved` owns its paths and `compute` is `Copy`, so neither
+    // outlives its use — the `self.timings` writes borrow freely between loads.
+    let decoder_start = Instant::now();
     crate::Model::prewarm(resolved.decoder_ref(), self.compute.decoder())?;
+    self.timings.decoder_specialization = decoder_start.elapsed();
+    let encoder_start = Instant::now();
     crate::Model::prewarm(resolved.encoder_ref(), self.compute.encoder())?;
+    self.timings.encoder_specialization = encoder_start.elapsed();
     Ok(())
   }
 
@@ -256,11 +328,20 @@ impl ModelManager {
     }
   }
 
-  fn resolve_and_load(&self) -> Result<LoadedModels, ModelError> {
+  fn resolve_and_load(&mut self) -> Result<LoadedModels, ModelError> {
     let resolved = LocalModelLoader::new().resolve(&self.folder)?;
     let mel = crate::Model::load(resolved.mel_ref(), self.compute.mel())?;
+    // The real (non-prewarm) per-model load is Swift's `*LoadTime`
+    // (`WhisperKit.swift:404-406,423-425`). Timed individually so a
+    // `WhisperKit` can populate `encoder_load_time`/`decoder_load_time`
+    // separately from the whole-pass `model_loading` total it measures
+    // around `into_loaded`.
+    let decoder_start = Instant::now();
     let decoder = crate::Model::load(resolved.decoder_ref(), self.compute.decoder())?;
+    self.timings.decoder_load = decoder_start.elapsed();
+    let encoder_start = Instant::now();
     let encoder = crate::Model::load(resolved.encoder_ref(), self.compute.encoder())?;
+    self.timings.encoder_load = encoder_start.elapsed();
     Ok(LoadedModels::new(mel, encoder, decoder))
   }
 
@@ -283,19 +364,24 @@ impl ModelManager {
   }
 
   /// [`Self::ensure_loaded`], then hands off ownership of the resulting
-  /// [`LoadedModels`] — the construction-time path a `WhisperKit::new`
-  /// (a later task) uses when its load-at-construction option is set.
+  /// [`LoadedModels`] together with the [`ModelLoadTimings`] observed while
+  /// bringing them up — the construction-time path `WhisperKit::new` uses
+  /// when its load-at-construction option is set, so it can fold the
+  /// per-model load/specialization splits into each run's timings. The
+  /// returned timings carry the specialization durations from a prior
+  /// [`Self::prewarm`] (all-zero if none ran) as well as this call's
+  /// per-model load durations.
   ///
   /// # Errors
   /// As [`Self::ensure_loaded`].
-  pub fn into_loaded(mut self) -> Result<LoadedModels, ModelError> {
+  pub fn into_loaded(mut self) -> Result<(LoadedModels, ModelLoadTimings), ModelError> {
     self.ensure_loaded()?;
-    Ok(
-      self
-        .models
-        .take()
-        .expect("ensure_loaded() above returned Ok, so models is populated"),
-    )
+    let timings = self.timings;
+    let models = self
+      .models
+      .take()
+      .expect("ensure_loaded() above returned Ok, so models is populated");
+    Ok((models, timings))
   }
 
   /// Moves to `new`, firing the installed callback (if any) with the prior

--- a/crates/coremlit/src/audio/whisper/model/manager/tests.rs
+++ b/crates/coremlit/src/audio/whisper/model/manager/tests.rs
@@ -53,3 +53,17 @@ fn unload_on_nothing_resident_is_silent() {
   assert!(seen.lock().unwrap().is_empty(), "no transitions fired");
   assert_eq!(manager.state(), ModelState::Unloaded);
 }
+
+#[test]
+fn model_load_timings_default_is_all_zero() {
+  // The all-zero default is the honest value a manager hands off when no
+  // prewarm pass ran (the two `*_specialization` durations) — and, more
+  // broadly, what `WhisperKit::with_backend` reports for a pipeline that
+  // loaded no models. Per-model non-zero measurement needs a real model and
+  // is covered by the gated pipeline test.
+  let t = ModelLoadTimings::default();
+  assert_eq!(t.encoder_load(), Duration::ZERO);
+  assert_eq!(t.decoder_load(), Duration::ZERO);
+  assert_eq!(t.encoder_specialization(), Duration::ZERO);
+  assert_eq!(t.decoder_specialization(), Duration::ZERO);
+}

--- a/crates/coremlit/src/audio/whisper/result/mod.rs
+++ b/crates/coremlit/src/audio/whisper/result/mod.rs
@@ -637,9 +637,16 @@ pub struct TranscriptionTimings {
   /// `0.0` cannot distinguish "never fell back" from "one fallback at
   /// attempt 0"; a true count would be `attempt + 1`. A multi-window task
   /// overwrites per window, keeping only the last window's index, and
-  /// merged results sum these per-result values. For an unambiguous "a
-  /// fallback occurred" signal, use
-  /// [`TaskFacts::drew_from_rng`](crate::audio::whisper::task_facts::TaskFacts::drew_from_rng).
+  /// merged results sum these per-result values.
+  /// [`TaskFacts::drew_from_rng`](crate::audio::whisper::task_facts::TaskFacts::drew_from_rng)
+  /// is the unambiguous "a fallback occurred" signal only when the base
+  /// temperature is zero (the default) — attempt 0 then always argmaxes, so
+  /// any draw implies a fallback raised the temperature first. Under a
+  /// configured non-zero base temperature (e.g.
+  /// `DecodingOptions::new().with_temperature(0.5)`) attempt 0 itself draws
+  /// with zero fallbacks, and a degenerate retry (zero tokens decoded, or
+  /// `temperature_increment_on_fallback == 0.0`) can fall back without ever
+  /// drawing.
   #[cfg_attr(feature = "serde", serde(default))]
   total_decoding_fallbacks: f64,
   /// Number of 30 s windows decoded.
@@ -1114,9 +1121,16 @@ impl TranscriptionTimings {
   /// `0.0` cannot distinguish "never fell back" from "one fallback at
   /// attempt 0"; a true count would be `attempt + 1`. A multi-window task
   /// overwrites per window, keeping only the last window's index, and
-  /// merged results sum these per-result values. For an unambiguous "a
-  /// fallback occurred" signal, use
-  /// [`TaskFacts::drew_from_rng`](crate::audio::whisper::task_facts::TaskFacts::drew_from_rng).
+  /// merged results sum these per-result values.
+  /// [`TaskFacts::drew_from_rng`](crate::audio::whisper::task_facts::TaskFacts::drew_from_rng)
+  /// is the unambiguous "a fallback occurred" signal only when the base
+  /// temperature is zero (the default) — attempt 0 then always argmaxes, so
+  /// any draw implies a fallback raised the temperature first. Under a
+  /// configured non-zero base temperature (e.g.
+  /// `DecodingOptions::new().with_temperature(0.5)`) attempt 0 itself draws
+  /// with zero fallbacks, and a degenerate retry (zero tokens decoded, or
+  /// `temperature_increment_on_fallback == 0.0`) can fall back without ever
+  /// drawing.
   #[inline(always)]
   pub const fn total_decoding_fallbacks(&self) -> f64 {
     self.total_decoding_fallbacks

--- a/crates/coremlit/src/audio/whisper/result/mod.rs
+++ b/crates/coremlit/src/audio/whisper/result/mod.rs
@@ -564,7 +564,12 @@ pub struct TranscriptionTimings {
   /// Time spent loading audio input.
   #[cfg_attr(feature = "serde", serde(default))]
   audio_loading: f64,
-  /// Time spent on audio pre-processing (pad/trim, energy, VAD).
+  /// Time spent padding/trimming decode windows to length — the per-window
+  /// [`audio::pad_or_trim`](crate::audio::whisper::audio::pad_or_trim) in the
+  /// seek loop, matching what Swift's `audioProcessing` bucket wraps
+  /// (`TranscribeTask.swift`: slice + pad/trim + window preprocess). It does
+  /// NOT include VAD chunking (`chunk_all`), which is untimed here and in
+  /// Swift, nor mel extraction (tracked separately by [`Self::logmels`]).
   #[cfg_attr(feature = "serde", serde(default))]
   audio_processing: f64,
   /// Time spent computing mel-spectrogram features.
@@ -624,7 +629,17 @@ pub struct TranscriptionTimings {
   /// Number of word-timestamp alignment passes run.
   #[cfg_attr(feature = "serde", serde(default))]
   total_timestamp_alignment_runs: f64,
-  /// Number of temperature-fallback retries performed.
+  /// Zero-based attempt index of the most recent temperature fallback — a
+  /// faithful port of Swift's `totalDecodingFallbacks = Double(i)`
+  /// (`TranscribeTask.swift`), *assigned* (not accumulated) on each
+  /// fallback, so despite the name it is NOT a fallback count. The first
+  /// fallback writes `0.0`, which is also this field's initial value, so
+  /// `0.0` cannot distinguish "never fell back" from "one fallback at
+  /// attempt 0"; a true count would be `attempt + 1`. A multi-window task
+  /// overwrites per window, keeping only the last window's index, and
+  /// merged results sum these per-result values. For an unambiguous "a
+  /// fallback occurred" signal, use
+  /// [`TaskFacts::drew_from_rng`](crate::audio::whisper::task_facts::TaskFacts::drew_from_rng).
   #[cfg_attr(feature = "serde", serde(default))]
   total_decoding_fallbacks: f64,
   /// Number of 30 s windows decoded.
@@ -833,7 +848,12 @@ impl TranscriptionTimings {
   }
 
   // -- audio_processing ----------------------------------------------------
-  /// Time spent on audio pre-processing (pad/trim, energy, VAD).
+  /// Time spent padding/trimming decode windows to length — the per-window
+  /// [`audio::pad_or_trim`](crate::audio::whisper::audio::pad_or_trim) in the
+  /// seek loop, matching what Swift's `audioProcessing` bucket wraps
+  /// (`TranscribeTask.swift`: slice + pad/trim + window preprocess). It does
+  /// NOT include VAD chunking (`chunk_all`), which is untimed here and in
+  /// Swift, nor mel extraction (tracked separately by [`Self::logmels`]).
   #[inline(always)]
   pub const fn audio_processing(&self) -> f64 {
     self.audio_processing
@@ -1086,7 +1106,17 @@ impl TranscriptionTimings {
   }
 
   // -- total_decoding_fallbacks --------------------------------------------
-  /// Number of temperature-fallback retries performed.
+  /// Zero-based attempt index of the most recent temperature fallback — a
+  /// faithful port of Swift's `totalDecodingFallbacks = Double(i)`
+  /// (`TranscribeTask.swift`), *assigned* (not accumulated) on each
+  /// fallback, so despite the name it is NOT a fallback count. The first
+  /// fallback writes `0.0`, which is also this field's initial value, so
+  /// `0.0` cannot distinguish "never fell back" from "one fallback at
+  /// attempt 0"; a true count would be `attempt + 1`. A multi-window task
+  /// overwrites per window, keeping only the last window's index, and
+  /// merged results sum these per-result values. For an unambiguous "a
+  /// fallback occurred" signal, use
+  /// [`TaskFacts::drew_from_rng`](crate::audio::whisper::task_facts::TaskFacts::drew_from_rng).
   #[inline(always)]
   pub const fn total_decoding_fallbacks(&self) -> f64 {
     self.total_decoding_fallbacks

--- a/crates/coremlit/src/audio/whisper/transcribe/mod.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/mod.rs
@@ -74,7 +74,7 @@ use std::{
     Mutex, PoisonError,
     atomic::{AtomicBool, Ordering},
   },
-  time::Instant,
+  time::{Duration, Instant},
 };
 
 use unicode_categories::UnicodeCategories;
@@ -90,7 +90,10 @@ use crate::audio::whisper::{
     sampler::{self, GreedyTokenSampler},
   },
   error::{DecodeError, ModelError, TranscribeError, VadError},
-  model::{ModelVariant, detect_variant, manager::ModelManager},
+  model::{
+    ModelVariant, detect_variant,
+    manager::{ModelLoadTimings, ModelManager},
+  },
   options::{DecodingOptions, Options},
   result::{
     DecodingResult, TranscriptionProgress, TranscriptionResult, TranscriptionSegment,
@@ -1184,6 +1187,56 @@ impl LanguageDetection {
 }
 
 // ---------------------------------------------------------------------
+// LoadTimings
+// ---------------------------------------------------------------------
+
+/// The one-time model/tokenizer load durations [`WhisperKit::<CoreMlBackend>::new`]
+/// measures at construction and [`WhisperKit`] then stamps into every run's
+/// fresh [`TranscriptionTimings`] — the port's stand-in for Swift's
+/// persistent `currentTimings`, whose load fields (populated in
+/// `loadModels`) ride into each result the same way
+/// (`WhisperKit.swift:396-441`, plumbed through `setupTranscribeTask`).
+/// [`Default`] (all [`Duration::ZERO`]) is the honest value for a
+/// [`WhisperKit::with_backend`] pipeline, which loads no models to time.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct LoadTimings {
+  /// Whole-construction load total: prewarm pass + real model load + tokenizer
+  /// (Swift's `modelLoading = load-pass + prewarmLoadTime`,
+  /// `WhisperKit.swift:439`).
+  model_loading: Duration,
+  /// The prewarm pass as a whole; [`Duration::ZERO`] when prewarm was off.
+  prewarm_load_time: Duration,
+  /// Real-load-pass encoder load (`ModelLoadTimings::encoder_load`).
+  encoder_load: Duration,
+  /// Real-load-pass decoder load (`ModelLoadTimings::decoder_load`).
+  decoder_load: Duration,
+  /// Prewarm-pass encoder specialization; [`Duration::ZERO`] without prewarm.
+  encoder_specialization: Duration,
+  /// Prewarm-pass decoder specialization; [`Duration::ZERO`] without prewarm.
+  decoder_specialization: Duration,
+  /// Tokenizer load.
+  tokenizer_load_time: Duration,
+}
+
+impl LoadTimings {
+  /// Writes all seven load durations (as fractional seconds, the unit
+  /// [`TranscriptionTimings`] stores) into `timings`. The load fields are
+  /// never touched by [`TranscribeTask::run`], so stamping them onto a
+  /// run's result overwrites only their zero defaults, leaving every
+  /// compute-stage timing the run accumulated intact.
+  fn stamp(&self, timings: &mut TranscriptionTimings) {
+    timings
+      .set_model_loading(self.model_loading.as_secs_f64())
+      .set_prewarm_load_time(self.prewarm_load_time.as_secs_f64())
+      .set_encoder_load_time(self.encoder_load.as_secs_f64())
+      .set_decoder_load_time(self.decoder_load.as_secs_f64())
+      .set_encoder_specialization_time(self.encoder_specialization.as_secs_f64())
+      .set_decoder_specialization_time(self.decoder_specialization.as_secs_f64())
+      .set_tokenizer_load_time(self.tokenizer_load_time.as_secs_f64());
+  }
+}
+
+// ---------------------------------------------------------------------
 // WhisperKit
 // ---------------------------------------------------------------------
 
@@ -1208,6 +1261,10 @@ pub struct WhisperKit<B> {
   /// pluggable or configurable rather than locking product behavior to
   /// the default energy VAD").
   vad_detector: Box<dyn audio::vad::VoiceActivityDetector + Send + Sync>,
+  /// One-time load durations measured at construction, stamped into every
+  /// run's [`TranscriptionTimings`] (see [`LoadTimings`]). All-zero for a
+  /// [`Self::with_backend`] pipeline, which loads no models.
+  load_timings: LoadTimings,
 }
 
 impl WhisperKit<CoreMlBackend> {
@@ -1253,19 +1310,48 @@ impl WhisperKit<CoreMlBackend> {
       );
     }
     let mut manager = ModelManager::new(options.model_folder(), options.compute());
-    if options.prewarm() {
+    // Time the load the same way the compute pipeline already times its
+    // stages (`Instant::elapsed`), populating the seven load fields Swift
+    // stamps into `currentTimings` inside `loadModels`
+    // (`WhisperKit.swift:396-441`). These are DURATIONS of a construction
+    // step that inherently loads models from disk, not the absolute
+    // wall-clock stamps the sans-I/O transcription rule (and #37.2) reject:
+    // the whole prewarm pass is `prewarm_load_time`; the encoder/decoder
+    // per-model splits come from the manager; and `model_loading` folds the
+    // real load pass and the prewarm total together as Swift does (`:439`).
+    let prewarm_load_time = if options.prewarm() {
+      let start = Instant::now();
       manager.prewarm()?;
-    }
-    let models = manager.into_loaded()?;
+      start.elapsed()
+    } else {
+      Duration::ZERO
+    };
+    let model_load_start = Instant::now();
+    let (models, model_splits): (_, ModelLoadTimings) = manager.into_loaded()?;
     let backend = CoreMlBackend::from_loaded(models).map_err(DecodeError::from)?;
+    let tokenizer_start = Instant::now();
     let tokenizer = WhisperTokenizer::from_folder(options.tokenizer_folder())?;
+    let tokenizer_load_time = tokenizer_start.elapsed();
     let dims = backend.dims();
     let variant = detect_variant(dims.vocab(), dims.embed_dim());
+    // Swift's `modelLoading = now - modelLoadStart + prewarmLoadTime`
+    // (`:439`): the whole real-load pass (models, tokenizer, and the dims
+    // introspection variant detection needs) plus the earlier prewarm pass.
+    let model_loading = model_load_start.elapsed() + prewarm_load_time;
     Ok(Self {
       backend,
       tokenizer,
       variant,
       vad_detector: Box::new(audio::vad::EnergyVad::new()),
+      load_timings: LoadTimings {
+        model_loading,
+        prewarm_load_time,
+        encoder_load: model_splits.encoder_load(),
+        decoder_load: model_splits.decoder_load(),
+        encoder_specialization: model_splits.encoder_specialization(),
+        decoder_specialization: model_splits.decoder_specialization(),
+        tokenizer_load_time,
+      },
     })
   }
 }
@@ -1289,6 +1375,9 @@ impl<B> WhisperKit<B> {
       tokenizer,
       variant: None,
       vad_detector: Box::new(audio::vad::EnergyVad::new()),
+      // No models loaded through this seam, so nothing to time: the honest
+      // load timings are all-zero (see [`LoadTimings`]).
+      load_timings: LoadTimings::default(),
     }
   }
 
@@ -1415,6 +1504,20 @@ impl<B> WhisperKit<B> {
     options: DecodingOptions,
   ) -> LocalAgreementTranscriber<'_, B> {
     LocalAgreementTranscriber::new(self, options)
+  }
+
+  /// Folds this pipeline's construction-time [`LoadTimings`] into `result`'s
+  /// timings — the port's counterpart to Swift carrying `currentTimings`'
+  /// load fields into every `TranscriptionResult`
+  /// (`WhisperKit.swift:396-441`, plumbed via `setupTranscribeTask`). Called
+  /// on every result [`Self::transcribe`]/[`Self::transcribe_all`] hands
+  /// back, after [`TranscribeTask::run`] built it: the run leaves the seven
+  /// load fields at their zero defaults, so this only fills them in. No
+  /// backend bound — this touches no [`InferenceBackend`] method.
+  fn stamp_load_timings(&self, result: &mut TranscriptionResult) {
+    let mut timings = result.timings().clone();
+    self.load_timings.stamp(&mut timings);
+    result.set_timings(timings);
   }
 }
 
@@ -1708,10 +1811,17 @@ where
         decoded_span,
       );
       *merged.task_facts_mut() = recovered;
+      // Load timings are identical for every chunk, and the merge
+      // max-combines them (all-zero out, since `run` never writes them), so
+      // stamping the merged result once is equivalent to stamping each chunk
+      // before the merge.
+      self.stamp_load_timings(&mut merged);
       return Ok(merged);
     }
 
-    TranscribeTask::new(&self.backend, &self.tokenizer).run(audio, options)
+    let mut result = TranscribeTask::new(&self.backend, &self.tokenizer).run(audio, options)?;
+    self.stamp_load_timings(&mut result);
+    Ok(result)
   }
 
   /// Runs one [`TranscribeTask`] per entry of `audios`, batched
@@ -1775,6 +1885,11 @@ where
       results.extend(batch_results);
     }
 
+    // Stamp construction-time load timings onto every successful result,
+    // mirroring Swift's `currentTimings` riding into each task's result.
+    for result in results.iter_mut().flatten() {
+      self.stamp_load_timings(result);
+    }
     results
   }
 

--- a/crates/coremlit/src/audio/whisper/transcribe/mod.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/mod.rs
@@ -1811,10 +1811,16 @@ where
         decoded_span,
       );
       *merged.task_facts_mut() = recovered;
-      // Load timings are identical for every chunk, and the merge
-      // max-combines them (all-zero out, since `run` never writes them), so
-      // stamping the merged result once is equivalent to stamping each chunk
-      // before the merge.
+      // Stamps the merged result once, not each chunk before merging — and
+      // the two are equivalent only for the five max-combined load fields.
+      // Load timings are identical for every chunk in this `WhisperKit`, so
+      // stamping post-merge lands the same value pre-merge stamping (then
+      // max-combining identical values) would. The two specialization
+      // fields differ: the merge (`merge_results`, `result/mod.rs:2381-2389`)
+      // always leaves them at zero regardless of what the inputs held, so
+      // pre-merge stamping would still merge away to 0.0 — stamping the
+      // merged result here is what carries real specialization values
+      // through.
       self.stamp_load_timings(&mut merged);
       return Ok(merged);
     }

--- a/crates/coremlit/src/audio/whisper/transcribe/tests.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/tests.rs
@@ -2809,3 +2809,56 @@ fn vad_run_with_zero_chunks_is_known_clean_not_unknown() {
     "a zero-chunk run did nothing to redo -- reproducible",
   );
 }
+
+// ---------------------------------------------------------------------
+// LoadTimings stamping (#37.3)
+// ---------------------------------------------------------------------
+
+#[test]
+fn load_timings_stamp_writes_all_seven_fields_as_seconds() {
+  // Dyadic (n/8 s) millisecond durations so `as_secs_f64` and the literal
+  // both land on the exact same f64 — the equality is bit-exact, not
+  // tolerance-based.
+  let load = LoadTimings {
+    model_loading: Duration::from_millis(750),
+    prewarm_load_time: Duration::from_millis(250),
+    encoder_load: Duration::from_millis(125),
+    decoder_load: Duration::from_millis(375),
+    encoder_specialization: Duration::from_millis(625),
+    decoder_specialization: Duration::from_millis(875),
+    tokenizer_load_time: Duration::from_millis(500),
+  };
+  let mut timings = TranscriptionTimings::new();
+  load.stamp(&mut timings);
+
+  assert_eq!(timings.model_loading(), 0.75);
+  assert_eq!(timings.prewarm_load_time(), 0.25);
+  assert_eq!(timings.encoder_load_time(), 0.125);
+  assert_eq!(timings.decoder_load_time(), 0.375);
+  assert_eq!(timings.encoder_specialization_time(), 0.625);
+  assert_eq!(timings.decoder_specialization_time(), 0.875);
+  assert_eq!(timings.tokenizer_load_time(), 0.5);
+
+  // The stamp touches only the seven load fields; a representative
+  // compute-stage bucket the run would own is left untouched.
+  assert_eq!(timings.decoding_loop(), 0.0);
+}
+
+#[test]
+fn load_timings_default_stamps_all_zero() {
+  // The `with_backend` (mock) path carries `LoadTimings::default()`, so its
+  // stamped load fields are honestly 0.0 -- no models were loaded to time.
+  let mut timings = TranscriptionTimings::new();
+  LoadTimings::default().stamp(&mut timings);
+  for value in [
+    timings.model_loading(),
+    timings.prewarm_load_time(),
+    timings.encoder_load_time(),
+    timings.decoder_load_time(),
+    timings.encoder_specialization_time(),
+    timings.decoder_specialization_time(),
+    timings.tokenizer_load_time(),
+  ] {
+    assert_eq!(value, 0.0);
+  }
+}

--- a/crates/coremlit/tests/whisper/pipeline.rs
+++ b/crates/coremlit/tests/whisper/pipeline.rs
@@ -209,7 +209,8 @@ fn manager_loads_tiny_idempotently_and_backend_builds() {
   assert_eq!(manager.state(), ModelState::Loaded);
   manager.ensure_loaded().unwrap(); // idempotent — no reload, still Loaded
   assert_eq!(manager.state(), ModelState::Loaded);
-  let backend = CoreMlBackend::from_loaded(manager.into_loaded().unwrap()).unwrap();
+  let (models, _timings) = manager.into_loaded().unwrap();
+  let backend = CoreMlBackend::from_loaded(models).unwrap();
   assert_eq!(backend.dims().vocab(), 51865);
 }
 
@@ -297,6 +298,77 @@ fn prewarm_over_loaded_models_is_rejected() {
   assert_eq!(manager.state(), ModelState::Prewarmed);
   manager.prewarm().unwrap(); // silent skip, no re-prewarm transitions
   assert_eq!(manager.state(), ModelState::Prewarmed);
+}
+
+#[test]
+#[ignore = "requires local tiny model (WHISPERKIT_TEST_MODELS)"]
+fn load_timings_are_populated_on_real_construction_with_prewarm() {
+  // #37.3: `WhisperKit::new` now measures the seven load/specialization/
+  // tokenizer durations and stamps them into every run's timings. With
+  // prewarm on, all seven are measured, so all seven must be finite and
+  // strictly positive on a real result -- they reported a flat 0.0 before
+  // this wiring.
+  let kit = WhisperKit::new(&tiny_options().with_prewarm()).unwrap();
+  let audio = common::load_wav_mono_f32(&common::fixtures_dir().join("audio/jfk.wav"));
+  let result = kit.transcribe(&audio, &DecodingOptions::new()).unwrap();
+  let t = result.timings();
+  for (name, value) in [
+    ("model_loading", t.model_loading()),
+    ("prewarm_load_time", t.prewarm_load_time()),
+    ("encoder_load_time", t.encoder_load_time()),
+    ("decoder_load_time", t.decoder_load_time()),
+    (
+      "encoder_specialization_time",
+      t.encoder_specialization_time(),
+    ),
+    (
+      "decoder_specialization_time",
+      t.decoder_specialization_time(),
+    ),
+    ("tokenizer_load_time", t.tokenizer_load_time()),
+  ] {
+    assert!(
+      value.is_finite() && value > 0.0,
+      "{name} should be finite and > 0 after wiring, got {value}"
+    );
+  }
+  // The grand total folds in the prewarm pass, so it is at least as large.
+  assert!(t.model_loading() >= t.prewarm_load_time());
+}
+
+#[test]
+#[ignore = "requires local tiny model (WHISPERKIT_TEST_MODELS)"]
+fn specialization_timings_stay_zero_without_prewarm() {
+  // Swift-faithful: `*SpecializationTime` is recorded only during a prewarm
+  // pass (`WhisperKit.swift:401-403,420-422`). Without prewarm the two
+  // specialization fields and `prewarm_load_time` stay 0.0, while the real
+  // load/tokenizer fields are still measured > 0.
+  let kit = WhisperKit::new(&tiny_options()).unwrap();
+  let audio = common::load_wav_mono_f32(&common::fixtures_dir().join("audio/jfk.wav"));
+  let result = kit.transcribe(&audio, &DecodingOptions::new()).unwrap();
+  let t = result.timings();
+  assert_eq!(t.prewarm_load_time(), 0.0, "no prewarm pass ran");
+  assert_eq!(
+    t.encoder_specialization_time(),
+    0.0,
+    "specialization is prewarm-only"
+  );
+  assert_eq!(
+    t.decoder_specialization_time(),
+    0.0,
+    "specialization is prewarm-only"
+  );
+  for (name, value) in [
+    ("model_loading", t.model_loading()),
+    ("encoder_load_time", t.encoder_load_time()),
+    ("decoder_load_time", t.decoder_load_time()),
+    ("tokenizer_load_time", t.tokenizer_load_time()),
+  ] {
+    assert!(
+      value.is_finite() && value > 0.0,
+      "{name} should be finite and > 0 even without prewarm, got {value}"
+    );
+  }
 }
 
 #[test]


### PR DESCRIPTION
Closes #37.

Addresses the whisper timing/observability defects from the audit. Each of the five was adversarially adjudicated (Fable-validated) against the current code and the pinned `argmax-oss-swift` @ `dcf3a00` — three are real and fixed here, two are confirmed by-design (rationale in the issue thread).

## #37.3 — load/specialization/tokenizer timings wired (the real code fix)

`WhisperKit::new` prewarmed, loaded models, and loaded the tokenizer with **zero** timing, so all seven public fields (`model_loading`, `prewarm_load_time`, `encoder_load_time`, `decoder_load_time`, `encoder_specialization_time`, `decoder_specialization_time`, `tokenizer_load_time`) reported `0.0` on every real result — while Swift production populates all seven. Now measured with `Instant::elapsed` (the same mechanism the pipeline already uses for `full_pipeline`/`encoding`; construction I/O, not the sans-I/O compute path) inside `WhisperKit::new` and `ModelManager`, snapshotted on the handle, and stamped into each run's `TranscriptionTimings` — mirroring Swift's `currentTimings`. The specialization split is honestly prewarm-only (real `Duration::ZERO` when prewarm is off, not faked). Confirmed on the ANE: `model_loading≈16.6s`, `encoder_spec≈14.3s`, `decoder_spec≈1.8s`.

## #37.1 / #37.4 — doc corrections (no behavior change)

- `total_decoding_fallbacks` is a **faithful port of Swift's `totalDecodingFallbacks = Double(i)` quirk** (the zero-based attempt index), with two in-tree Swift-parity consumers — so the value is NOT redefined; the field/getter docs are corrected to describe the actual semantics (index, not count; `0.0` ambiguous), with `TaskFacts::drew_from_rng` noted as the fallback signal *at the default zero base temperature*.
- `audio_processing`'s "(pad/trim, energy, VAD)" description was false of **both** Rust and Swift (both time only window pad/trim); corrected. A separately-attributable VAD-timing bucket is a deliberate deviation from Swift — a future feature, not this fix.

The stored fallback value and all three of its consumers (write, window-id arithmetic, stream comparison) plus the merge sum are **byte-identical**; #37.3 changes no transcription output and no serde field.

## By-design (not changed) — see the issue thread for evidence

- **#37.2** (`pipeline_start`/`first_token_time` sentinels) — a documented deliberate sans-I/O no-wall-clock deviation (three doc sites + a regression test; the merge special-cases the all-sentinel case). TTFT would be a separate feature.
- **#37.5** (logging/RSS helpers unwired) — the crate's documented "Not ported" precedent for Swift's Progress/Logging instrumentation; the requested structured event stream exceeds Swift WhisperKit itself.

## Review

Fable 5 max-effort review: **ship-ready** (0 Critical). Wiring re-derived Swift-faithful against the pinned source. Follow-up noted (not in this PR): a >30s gated test to detect removal of the VAD-path/`transcribe_all` stamp call sites (current gated tests are single-window).

Merge held for the owner.
