### PR TITLE
feat(coremlit): siglip2-naflex image+text embedding core (hermetic Wave A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,9 @@ jobs:
           - "clap"                                                          # CLAP encoders alone (Rust mel + tokenizers, no ort)
           - "clap-oracle"                                                   # + textclap model-level parity oracle (ort)
           - "granite"                                                       # granite text embeddings alone (committed goldens, no ort)
-          - "whisper,align,speaker,vad,clap,granite,serde,tracing,nl-recognizer"    # all non-oracle
-          - "whisper,align-oracle,speaker-oracle,vad-bundled,clap-oracle,granite,serde,tracing,nl-recognizer"  # all-on
+          - "siglip"                                                        # SigLIP 2 image+text embeddings alone (committed goldens, no ort)
+          - "whisper,align,speaker,vad,clap,granite,siglip,serde,tracing,nl-recognizer"    # all non-oracle
+          - "whisper,align-oracle,speaker-oracle,vad-bundled,clap-oracle,granite,siglip,serde,tracing,nl-recognizer"  # all-on
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Initial release: a safe, synchronous CoreML runtime layer.
 - `Features`: insertion-ordered named I/O bridging `MLFeatureProvider` in both directions (output extraction de-aliases buffers shared with inputs or other outputs).
 - Threading: `Model`, `MultiArray`, and `State` are `Send` but deliberately **not** `Sync` — move them between threads or hold one per worker; concurrent shared access is outside the contract.
 - `ComputeUnits`/`DataType` vocabularies; structured `thiserror` errors capturing `NSError` domain/code/message.
+- `embeddings::siglip` (feature `siglip`): SigLIP 2 (`siglip2-base-patch16-naflex`) image+text embeddings into a shared 768-dim joint space — NaFlex host-side preprocessing (aspect-preserving patch-budget solver, antialiased-bilinear resize, position-embedding lift; no image-decoder dep), a single-input 64-token text tower, and cross-modal `rank`, L2-normalized in Rust; committed transformers-fp32 goldens (no `ort`). Hermetic preprocessing + embedding core landed; model-gated parity gates await the staged conversion.
 
 ## whisperkit 0.1.0 (unreleased)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ npyz = "0.9"
 cpal = "0.16"
 rubato = "0.16"
 criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
+# Pure-Rust PNG decoder — a DEV-dep only, for decoding the committed siglip
+# corpus PNG fixtures in tests (the crate itself is sans-I/O: `Rgb8Image` takes
+# already-decoded RGB, so no image-decoder enters the library's own graph).
+png = "0.17"
 
 [workspace.lints.rust]
 missing_docs = "deny"

--- a/NOTICE
+++ b/NOTICE
@@ -4,23 +4,24 @@ Copyright the coremlit authors
 The coremlit Rust source is dual-licensed under MIT OR Apache-2.0 (caller's
 choice). See LICENSE-MIT and LICENSE-APACHE for those terms.
 
-NOTE: coremlit ships NO model weight files, but embeddings::clap and
-embeddings::granite each BUNDLE a third-party tokenizer artifact (via
-include_bytes! — sections 6b and 7b). Each feature-gated pipeline
-(audio::whisper / audio::align / audio::speaker / audio::vad / embeddings::clap
-/ embeddings::granite) otherwise LOADS, at runtime, CoreML model artifacts that
-a downstream user fetches separately from Hugging Face (see the crate README and
-each module's model_io tests for the repo id, revision, and per-file SHA-256).
-This NOTICE records the attribution a binary that distributes or bundles those
-components must honor.
+NOTE: coremlit ships NO model weight files, but embeddings::clap,
+embeddings::granite, and embeddings::siglip each BUNDLE a third-party tokenizer
+artifact (via include_bytes! — sections 6b, 7b, and 8b). Each feature-gated
+pipeline (audio::whisper / audio::align / audio::speaker / audio::vad /
+embeddings::clap / embeddings::granite / embeddings::siglip) otherwise LOADS, at
+runtime, CoreML model artifacts that a downstream user fetches separately from
+Hugging Face (see the crate README and each module's model_io tests for the repo
+id, revision, and per-file SHA-256). This NOTICE records the attribution a binary
+that distributes or bundles those components must honor.
 
 Sections 1-2 (the audio::vad models) are preserved verbatim from the former
 vadkit NOTICE. Sections 3-5 record the whisper, speaker, and align model
 attributions folded in by the mono-crate restructure. Section 6 records the
 CLAP audio+text encoder weights and the bundled Xenova tokenizer, folded in by
 the clapkit port. Section 7 records the granite text-embedding encoder and its
-bundled tokenizer, added by the embedkit phase. Both audio::vad components below
-are MIT.
+bundled tokenizer, added by the embedkit phase. Section 8 records the SigLIP 2
+image+text encoder weights and the bundled Gemma tokenizer, added by the siglip
+phase. Both audio::vad components below are MIT.
 
 ────────────────────────────────────────────────────────────────────────
 1. Silero VAD (upstream model)
@@ -230,3 +231,54 @@ crate via `include_bytes!` (exposed as
       (an o200k-style BPE); it carries no model weights. It is distributed under
       the same upstream Apache-2.0 terms as the model; retain the license notice
       when redistributing it.
+
+────────────────────────────────────────────────────────────────────────
+8. SigLIP 2 image + text encoders and bundled tokenizer (embeddings::siglip)
+
+embeddings::siglip runs CoreML conversions of Google DeepMind's SigLIP 2
+`siglip2-base-patch16-naflex` vision and text encoders (a shared 768-dim joint
+embedding space), and BUNDLES that model's Gemma tokenizer into the compiled
+crate via `include_bytes!` (exposed as
+`coremlit::embeddings::siglip::BUNDLED_TOKENIZER`).
+
+  8a) Encoder weights — google/siglip2-base-patch16-naflex. The crate ships NO
+      model files; it loads FinDIT-Studio's CoreML conversion of the Google
+      weights.
+
+        Original model: google/siglip2-base-patch16-naflex
+        https://huggingface.co/google/siglip2-base-patch16-naflex
+        License: Apache-2.0 (verify on the model card at staging — STOP if not) —
+        preserve the Apache-2.0 attribution when redistributing the weights (or a
+        binary bundling them).
+        Attribution: Google DeepMind — SigLIP 2 (Tschannen et al., 2025).
+
+        CoreML conversion actually loaded: FinDIT-Studio/siglip2-naflex-coreml
+        https://huggingface.co/FinDIT-Studio/siglip2-naflex-coreml
+        revision: PENDING (recorded at the conversion runbook's upload step — the
+        immutable commit SHA and per-file SHA-256 are pinned in
+        tests/siglip/model_io.rs / tests/siglip/text_model_io.rs when staged).
+
+      As an Apache-2.0 work, a redistributor must retain the license and
+      copyright notices AND STATE ANY CHANGES. Unlike a pure format conversion,
+      the CoreML graph is RESTRUCTURED: the per-image position-embedding resize is
+      lifted to a host-side `position_embeddings` input, the attention-pooling
+      head is re-expressed from the identical packed weights with static Q/K/V
+      projections, and the encoder uses eager attention. The weight VALUES are
+      unchanged (parity receipts in the model card); these graph changes are the
+      stated changes.
+
+  8b) Bundled tokenizer — siglip2-base-patch16-naflex Gemma tokenizer (via
+      include_bytes!). Compiled into the crate, so any binary linking coremlit
+      with the `siglip` feature redistributes it.
+
+        Source: https://huggingface.co/google/siglip2-base-patch16-naflex
+        Revision (commit SHA): PENDING (recorded at staging)
+        Artifact: tokenizer.json
+        SHA-256: PENDING (pinned in tests/siglip/tokenizer_identity.rs at staging)
+
+      The artifact is the SigLIP 2 Gemma tokenizer configuration and vocabulary
+      (256000 entries); it carries no model weights. It is distributed under the
+      same upstream Apache-2.0 terms as the model; retain the license notice when
+      redistributing it. (The committed `assets/tokenizer.json` is a placeholder
+      until the source-revision bytes are staged; the identity gate forces the
+      real artifact in.)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 | [`audio::align`](crates/coremlit/src/audio/align) | `align` (`align-oracle`) | CoreML wav2vec2 forced word-level alignment: audio + a known transcript → per-word time spans with confidence, over `asry`'s parity-tested alignment seam. |
 | [`audio::speaker`](crates/coremlit/src/audio/speaker) | `speaker` (`speaker-oracle`) | CoreML segmentation + embedding backends for `dia`'s diarization: runs pyannote's `segmentation-3.0` and WeSpeaker on the ANE and produces the `dia`-shaped tensors (`Extraction`) that feed [`dia`](https://github.com/findit-studio/diarization)'s VBx/PLDA clustering. Multi-source (FluidAudio default + Argmax). Never assigns a speaker label — clustering stays in `dia`. |
 | [`audio::vad`](crates/coremlit/src/audio/vad) | `vad` (`vad-bundled`) | Silero VAD on CoreML: runs the FluidInference unified 256 ms model and implements the published [`silero`](https://github.com/Findit-AI/silero) crate's `VadBackend` seam, re-exporting its detector so a consumer gets the full offline + streaming API with **zero** detection logic duplicated; `ort`/ONNX never enters the runtime graph. |
-| `embeddings` | (reserved) | Reserved namespace for embedding producers (CLAP, sentence embeddings) — documented, filled by later waves. `video` is likewise reserved and **not** created until a video kit exists. |
+| [`embeddings`](crates/coremlit/src/embeddings) | `clap` / `granite` / `siglip` | Embedding producers, each a feature-gated CoreML pipeline projecting into a shared joint space, L2-normalized in Rust: CLAP-HTSAT audio+text (`clap`), granite sentence embeddings (`granite`), and SigLIP 2 (`siglip2-base-patch16-naflex`) image+text (`siglip`, NaFlex — no windowing). Parity against committed transformers-fp32 goldens, no `ort`. `video` is likewise reserved and **not** created until a video kit exists. |
 
 ## Layering map
 
@@ -149,6 +149,7 @@ Flat and additive; `default = []`.
 | `align` / `align-oracle` | forced alignment / + the asry ONNX word-timing parity oracle (DEV/TEST) |
 | `speaker` / `speaker-oracle` | diarization backends + dia offline bridge / + dia's ort DER oracle (DEV/TEST) |
 | `vad` / `vad-bundled` | Silero VAD model layer / + silero's ONNX cross-backend oracle (DEV/TEST) |
+| `clap` / `granite` / `siglip` | embedding producers: CLAP audio+text / granite sentence / SigLIP 2 image+text — each committed-golden parity, no `ort` (`clap-oracle` adds the textclap ort oracle) |
 | `serde` | `Serialize`/`Deserialize` on options/results/provenance (+ the whisper JSON writer) |
 | `tracing` | internal log events additionally emitted as `tracing` events |
 

--- a/crates/coremlit/Cargo.toml
+++ b/crates/coremlit/Cargo.toml
@@ -100,6 +100,19 @@ clap-oracle = ["clap", "dep:textclap"]
 # `default = []` pulls none of it.
 granite = ["dep:tokenizers", "dep:windit", "windit/text"]
 
+# --- embeddings::siglip (the SigLIP 2 image+text phase) ---
+# SigLIP 2 (`siglip2-base-patch16-naflex`) dual-tower image+text embeddings on
+# CoreML: a shared 768-dim joint space. A Rust NaFlex vision front-end
+# (aspect-preserving patch-budget solver + antialiased-bilinear resize +
+# position-embedding lift; resize/patchify hand-rolled, no `image`/decoder dep)
+# around two fp16 graphs, plus a bundled Gemma tokenizer (`tokenizers`, shared
+# with `whisper`/`clap`/`granite`), L2-normalized in Rust. NaFlex resizes
+# natively to a fixed patch budget, so no windowing is used. The parity oracle is
+# COMMITTED transformers-fp32 goldens (`tests/siglip/fixtures/goldens/`), never a
+# live ONNX crate — so there is NO `siglip-oracle` feature and NO `ort` in this
+# path. `default = []` pulls none of it.
+siglip = ["dep:tokenizers"]
+
 [dependencies]
 # --- core CoreML runtime (always compiled) ---
 objc2.workspace = true
@@ -259,8 +272,13 @@ tempfile.workspace = true
 tokenizers.workspace = true
 # The mel-parity unit tests (`src/embeddings/clap/audio/mel/tests.rs`, feature
 # `clap`) read committed librosa `.npy` mel oracles via `npyz` (former clapkit
-# dev-dep).
+# dev-dep). The siglip full-tensor preprocessing gate (model-gated) reads staged
+# `.npy` NaFlex fixtures via the same dep.
 npyz.workspace = true
+# The siglip corpus PNG fixtures are decoded to RGB8 for the (model-gated) e2e /
+# parity gates via the pure-Rust `png` dev-dep; the library itself takes decoded
+# `Rgb8Image` (sans-I/O), so `png` never enters the library's feature graph.
+png.workspace = true
 # The `clap_encode` bench reports process RSS via `task_info(MACH_TASK_BASIC_INFO)`
 # (the same query as `audio::whisper::log::resident_memory_bytes`, which rides the
 # `whisper` feature the bench does not enable). Dev-deps compile only for
@@ -588,6 +606,47 @@ required-features = ["granite"]
 name = "granite_embed_long"
 path = "tests/granite/embed_long.rs"
 required-features = ["granite"]
+
+# --- embeddings::siglip ---
+# The whole `embeddings::siglip` module is feature-gated, so its tests compile
+# only under `siglip`. The tokenizer-identity + preprocess small-oracle gates are
+# hermetic (committed goldens, no model); the model_io / parity / placement / e2e
+# gates keep their `#[ignore]` + Models/ layout. There is NO oracle feature —
+# parity scores against COMMITTED transformers-fp32 goldens.
+[[test]]
+name = "siglip_tokenizer_identity"
+path = "tests/siglip/tokenizer_identity.rs"
+required-features = ["siglip"]
+
+[[test]]
+name = "siglip_preprocess"
+path = "tests/siglip/preprocess.rs"
+required-features = ["siglip"]
+
+[[test]]
+name = "siglip_model_io"
+path = "tests/siglip/model_io.rs"
+required-features = ["siglip"]
+
+[[test]]
+name = "siglip_text_model_io"
+path = "tests/siglip/text_model_io.rs"
+required-features = ["siglip"]
+
+[[test]]
+name = "siglip_parity_embed"
+path = "tests/siglip/parity_embed.rs"
+required-features = ["siglip"]
+
+[[test]]
+name = "siglip_placement"
+path = "tests/siglip/placement.rs"
+required-features = ["siglip"]
+
+[[test]]
+name = "siglip_e2e"
+path = "tests/siglip/e2e.rs"
+required-features = ["siglip"]
 # Dual-tower encode harness: first-observed/cached load, first + warm inference
 # per tower × ComputeUnits (model-gated; `harness = false` custom main — the load
 # phases are one-shot costs criterion's resampling cannot see). Mirrors the

--- a/crates/coremlit/FEATURE_MAP.md
+++ b/crates/coremlit/FEATURE_MAP.md
@@ -33,7 +33,7 @@ rename or a dropped feature cannot land silently.
 
 `whisper`, `nl-recognizer`, `align`, `align-oracle`, `speaker`,
 `speaker-oracle`, `vad`, `vad-bundled`, `clap`, `clap-oracle`, `granite`,
-`serde`, `tracing`.
+`siglip`, `serde`, `tracing`.
 
 `granite` is not a former per-crate kit but a NEW module (`embeddings::granite`,
 the embedkit phase): general text sentence-embeddings on CoreML, first model
@@ -44,10 +44,17 @@ new-module note, not an old-crate row. Its long-input `embed_long` path pulls th
 rev-pinned `windit` git dep (with `windit/text` for content-aware chunking); the
 single-text `embed` path does not depend on it.
 
+`siglip` is likewise a NEW module (`embeddings::siglip`): SigLIP 2
+(`siglip2-base-patch16-naflex`) dual-tower image+text embeddings on CoreML (a
+shared 768-dim joint space). Same posture as `granite` — COMMITTED
+transformers-fp32 goldens, so NO `siglip-oracle` sibling and no `ort` — and it
+composes with nothing (a single leaf feature). NaFlex resizes natively to a fixed
+patch budget, so it is a `windit` non-consumer (no windowing).
+
 Compositions (pinned by the golden test): `nl-recognizer` → `whisper`;
 `align-oracle` → `align`; `speaker-oracle` → `speaker`; `vad-bundled` → `vad`;
-`clap-oracle` → `clap`. (`granite` composes with nothing — a single leaf
-feature.)
+`clap-oracle` → `clap`. (`granite` and `siglip` each compose with nothing — a
+single leaf feature.)
 
 ## Curated CI feature-combination list
 
@@ -69,8 +76,9 @@ none. It is pinned here and driven by CI (`.github/workflows/ci.yml`):
 | `clap` | CLAP audio+text encoders alone (Rust mel + tokenizers, no ort) |
 | `clap-oracle` | + textclap model-level parity oracle (ort) |
 | `granite` | granite text embeddings alone (bundled tokenizer + committed transformers-fp32 goldens, no ort; `embed_long` rides the rev-pinned `windit` engine + `windit/text`) |
-| `whisper,align,speaker,vad,clap,granite,serde,tracing,nl-recognizer` | all non-oracle features on |
-| `whisper,align-oracle,speaker-oracle,vad-bundled,clap-oracle,granite,serde,tracing,nl-recognizer` | all-on (every feature, oracles included) |
+| `siglip` | SigLIP 2 image+text embeddings alone (bundled tokenizer + committed transformers-fp32 goldens, no ort) |
+| `whisper,align,speaker,vad,clap,granite,siglip,serde,tracing,nl-recognizer` | all non-oracle features on |
+| `whisper,align-oracle,speaker-oracle,vad-bundled,clap-oracle,granite,siglip,serde,tracing,nl-recognizer` | all-on (every feature, oracles included) |
 
 `serde` and `tracing` are cross-cutting and covered by the all-on runs. The
 list embodies the combinatorial-honesty rule: it is explicit and reviewable,

--- a/crates/coremlit/src/embeddings/mod.rs
+++ b/crates/coremlit/src/embeddings/mod.rs
@@ -13,6 +13,12 @@
 //!   `granite`; committed transformers-fp32 goldens as the parity oracle — NO
 //!   ort). The T2/T3 core is landed; long-input windowing (T4) is a later phase.
 //!   `gemma` was DROPPED per the embedkit design's Amendment 3.
+//! - `siglip` — SigLIP 2 (`siglip2-base-patch16-naflex`) dual-tower image+text
+//!   embeddings on CoreML, a shared 768-dim joint space with cross-modal `rank`
+//!   (feature `siglip`; committed transformers-fp32 goldens as the parity
+//!   oracle — NO ort). NaFlex resizes natively to a fixed patch budget, so no
+//!   windowing is used. The hermetic preprocessing + embedding core is landed;
+//!   the model-gated parity gates await the staged conversion.
 //!
 //! See the crate README's layering map for module authority. The `video/`
 //! sibling namespace is likewise reserved, but is not created until a video kit
@@ -23,3 +29,6 @@ pub mod clap;
 
 #[cfg(feature = "granite")]
 pub mod granite;
+
+#[cfg(feature = "siglip")]
+pub mod siglip;

--- a/crates/coremlit/src/embeddings/siglip/assets/tokenizer.json
+++ b/crates/coremlit/src/embeddings/siglip/assets/tokenizer.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [],
+  "normalizer": null,
+  "pre_tokenizer": { "type": "Whitespace" },
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "WordLevel",
+    "vocab": {
+      "<pad>": 0,
+      "PLACEHOLDER_REPLACE_WITH_SOURCE_REVISION_GEMMA_TOKENIZER_IN_WAVE_B": 1
+    },
+    "unk_token": "<pad>"
+  }
+}

--- a/crates/coremlit/src/embeddings/siglip/compute_units_serde.rs
+++ b/crates/coremlit/src/embeddings/siglip/compute_units_serde.rs
@@ -1,0 +1,28 @@
+//! Shared serde bridge for [`crate::ComputeUnits`] (module-private, `serde`
+//! feature only).
+//!
+//! `crate::ComputeUnits` carries no serde impl of its own, so bridge it
+//! through its existing `as_str`/`FromStr` — the same shape the `granite` and
+//! `clap` modules' private compute-units bridges use. Used by
+//! [`crate::embeddings::siglip::ImageEmbedderOptions`] and
+//! [`crate::embeddings::siglip::TextEmbedderOptions`] via
+//! `serde(with = "crate::embeddings::siglip::compute_units_serde")`.
+
+use core::str::FromStr;
+
+use crate::ComputeUnits;
+use serde::{Deserialize, Deserializer, Serializer};
+
+pub(crate) fn serialize<S: Serializer>(
+  value: &ComputeUnits,
+  serializer: S,
+) -> Result<S::Ok, S::Error> {
+  serializer.serialize_str(value.as_str())
+}
+
+pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+  deserializer: D,
+) -> Result<ComputeUnits, D::Error> {
+  let name = String::deserialize(deserializer)?;
+  ComputeUnits::from_str(&name).map_err(serde::de::Error::custom)
+}

--- a/crates/coremlit/src/embeddings/siglip/embedding/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/embedding/mod.rs
@@ -1,0 +1,256 @@
+//! The 768-dim L2-normalized siglip [`Embedding`], shared by both towers.
+//!
+//! The type and its numeric contract (f64-accumulated normalization,
+//! `is_close` / `is_close_cosine`, no `PartialEq`) mirror `granite`'s and
+//! `clap`'s `Embedding` deliberately, so the embedding surfaces read
+//! identically; only the dimension (768) and the names change. The image and
+//! text towers project into ONE shared joint space, so both produce this same
+//! type (siglip is single-`Embedding`, like clap's shared-space model). (Plain-
+//! text reference — siglip builds without the `clap`/`granite` features, so its
+//! docs must not link across them.)
+
+use core::{fmt, ops::Deref};
+
+use crate::embeddings::siglip::error::{Error, Result};
+
+/// Dimensionality of a siglip joint embedding (both the vision and text towers
+/// project to 768). Pinned from the converted graphs' output contract
+/// (`tests/siglip/model_io.rs` / `tests/siglip/text_model_io.rs`).
+pub const EMBEDDING_DIM: usize = 768;
+
+/// Norm-tolerance budget for the trusted-path unit-norm check
+/// ([`Embedding::try_from_unit_slice`]). Worst case `768 · ulp(1) ≈ 9.2e-5`,
+/// rounded to `1e-4` — the same budget the `granite` (384-d) and `clap` (512-d)
+/// embeddings use, above the 768-term accumulation error.
+pub(crate) const NORM_BUDGET: f32 = 1e-4;
+
+/// A 768-dim L2-normalized siglip embedding.
+///
+/// Returned by [`crate::embeddings::siglip::ImageEmbedder::embed`] and
+/// [`crate::embeddings::siglip::TextEmbedder::embed`]. The unit-norm invariant
+/// holds within fp32 ULP.
+///
+/// # Compile-fail contracts
+///
+/// `Embedding` exposes no `DIM` associated const (use the module-level
+/// [`EMBEDDING_DIM`]):
+///
+/// ```compile_fail
+/// let _ = coremlit::embeddings::siglip::Embedding::DIM;
+/// ```
+///
+/// `Embedding` does not implement `PartialEq` — f32 outputs of an ML model are
+/// not bit-stable across runs / threads / OSes; use [`Embedding::is_close`] or
+/// [`Embedding::is_close_cosine`]:
+///
+/// ```compile_fail
+/// # let mut s = [0.0_f32; 768]; s[0] = 1.0;
+/// # let a = coremlit::embeddings::siglip::Embedding::from_slice_normalizing(&s).unwrap();
+/// # let b = a.clone();
+/// let _ = a == b;
+/// ```
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct Embedding {
+  inner: [f32; EMBEDDING_DIM],
+}
+
+impl Embedding {
+  /// Length of the embedding (768).
+  #[inline]
+  pub const fn dim(&self) -> usize {
+    self.inner.len()
+  }
+
+  /// Borrow the embedding as a slice.
+  #[inline]
+  pub const fn as_slice(&self) -> &[f32] {
+    self.inner.as_slice()
+  }
+
+  /// Owned conversion to a `Vec<f32>`. Allocates.
+  #[inline]
+  pub fn to_vec(&self) -> Vec<f32> {
+    self.inner.to_vec()
+  }
+
+  /// Reconstruct from a stored unit vector. Validates length, finiteness, AND
+  /// unit-norm (`(norm² − 1).abs() ≤ ``NORM_BUDGET`).
+  ///
+  /// # Errors
+  /// [`Error::EmbeddingDimMismatch`] if `s.len() != `[`EMBEDDING_DIM`];
+  /// [`Error::NonFiniteEmbedding`] on any non-finite component;
+  /// [`Error::EmbeddingNotUnitNorm`] if the norm is outside the budget.
+  pub fn try_from_unit_slice(s: &[f32]) -> Result<Self> {
+    if s.len() != EMBEDDING_DIM {
+      return Err(Error::EmbeddingDimMismatch {
+        expected: EMBEDDING_DIM,
+        got: s.len(),
+      });
+    }
+    for (i, &v) in s.iter().enumerate() {
+      if !v.is_finite() {
+        return Err(Error::NonFiniteEmbedding { component_index: i });
+      }
+    }
+    let norm_sq: f32 = s.iter().map(|x| x * x).sum();
+    let dev = (norm_sq - 1.0).abs();
+    if dev > NORM_BUDGET {
+      return Err(Error::EmbeddingNotUnitNorm {
+        norm_sq_deviation: dev,
+      });
+    }
+    let mut inner = [0.0f32; EMBEDDING_DIM];
+    inner.copy_from_slice(s);
+    Ok(Self { inner })
+  }
+
+  /// Construct from any non-zero finite slice, re-normalizing to unit length.
+  ///
+  /// The norm is accumulated in f64 so any finite f32 input normalizes without
+  /// intermediate overflow (e.g. `f32::MAX`) or underflow-to-`+Inf` (e.g.
+  /// subnormal magnitudes).
+  ///
+  /// # Errors
+  /// [`Error::EmbeddingDimMismatch`] if `s.len() != `[`EMBEDDING_DIM`];
+  /// [`Error::NonFiniteEmbedding`] on any non-finite component;
+  /// [`Error::EmbeddingZero`] if the input has zero magnitude.
+  pub fn from_slice_normalizing(s: &[f32]) -> Result<Self> {
+    if s.len() != EMBEDDING_DIM {
+      return Err(Error::EmbeddingDimMismatch {
+        expected: EMBEDDING_DIM,
+        got: s.len(),
+      });
+    }
+    for (i, &v) in s.iter().enumerate() {
+      if !v.is_finite() {
+        return Err(Error::NonFiniteEmbedding { component_index: i });
+      }
+    }
+    // f64 accumulation: for any finite f32 (|x| ≤ ~3.4e38), x² ≤ ~1.16e77 and
+    // 768 terms sum to at most ~8.9e79, well inside f64's ~1.8e308 range.
+    let norm_sq_f64: f64 = s.iter().map(|&x| (x as f64) * (x as f64)).sum();
+    if norm_sq_f64 == 0.0 {
+      return Err(Error::EmbeddingZero);
+    }
+    let inv_norm_f64 = 1.0_f64 / norm_sq_f64.sqrt();
+    // Multiply per-component in f64 then cast: casting inv_norm to f32 first
+    // would overflow to +Inf for subnormal-magnitude inputs.
+    let mut inner = [0.0f32; EMBEDDING_DIM];
+    for (out, &v) in inner.iter_mut().zip(s.iter()) {
+      *out = ((v as f64) * inv_norm_f64) as f32;
+    }
+    Ok(Self { inner })
+  }
+
+  /// Module-internal constructor for producers whose upstream guard already
+  /// validated unit-norm within `NORM_BUDGET`. Bypasses re-normalization.
+  #[allow(dead_code)]
+  pub(crate) fn from_array_trusted_unit_norm(arr: [f32; EMBEDDING_DIM]) -> Self {
+    debug_assert!({
+      let n: f32 = arr.iter().map(|x| x * x).sum();
+      (n - 1.0).abs() <= NORM_BUDGET
+    });
+    Self { inner: arr }
+  }
+
+  /// Inner product. For two unit vectors this equals [`Self::cosine`] to fp32
+  /// ULP.
+  pub fn dot(&self, other: &Embedding) -> f32 {
+    self
+      .inner
+      .iter()
+      .zip(other.inner.iter())
+      .map(|(a, b)| a * b)
+      .sum()
+  }
+
+  /// Cosine similarity. For unit vectors, equivalent to [`Self::dot`].
+  pub fn cosine(&self, other: &Embedding) -> f32 {
+    self.dot(other)
+  }
+
+  /// Approximate equality — max-abs metric. `true` iff
+  /// `(self − other).max_abs() ≤ tol` (inclusive, so `is_close(self, 0.0)` is
+  /// always true).
+  pub fn is_close(&self, other: &Embedding, tol: f32) -> bool {
+    self
+      .inner
+      .iter()
+      .zip(other.inner.iter())
+      .map(|(a, b)| (a - b).abs())
+      .fold(0.0f32, f32::max)
+      <= tol
+  }
+
+  /// Approximate equality — semantic (cosine) metric. `true` iff
+  /// `1 − cosine(other) ≤ tol`, computed as `0.5·‖a − b‖² ≤ tol` to avoid
+  /// catastrophic cancellation near identity (valid because both operands are
+  /// unit-norm to fp32 ULP).
+  pub fn is_close_cosine(&self, other: &Embedding, tol: f32) -> bool {
+    let sq: f32 = self
+      .inner
+      .iter()
+      .zip(other.inner.iter())
+      .map(|(a, b)| {
+        let d = a - b;
+        d * d
+      })
+      .sum();
+    (sq * 0.5) <= tol
+  }
+}
+
+impl AsRef<[f32]> for Embedding {
+  #[inline]
+  fn as_ref(&self) -> &[f32] {
+    self.as_slice()
+  }
+}
+
+impl Deref for Embedding {
+  type Target = [f32];
+
+  #[inline]
+  fn deref(&self) -> &[f32] {
+    &self.inner
+  }
+}
+
+impl fmt::Debug for Embedding {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(
+      f,
+      "Embedding {{ dim: {}, head: [{:.4}, {:.4}, {:.4}, ..] }}",
+      self.dim(),
+      self.inner[0],
+      self.inner[1],
+      self.inner[2],
+    )
+  }
+}
+
+/// Scans a raw model-output projection — the copied CoreML tensor, before it is
+/// normalized into an [`Embedding`] — for the first non-finite (NaN/±∞)
+/// component, classifying it as MODEL corruption ([`Error::NonFiniteOutput`]).
+/// This is the counterpart to the caller-data corruption
+/// ([`Error::NonFiniteEmbedding`]) that [`Embedding::from_slice_normalizing`]
+/// raises for a caller's own slice: the towers run this on the model output
+/// *before* normalizing, so a NaN the runtime produced is reported as
+/// model-output corruption rather than mislabeled as caller-supplied embedding
+/// data (the workspace convention — it mirrors the `granite`/`clap` towers'
+/// identically shaped `check_finite_output`). Extracted so the classification is
+/// hermetically testable without a loaded model.
+///
+/// # Errors
+/// [`Error::NonFiniteOutput`] carrying the flat index of the first non-finite
+/// component.
+pub(crate) fn check_finite_output(values: &[f32]) -> Result<()> {
+  if let Some(index) = values.iter().position(|v| !v.is_finite()) {
+    return Err(Error::NonFiniteOutput { index });
+  }
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coremlit/src/embeddings/siglip/embedding/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/embedding/tests.rs
@@ -1,0 +1,213 @@
+use super::*;
+
+/// A unit vector: `e_0` (all mass on component 0).
+fn e0() -> [f32; EMBEDDING_DIM] {
+  let mut s = [0.0f32; EMBEDDING_DIM];
+  s[0] = 1.0;
+  s
+}
+
+#[test]
+fn from_slice_normalizing_produces_unit_norm() {
+  let s: Vec<f32> = (0..EMBEDDING_DIM).map(|i| (i as f32) + 1.0).collect();
+  let e = Embedding::from_slice_normalizing(&s).unwrap();
+  let norm_sq: f32 = e.as_slice().iter().map(|x| x * x).sum();
+  assert!((norm_sq - 1.0).abs() <= NORM_BUDGET, "norm² = {norm_sq}");
+}
+
+#[test]
+fn from_slice_normalizing_rejects_zero() {
+  let s = [0.0f32; EMBEDDING_DIM];
+  let err = Embedding::from_slice_normalizing(&s).unwrap_err();
+  assert!(matches!(err, Error::EmbeddingZero), "got {err:?}");
+}
+
+#[test]
+fn from_slice_normalizing_rejects_nan() {
+  let mut s = e0();
+  s[7] = f32::NAN;
+  let err = Embedding::from_slice_normalizing(&s).unwrap_err();
+  assert!(
+    matches!(err, Error::NonFiniteEmbedding { component_index: 7 }),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn from_slice_normalizing_rejects_inf() {
+  let mut s = e0();
+  s[3] = f32::INFINITY;
+  let err = Embedding::from_slice_normalizing(&s).unwrap_err();
+  assert!(
+    matches!(err, Error::NonFiniteEmbedding { component_index: 3 }),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn check_finite_output_accepts_finite() {
+  // A finite model-output row (need not be unit-norm — this gate runs BEFORE
+  // normalization) passes.
+  let s: Vec<f32> = (0..EMBEDDING_DIM).map(|i| (i as f32) - 100.0).collect();
+  assert!(check_finite_output(&s).is_ok());
+}
+
+#[test]
+fn check_finite_output_rejects_model_nan_as_output_not_embedding() {
+  // A NaN the model produced is MODEL corruption (`NonFiniteOutput`), NOT
+  // caller-supplied embedding data (`NonFiniteEmbedding`). This is the seam the
+  // embedder calls before `from_slice_normalizing`, so the CoreML corruption
+  // mode is classified correctly. Removing that call site (or this gate) makes
+  // `NonFiniteOutput` unreachable again.
+  let mut s = e0();
+  s[5] = f32::NAN;
+  let err = check_finite_output(&s).unwrap_err();
+  assert!(
+    matches!(err, Error::NonFiniteOutput { index: 5 }),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn check_finite_output_rejects_inf() {
+  let mut s = e0();
+  s[9] = f32::NEG_INFINITY;
+  let err = check_finite_output(&s).unwrap_err();
+  assert!(
+    matches!(err, Error::NonFiniteOutput { index: 9 }),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn from_slice_normalizing_handles_overflow_magnitude() {
+  // f32::MAX components would overflow an f32 norm accumulator; the f64 path
+  // must still produce a finite unit vector.
+  let s = [f32::MAX; EMBEDDING_DIM];
+  let e = Embedding::from_slice_normalizing(&s).expect("f32::MAX normalizes via f64");
+  let norm_sq: f32 = e.as_slice().iter().map(|x| x * x).sum();
+  assert!((norm_sq - 1.0).abs() <= NORM_BUDGET, "norm² = {norm_sq}");
+}
+
+#[test]
+fn from_slice_normalizing_handles_smallest_subnormal() {
+  // Casting inv_norm to f32 before the per-component multiply would overflow to
+  // +Inf here; the f64 multiply must keep it finite and unit-norm.
+  let s = [f32::from_bits(1); EMBEDDING_DIM]; // ~1.4e-45
+  let e = Embedding::from_slice_normalizing(&s).expect("subnormal magnitude normalizes");
+  let norm_sq: f32 = e.as_slice().iter().map(|x| x * x).sum();
+  assert!((norm_sq - 1.0).abs() <= NORM_BUDGET, "norm² = {norm_sq}");
+}
+
+#[test]
+fn from_slice_normalizing_wrong_len() {
+  let s = [0.0f32; EMBEDDING_DIM - 1];
+  let err = Embedding::from_slice_normalizing(&s).unwrap_err();
+  assert!(
+    matches!(
+      err,
+      Error::EmbeddingDimMismatch {
+        expected: EMBEDDING_DIM,
+        got
+      } if got == EMBEDDING_DIM - 1
+    ),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn try_from_unit_slice_accepts_at_budget_edge() {
+  // norm² = 1 + 0.5·NORM_BUDGET must pass (≤ inclusive).
+  let target_sq = 1.0 + 0.5 * NORM_BUDGET;
+  let mut s = [0.0f32; EMBEDDING_DIM];
+  s[0] = target_sq.sqrt();
+  Embedding::try_from_unit_slice(&s).expect("within budget");
+}
+
+#[test]
+fn try_from_unit_slice_rejects_beyond_budget() {
+  // norm² = 1 + 2·NORM_BUDGET must fail.
+  let mut s = [0.0f32; EMBEDDING_DIM];
+  s[0] = (1.0 + 2.0 * NORM_BUDGET).sqrt();
+  let err = Embedding::try_from_unit_slice(&s).unwrap_err();
+  assert!(
+    matches!(err, Error::EmbeddingNotUnitNorm { .. }),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn try_from_unit_slice_wrong_len() {
+  let s = [0.0f32; EMBEDDING_DIM + 1];
+  let err = Embedding::try_from_unit_slice(&s).unwrap_err();
+  assert!(
+    matches!(
+      err,
+      Error::EmbeddingDimMismatch {
+        expected: EMBEDDING_DIM,
+        got
+      } if got == EMBEDDING_DIM + 1
+    ),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn dot_and_cosine_agree_for_unit_vectors() {
+  let e = Embedding::from_slice_normalizing(&e0()).unwrap();
+  assert_eq!(e.dot(&e), e.cosine(&e));
+  assert!((e.cosine(&e) - 1.0).abs() <= 1e-6);
+}
+
+#[test]
+fn orthogonal_unit_vectors_have_zero_cosine() {
+  let a = Embedding::from_slice_normalizing(&e0()).unwrap();
+  let mut y = [0.0f32; EMBEDDING_DIM];
+  y[1] = 1.0;
+  let b = Embedding::from_slice_normalizing(&y).unwrap();
+  assert!(a.cosine(&b).abs() <= 1e-6);
+}
+
+#[test]
+fn is_close_self_at_zero_tolerance() {
+  let a = Embedding::from_slice_normalizing(&e0()).unwrap();
+  assert!(a.is_close(&a, 0.0));
+  assert!(a.is_close_cosine(&a, 0.0));
+}
+
+#[test]
+fn is_close_cosine_separates_orthogonal() {
+  let a = Embedding::from_slice_normalizing(&e0()).unwrap();
+  let mut y = [0.0f32; EMBEDDING_DIM];
+  y[1] = 1.0;
+  let b = Embedding::from_slice_normalizing(&y).unwrap();
+  // 1 − cos = 1 for orthogonal; must exceed a tiny tolerance.
+  assert!(!a.is_close_cosine(&b, 1.0e-6));
+  assert!(!a.is_close(&b, 1.0e-6));
+}
+
+#[test]
+fn deref_and_as_ref_expose_the_slice() {
+  let e = Embedding::from_slice_normalizing(&e0()).unwrap();
+  assert_eq!(e.len(), EMBEDDING_DIM); // via Deref<[f32]>
+  let r: &[f32] = e.as_ref();
+  assert_eq!(r.len(), EMBEDDING_DIM);
+  assert_eq!(e.dim(), EMBEDDING_DIM);
+}
+
+#[test]
+fn to_vec_roundtrips_via_try_from_unit_slice() {
+  let e = Embedding::from_slice_normalizing(&e0()).unwrap();
+  let v = e.to_vec();
+  assert_eq!(v.len(), EMBEDDING_DIM);
+  // The unit vector round-trips back through the trusted-path constructor.
+  let back = Embedding::try_from_unit_slice(&v).expect("unit vector round-trips");
+  assert!(back.is_close(&e, 0.0));
+}
+
+#[test]
+fn from_array_trusted_unit_norm_wraps_without_renormalizing() {
+  let e = Embedding::from_array_trusted_unit_norm(e0());
+  assert_eq!(e.as_slice()[0], 1.0);
+  assert_eq!(e.dim(), EMBEDDING_DIM);
+}

--- a/crates/coremlit/src/embeddings/siglip/error/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/error/mod.rs
@@ -1,0 +1,185 @@
+//! The module's single error type and `Result` alias.
+//!
+//! Foreign errors from [`crate`] are wrapped as typed `#[from]` variants;
+//! tokenizer errors preserve their `#[source]` chain. Model-contract,
+//! image-preprocessing, and embedding-invariant failures are their own variants
+//! so callers can match on cause. Mirrors `granite`'s error module, extended
+//! with the vision-tower image / position-embedding variants (siglip is a
+//! dual-tower image+text surface). (Plain-text reference — siglip builds without
+//! the `granite`/`clap` features, so its docs must not link across them.)
+
+/// Convenience alias for `Result<T, `[`Error`]`>`.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Any failure loading a siglip tower, preprocessing an image, running
+/// inference, tokenizing text, or constructing an
+/// [`crate::embeddings::siglip::Embedding`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+  /// The CoreML runtime failed to load a compiled model.
+  #[error("failed to load model: {0}")]
+  Load(#[from] crate::LoadError),
+
+  /// A CoreML prediction call failed.
+  #[error("prediction failed: {0}")]
+  Prediction(#[from] crate::PredictionError),
+
+  /// A tensor failed to construct or view.
+  #[error("tensor failed: {0}")]
+  Tensor(#[from] crate::TensorError),
+
+  /// A loaded model's input or output feature does not match the shape/dtype
+  /// contract this module was built against (the pinned ground truth lives in
+  /// `tests/siglip/model_io.rs` / `tests/siglip/text_model_io.rs`).
+  #[error("model contract mismatch on `{feature}`: expected {expected}, got {actual}")]
+  ContractMismatch {
+    /// Name of the input/output feature that mismatched.
+    feature: &'static str,
+    /// The contract this module expects, rendered for display.
+    expected: String,
+    /// What the loaded model actually declares, rendered for display.
+    actual: String,
+  },
+
+  /// A predict-time output tensor's shape diverged from the contract validated
+  /// at construction. [`crate::MultiArray::copy_into`] alone validates only
+  /// total element count, so an axes-swapped output would otherwise pass
+  /// silently — the CoreML runtime is re-checked on every call.
+  #[error("output shape mismatch: expected {expected:?}, got {got:?}")]
+  OutputShape {
+    /// Shape the runtime tensor actually had.
+    got: Vec<usize>,
+    /// Shape the construction-time contract declares.
+    expected: Vec<usize>,
+  },
+
+  /// A model output component was NaN or infinite.
+  #[error("model output contains a non-finite value at index {index}")]
+  NonFiniteOutput {
+    /// Flat index of the offending element.
+    index: usize,
+  },
+
+  /// An [`crate::embeddings::siglip::Rgb8Image`] view had a zero dimension, or
+  /// its `width · height · 3` byte length overflowed `usize`. A real decoded RGB
+  /// image has non-zero dimensions and a length that fits.
+  #[error("invalid image dimensions: {width}×{height} (zero dimension or size overflow)")]
+  ImageDimensions {
+    /// The width supplied.
+    width: usize,
+    /// The height supplied.
+    height: usize,
+  },
+
+  /// An [`crate::embeddings::siglip::Rgb8Image`] view's backing slice length did
+  /// not equal `width · height · 3` (row-major, RGB-interleaved, 3 bytes/pixel).
+  #[error("image data length mismatch: expected {expected} bytes (w·h·3), got {got}")]
+  ImageDataLength {
+    /// The backing slice length the caller supplied.
+    got: usize,
+    /// The required `width · height · 3` length.
+    expected: usize,
+  },
+
+  /// Reading the base position-embedding grid sidecar
+  /// (`pos_embed_16x16x768.f32le.bin`) failed.
+  #[error("failed to read position-embedding grid: {0}")]
+  PosEmbedLoad(#[source] std::io::Error),
+
+  /// The base position-embedding grid sidecar's byte length did not equal the
+  /// exact `16 · 16 · 768 · 4` raw little-endian f32 grid the vision tower
+  /// requires (the load-time hard-validation of D5). A short or long file is a
+  /// wrong or corrupt artifact.
+  #[error("position-embedding grid length mismatch: expected {expected} bytes, got {got}")]
+  PosEmbedLength {
+    /// The sidecar's actual byte length.
+    got: usize,
+    /// The required `16 · 16 · 768 · 4` byte length.
+    expected: usize,
+  },
+
+  /// Preprocessing produced more real patches than the resolved patch budget
+  /// `P`. The budget solver caps `h_p · w_p ≤ P` by construction, so this is a
+  /// defensive backstop — returned instead of an out-of-bounds write — against a
+  /// future solver/plumbing bug.
+  #[error("preprocessing produced {got} patches, exceeding the {max}-patch budget")]
+  PatchCount {
+    /// Number of real patches produced.
+    got: usize,
+    /// The resolved patch budget `P`.
+    max: usize,
+  },
+
+  /// The caller passed an empty text string; there is nothing to embed.
+  #[error("text input is empty")]
+  EmptyText,
+
+  /// An embedding slice did not have the expected dimension.
+  #[error("embedding dimension mismatch: expected {expected}, got {got}")]
+  EmbeddingDimMismatch {
+    /// The required dimension
+    /// ([`crate::embeddings::siglip::embedding::EMBEDDING_DIM`]).
+    expected: usize,
+    /// The dimension the caller supplied.
+    got: usize,
+  },
+
+  /// An embedding component was NaN or infinite.
+  #[error("embedding contains a non-finite value at component {component_index}")]
+  NonFiniteEmbedding {
+    /// Index of the offending component.
+    component_index: usize,
+  },
+
+  /// An embedding to be normalized had zero magnitude (undefined direction).
+  #[error("embedding has zero magnitude and cannot be normalized")]
+  EmbeddingZero,
+
+  /// A trusted-path embedding was not unit-norm within the module's norm budget
+  /// (`crate::embeddings::siglip::embedding::NORM_BUDGET`).
+  #[error("embedding is not unit-norm: |norm² − 1| = {norm_sq_deviation}")]
+  EmbeddingNotUnitNorm {
+    /// `(norm² − 1).abs()`, the amount by which the invariant was violated.
+    norm_sq_deviation: f32,
+  },
+
+  /// The tokenizer failed to load from its JSON definition.
+  #[error("failed to load tokenizer: {0}")]
+  TokenizerLoad(#[source] tokenizers::Error),
+
+  /// Configuring the tokenizer (truncation) failed.
+  #[error("failed to configure tokenizer: {0}")]
+  TokenizerConfig(#[source] tokenizers::Error),
+
+  /// Encoding text into token ids failed.
+  #[error("failed to tokenize text: {0}")]
+  Tokenize(#[source] tokenizers::Error),
+
+  /// The tokenized input exceeded the fixed text window
+  /// ([`max_tokens`](crate::embeddings::siglip::TextEmbedder::max_tokens)).
+  /// Every constructor forces truncation at that length and disables the
+  /// tokenizer's own padding, so this is a defensive backstop — returned instead
+  /// of an out-of-bounds panic — against a tokenizer that still yields more ids
+  /// than the window.
+  #[error("tokenized input has {got} tokens, exceeding the fixed {max}-token window")]
+  TokenCount {
+    /// Number of token ids the tokenizer produced.
+    got: usize,
+    /// The fixed window length (the text tower's resolved `T`).
+    max: usize,
+  },
+
+  /// A token id did not fit the model's `int32` `input_ids` tensor. siglip's
+  /// Gemma vocabulary (256000) is far below `i32::MAX`, so this only fires for a
+  /// foreign tokenizer with an out-of-range id — returned instead of a silently
+  /// wrapping cast.
+  #[error("token id {id} exceeds the model's int32 input range")]
+  TokenIdRange {
+    /// The offending token id.
+    id: u32,
+  },
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coremlit/src/embeddings/siglip/error/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/error/mod.rs
@@ -111,6 +111,17 @@ pub enum Error {
     max: usize,
   },
 
+  /// Preprocessing could not allocate a resize working buffer of `bytes` bytes
+  /// (a pathologically large source geometry, or memory exhaustion). Returned
+  /// instead of aborting the process on allocator failure. `bytes` is
+  /// [`usize::MAX`] when the buffer's element count overflowed `usize` (a
+  /// geometry that could never be allocated).
+  #[error("image preprocessing failed to allocate a {bytes}-byte resize buffer")]
+  PreprocessAllocation {
+    /// The size of the refused allocation, or [`usize::MAX`] on size overflow.
+    bytes: usize,
+  },
+
   /// The caller passed an empty text string; there is nothing to embed.
   #[error("text input is empty")]
   EmptyText,
@@ -147,6 +158,15 @@ pub enum Error {
   /// The tokenizer failed to load from its JSON definition.
   #[error("failed to load tokenizer: {0}")]
   TokenizerLoad(#[source] tokenizers::Error),
+
+  /// The bundled `tokenizer.json` is still the build-time placeholder (its
+  /// vocab carries the `PLACEHOLDER_…_IN_WAVE_B` sentinel), which maps every
+  /// ordinary word to `<pad>` — embedding with it would silently produce
+  /// meaningless vectors. Stage the source-revision Gemma tokenizer bytes (the
+  /// golden-generation step of the port plan), or supply a real tokenizer via
+  /// [`crate::embeddings::siglip::TextEmbedder::from_files`].
+  #[error("bundled tokenizer is the build-time placeholder; stage the real Gemma tokenizer.json")]
+  TokenizerPlaceholder,
 
   /// Configuring the tokenizer (truncation) failed.
   #[error("failed to configure tokenizer: {0}")]

--- a/crates/coremlit/src/embeddings/siglip/error/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/error/mod.rs
@@ -61,10 +61,16 @@ pub enum Error {
     index: usize,
   },
 
-  /// An [`crate::embeddings::siglip::Rgb8Image`] view had a zero dimension, or
-  /// its `width · height · 3` byte length overflowed `usize`. A real decoded RGB
-  /// image has non-zero dimensions and a length that fits.
-  #[error("invalid image dimensions: {width}×{height} (zero dimension or size overflow)")]
+  /// An [`crate::embeddings::siglip::Rgb8Image`] view had a zero dimension, a
+  /// `width · height · 3` byte length overflowing `usize`, or an axis exceeding
+  /// the preprocessing bound
+  /// [`crate::embeddings::siglip::image::MAX_IMAGE_AXIS`] (which keeps every
+  /// accepted extent inside Pillow's `f32` box envelope and bounds resize
+  /// working memory). A real decoded RGB image has non-zero, in-bound
+  /// dimensions and a length that fits.
+  #[error(
+    "invalid image dimensions: {width}×{height} (zero, over the per-axis maximum, or size overflow)"
+  )]
   ImageDimensions {
     /// The width supplied.
     width: usize,

--- a/crates/coremlit/src/embeddings/siglip/error/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/error/mod.rs
@@ -199,6 +199,94 @@ pub enum Error {
     /// The offending token id.
     id: u32,
   },
+
+  /// A [`crate::embeddings::siglip::PreprocessedImage`] patch budget was zero,
+  /// or so large that the `[P · 768]` tensor lengths would overflow `usize`.
+  /// A real budget is the loaded model's resolved `P` (e.g. 512) — small and
+  /// non-zero.
+  #[error("invalid preprocessed patch budget {max_num_patches} (zero, or tensor lengths overflow)")]
+  PreprocessedPatchBudget {
+    /// The budget supplied to `try_new`.
+    max_num_patches: usize,
+  },
+
+  /// A caller-supplied preprocessed tensor's length did not match the padded
+  /// contract at the supplied patch budget (`pixel_values` = `P · 768`,
+  /// `position_embeddings` = `P · 768`, `attention_mask` = `P`).
+  #[error("preprocessed `{feature}` length mismatch: expected {expected}, got {got}")]
+  PreprocessedLength {
+    /// The model input feature (`pixel_values` / `position_embeddings` /
+    /// `attention_mask`) whose length mismatched.
+    feature: &'static str,
+    /// The length the caller supplied.
+    got: usize,
+    /// The required length at the supplied budget.
+    expected: usize,
+  },
+
+  /// A caller-supplied preprocessed tensor contained a NaN or infinite value
+  /// — caller-data corruption, classified apart from the model-output
+  /// counterpart ([`Error::NonFiniteOutput`]).
+  #[error("preprocessed `{feature}` contains a non-finite value at index {index}")]
+  PreprocessedNonFinite {
+    /// The model input feature containing the non-finite value.
+    feature: &'static str,
+    /// Flat index of the first non-finite element.
+    index: usize,
+  },
+
+  /// A preprocessed attention-mask entry was not exactly `0.0` or `1.0`. The
+  /// NaFlex pipeline emits an exact binary real/pad mask; anything else is
+  /// not its output. (A NaN mask entry is classified here rather than as
+  /// [`Error::PreprocessedNonFinite`] — the mask's domain check subsumes
+  /// finiteness.)
+  #[error("preprocessed attention mask entry {index} is {value}, not exactly 0.0 or 1.0")]
+  PreprocessedMaskValue {
+    /// Index of the offending entry.
+    index: usize,
+    /// The offending value.
+    value: f32,
+  },
+
+  /// A preprocessed attention mask had a real (`1.0`) entry after a pad
+  /// (`0.0`). The NaFlex pipeline packs real patches as a contiguous prefix
+  /// with pads only at the tail; a non-prefix mask is not its output.
+  #[error("preprocessed attention mask has a real (1.0) entry at index {index} after a pad")]
+  PreprocessedMaskOrder {
+    /// Index of the out-of-order `1.0`.
+    index: usize,
+  },
+
+  /// A preprocessed attention mask had no real (`1.0`) entries. The budget
+  /// solver guarantees at least one real patch; an all-pad input would make
+  /// the graph attend over nothing.
+  #[error("preprocessed attention mask has no real (1.0) entries")]
+  PreprocessedMaskEmpty,
+
+  /// A padded (mask `0.0`) row of a preprocessed tensor contained a nonzero
+  /// value. The NaFlex pipeline zero-fills pad rows and the module's parity
+  /// evidence covers only zero pads, so nonzero pad content is rejected
+  /// fail-closed rather than trusted to be masked out by the graph.
+  #[error("preprocessed `{feature}` has a nonzero value at index {index} inside a padded row")]
+  PreprocessedPadNonZero {
+    /// The model input feature (`pixel_values` / `position_embeddings`).
+    feature: &'static str,
+    /// Flat index of the first nonzero pad element.
+    index: usize,
+  },
+
+  /// A [`crate::embeddings::siglip::PreprocessedImage`] was validated against
+  /// a different patch budget than the loaded model resolved at load (e.g. a
+  /// 256-tier bundle fed to a 512-tier model). Rebuild the bundle with this
+  /// embedder's
+  /// [`crate::embeddings::siglip::ImageEmbedder::max_num_patches`].
+  #[error("preprocessed patch budget {input} does not match the model's resolved budget {model}")]
+  PatchBudgetMismatch {
+    /// The budget the input bundle was validated against.
+    input: usize,
+    /// The budget the loaded model resolved at load.
+    model: usize,
+  },
 }
 
 #[cfg(test)]

--- a/crates/coremlit/src/embeddings/siglip/error/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/error/tests.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+#[test]
+fn contract_mismatch_display_names_feature() {
+  let e = Error::ContractMismatch {
+    feature: "pixel_values",
+    expected: "[1, 512, 768] float32".to_string(),
+    actual: "[1, 512, 768] float16".to_string(),
+  };
+  let msg = e.to_string();
+  assert!(msg.contains("pixel_values"), "{msg}");
+  assert!(msg.contains("float16"), "{msg}");
+}
+
+#[test]
+fn output_shape_display_shows_both() {
+  let e = Error::OutputShape {
+    got: vec![768, 1],
+    expected: vec![1, 768],
+  };
+  let msg = e.to_string();
+  assert!(
+    msg.contains("[768, 1]") && msg.contains("[1, 768]"),
+    "{msg}"
+  );
+}
+
+#[test]
+fn coremlit_errors_convert_via_from() {
+  // `#[from]` lets `?` lift coremlit errors into siglip's Error.
+  let e = Error::from(crate::PredictionError::MissingOutput {
+    name: "image_features".to_string(),
+  });
+  assert!(matches!(e, Error::Prediction(_)), "got {e:?}");
+}
+
+#[test]
+fn non_finite_variants_carry_index() {
+  assert!(
+    Error::NonFiniteOutput { index: 7 }
+      .to_string()
+      .contains('7')
+  );
+  assert!(
+    Error::NonFiniteEmbedding { component_index: 3 }
+      .to_string()
+      .contains('3')
+  );
+}
+
+#[test]
+fn image_dimensions_display_shows_both_dims() {
+  let e = Error::ImageDimensions {
+    width: 640,
+    height: 0,
+  };
+  let msg = e.to_string();
+  assert!(msg.contains("640") && msg.contains('0'), "{msg}");
+}
+
+#[test]
+fn image_data_length_display_shows_expected_and_got() {
+  let e = Error::ImageDataLength {
+    got: 100,
+    expected: 640 * 480 * 3,
+  };
+  let msg = e.to_string();
+  assert!(
+    msg.contains("100") && msg.contains(&(640 * 480 * 3).to_string()),
+    "{msg}"
+  );
+}
+
+#[test]
+fn pos_embed_length_display_shows_expected_and_got() {
+  let e = Error::PosEmbedLength {
+    got: 123,
+    expected: 16 * 16 * 768 * 4,
+  };
+  let msg = e.to_string();
+  assert!(
+    msg.contains("123") && msg.contains(&(16 * 16 * 768 * 4).to_string()),
+    "{msg}"
+  );
+}
+
+#[test]
+fn pos_embed_load_wraps_io_error_as_source() {
+  let io = std::io::Error::new(std::io::ErrorKind::NotFound, "no such file");
+  let e = Error::PosEmbedLoad(io);
+  // The source chain is preserved (`#[source]`).
+  assert!(std::error::Error::source(&e).is_some(), "source chain lost");
+}
+
+#[test]
+fn patch_count_display_shows_both() {
+  let e = Error::PatchCount { got: 600, max: 512 };
+  let msg = e.to_string();
+  assert!(msg.contains("600") && msg.contains("512"), "{msg}");
+}
+
+#[test]
+fn token_variants_carry_values() {
+  assert!(
+    Error::TokenCount { got: 70, max: 64 }
+      .to_string()
+      .contains("70")
+  );
+  assert!(
+    Error::TokenIdRange { id: u32::MAX }
+      .to_string()
+      .contains(&u32::MAX.to_string())
+  );
+}

--- a/crates/coremlit/src/embeddings/siglip/error/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/error/tests.rs
@@ -118,3 +118,68 @@ fn token_variants_carry_values() {
       .contains(&u32::MAX.to_string())
   );
 }
+
+#[test]
+fn preprocessed_length_display_names_feature() {
+  let msg = Error::PreprocessedLength {
+    feature: "pixel_values",
+    got: 100,
+    expected: 393_216,
+  }
+  .to_string();
+  assert!(msg.contains("pixel_values"), "{msg}");
+  assert!(msg.contains("100"), "{msg}");
+  assert!(msg.contains("393216"), "{msg}");
+  assert!(
+    Error::PreprocessedPatchBudget { max_num_patches: 0 }
+      .to_string()
+      .contains('0')
+  );
+}
+
+#[test]
+fn preprocessed_mask_and_pad_variants_display_carry_diagnostics() {
+  let non_finite = Error::PreprocessedNonFinite {
+    feature: "position_embeddings",
+    index: 7,
+  }
+  .to_string();
+  assert!(
+    non_finite.contains("position_embeddings") && non_finite.contains('7'),
+    "{non_finite}"
+  );
+
+  let mask_value = Error::PreprocessedMaskValue {
+    index: 1,
+    value: 0.5,
+  }
+  .to_string();
+  assert!(
+    mask_value.contains('1') && mask_value.contains("0.5"),
+    "{mask_value}"
+  );
+
+  assert!(
+    Error::PreprocessedMaskOrder { index: 2 }
+      .to_string()
+      .contains('2')
+  );
+  assert!(Error::PreprocessedMaskEmpty.to_string().contains("no real"));
+
+  let pad = Error::PreprocessedPadNonZero {
+    feature: "pixel_values",
+    index: 9,
+  }
+  .to_string();
+  assert!(pad.contains("pixel_values") && pad.contains('9'), "{pad}");
+}
+
+#[test]
+fn patch_budget_mismatch_display_shows_both() {
+  let msg = Error::PatchBudgetMismatch {
+    input: 256,
+    model: 512,
+  }
+  .to_string();
+  assert!(msg.contains("256") && msg.contains("512"), "{msg}");
+}

--- a/crates/coremlit/src/embeddings/siglip/error/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/error/tests.rs
@@ -100,6 +100,12 @@ fn patch_count_display_shows_both() {
 }
 
 #[test]
+fn tokenizer_placeholder_display_names_the_placeholder() {
+  let msg = Error::TokenizerPlaceholder.to_string();
+  assert!(msg.contains("placeholder"), "{msg}");
+}
+
+#[test]
 fn token_variants_carry_values() {
   assert!(
     Error::TokenCount { got: 70, max: 64 }

--- a/crates/coremlit/src/embeddings/siglip/image/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/mod.rs
@@ -437,7 +437,9 @@ impl ImageEmbedder {
   ///
   /// # Errors
   /// [`Error::PatchCount`] if preprocessing overflows the budget (a solver
-  /// bug — the defensive backstop, as in [`Self::embed`]).
+  /// bug — the defensive backstop, as in [`Self::embed`]);
+  /// [`Error::PreprocessAllocation`] if a resize working buffer cannot be sized
+  /// or reserved for an extreme source geometry.
   pub fn preprocess(&self, image: Rgb8Image<'_>) -> Result<PreprocessedImage> {
     let inputs = preprocess_image(
       image.data(),

--- a/crates/coremlit/src/embeddings/siglip/image/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/mod.rs
@@ -1,0 +1,431 @@
+//! The siglip [`ImageEmbedder`]: the NaFlex host-side preprocessing (the private
+//! `preprocess` submodule) around the fp16 CoreML vision graph, with L2
+//! normalization applied in Rust.
+
+mod preprocess;
+
+use std::path::Path;
+
+use crate::{ComputeUnits, DataType, Model, ModelDescription, MultiArray};
+
+use crate::embeddings::siglip::{
+  embedding::{EMBEDDING_DIM, Embedding, check_finite_output},
+  error::{Error, Result},
+  image::preprocess::{PATCH_DIM, parse_base_pos_grid, preprocess_image},
+};
+
+/// Declared feature names on the siglip vision `.mlmodelc` (pinned by
+/// `tests/siglip/model_io.rs`).
+mod names {
+  pub const PIXEL_VALUES: &str = "pixel_values";
+  pub const POSITION_EMBEDDINGS: &str = "position_embeddings";
+  pub const ATTENTION_MASK: &str = "attention_mask";
+  pub const IMAGE_FEATURES: &str = "image_features";
+}
+
+/// Default [`ImageEmbedderOptions::compute`]: [`ComputeUnits::CpuAndGpu`] — the
+/// **measured floor-holding** placement, deliberately NOT [`ComputeUnits::All`].
+///
+/// The conversion probe measured the vision graph as **99.1% ANE-preferred** in
+/// its CoreML compute plan, yet its fp16-on-ANE parity is **0.998118 worst**,
+/// *below* the committed **0.99917** floor; the identical fp16 weights reach
+/// **0.999959** on the GPU (fp32 accumulation). Because the planner prefers the
+/// ANE for nearly every op, [`ComputeUnits::All`] risks silently dispatching the
+/// vision tower to the below-floor ANE arm. `CpuAndGpu` pins the graph to the
+/// floor-holding GPU path (mirroring `clap`'s measure-then-pin `text` default).
+///
+/// This is a deliberate spec deviation pending the conversion runbook's `All`-arm
+/// characterization (placement + parity + compute-plan dispatch); if `All`
+/// measures GPU-identical and floor-holding, the default may move to `All` in a
+/// follow-up — with the measurement in hand. Every unit stays selectable via
+/// [`ImageEmbedderOptions::with_compute`] / [`ImageEmbedderOptions::set_compute`];
+/// placement is characterized, not asserted (`tests/siglip/placement.rs`).
+pub const DEFAULT_IMAGE_COMPUTE: ComputeUnits = ComputeUnits::CpuAndGpu;
+
+#[cfg(feature = "serde")]
+fn default_image_compute() -> ComputeUnits {
+  DEFAULT_IMAGE_COMPUTE
+}
+
+/// Construction options for [`ImageEmbedder`] (rust-options-pattern): a single
+/// `compute` knob with one source of truth shared by `const new`/`Default`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ImageEmbedderOptions {
+  #[cfg_attr(
+    feature = "serde",
+    serde(
+      default = "default_image_compute",
+      with = "crate::embeddings::siglip::compute_units_serde"
+    )
+  )]
+  compute: ComputeUnits,
+}
+
+impl Default for ImageEmbedderOptions {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl ImageEmbedderOptions {
+  /// Options matching the module default: [`DEFAULT_IMAGE_COMPUTE`].
+  pub const fn new() -> Self {
+    Self {
+      compute: DEFAULT_IMAGE_COMPUTE,
+    }
+  }
+
+  /// Which hardware CoreML may schedule the vision graph on.
+  #[inline]
+  pub const fn compute(&self) -> ComputeUnits {
+    self.compute
+  }
+
+  /// Builder form of [`Self::set_compute`].
+  #[must_use]
+  #[inline]
+  pub const fn with_compute(mut self, compute: ComputeUnits) -> Self {
+    self.set_compute(compute);
+    self
+  }
+
+  /// Sets [`Self::compute`] in place.
+  #[inline]
+  pub const fn set_compute(&mut self, compute: ComputeUnits) -> &mut Self {
+    self.compute = compute;
+    self
+  }
+}
+
+/// A borrowed view of one decoded RGB8 image: a `width · height · 3` row-major,
+/// RGB-interleaved `&[u8]` (the sans-I/O seam — decoding PNG/JPEG is the
+/// caller's responsibility, like `clap`'s 48 kHz resampling, so the crate gains
+/// no image-decoder runtime dependency).
+///
+/// [`Rgb8Image::new`] validates the geometry so preprocessing can index without
+/// bounds surprises.
+#[derive(Debug, Clone, Copy)]
+pub struct Rgb8Image<'a> {
+  data: &'a [u8],
+  width: usize,
+  height: usize,
+}
+
+impl<'a> Rgb8Image<'a> {
+  /// Wrap a decoded RGB8 buffer, validating its geometry.
+  ///
+  /// `data` must be exactly `width · height · 3` bytes, row-major with the three
+  /// RGB channels interleaved per pixel.
+  ///
+  /// # Errors
+  /// [`Error::ImageDimensions`] if `width` or `height` is zero, or if
+  /// `width · height · 3` overflows `usize`; [`Error::ImageDataLength`] if
+  /// `data.len()` is not exactly `width · height · 3`.
+  pub fn new(data: &'a [u8], width: usize, height: usize) -> Result<Self> {
+    if width == 0 || height == 0 {
+      return Err(Error::ImageDimensions { width, height });
+    }
+    let expected = width
+      .checked_mul(height)
+      .and_then(|hw| hw.checked_mul(3))
+      .ok_or(Error::ImageDimensions { width, height })?;
+    if data.len() != expected {
+      return Err(Error::ImageDataLength {
+        got: data.len(),
+        expected,
+      });
+    }
+    Ok(Self {
+      data,
+      width,
+      height,
+    })
+  }
+
+  /// The image width in pixels.
+  #[inline]
+  pub const fn width(&self) -> usize {
+    self.width
+  }
+
+  /// The image height in pixels.
+  #[inline]
+  pub const fn height(&self) -> usize {
+    self.height
+  }
+
+  /// The backing RGB8 bytes (`width · height · 3`, row-major, interleaved).
+  #[inline]
+  pub const fn data(&self) -> &'a [u8] {
+    self.data
+  }
+}
+
+/// siglip vision embedder: a decoded [`Rgb8Image`] in, a unit-norm 768-d
+/// [`Embedding`] out — the same joint-space [`Embedding`] the text tower emits.
+///
+/// The front-end is a Rust NaFlex port (the private `preprocess` submodule):
+/// it fits the image to the resolved patch budget `P`, resizes with an
+/// antialiased-bilinear kernel, normalizes, patchifies into the graph's `[1, P,
+/// 768]` `pixel_values` + `[1, P]` `attention_mask`, and lifts the base position
+/// grid into `[1, P, 768]` `position_embeddings`. The fp16 CoreML graph maps
+/// those to a pre-normalization 768-d projection, which this embedder
+/// L2-normalizes.
+///
+/// `&self` inference: preprocessing scratch is per-call local, so fan-out means
+/// one [`ImageEmbedder`] per worker over a `Send` (but deliberately `!Sync`)
+/// [`crate::Model`].
+#[derive(Debug)]
+pub struct ImageEmbedder {
+  model: Model,
+  /// The base `16×16×768` position grid (parsed from the `.f32le.bin` sidecar),
+  /// resized per image by the pos-emb lift.
+  base_pos_embed: Vec<f32>,
+  /// The patch budget `P` resolved from the loaded model's `pixel_values [1, P,
+  /// 768]` contract (D2 — never a code constant; a 256/1024 tier is a drop-in
+  /// artifact with no inference-core change).
+  max_num_patches: usize,
+}
+
+impl ImageEmbedder {
+  /// Loads the vision `.mlmodelc` and its base position-grid sidecar
+  /// (`pos_embed_16x16x768.f32le.bin`) from paths, with custom `options` — the
+  /// primary constructor. Resolves the patch budget `P` and validates the I/O
+  /// contract against the metadata at load.
+  ///
+  /// # Errors
+  /// [`Error::PosEmbedLoad`] if the sidecar is unreadable; [`Error::PosEmbedLength`]
+  /// if its byte length is not the exact `16·16·768·4` grid; [`Error::Load`] if
+  /// CoreML rejects the model; [`Error::ContractMismatch`] if the model's I/O
+  /// contract mismatches the vision graph contract.
+  pub fn load(
+    model_path: impl AsRef<Path>,
+    pos_embed_path: impl AsRef<Path>,
+    options: ImageEmbedderOptions,
+  ) -> Result<Self> {
+    let bytes = std::fs::read(pos_embed_path.as_ref()).map_err(Error::PosEmbedLoad)?;
+    let base_pos_embed = parse_base_pos_grid(&bytes)?;
+    Self::from_parts(model_path, base_pos_embed, options)
+  }
+
+  /// Loads the vision model and sidecar from paths using
+  /// [`ImageEmbedderOptions::new`].
+  ///
+  /// # Errors
+  /// As [`Self::load`].
+  pub fn from_files(
+    model_path: impl AsRef<Path>,
+    pos_embed_path: impl AsRef<Path>,
+  ) -> Result<Self> {
+    Self::load(model_path, pos_embed_path, ImageEmbedderOptions::new())
+  }
+
+  /// Loads the vision model from a path and the base position grid from
+  /// caller-supplied bytes (raw little-endian f32, exactly `16·16·768·4` bytes).
+  ///
+  /// # Errors
+  /// As [`Self::load`] (minus [`Error::PosEmbedLoad`] — the caller owns the
+  /// bytes); [`Error::PosEmbedLength`] on a wrong byte length.
+  pub fn from_memory(
+    model_path: impl AsRef<Path>,
+    pos_embed_bytes: &[u8],
+    options: ImageEmbedderOptions,
+  ) -> Result<Self> {
+    let base_pos_embed = parse_base_pos_grid(pos_embed_bytes)?;
+    Self::from_parts(model_path, base_pos_embed, options)
+  }
+
+  fn from_parts(
+    model_path: impl AsRef<Path>,
+    base_pos_embed: Vec<f32>,
+    options: ImageEmbedderOptions,
+  ) -> Result<Self> {
+    let model = Model::load(model_path, options.compute())?;
+    let max_num_patches = resolve_patch_budget(model.description())?;
+    Ok(Self {
+      model,
+      base_pos_embed,
+      max_num_patches,
+    })
+  }
+
+  /// The patch budget `P` this model was converted at — resolved from the
+  /// loaded `pixel_values [1, P, 768]` contract (D2), not a code constant.
+  #[inline]
+  pub const fn max_num_patches(&self) -> usize {
+    self.max_num_patches
+  }
+
+  /// Embeds one decoded image into a unit-norm [`Embedding`].
+  ///
+  /// # Errors
+  /// [`Error::PatchCount`] if preprocessing overflows the budget (a solver bug);
+  /// [`Error::Tensor`] / [`Error::Prediction`] on a tensor or CoreML failure;
+  /// [`Error::OutputShape`] if the predicted `image_features` shape diverges from
+  /// `[1, `[`EMBEDDING_DIM`]`]`; [`Error::NonFiniteOutput`] if the model output
+  /// has a NaN/infinite component — model corruption, classified apart from a
+  /// caller's own non-finite embedding data ([`Error::NonFiniteEmbedding`]);
+  /// [`Error::EmbeddingZero`] if the (finite) projection has zero magnitude.
+  pub fn embed(&self, image: Rgb8Image<'_>) -> Result<Embedding> {
+    let inputs = preprocess_image(
+      image.data(),
+      image.width(),
+      image.height(),
+      &self.base_pos_embed,
+      self.max_num_patches,
+    )?;
+
+    let pixel_values =
+      MultiArray::from_slice(&[1, self.max_num_patches, PATCH_DIM], &inputs.pixel_values)?;
+    let position_embeddings = MultiArray::from_slice(
+      &[1, self.max_num_patches, EMBEDDING_DIM],
+      &inputs.position_embeddings,
+    )?;
+    let attention_mask =
+      MultiArray::from_slice(&[1, self.max_num_patches], &inputs.attention_mask)?;
+
+    let mut outputs = self.model.predict_with(&[
+      (names::PIXEL_VALUES, &pixel_values),
+      (names::POSITION_EMBEDDINGS, &position_embeddings),
+      (names::ATTENTION_MASK, &attention_mask),
+    ])?;
+    let feats =
+      outputs
+        .take(names::IMAGE_FEATURES)
+        .ok_or_else(|| crate::PredictionError::MissingOutput {
+          name: names::IMAGE_FEATURES.to_string(),
+        })?;
+    if feats.shape() != [1, EMBEDDING_DIM] {
+      return Err(Error::OutputShape {
+        got: feats.shape().to_vec(),
+        expected: vec![1, EMBEDDING_DIM],
+      });
+    }
+
+    let mut row = [0.0f32; EMBEDDING_DIM];
+    feats.copy_into::<f32>(&mut row)?;
+    // Classify a NaN/∞ the CoreML runtime produced as model-output corruption
+    // (`NonFiniteOutput`) before it reaches `from_slice_normalizing`.
+    check_finite_output(&row)?;
+    Embedding::from_slice_normalizing(&row)
+  }
+
+  /// Runs one throwaway [`Self::embed`] to fully specialize the prediction path,
+  /// so the first user-facing request is warm. Construction pays the model load;
+  /// this pays the first prediction's graph specialization. Then **reuse** this
+  /// same embedder for every request (it is `&self`).
+  ///
+  /// # Errors
+  /// As [`Self::embed`] (the warm-up uses a fixed synthetic image, so no caller
+  /// input is read); a failure surfaces a broken model at prewarm time rather
+  /// than on the first request.
+  pub fn prewarm(&self) -> Result<()> {
+    // A fixed 64×64 mid-gray image: valid geometry, non-degenerate, upscaled by
+    // NaFlex to the full patch budget exactly as a real image is.
+    let data = vec![128u8; 64 * 64 * 3];
+    let image = Rgb8Image::new(&data, 64, 64)?;
+    self.embed(image)?;
+    Ok(())
+  }
+}
+
+/// Resolves the patch budget `P` from the loaded vision model's `pixel_values
+/// [1, P, 768]` contract and validates the full I/O contract against it (D2 +
+/// cross-input consistency): `pixel_values` and `position_embeddings` are both
+/// `[1, P, 768]` f32, `attention_mask` is `[1, P]` f32, and `image_features` is
+/// `[1, 768]` f32 — the same `P` across all three inputs.
+fn resolve_patch_budget(description: &ModelDescription) -> Result<usize> {
+  // pixel_values [1, P, PATCH_DIM] f32 — the source of the resolved P.
+  let pv_expected = format!("[1, P, {PATCH_DIM}] float32");
+  let pixel_values =
+    description
+      .input(names::PIXEL_VALUES)
+      .ok_or_else(|| Error::ContractMismatch {
+        feature: names::PIXEL_VALUES,
+        expected: pv_expected.clone(),
+        actual: "missing".to_string(),
+      })?;
+  let shape = pixel_values.shape();
+  if shape.len() != 3
+    || shape[0] != 1
+    || shape[2] != PATCH_DIM
+    || pixel_values.data_type() != Some(DataType::F32)
+  {
+    return Err(Error::ContractMismatch {
+      feature: names::PIXEL_VALUES,
+      expected: pv_expected,
+      actual: describe(shape, pixel_values.data_type()),
+    });
+  }
+  let p = shape[1];
+  if p == 0 {
+    return Err(Error::ContractMismatch {
+      feature: names::PIXEL_VALUES,
+      expected: pv_expected,
+      actual: describe(shape, pixel_values.data_type()),
+    });
+  }
+
+  // position_embeddings [1, P, EMBEDDING_DIM] f32 — same resolved P.
+  check_input(
+    description,
+    names::POSITION_EMBEDDINGS,
+    &[1, p, EMBEDDING_DIM],
+  )?;
+  // attention_mask [1, P] f32 (note: f32, not int32) — same resolved P.
+  check_input(description, names::ATTENTION_MASK, &[1, p])?;
+
+  // image_features [1, EMBEDDING_DIM] f32.
+  let out_expected = format!("[1, {EMBEDDING_DIM}] float32");
+  let output =
+    description
+      .output(names::IMAGE_FEATURES)
+      .ok_or_else(|| Error::ContractMismatch {
+        feature: names::IMAGE_FEATURES,
+        expected: out_expected.clone(),
+        actual: "missing".to_string(),
+      })?;
+  if output.shape() != [1, EMBEDDING_DIM] || output.data_type() != Some(DataType::F32) {
+    return Err(Error::ContractMismatch {
+      feature: names::IMAGE_FEATURES,
+      expected: out_expected,
+      actual: describe(output.shape(), output.data_type()),
+    });
+  }
+
+  Ok(p)
+}
+
+/// Validates one f32 input feature against an exact resolved shape.
+fn check_input(
+  description: &ModelDescription,
+  name: &'static str,
+  expected_shape: &[usize],
+) -> Result<()> {
+  let expected = format!("{expected_shape:?} float32");
+  let input = description
+    .input(name)
+    .ok_or_else(|| Error::ContractMismatch {
+      feature: name,
+      expected: expected.clone(),
+      actual: "missing".to_string(),
+    })?;
+  if input.shape() != expected_shape || input.data_type() != Some(DataType::F32) {
+    return Err(Error::ContractMismatch {
+      feature: name,
+      expected,
+      actual: describe(input.shape(), input.data_type()),
+    });
+  }
+  Ok(())
+}
+
+/// Human-readable `shape dtype` rendering for [`Error::ContractMismatch`].
+fn describe(shape: &[usize], dtype: Option<DataType>) -> String {
+  let dtype = dtype.map_or("none", |d| d.as_str());
+  format!("{shape:?} {dtype}")
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coremlit/src/embeddings/siglip/image/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/mod.rs
@@ -166,12 +166,12 @@ impl<'a> Rgb8Image<'a> {
 /// [`Embedding`] out — the same joint-space [`Embedding`] the text tower emits.
 ///
 /// The front-end is a Rust NaFlex port (the private `preprocess` submodule):
-/// it fits the image to the resolved patch budget `P`, resizes with an
-/// antialiased-bilinear kernel, normalizes, patchifies into the graph's `[1, P,
-/// 768]` `pixel_values` + `[1, P]` `attention_mask`, and lifts the base position
-/// grid into `[1, P, 768]` `position_embeddings`. The fp16 CoreML graph maps
-/// those to a pre-normalization 768-d projection, which this embedder
-/// L2-normalizes.
+/// it fits the image to the resolved patch budget `P`, resizes with a uint8
+/// PIL-parity antialiased-bilinear kernel, normalizes, patchifies into the
+/// graph's `[1, P, 768]` `pixel_values` + `[1, P]` `attention_mask`, and lifts
+/// the base position grid into `[1, P, 768]` `position_embeddings`. The fp16
+/// CoreML graph maps those to a pre-normalization 768-d projection, which this
+/// embedder L2-normalizes.
 ///
 /// `&self` inference: preprocessing scratch is per-call local, so fan-out means
 /// one [`ImageEmbedder`] per worker over a `Send` (but deliberately `!Sync`)
@@ -261,6 +261,8 @@ impl ImageEmbedder {
   ///
   /// # Errors
   /// [`Error::PatchCount`] if preprocessing overflows the budget (a solver bug);
+  /// [`Error::PreprocessAllocation`] if a resize working buffer cannot be sized
+  /// or reserved (pathological source geometry);
   /// [`Error::Tensor`] / [`Error::Prediction`] on a tensor or CoreML failure;
   /// [`Error::OutputShape`] if the predicted `image_features` shape diverges from
   /// `[1, `[`EMBEDDING_DIM`]`]`; [`Error::NonFiniteOutput`] if the model output

--- a/crates/coremlit/src/embeddings/siglip/image/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/mod.rs
@@ -4,6 +4,7 @@
 
 mod preprocess;
 
+use core::fmt;
 use std::path::Path;
 
 use crate::{ComputeUnits, DataType, Model, ModelDescription, MultiArray};
@@ -11,8 +12,10 @@ use crate::{ComputeUnits, DataType, Model, ModelDescription, MultiArray};
 use crate::embeddings::siglip::{
   embedding::{EMBEDDING_DIM, Embedding, check_finite_output},
   error::{Error, Result},
-  image::preprocess::{PATCH_DIM, parse_base_pos_grid, preprocess_image},
+  image::preprocess::{parse_base_pos_grid, preprocess_image},
 };
+
+pub use preprocess::PATCH_DIM;
 
 /// Declared feature names on the siglip vision `.mlmodelc` (pinned by
 /// `tests/siglip/model_io.rs`).
@@ -162,6 +165,174 @@ impl<'a> Rgb8Image<'a> {
   }
 }
 
+/// Caller-supplied NaFlex-preprocessed vision tensors for
+/// [`ImageEmbedder::embed_preprocessed`]: the graph's three inputs —
+/// `pixel_values` `[1, P, `[`PATCH_DIM`]`]`, `position_embeddings`
+/// `[1, P, `[`EMBEDDING_DIM`]`]`, `attention_mask` `[1, P]` — flattened
+/// row-major and **already padded to the patch budget** `P`
+/// ([`ImageEmbedder::max_num_patches`]), exactly as the NaFlex pipeline emits
+/// them: real patch rows as a contiguous prefix (mask `1.0`), zero-filled pad
+/// rows after (mask `0.0`).
+///
+/// [`PreprocessedImage::try_new`] validates shape and structure once; the
+/// tensors are immutable afterwards (private fields, no mutators), so a
+/// constructed value stays valid. [`ImageEmbedder::preprocess`] produces this
+/// type from a decoded [`Rgb8Image`] — the in-crate reference for what
+/// `try_new` accepts.
+///
+/// **What validation cannot see:** whether the tensors were produced by the
+/// exact NaFlex pipeline this model was converted against — the
+/// antialiased-bilinear resize coefficients, the `((x/255) − 0.5)/0.5`
+/// normalization, the `(patch_row, patch_col, py, px, channel)` flatten order,
+/// and the base-grid position-embedding lift. Tensors from a deviating
+/// pipeline pass validation and **silently degrade** the embedding — no error
+/// is raised. Unless inputs must be precomputed offline, use
+/// [`ImageEmbedder::embed`], the safe default.
+#[derive(Clone)]
+pub struct PreprocessedImage {
+  /// `[max_num_patches · PATCH_DIM]`: real patch rows, then zero pad rows.
+  pixel_values: Vec<f32>,
+  /// `[max_num_patches · EMBEDDING_DIM]`: lifted rows, then zero pad rows.
+  position_embeddings: Vec<f32>,
+  /// `[max_num_patches]`: exactly `1.0` on the real-patch prefix, `0.0` after.
+  attention_mask: Vec<f32>,
+  /// The patch budget `P` the lengths were validated against.
+  max_num_patches: usize,
+}
+
+impl PreprocessedImage {
+  /// Validates and wraps a padded NaFlex tensor bundle for a model whose
+  /// resolved patch budget is `max_num_patches`
+  /// ([`ImageEmbedder::max_num_patches`]).
+  ///
+  /// Checks, in order: the budget is usable (non-zero, lengths representable);
+  /// exact lengths (`pixel_values` = `max_num_patches · `[`PATCH_DIM`],
+  /// `position_embeddings` = `max_num_patches · `[`EMBEDDING_DIM`],
+  /// `attention_mask` = `max_num_patches`); `pixel_values` and
+  /// `position_embeddings` are finite; the mask is an exact binary
+  /// prefix mask (every entry exactly `0.0` or `1.0`, all `1.0`s before the
+  /// first `0.0`, at least one `1.0` — the mask's domain check subsumes its
+  /// finiteness); and every padded (mask `0.0`) row of `pixel_values` and
+  /// `position_embeddings` is all-zero, as the NaFlex pipeline emits and as
+  /// the module's parity evidence covers (fail-closed).
+  ///
+  /// It **cannot** validate that the values came from the exact NaFlex
+  /// pipeline (see the type docs): that is the caller's contract.
+  ///
+  /// # Errors
+  /// [`Error::PreprocessedPatchBudget`] if `max_num_patches` is zero or too
+  /// large for the tensor lengths to be representable;
+  /// [`Error::PreprocessedLength`] on a wrong tensor length;
+  /// [`Error::PreprocessedNonFinite`] on a NaN/infinite `pixel_values` or
+  /// `position_embeddings` element; [`Error::PreprocessedMaskValue`] /
+  /// [`Error::PreprocessedMaskOrder`] / [`Error::PreprocessedMaskEmpty`] on a
+  /// non-binary, non-prefix, or all-pad mask;
+  /// [`Error::PreprocessedPadNonZero`] on a nonzero value inside a padded row.
+  pub fn try_new(
+    pixel_values: Vec<f32>,
+    position_embeddings: Vec<f32>,
+    attention_mask: Vec<f32>,
+    max_num_patches: usize,
+  ) -> Result<Self> {
+    validate_budget_and_lengths(
+      &pixel_values,
+      &position_embeddings,
+      &attention_mask,
+      max_num_patches,
+    )?;
+    check_tensor_finite(names::PIXEL_VALUES, &pixel_values)?;
+    check_tensor_finite(names::POSITION_EMBEDDINGS, &position_embeddings)?;
+    let num_real = validate_mask(&attention_mask)?;
+    validate_pad_rows(names::PIXEL_VALUES, &pixel_values, num_real, PATCH_DIM)?;
+    validate_pad_rows(
+      names::POSITION_EMBEDDINGS,
+      &position_embeddings,
+      num_real,
+      EMBEDDING_DIM,
+    )?;
+    Ok(Self {
+      pixel_values,
+      position_embeddings,
+      attention_mask,
+      max_num_patches,
+    })
+  }
+
+  /// Module-internal constructor for the pipeline's own outputs, whose
+  /// structural invariants (lengths, binary prefix mask, zero pads) hold by
+  /// construction in `patchify` / `lift_position_embeddings` (cf.
+  /// `Embedding::from_array_trusted_unit_norm`). Deliberately does NOT assert
+  /// finiteness: a non-finite value in a caller-supplied position-grid sidecar
+  /// must keep flowing to the same typed predict-time error it always did, not
+  /// become a debug panic.
+  fn from_pipeline(
+    pixel_values: Vec<f32>,
+    position_embeddings: Vec<f32>,
+    attention_mask: Vec<f32>,
+    max_num_patches: usize,
+  ) -> Self {
+    debug_assert!(
+      validate_structural(
+        &pixel_values,
+        &position_embeddings,
+        &attention_mask,
+        max_num_patches
+      )
+      .is_ok(),
+      "internal NaFlex pipeline emitted a structurally invalid tensor bundle"
+    );
+    Self {
+      pixel_values,
+      position_embeddings,
+      attention_mask,
+      max_num_patches,
+    }
+  }
+
+  /// The patch budget `P` this bundle was validated against — must equal the
+  /// target embedder's [`ImageEmbedder::max_num_patches`].
+  #[inline]
+  pub const fn max_num_patches(&self) -> usize {
+    self.max_num_patches
+  }
+
+  /// The flattened `[max_num_patches · `[`PATCH_DIM`]`]` `pixel_values` rows.
+  #[inline]
+  pub fn pixel_values(&self) -> &[f32] {
+    &self.pixel_values
+  }
+
+  /// The flattened `[max_num_patches · `[`EMBEDDING_DIM`]`]`
+  /// `position_embeddings` rows.
+  #[inline]
+  pub fn position_embeddings(&self) -> &[f32] {
+    &self.position_embeddings
+  }
+
+  /// The `[max_num_patches]` real/pad `attention_mask` (`1.0` real prefix,
+  /// `0.0` pads).
+  #[inline]
+  pub fn attention_mask(&self) -> &[f32] {
+    &self.attention_mask
+  }
+}
+
+impl fmt::Debug for PreprocessedImage {
+  /// Compact — elides the megabyte-scale tensors (the `Embedding` Debug
+  /// convention), showing the budget and the mask's real-prefix length.
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let num_real = self
+      .attention_mask
+      .iter()
+      .take_while(|&&v| v == 1.0)
+      .count();
+    f.debug_struct("PreprocessedImage")
+      .field("max_num_patches", &self.max_num_patches)
+      .field("num_real_patches", &num_real)
+      .finish_non_exhaustive()
+  }
+}
+
 /// siglip vision embedder: a decoded [`Rgb8Image`] in, a unit-norm 768-d
 /// [`Embedding`] out — the same joint-space [`Embedding`] the text tower emits.
 ///
@@ -257,6 +428,32 @@ impl ImageEmbedder {
     self.max_num_patches
   }
 
+  /// Runs the module's own NaFlex pipeline on `image` without predicting:
+  /// pure host-side math (no CoreML call), producing the validated
+  /// [`PreprocessedImage`] that [`Self::embed_preprocessed`] accepts.
+  /// `embed(image)` is exactly `embed_preprocessed(&preprocess(image)?)`;
+  /// capture the bundle to embed later, or to feed another embedder of the
+  /// same patch budget.
+  ///
+  /// # Errors
+  /// [`Error::PatchCount`] if preprocessing overflows the budget (a solver
+  /// bug — the defensive backstop, as in [`Self::embed`]).
+  pub fn preprocess(&self, image: Rgb8Image<'_>) -> Result<PreprocessedImage> {
+    let inputs = preprocess_image(
+      image.data(),
+      image.width(),
+      image.height(),
+      &self.base_pos_embed,
+      self.max_num_patches,
+    )?;
+    Ok(PreprocessedImage::from_pipeline(
+      inputs.pixel_values,
+      inputs.position_embeddings,
+      inputs.attention_mask,
+      self.max_num_patches,
+    ))
+  }
+
   /// Embeds one decoded image into a unit-norm [`Embedding`].
   ///
   /// # Errors
@@ -270,22 +467,59 @@ impl ImageEmbedder {
   /// caller's own non-finite embedding data ([`Error::NonFiniteEmbedding`]);
   /// [`Error::EmbeddingZero`] if the (finite) projection has zero magnitude.
   pub fn embed(&self, image: Rgb8Image<'_>) -> Result<Embedding> {
-    let inputs = preprocess_image(
-      image.data(),
-      image.width(),
-      image.height(),
-      &self.base_pos_embed,
-      self.max_num_patches,
-    )?;
+    let inputs = self.preprocess(image)?;
+    self.embed_preprocessed(&inputs)
+  }
 
-    let pixel_values =
-      MultiArray::from_slice(&[1, self.max_num_patches, PATCH_DIM], &inputs.pixel_values)?;
+  /// Embeds caller-supplied NaFlex-preprocessed tensors, skipping this
+  /// embedder's own preprocessing — the bring-your-own-tensors bypass for
+  /// pipelines that run the exact NaFlex front-end offline/batch.
+  /// [`Self::embed`] routes through this method, so `embed(image)` ≡
+  /// `embed_preprocessed(&preprocess(image)?)` by construction.
+  ///
+  /// The bundle's shape and structure were validated at
+  /// [`PreprocessedImage::try_new`]; here only the patch-budget binding is
+  /// checked against this model's resolved `P`
+  /// ([`Self::max_num_patches`]). coremlit cannot verify the tensor VALUES
+  /// came from the exact NaFlex pipeline this model was converted against —
+  /// tensors from a deviating pipeline pass validation and **silently
+  /// degrade** the embedding (see [`PreprocessedImage`]). Prefer
+  /// [`Self::embed`] unless inputs must be precomputed.
+  ///
+  /// # Errors
+  /// [`Error::PatchBudgetMismatch`] if `inputs` was validated against a
+  /// different patch budget than this model resolved at load (e.g. a
+  /// 256-tier bundle fed to a 512-tier model); otherwise as
+  /// [`Self::embed`]'s predict path: [`Error::Tensor`] /
+  /// [`Error::Prediction`] on a tensor or CoreML failure;
+  /// [`Error::OutputShape`] if the predicted `image_features` shape diverges
+  /// from `[1, `[`EMBEDDING_DIM`]`]`; [`Error::NonFiniteOutput`] on a
+  /// NaN/infinite model output; [`Error::EmbeddingZero`] if the (finite)
+  /// projection has zero magnitude.
+  pub fn embed_preprocessed(&self, inputs: &PreprocessedImage) -> Result<Embedding> {
+    check_patch_budget(inputs.max_num_patches(), self.max_num_patches)?;
+    self.predict_embedding(
+      inputs.pixel_values(),
+      inputs.position_embeddings(),
+      inputs.attention_mask(),
+    )
+  }
+
+  /// Shared predict tail of [`Self::embed`] / [`Self::embed_preprocessed`]:
+  /// builds the three input tensors, predicts, validates the `image_features`
+  /// contract, and L2-normalizes.
+  fn predict_embedding(
+    &self,
+    pixel_values: &[f32],
+    position_embeddings: &[f32],
+    attention_mask: &[f32],
+  ) -> Result<Embedding> {
+    let pixel_values = MultiArray::from_slice(&[1, self.max_num_patches, PATCH_DIM], pixel_values)?;
     let position_embeddings = MultiArray::from_slice(
       &[1, self.max_num_patches, EMBEDDING_DIM],
-      &inputs.position_embeddings,
+      position_embeddings,
     )?;
-    let attention_mask =
-      MultiArray::from_slice(&[1, self.max_num_patches], &inputs.attention_mask)?;
+    let attention_mask = MultiArray::from_slice(&[1, self.max_num_patches], attention_mask)?;
 
     let mut outputs = self.model.predict_with(&[
       (names::PIXEL_VALUES, &pixel_values),
@@ -419,6 +653,151 @@ fn check_input(
       expected,
       actual: describe(input.shape(), input.data_type()),
     });
+  }
+  Ok(())
+}
+
+/// Budget + exact-length validation for a preprocessed bundle. The budget
+/// guard makes every `max_num_patches · row_dim` product below (and in
+/// [`validate_pad_rows`]) provably in-range, so plain multiplication is safe.
+fn validate_budget_and_lengths(
+  pixel_values: &[f32],
+  position_embeddings: &[f32],
+  attention_mask: &[f32],
+  max_num_patches: usize,
+) -> Result<()> {
+  // PATCH_DIM and EMBEDDING_DIM coincide (768) but are distinct quantities;
+  // guard against the larger so both products stay in range by construction.
+  const MAX_ROW_DIM: usize = if PATCH_DIM > EMBEDDING_DIM {
+    PATCH_DIM
+  } else {
+    EMBEDDING_DIM
+  };
+  if max_num_patches == 0 || max_num_patches > usize::MAX / MAX_ROW_DIM {
+    return Err(Error::PreprocessedPatchBudget { max_num_patches });
+  }
+  check_len(
+    names::PIXEL_VALUES,
+    pixel_values.len(),
+    max_num_patches * PATCH_DIM,
+  )?;
+  check_len(
+    names::POSITION_EMBEDDINGS,
+    position_embeddings.len(),
+    max_num_patches * EMBEDDING_DIM,
+  )?;
+  check_len(names::ATTENTION_MASK, attention_mask.len(), max_num_patches)?;
+  Ok(())
+}
+
+/// One exact-length check, reported as [`Error::PreprocessedLength`].
+fn check_len(feature: &'static str, got: usize, expected: usize) -> Result<()> {
+  if got != expected {
+    return Err(Error::PreprocessedLength {
+      feature,
+      got,
+      expected,
+    });
+  }
+  Ok(())
+}
+
+/// Scans a caller-supplied preprocessed tensor for the first non-finite
+/// (NaN/±∞) component (cf. `check_finite_output`, which classifies the same
+/// defect on the MODEL-output side).
+fn check_tensor_finite(feature: &'static str, values: &[f32]) -> Result<()> {
+  if let Some(index) = values.iter().position(|v| !v.is_finite()) {
+    return Err(Error::PreprocessedNonFinite { feature, index });
+  }
+  Ok(())
+}
+
+/// Validates the `[P]` attention mask is an exact NaFlex real/pad mask —
+/// every entry exactly `0.0` or `1.0` (IEEE equality, so `-0.0` counts as
+/// `0.0`; a NaN entry fails the domain check, which subsumes finiteness), the
+/// `1.0`s a contiguous prefix, at least one real patch — and returns the
+/// real-patch count (the prefix length). Exact comparison is deliberate: the
+/// pipeline writes these constants literally, and an approximate check would
+/// defeat the domain validation.
+fn validate_mask(mask: &[f32]) -> Result<usize> {
+  let mut num_real = 0usize;
+  let mut in_pad = false;
+  for (index, &value) in mask.iter().enumerate() {
+    if value == 1.0 {
+      if in_pad {
+        return Err(Error::PreprocessedMaskOrder { index });
+      }
+      num_real += 1;
+    } else if value == 0.0 {
+      in_pad = true;
+    } else {
+      return Err(Error::PreprocessedMaskValue { index, value });
+    }
+  }
+  if num_real == 0 {
+    return Err(Error::PreprocessedMaskEmpty);
+  }
+  Ok(num_real)
+}
+
+/// Validates rows `num_real..` of a `[P · row_dim]` tensor are all-zero: the
+/// NaFlex pipeline zero-fills pad rows and the module's parity evidence covers
+/// only zero pads, so nonzero pad content is rejected fail-closed rather than
+/// trusted to be masked out by the graph. Callers guarantee
+/// `num_real · row_dim ≤ values.len()` (both bounded by the budget guard and
+/// the mask length check).
+fn validate_pad_rows(
+  feature: &'static str,
+  values: &[f32],
+  num_real: usize,
+  row_dim: usize,
+) -> Result<()> {
+  let pad_start = num_real * row_dim;
+  if let Some(offset) = values[pad_start..].iter().position(|&v| v != 0.0) {
+    return Err(Error::PreprocessedPadNonZero {
+      feature,
+      index: pad_start + offset,
+    });
+  }
+  Ok(())
+}
+
+/// The structural (non-finiteness) subset of [`PreprocessedImage::try_new`]'s
+/// validation — budget, lengths, mask shape, zero pads: exactly the invariants
+/// the internal pipeline guarantees by construction, debug-asserted by
+/// `PreprocessedImage::from_pipeline`.
+fn validate_structural(
+  pixel_values: &[f32],
+  position_embeddings: &[f32],
+  attention_mask: &[f32],
+  max_num_patches: usize,
+) -> Result<()> {
+  validate_budget_and_lengths(
+    pixel_values,
+    position_embeddings,
+    attention_mask,
+    max_num_patches,
+  )?;
+  let num_real = validate_mask(attention_mask)?;
+  validate_pad_rows(names::PIXEL_VALUES, pixel_values, num_real, PATCH_DIM)?;
+  validate_pad_rows(
+    names::POSITION_EMBEDDINGS,
+    position_embeddings,
+    num_real,
+    EMBEDDING_DIM,
+  )?;
+  Ok(())
+}
+
+/// Validates a [`PreprocessedImage`]'s budget binding against the loaded
+/// model's resolved `P`. Extracted so the classification is hermetically
+/// testable without a loaded model (the `check_finite_output` pattern).
+///
+/// # Errors
+/// [`Error::PatchBudgetMismatch`] carrying both budgets.
+fn check_patch_budget(input: usize, model: usize) -> Result<()> {
+  if input != model {
+    return Err(Error::PatchBudgetMismatch { input, model });
   }
   Ok(())
 }

--- a/crates/coremlit/src/embeddings/siglip/image/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/mod.rs
@@ -15,7 +15,7 @@ use crate::embeddings::siglip::{
   image::preprocess::{parse_base_pos_grid, preprocess_image},
 };
 
-pub use preprocess::PATCH_DIM;
+pub use preprocess::{MAX_IMAGE_AXIS, PATCH_DIM};
 
 /// Declared feature names on the siglip vision `.mlmodelc` (pinned by
 /// `tests/siglip/model_io.rs`).
@@ -436,6 +436,7 @@ impl ImageEmbedder {
   /// same patch budget.
   ///
   /// # Errors
+  /// [`Error::ImageDimensions`] if an image axis exceeds [`MAX_IMAGE_AXIS`];
   /// [`Error::PatchCount`] if preprocessing overflows the budget (a solver
   /// bug — the defensive backstop, as in [`Self::embed`]);
   /// [`Error::PreprocessAllocation`] if a resize working buffer cannot be sized
@@ -459,6 +460,7 @@ impl ImageEmbedder {
   /// Embeds one decoded image into a unit-norm [`Embedding`].
   ///
   /// # Errors
+  /// [`Error::ImageDimensions`] if an image axis exceeds [`MAX_IMAGE_AXIS`];
   /// [`Error::PatchCount`] if preprocessing overflows the budget (a solver bug);
   /// [`Error::PreprocessAllocation`] if a resize working buffer cannot be sized
   /// or reserved (pathological source geometry);

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
@@ -14,7 +14,9 @@
 //!    22-bit coefficients, per-pass u8 rounding), matching the SigLIP2 processor
 //!    (resize on u8, THEN rescale+normalize). Its sibling f64
 //!    [`resize_bilinear_antialias`] is the position-embedding lift's kernel
-//!    (stage 5), which the reference genuinely computes in float.
+//!    (stage 5), which the reference genuinely computes in float. The u8
+//!    kernel's bit-exactness holds for source axes ≤ [`MAX_IMAGE_AXIS`], which
+//!    [`preprocess_image`] enforces.
 //! 3. [`normalize_u8`] — rescale + normalize `((v/255) − 0.5)/0.5`.
 //! 4. [`patchify`] — reshape the resized+normalized image to `[P, 768]` patch
 //!    rows plus the `[P]` real/pad mask.
@@ -49,6 +51,34 @@ pub(crate) const CHANNELS: usize = 3;
 /// carries `max_num_patches · PATCH_DIM` pixel values. Coincides with
 /// [`EMBEDDING_DIM`] for `base-patch16`, but is a distinct quantity.
 pub const PATCH_DIM: usize = CHANNELS * PATCH_SIZE * PATCH_SIZE;
+
+/// Maximum accepted source-image extent per axis, `2²⁰ = 1 048 576` pixels.
+/// `preprocess_image` rejects a larger axis with
+/// [`Error::ImageDimensions`] before any resize work. The bound is a property
+/// of the resize kernels, not of the model:
+///
+/// * **Pillow-exactness envelope.** Pillow passes the resize box through
+///   `float box[4]` (`_imaging.c` parses `(ffff)`; `Resample.c`
+///   `precompute_coeffs(int inSize, float in0, float in1, …)` computes
+///   `scale = (double)(in1 - in0) / outSize`), so the source extent is rounded
+///   to `f32` before the `f64` coefficient math. Every integer extent `≤ 2²⁴`
+///   is exactly `f32`-representable, making the pure-`f64`
+///   `precompute_coeffs` here bit-identical to Pillow's; from `2²⁴ + 1`
+///   upward Pillow computes with a different extent (`16 777 219 →
+///   16 777 220.0f32`) and the uint8 kernel's bit-exact contract would
+///   silently break. The cap keeps every accepted extent 16× inside the
+///   envelope.
+/// * **Bounded working memory.** The per-axis coefficient tables (`~2·axis`
+///   taps) and the horizontal pass's `u8` intermediate (`src_h · dst_w · 3`
+///   bytes) grow linearly with the accepted axis — hundreds of MB to over a
+///   GB for degenerate strips the budget solver otherwise accepts. Under the
+///   cap the whole resize working set stays ≈ 100 MB even at the boundary.
+///
+/// `2²⁰` px per axis is far beyond any physically decodable image (record
+/// stitched panoramas peak near `8.5 × 10⁵` px on the long axis), so the
+/// bound rejects nothing realistic while making the Pillow-parity contract
+/// hold over the entire accepted domain.
+pub const MAX_IMAGE_AXIS: usize = 1 << 20;
 
 /// Side of the base position-embedding grid: the model's `num_patches = 256`
 /// position table reshaped to `16×16` (per the probe). Architecture constant.
@@ -143,6 +173,10 @@ fn triangle(t: f64) -> f64 {
 /// downsampling low-passes; upsampling (`scale ≤ 1`) keeps unit support (plain
 /// bilinear). `align_corners=False` sample centers `(o + 0.5)·scale`. Each entry
 /// is `(start_input_index, normalized_weights)`.
+///
+/// Image-path callers bound `in_size` by [`MAX_IMAGE_AXIS`], under which this
+/// pure-`f64` extent math coincides bit-for-bit with Pillow's `float box[4]`
+/// semantics (see the const's doc for the threshold).
 ///
 /// # Errors
 /// [`Error::PreprocessAllocation`] if a pathological source extent makes the
@@ -283,11 +317,16 @@ pub(crate) fn resize_bilinear_antialias(
 /// away from zero. Bilinear weights are non-negative in practice; the negative
 /// branch mirrors PIL exactly for any residual.
 ///
+/// Consumes `coeffs` by value: each entry's `f64` weights vector drops as soon
+/// as its `i32` twin is built, so the two precisions never fully coexist —
+/// the safe-Rust analogue of Pillow's in-place `kk = (INT32 *)prekk` reuse
+/// (`normalize_coeffs_8bpc`).
+///
 /// # Errors
 /// [`Error::PreprocessAllocation`] if a quantized coefficient vector cannot be
 /// reserved (the input table is already bounded, so only the reservation can
 /// fail; the quantized values are unchanged from the infallible form).
-fn quantize_coeffs_8bpc(coeffs: &[(usize, Vec<f64>)]) -> Result<Vec<(usize, Vec<i32>)>, Error> {
+fn quantize_coeffs_8bpc(coeffs: Vec<(usize, Vec<f64>)>) -> Result<Vec<(usize, Vec<i32>)>, Error> {
   let scale = f64::from(1i32 << PRECISION_BITS);
   let mut out = Vec::new();
   out
@@ -303,7 +342,7 @@ fn quantize_coeffs_8bpc(coeffs: &[(usize, Vec<f64>)]) -> Result<Vec<(usize, Vec<
       .map_err(|_| Error::PreprocessAllocation {
         bytes: weights.len().saturating_mul(core::mem::size_of::<i32>()),
       })?;
-    for &w in weights {
+    for &w in &weights {
       let q = if w < 0.0 {
         (-0.5 + w * scale) as i32
       } else {
@@ -311,7 +350,7 @@ fn quantize_coeffs_8bpc(coeffs: &[(usize, Vec<f64>)]) -> Result<Vec<(usize, Vec<
       };
       kk.push(q);
     }
-    out.push((*start, kk));
+    out.push((start, kk));
   }
   Ok(out)
 }
@@ -361,6 +400,17 @@ fn alloc_u8(len: usize) -> Result<Vec<u8>, Error> {
 /// rather than aborting. A `src` shorter than `src_h·src_w·channels` panics on
 /// an out-of-bounds tap — a caller-internal invariant.
 ///
+/// [`quantize_coeffs_8bpc`] consumes its `f64` input table, so the `f64` and
+/// `i32` tables never fully coexist; this fn also drops the horizontal `i32`
+/// table with `drop` before the vertical one is built, so peak coefficient
+/// memory is one table at a time. The only caller, [`preprocess_image`],
+/// bounds `src_h`/`src_w` by [`MAX_IMAGE_AXIS`], which keeps every table and
+/// the horizontal intermediate under ≈ 100 MB and — because every accepted
+/// axis is then exactly `f32`-representable — keeps this kernel inside
+/// Pillow's `float box[4]` exact envelope (see [`MAX_IMAGE_AXIS`]'s doc for
+/// the threshold); the bound is an invariant of the caller, not re-checked
+/// here.
+///
 /// # Errors
 /// [`Error::PreprocessAllocation`] if a working buffer or coefficient table's
 /// size overflows `usize` or cannot be reserved.
@@ -375,7 +425,7 @@ pub(crate) fn resize_bilinear_antialias_u8(
   const OFFSET: i64 = 1 << (PRECISION_BITS - 1);
 
   // Horizontal pass: (src_h, src_w, C) → (src_h, dst_w, C), u8 intermediate.
-  let wc = quantize_coeffs_8bpc(&precompute_coeffs(src_w, dst_w)?)?;
+  let wc = quantize_coeffs_8bpc(precompute_coeffs(src_w, dst_w)?)?;
   let mut tmp = alloc_u8(checked_len3(src_h, dst_w, channels)?)?;
   for y in 0..src_h {
     for (ox, (start, weights)) in wc.iter().enumerate() {
@@ -388,9 +438,10 @@ pub(crate) fn resize_bilinear_antialias_u8(
       }
     }
   }
+  drop(wc); // horizontal table is dead before the vertical pass builds its own
 
   // Vertical pass: (src_h, dst_w, C) → (dst_h, dst_w, C).
-  let hc = quantize_coeffs_8bpc(&precompute_coeffs(src_h, dst_h)?)?;
+  let hc = quantize_coeffs_8bpc(precompute_coeffs(src_h, dst_h)?)?;
   let mut out = alloc_u8(checked_len3(dst_h, dst_w, channels)?)?;
   for (oy, (start, weights)) in hc.iter().enumerate() {
     for x in 0..dst_w {
@@ -529,6 +580,7 @@ pub(crate) fn lift_position_embeddings(
 
 /// The three vision-graph input tensors produced from one decoded image, plus
 /// the resolved `(grid_h, grid_w)` patch grid.
+#[derive(Debug)]
 pub(crate) struct VisionInputs {
   /// Patchified pixels `[budget · PATCH_DIM]` (the `pixel_values` input).
   pub pixel_values: Vec<f32>,
@@ -557,6 +609,7 @@ pub(crate) struct VisionInputs {
 /// parsed `POS_EMBED_ELEMS` base position grid.
 ///
 /// # Errors
+/// [`Error::ImageDimensions`] if an image axis exceeds [`MAX_IMAGE_AXIS`];
 /// [`Error::PatchCount`] if the solved grid exceeds `budget` (a solver bug);
 /// [`Error::PreprocessAllocation`] if a resize working buffer cannot be sized or
 /// reserved (pathological source geometry).
@@ -567,6 +620,10 @@ pub(crate) fn preprocess_image(
   base_grid: &[f32],
   budget: usize,
 ) -> Result<VisionInputs, Error> {
+  if width > MAX_IMAGE_AXIS || height > MAX_IMAGE_AXIS {
+    return Err(Error::ImageDimensions { width, height });
+  }
+
   let (grid_h, grid_w) = fit_to_patch_budget(height, width, PATCH_SIZE, budget);
 
   // Resize in the u8 domain (PIL-parity fixed-point kernel), then

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
@@ -143,13 +143,36 @@ fn triangle(t: f64) -> f64 {
 /// downsampling low-passes; upsampling (`scale ≤ 1`) keeps unit support (plain
 /// bilinear). `align_corners=False` sample centers `(o + 0.5)·scale`. Each entry
 /// is `(start_input_index, normalized_weights)`.
-fn precompute_coeffs(in_size: usize, out_size: usize) -> Vec<(usize, Vec<f64>)> {
+///
+/// # Errors
+/// [`Error::PreprocessAllocation`] if a pathological source extent makes the
+/// coefficient table's element count overflow `usize`, or a coefficient vector
+/// cannot be reserved.
+fn precompute_coeffs(in_size: usize, out_size: usize) -> Result<Vec<(usize, Vec<f64>)>, Error> {
   let scale = in_size as f64 / out_size as f64;
   let filterscale = if scale < 1.0 { 1.0 } else { scale };
   let support = filterscale; // triangle filter support is 1.0
   let inv_filterscale = 1.0 / filterscale;
 
-  let mut coeffs = Vec::with_capacity(out_size);
+  // Representability pre-guard: every clamped output draws at most
+  // `2·⌈support⌉ + 1` taps, so the table holds at most
+  // `out_size·(2·⌈support⌉ + 1)` weights. If that element count cannot even be
+  // expressed in `usize` (a pathological source extent), no table could be
+  // allocated — refuse with the size-overflow sentinel rather than aborting in
+  // the fallible reservations below. Computed fully checked so the bound's own
+  // arithmetic cannot overflow-abort.
+  (support.ceil() as usize)
+    .checked_mul(2)
+    .and_then(|two_support| two_support.checked_add(1))
+    .and_then(|ksize_bound| out_size.checked_mul(ksize_bound))
+    .ok_or(Error::PreprocessAllocation { bytes: usize::MAX })?;
+
+  let mut coeffs = Vec::new();
+  coeffs
+    .try_reserve_exact(out_size)
+    .map_err(|_| Error::PreprocessAllocation {
+      bytes: out_size.saturating_mul(core::mem::size_of::<(usize, Vec<f64>)>()),
+    })?;
   for o in 0..out_size {
     let center = (o as f64 + 0.5) * scale;
 
@@ -169,7 +192,12 @@ fn precompute_coeffs(in_size: usize, out_size: usize) -> Vec<(usize, Vec<f64>)> 
     let start = xmin as usize;
     let taps = (xmax - xmin) as usize;
 
-    let mut weights = Vec::with_capacity(taps);
+    let mut weights = Vec::new();
+    weights
+      .try_reserve_exact(taps)
+      .map_err(|_| Error::PreprocessAllocation {
+        bytes: taps.saturating_mul(core::mem::size_of::<f64>()),
+      })?;
     let mut sum = 0.0f64;
     for k in 0..taps {
       let x = (start + k) as f64;
@@ -184,7 +212,7 @@ fn precompute_coeffs(in_size: usize, out_size: usize) -> Vec<(usize, Vec<f64>)> 
     }
     coeffs.push((start, weights));
   }
-  coeffs
+  Ok(coeffs)
 }
 
 /// Antialiased-bilinear resample of an `(src_h, src_w, channels)` row-major
@@ -197,6 +225,12 @@ fn precompute_coeffs(in_size: usize, out_size: usize) -> Vec<(usize, Vec<f64>)> 
 /// (the SigLIP2 processor resizes on `u8`, then rescale+normalizes). Panics only
 /// on an inconsistent `src` length (`src.len() != src_h·src_w·channels`) — a
 /// caller-internal invariant.
+///
+/// # Errors
+/// [`Error::PreprocessAllocation`] if a coefficient table cannot be sized or
+/// reserved (a pathological axis extent). The pos-emb lift's `16×16` source
+/// makes this unreachable in practice; the `Result` propagates the shared
+/// kernel's allocation fallibility to its callers.
 pub(crate) fn resize_bilinear_antialias(
   src: &[f32],
   src_h: usize,
@@ -204,7 +238,7 @@ pub(crate) fn resize_bilinear_antialias(
   channels: usize,
   dst_h: usize,
   dst_w: usize,
-) -> Vec<f32> {
+) -> Result<Vec<f32>, Error> {
   assert_eq!(
     src.len(),
     src_h * src_w * channels,
@@ -213,7 +247,7 @@ pub(crate) fn resize_bilinear_antialias(
 
   // Horizontal pass: (src_h, src_w, C) → (src_h, dst_w, C), kept in f64 to avoid
   // an intermediate rounding between the two separable passes.
-  let wc = precompute_coeffs(src_w, dst_w);
+  let wc = precompute_coeffs(src_w, dst_w)?;
   let mut tmp = vec![0.0f64; src_h * dst_w * channels];
   for y in 0..src_h {
     for (ox, (start, weights)) in wc.iter().enumerate() {
@@ -228,7 +262,7 @@ pub(crate) fn resize_bilinear_antialias(
   }
 
   // Vertical pass: (src_h, dst_w, C) → (dst_h, dst_w, C).
-  let hc = precompute_coeffs(src_h, dst_h);
+  let hc = precompute_coeffs(src_h, dst_h)?;
   let mut out = vec![0.0f32; dst_h * dst_w * channels];
   for (oy, (start, weights)) in hc.iter().enumerate() {
     for x in 0..dst_w {
@@ -241,31 +275,45 @@ pub(crate) fn resize_bilinear_antialias(
       }
     }
   }
-  out
+  Ok(out)
 }
 
 /// Quantizes one axis's `f64` resample coefficients to Pillow's 22-bit fixed
 /// point (`normalize_coeffs_8bpc`): `kk = (int)(±0.5 + w·2²²)`, rounding half
 /// away from zero. Bilinear weights are non-negative in practice; the negative
 /// branch mirrors PIL exactly for any residual.
-fn quantize_coeffs_8bpc(coeffs: &[(usize, Vec<f64>)]) -> Vec<(usize, Vec<i32>)> {
+///
+/// # Errors
+/// [`Error::PreprocessAllocation`] if a quantized coefficient vector cannot be
+/// reserved (the input table is already bounded, so only the reservation can
+/// fail; the quantized values are unchanged from the infallible form).
+fn quantize_coeffs_8bpc(coeffs: &[(usize, Vec<f64>)]) -> Result<Vec<(usize, Vec<i32>)>, Error> {
   let scale = f64::from(1i32 << PRECISION_BITS);
-  coeffs
-    .iter()
-    .map(|(start, weights)| {
-      let kk = weights
-        .iter()
-        .map(|&w| {
-          if w < 0.0 {
-            (-0.5 + w * scale) as i32
-          } else {
-            (0.5 + w * scale) as i32
-          }
-        })
-        .collect();
-      (*start, kk)
-    })
-    .collect()
+  let mut out = Vec::new();
+  out
+    .try_reserve_exact(coeffs.len())
+    .map_err(|_| Error::PreprocessAllocation {
+      bytes: coeffs
+        .len()
+        .saturating_mul(core::mem::size_of::<(usize, Vec<i32>)>()),
+    })?;
+  for (start, weights) in coeffs {
+    let mut kk = Vec::new();
+    kk.try_reserve_exact(weights.len())
+      .map_err(|_| Error::PreprocessAllocation {
+        bytes: weights.len().saturating_mul(core::mem::size_of::<i32>()),
+      })?;
+    for &w in weights {
+      let q = if w < 0.0 {
+        (-0.5 + w * scale) as i32
+      } else {
+        (0.5 + w * scale) as i32
+      };
+      kk.push(q);
+    }
+    out.push((*start, kk));
+  }
+  Ok(out)
 }
 
 /// Pillow's `clip8`: arithmetic-shift the fixed-point accumulator back to the
@@ -307,12 +355,15 @@ fn alloc_u8(len: usize) -> Result<Vec<u8>, Error> {
 /// The accumulator is `i64`; PIL relies on `ss ≤ 2²¹ + 255·(2²² + ksize/2) ≈
 /// 1.07e9 < i32::MAX` holding, and `i64` gives the identical result while
 /// immunizing debug-overflow. The src-dependent horizontal intermediate is
-/// sized with [`checked_len3`] and reserved with [`alloc_u8`] (fallible), so a
-/// pathological geometry returns a typed error rather than aborting.
+/// sized with [`checked_len3`] and reserved with [`alloc_u8`] (fallible), and
+/// the coefficient tables are reserved fallibly by [`precompute_coeffs`] /
+/// [`quantize_coeffs_8bpc`], so a pathological geometry returns a typed error
+/// rather than aborting. A `src` shorter than `src_h·src_w·channels` panics on
+/// an out-of-bounds tap — a caller-internal invariant.
 ///
 /// # Errors
-/// [`Error::PreprocessAllocation`] if a working buffer's size overflows `usize`
-/// or cannot be reserved.
+/// [`Error::PreprocessAllocation`] if a working buffer or coefficient table's
+/// size overflows `usize` or cannot be reserved.
 pub(crate) fn resize_bilinear_antialias_u8(
   src: &[u8],
   src_h: usize,
@@ -324,7 +375,7 @@ pub(crate) fn resize_bilinear_antialias_u8(
   const OFFSET: i64 = 1 << (PRECISION_BITS - 1);
 
   // Horizontal pass: (src_h, src_w, C) → (src_h, dst_w, C), u8 intermediate.
-  let wc = quantize_coeffs_8bpc(&precompute_coeffs(src_w, dst_w));
+  let wc = quantize_coeffs_8bpc(&precompute_coeffs(src_w, dst_w)?)?;
   let mut tmp = alloc_u8(checked_len3(src_h, dst_w, channels)?)?;
   for y in 0..src_h {
     for (ox, (start, weights)) in wc.iter().enumerate() {
@@ -339,7 +390,7 @@ pub(crate) fn resize_bilinear_antialias_u8(
   }
 
   // Vertical pass: (src_h, dst_w, C) → (dst_h, dst_w, C).
-  let hc = quantize_coeffs_8bpc(&precompute_coeffs(src_h, dst_h));
+  let hc = quantize_coeffs_8bpc(&precompute_coeffs(src_h, dst_h)?)?;
   let mut out = alloc_u8(checked_len3(dst_h, dst_w, channels)?)?;
   for (oy, (start, weights)) in hc.iter().enumerate() {
     for x in 0..dst_w {
@@ -451,12 +502,17 @@ pub(crate) fn parse_base_pos_grid(bytes: &[u8]) -> Result<Vec<f32>, Error> {
 /// `base_grid` must be `POS_EMBED_ELEMS` long (as [`parse_base_pos_grid`]
 /// returns) and `grid_h · grid_w ≤ budget` (the budget solver guarantees it;
 /// excess is defensively truncated rather than panicking).
+///
+/// # Errors
+/// [`Error::PreprocessAllocation`] if the resize's coefficient tables cannot be
+/// sized or reserved (propagated from [`resize_bilinear_antialias`]; the fixed
+/// `16×16` base grid makes this unreachable in practice).
 pub(crate) fn lift_position_embeddings(
   base_grid: &[f32],
   grid_h: usize,
   grid_w: usize,
   budget: usize,
-) -> Vec<f32> {
+) -> Result<Vec<f32>, Error> {
   let resized = resize_bilinear_antialias(
     base_grid,
     POS_GRID_SIDE,
@@ -464,11 +520,11 @@ pub(crate) fn lift_position_embeddings(
     EMBEDDING_DIM,
     grid_h,
     grid_w,
-  );
+  )?;
   let mut out = vec![0.0f32; budget * EMBEDDING_DIM];
   let copy_len = resized.len().min(out.len());
   out[..copy_len].copy_from_slice(&resized[..copy_len]);
-  out
+  Ok(out)
 }
 
 /// The three vision-graph input tensors produced from one decoded image, plus
@@ -524,7 +580,7 @@ pub(crate) fn preprocess_image(
   let resized: Vec<f32> = resized_u8.iter().map(|&v| normalize_u8(v)).collect();
 
   let (pixel_values, attention_mask) = patchify(&resized, grid_h, grid_w, budget)?;
-  let position_embeddings = lift_position_embeddings(base_grid, grid_h, grid_w, budget);
+  let position_embeddings = lift_position_embeddings(base_grid, grid_h, grid_w, budget)?;
 
   Ok(VisionInputs {
     pixel_values,

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
@@ -1,0 +1,395 @@
+//! NaFlex vision preprocessing — pure host-side math, no CoreML.
+//!
+//! Ports the SigLIP2 NaFlex image pipeline (transformers
+//! `image_processing_siglip2.py` + the `resize_positional_embeddings` lift from
+//! `modeling_siglip2.py`) into dependency-free Rust, in the stages the vision
+//! graph's `[1, P, 768]` `pixel_values` / `position_embeddings` / `[1, P]`
+//! `attention_mask` contract needs:
+//!
+//! 1. [`fit_to_patch_budget`] — the aspect-preserving budget solver: binary-
+//!    search the largest multiple-of-`patch` target whose patch count `h_p·w_p`
+//!    fits `P`.
+//! 2. [`resize_bilinear_antialias`] — the shared antialiased-bilinear resample
+//!    (PIL/torch `F.interpolate(mode="bilinear", antialias=True,
+//!    align_corners=False)` coefficients), generic over channel count, used both
+//!    to resize the image and to lift the position-embedding grid.
+//! 3. [`normalize_pixel`] — rescale + normalize `((x/255) − 0.5)/0.5`.
+//! 4. [`patchify`] — reshape the resized+normalized image to `[P, 768]` patch
+//!    rows plus the `[P]` real/pad mask.
+//! 5. [`lift_position_embeddings`] — resize the base `16×16×768` grid to the
+//!    `(h_p, w_p)` grid, flatten row-major, and zero-pad to `[P, 768]`.
+//!
+//! The pixel-normalization constants and patch flatten order are pinned by
+//! committed fixtures (`tests/siglip/fixtures/goldens/preprocess.json`, Wave B)
+//! and the full-tensor parity against staged `.npy` fixtures (Wave C); the pure
+//! stage math here is proven hermetically in `tests.rs`.
+//!
+//! Accumulation is in `f64` (weights and dot-products) for determinism; the
+//! measured-then-pinned resize tolerance (Wave B3) absorbs any residual delta
+//! against the torch reference's working precision.
+
+use crate::embeddings::siglip::{embedding::EMBEDDING_DIM, error::Error};
+
+/// Vision patch side in pixels (a `16×16` patch). Architecture constant of the
+/// `patch16` model — not a resolved parameter (unlike the patch budget `P`).
+pub(crate) const PATCH_SIZE: usize = 16;
+
+/// RGB channel count of a decoded image.
+pub(crate) const CHANNELS: usize = 3;
+
+/// Flattened per-patch dimension `CHANNELS · PATCH_SIZE · PATCH_SIZE = 3·16·16 =
+/// 768` — the `pixel_values` inner dimension. Coincides with [`EMBEDDING_DIM`]
+/// for `base-patch16`, but is a distinct quantity.
+pub(crate) const PATCH_DIM: usize = CHANNELS * PATCH_SIZE * PATCH_SIZE;
+
+/// Side of the base position-embedding grid: the model's `num_patches = 256`
+/// position table reshaped to `16×16` (per the probe). Architecture constant.
+pub(crate) const POS_GRID_SIDE: usize = 16;
+
+/// Element count of the base position-embedding grid,
+/// `POS_GRID_SIDE · POS_GRID_SIDE · EMBEDDING_DIM = 16·16·768 = 196 608` f32.
+pub(crate) const POS_EMBED_ELEMS: usize = POS_GRID_SIDE * POS_GRID_SIDE * EMBEDDING_DIM;
+
+/// Byte length of the raw little-endian f32 base position-embedding grid sidecar
+/// (`pos_embed_16x16x768.f32le.bin`): `POS_EMBED_ELEMS · 4 = 786 432` bytes.
+/// Derived from the dimensional constants so it stays correct by construction
+/// (the load-time hard-validation of D5).
+pub(crate) const POS_EMBED_BYTES: usize = POS_EMBED_ELEMS * 4;
+
+/// Pixel rescale factor `1/255` (`preprocessor_config.json` `rescale_factor`).
+const RESCALE_FACTOR: f32 = 1.0 / 255.0;
+/// Per-channel normalization mean `0.5` (`image_mean`).
+const IMAGE_MEAN: f32 = 0.5;
+/// Per-channel normalization std `0.5` (`image_std`).
+const IMAGE_STD: f32 = 0.5;
+
+/// Aspect-preserving patch-budget solver: the largest multiple-of-`patch`
+/// target size whose patch grid `h_p · w_p` fits `budget`, returned as the
+/// `(grid_height, grid_width)` patch counts (the processor's `spatial_shapes`).
+///
+/// A direct port of transformers `get_image_size_for_max_num_patches`: binary-
+/// search a uniform scale in `[eps/10, 100]` to `eps = 1e-5`, where each
+/// candidate maps a dimension to `max(patch, ceil(scale·size/patch)·patch)`, and
+/// keep the largest scale whose grid fits the budget. Uniform scaling preserves
+/// aspect ratio; the `max(patch, …)` clamp guarantees at least one patch per
+/// dimension (so an extreme aspect keeps a `1`-patch short side). The result is
+/// (essentially) a function of aspect ratio and `budget`, near-independent of
+/// absolute pixel size — a small image is upscaled to fill the budget exactly as
+/// NaFlex does.
+///
+/// `patch` and `budget` must be non-zero (the caller resolves `budget = P` from
+/// the loaded model; `patch = PATCH_SIZE`).
+pub(crate) fn fit_to_patch_budget(
+  image_height: usize,
+  image_width: usize,
+  patch: usize,
+  budget: usize,
+) -> (usize, usize) {
+  const EPS: f64 = 1e-5;
+  let patch_f = patch as f64;
+
+  let scaled = |scale: f64, size: usize| -> usize {
+    let s = (scale * size as f64) / patch_f;
+    let s = s.ceil() * patch_f;
+    let s = s.max(patch_f);
+    s as usize
+  };
+  let grid = |target: usize| target / patch;
+
+  let mut scale_min = EPS / 10.0;
+  let mut scale_max = 100.0;
+  while (scale_max - scale_min) >= EPS {
+    let scale = (scale_min + scale_max) / 2.0;
+    let th = scaled(scale, image_height);
+    let tw = scaled(scale, image_width);
+    if grid(th) * grid(tw) <= budget {
+      scale_min = scale;
+    } else {
+      scale_max = scale;
+    }
+  }
+  let th = scaled(scale_min, image_height);
+  let tw = scaled(scale_min, image_width);
+  (grid(th), grid(tw))
+}
+
+/// The antialiased-bilinear filter weight (triangle): `max(0, 1 − |t|)`.
+fn triangle(t: f64) -> f64 {
+  let t = t.abs();
+  if t < 1.0 { 1.0 - t } else { 0.0 }
+}
+
+/// Per-output-sample resample coefficients for one axis (`in_size → out_size`),
+/// the PIL/torch `precompute_coeffs` for a bilinear filter with `antialias`:
+/// the triangle support widens by the downscale ratio (`filterscale`) so
+/// downsampling low-passes; upsampling (`scale ≤ 1`) keeps unit support (plain
+/// bilinear). `align_corners=False` sample centers `(o + 0.5)·scale`. Each entry
+/// is `(start_input_index, normalized_weights)`.
+fn precompute_coeffs(in_size: usize, out_size: usize) -> Vec<(usize, Vec<f64>)> {
+  let scale = in_size as f64 / out_size as f64;
+  let filterscale = if scale < 1.0 { 1.0 } else { scale };
+  let support = filterscale; // triangle filter support is 1.0
+  let inv_filterscale = 1.0 / filterscale;
+
+  let mut coeffs = Vec::with_capacity(out_size);
+  for o in 0..out_size {
+    let center = (o as f64 + 0.5) * scale;
+
+    let mut xmin = (center - support + 0.5).floor() as isize;
+    if xmin < 0 {
+      xmin = 0;
+    }
+    let mut xmax = (center + support + 0.5).floor() as isize;
+    if xmax > in_size as isize {
+      xmax = in_size as isize;
+    }
+    // Guarantee at least one in-bounds tap (degenerate only at extreme edges).
+    if xmax <= xmin {
+      xmin = xmin.min(in_size as isize - 1).max(0);
+      xmax = xmin + 1;
+    }
+    let start = xmin as usize;
+    let taps = (xmax - xmin) as usize;
+
+    let mut weights = Vec::with_capacity(taps);
+    let mut sum = 0.0f64;
+    for k in 0..taps {
+      let x = (start + k) as f64;
+      let w = triangle((x - center + 0.5) * inv_filterscale);
+      weights.push(w);
+      sum += w;
+    }
+    if sum != 0.0 {
+      for w in &mut weights {
+        *w /= sum;
+      }
+    }
+    coeffs.push((start, weights));
+  }
+  coeffs
+}
+
+/// Antialiased-bilinear resample of an `(src_h, src_w, channels)` row-major
+/// buffer to `(dst_h, dst_w, channels)`. Separable: resize width, then height
+/// (the PIL horizontal-then-vertical order), accumulating in `f64`.
+///
+/// Shared by the image resize (`channels = 3`) and the position-embedding grid
+/// lift (`channels = 768`). Panics only on an inconsistent `src` length
+/// (`src.len() != src_h·src_w·channels`) — a caller-internal invariant.
+pub(crate) fn resize_bilinear_antialias(
+  src: &[f32],
+  src_h: usize,
+  src_w: usize,
+  channels: usize,
+  dst_h: usize,
+  dst_w: usize,
+) -> Vec<f32> {
+  assert_eq!(
+    src.len(),
+    src_h * src_w * channels,
+    "resize src length inconsistent with src_h·src_w·channels"
+  );
+
+  // Horizontal pass: (src_h, src_w, C) → (src_h, dst_w, C), kept in f64 to avoid
+  // an intermediate rounding between the two separable passes.
+  let wc = precompute_coeffs(src_w, dst_w);
+  let mut tmp = vec![0.0f64; src_h * dst_w * channels];
+  for y in 0..src_h {
+    for (ox, (start, weights)) in wc.iter().enumerate() {
+      for c in 0..channels {
+        let mut acc = 0.0f64;
+        for (k, &wk) in weights.iter().enumerate() {
+          acc += wk * src[(y * src_w + start + k) * channels + c] as f64;
+        }
+        tmp[(y * dst_w + ox) * channels + c] = acc;
+      }
+    }
+  }
+
+  // Vertical pass: (src_h, dst_w, C) → (dst_h, dst_w, C).
+  let hc = precompute_coeffs(src_h, dst_h);
+  let mut out = vec![0.0f32; dst_h * dst_w * channels];
+  for (oy, (start, weights)) in hc.iter().enumerate() {
+    for x in 0..dst_w {
+      for c in 0..channels {
+        let mut acc = 0.0f64;
+        for (k, &wk) in weights.iter().enumerate() {
+          acc += wk * tmp[((start + k) * dst_w + x) * channels + c];
+        }
+        out[(oy * dst_w + x) * channels + c] = acc as f32;
+      }
+    }
+  }
+  out
+}
+
+/// Rescale + normalize one pixel channel value from `[0, 255]` to
+/// `((x/255) − 0.5)/0.5 ∈ [−1, 1]` — the SigLIP2 processor's `do_rescale` +
+/// `do_normalize` (mean `0.5`, std `0.5`), evaluated in that order.
+pub(crate) fn normalize_pixel(x: f32) -> f32 {
+  (x * RESCALE_FACTOR - IMAGE_MEAN) / IMAGE_STD
+}
+
+/// Reshape a resized+normalized `(grid_h·PATCH_SIZE, grid_w·PATCH_SIZE, 3)`
+/// image (row-major, RGB-interleaved f32) into the `[budget, PATCH_DIM]`
+/// `pixel_values` rows plus the `[budget]` real/pad `attention_mask` (1.0 real,
+/// 0.0 pad).
+///
+/// Patch rows are in `(patch_row, patch_col)` row-major order; each row is the
+/// patch's pixels flattened `(py, px, channel)` — `py`-major, then `px`, then
+/// the RGB channel — matching the transformers reshape. Rows `grid_h·grid_w ..
+/// budget` are zero-padded (mask `0.0`).
+///
+/// # Errors
+/// [`Error::PatchCount`] if `grid_h · grid_w > budget` (a solver/plumbing bug —
+/// the budget solver caps this by construction).
+pub(crate) fn patchify(
+  image_hwc: &[f32],
+  grid_h: usize,
+  grid_w: usize,
+  budget: usize,
+) -> Result<(Vec<f32>, Vec<f32>), Error> {
+  let n_real = grid_h * grid_w;
+  if n_real > budget {
+    return Err(Error::PatchCount {
+      got: n_real,
+      max: budget,
+    });
+  }
+  let img_w = grid_w * PATCH_SIZE;
+  let mut pixel_values = vec![0.0f32; budget * PATCH_DIM];
+  let mut mask = vec![0.0f32; budget];
+
+  for ph in 0..grid_h {
+    for pw in 0..grid_w {
+      let row = ph * grid_w + pw;
+      let dst_base = row * PATCH_DIM;
+      let mut k = 0;
+      for py in 0..PATCH_SIZE {
+        let iy = ph * PATCH_SIZE + py;
+        for px in 0..PATCH_SIZE {
+          let ix = pw * PATCH_SIZE + px;
+          let src_base = (iy * img_w + ix) * CHANNELS;
+          for c in 0..CHANNELS {
+            pixel_values[dst_base + k] = image_hwc[src_base + c];
+            k += 1;
+          }
+        }
+      }
+      mask[row] = 1.0;
+    }
+  }
+  Ok((pixel_values, mask))
+}
+
+/// Parse the raw little-endian f32 base position-embedding grid sidecar into a
+/// `POS_EMBED_ELEMS`-length `Vec<f32>` (`16×16×768`, row-major), hard-validating
+/// the byte length (D5).
+///
+/// # Errors
+/// [`Error::PosEmbedLength`] if `bytes.len() != POS_EMBED_BYTES`.
+pub(crate) fn parse_base_pos_grid(bytes: &[u8]) -> Result<Vec<f32>, Error> {
+  if bytes.len() != POS_EMBED_BYTES {
+    return Err(Error::PosEmbedLength {
+      got: bytes.len(),
+      expected: POS_EMBED_BYTES,
+    });
+  }
+  let (chunks, _rest) = bytes.as_chunks::<4>(); // len is an exact multiple of 4
+  let grid = chunks.iter().map(|&c| f32::from_le_bytes(c)).collect();
+  Ok(grid)
+}
+
+/// Lift the base `16×16×768` position grid to the `(grid_h, grid_w)` patch grid
+/// and flatten to the `[budget, 768]` `position_embeddings` input: resize the
+/// grid with the shared antialiased-bilinear kernel, take its row-major
+/// `(grid_h·grid_w, 768)` flattening (the resize already emits that layout), and
+/// zero-pad the remaining `budget − grid_h·grid_w` rows.
+///
+/// `base_grid` must be `POS_EMBED_ELEMS` long (as [`parse_base_pos_grid`]
+/// returns) and `grid_h · grid_w ≤ budget` (the budget solver guarantees it;
+/// excess is defensively truncated rather than panicking).
+pub(crate) fn lift_position_embeddings(
+  base_grid: &[f32],
+  grid_h: usize,
+  grid_w: usize,
+  budget: usize,
+) -> Vec<f32> {
+  let resized = resize_bilinear_antialias(
+    base_grid,
+    POS_GRID_SIDE,
+    POS_GRID_SIDE,
+    EMBEDDING_DIM,
+    grid_h,
+    grid_w,
+  );
+  let mut out = vec![0.0f32; budget * EMBEDDING_DIM];
+  let copy_len = resized.len().min(out.len());
+  out[..copy_len].copy_from_slice(&resized[..copy_len]);
+  out
+}
+
+/// The three vision-graph input tensors produced from one decoded image, plus
+/// the resolved `(grid_h, grid_w)` patch grid.
+pub(crate) struct VisionInputs {
+  /// Patchified pixels `[budget · PATCH_DIM]` (the `pixel_values` input).
+  pub pixel_values: Vec<f32>,
+  /// Real/pad patch mask `[budget]` (1.0 real, 0.0 pad; the `attention_mask`
+  /// input — f32, per the graph contract).
+  pub attention_mask: Vec<f32>,
+  /// Lifted position embeddings `[budget · EMBEDDING_DIM]` (the
+  /// `position_embeddings` input).
+  pub position_embeddings: Vec<f32>,
+  /// The resolved patch grid `(h_p, w_p)` (the processor's `spatial_shapes`).
+  /// Consumed host-side (mask + pos-emb are already built from it) rather than
+  /// fed to the graph, so production `embed` does not read it back; the hermetic
+  /// pipeline tests assert it.
+  #[allow(dead_code)]
+  pub grid: (usize, usize),
+}
+
+/// The full model-free NaFlex image pipeline: decoded RGB8 in, the three vision-
+/// graph input tensors out. Fits the image to the patch `budget`, resizes it
+/// with the antialiased-bilinear kernel to `(grid·PATCH_SIZE)` pixels, rescale+
+/// normalizes, patchifies to `pixel_values` + `attention_mask`, and lifts the
+/// base position grid to `position_embeddings`.
+///
+/// `rgb` is row-major RGB-interleaved (`width · height · 3`, as a validated
+/// [`crate::embeddings::siglip::Rgb8Image`] guarantees); `base_grid` is the
+/// parsed `POS_EMBED_ELEMS` base position grid.
+///
+/// # Errors
+/// [`Error::PatchCount`] if the solved grid exceeds `budget` (a solver bug).
+pub(crate) fn preprocess_image(
+  rgb: &[u8],
+  width: usize,
+  height: usize,
+  base_grid: &[f32],
+  budget: usize,
+) -> Result<VisionInputs, Error> {
+  let (grid_h, grid_w) = fit_to_patch_budget(height, width, PATCH_SIZE, budget);
+
+  // Decode to f32 [0, 255] in (H, W, C) row-major (the Rgb8Image layout).
+  let img_f32: Vec<f32> = rgb.iter().map(|&b| b as f32).collect();
+
+  // Resize (on 0..255 floats), then rescale+normalize — the processor's order.
+  let dst_h = grid_h * PATCH_SIZE;
+  let dst_w = grid_w * PATCH_SIZE;
+  let mut resized = resize_bilinear_antialias(&img_f32, height, width, CHANNELS, dst_h, dst_w);
+  for v in &mut resized {
+    *v = normalize_pixel(*v);
+  }
+
+  let (pixel_values, attention_mask) = patchify(&resized, grid_h, grid_w, budget)?;
+  let position_embeddings = lift_position_embeddings(base_grid, grid_h, grid_w, budget);
+
+  Ok(VisionInputs {
+    pixel_values,
+    attention_mask,
+    position_embeddings,
+    grid: (grid_h, grid_w),
+  })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
@@ -9,24 +9,31 @@
 //! 1. [`fit_to_patch_budget`] — the aspect-preserving budget solver: binary-
 //!    search the largest multiple-of-`patch` target whose patch count `h_p·w_p`
 //!    fits `P`.
-//! 2. [`resize_bilinear_antialias`] — the shared antialiased-bilinear resample
-//!    (PIL/torch `F.interpolate(mode="bilinear", antialias=True,
-//!    align_corners=False)` coefficients), generic over channel count, used both
-//!    to resize the image and to lift the position-embedding grid.
-//! 3. [`normalize_pixel`] — rescale + normalize `((x/255) − 0.5)/0.5`.
+//! 2. [`resize_bilinear_antialias_u8`] — the PIL-parity antialiased-bilinear
+//!    image resize in the **uint8 domain** (Pillow `Resample.c` fixed-point:
+//!    22-bit coefficients, per-pass u8 rounding), matching the SigLIP2 processor
+//!    (resize on u8, THEN rescale+normalize). Its sibling f64
+//!    [`resize_bilinear_antialias`] is the position-embedding lift's kernel
+//!    (stage 5), which the reference genuinely computes in float.
+//! 3. [`normalize_u8`] — rescale + normalize `((v/255) − 0.5)/0.5`.
 //! 4. [`patchify`] — reshape the resized+normalized image to `[P, 768]` patch
 //!    rows plus the `[P]` real/pad mask.
 //! 5. [`lift_position_embeddings`] — resize the base `16×16×768` grid to the
-//!    `(h_p, w_p)` grid, flatten row-major, and zero-pad to `[P, 768]`.
+//!    `(h_p, w_p)` grid, flatten row-major, and zero-pad to `[P, 768]`. Pad rows
+//!    are zero-filled — a deliberate deviation from transformers (which fills
+//!    them with the first resized row); pad positions are attention-masked, so
+//!    the model output is exactly invariant to the fill (see the fn doc).
 //!
 //! The pixel-normalization constants and patch flatten order are pinned by
 //! committed fixtures (`tests/siglip/fixtures/goldens/preprocess.json`, Wave B)
 //! and the full-tensor parity against staged `.npy` fixtures (Wave C); the pure
 //! stage math here is proven hermetically in `tests.rs`.
 //!
-//! Accumulation is in `f64` (weights and dot-products) for determinism; the
-//! measured-then-pinned resize tolerance (Wave B3) absorbs any residual delta
-//! against the torch reference's working precision.
+//! The image resize is bit-exact fixed-point (uint8 taps, per-pass rounding), so
+//! its `pixel_values` match the slow-processor fixture exactly (Wave B3/C2, no
+//! tolerance). The position-embedding lift accumulates in `f64` for determinism,
+//! with the measured-then-pinned tolerance (Wave B3) absorbing any residual
+//! delta against the torch reference's working precision.
 
 use crate::embeddings::siglip::{embedding::EMBEDDING_DIM, error::Error};
 
@@ -56,12 +63,22 @@ pub(crate) const POS_EMBED_ELEMS: usize = POS_GRID_SIDE * POS_GRID_SIDE * EMBEDD
 /// (the load-time hard-validation of D5).
 pub(crate) const POS_EMBED_BYTES: usize = POS_EMBED_ELEMS * 4;
 
-/// Pixel rescale factor `1/255` (`preprocessor_config.json` `rescale_factor`).
-const RESCALE_FACTOR: f32 = 1.0 / 255.0;
+/// Pixel rescale factor `1/255` as `f64` — bit-for-bit the checkpoint's
+/// `preprocessor_config.json` `rescale_factor` literal `0.00392156862745098`
+/// (the shortest round-trip repr of `1.0/255.0`). The reference multiplies the
+/// `u8` pixel by this Python float (`f64`) and casts the product to `f32`
+/// (`rescale(..., dtype=np.float32)`), so [`normalize_u8`] mirrors that order.
+const RESCALE_FACTOR_F64: f64 = 1.0 / 255.0;
 /// Per-channel normalization mean `0.5` (`image_mean`).
 const IMAGE_MEAN: f32 = 0.5;
 /// Per-channel normalization std `0.5` (`image_std`).
 const IMAGE_STD: f32 = 0.5;
+
+/// Fixed-point precision of the uint8 resample coefficients, Pillow's
+/// `PRECISION_BITS = 32 − 8 − 2 = 22` (`Resample.c`): weights are quantized to
+/// `2²²`, accumulated over `u8` taps with a `1 << 21` half-unit rounding offset,
+/// then shifted right by 22 and clamped to `u8`.
+const PRECISION_BITS: u32 = 22;
 
 /// Aspect-preserving patch-budget solver: the largest multiple-of-`patch`
 /// target size whose patch grid `h_p · w_p` fits `budget`, returned as the
@@ -170,12 +187,15 @@ fn precompute_coeffs(in_size: usize, out_size: usize) -> Vec<(usize, Vec<f64>)> 
 }
 
 /// Antialiased-bilinear resample of an `(src_h, src_w, channels)` row-major
-/// buffer to `(dst_h, dst_w, channels)`. Separable: resize width, then height
-/// (the PIL horizontal-then-vertical order), accumulating in `f64`.
+/// `f32` buffer to `(dst_h, dst_w, channels)`. Separable: resize width, then
+/// height (the PIL horizontal-then-vertical order), accumulating in `f64`.
 ///
-/// Shared by the image resize (`channels = 3`) and the position-embedding grid
-/// lift (`channels = 768`). Panics only on an inconsistent `src` length
-/// (`src.len() != src_h·src_w·channels`) — a caller-internal invariant.
+/// This is the **position-embedding lift's** kernel (`channels = 768`), which
+/// the reference computes in float (`F.interpolate` on the fp32 grid). The
+/// image pixels take the uint8 kernel [`resize_bilinear_antialias_u8`] instead
+/// (the SigLIP2 processor resizes on `u8`, then rescale+normalizes). Panics only
+/// on an inconsistent `src` length (`src.len() != src_h·src_w·channels`) — a
+/// caller-internal invariant.
 pub(crate) fn resize_bilinear_antialias(
   src: &[f32],
   src_h: usize,
@@ -223,11 +243,123 @@ pub(crate) fn resize_bilinear_antialias(
   out
 }
 
-/// Rescale + normalize one pixel channel value from `[0, 255]` to
-/// `((x/255) − 0.5)/0.5 ∈ [−1, 1]` — the SigLIP2 processor's `do_rescale` +
-/// `do_normalize` (mean `0.5`, std `0.5`), evaluated in that order.
-pub(crate) fn normalize_pixel(x: f32) -> f32 {
-  (x * RESCALE_FACTOR - IMAGE_MEAN) / IMAGE_STD
+/// Quantizes one axis's `f64` resample coefficients to Pillow's 22-bit fixed
+/// point (`normalize_coeffs_8bpc`): `kk = (int)(±0.5 + w·2²²)`, rounding half
+/// away from zero. Bilinear weights are non-negative in practice; the negative
+/// branch mirrors PIL exactly for any residual.
+fn quantize_coeffs_8bpc(coeffs: &[(usize, Vec<f64>)]) -> Vec<(usize, Vec<i32>)> {
+  let scale = f64::from(1i32 << PRECISION_BITS);
+  coeffs
+    .iter()
+    .map(|(start, weights)| {
+      let kk = weights
+        .iter()
+        .map(|&w| {
+          if w < 0.0 {
+            (-0.5 + w * scale) as i32
+          } else {
+            (0.5 + w * scale) as i32
+          }
+        })
+        .collect();
+      (*start, kk)
+    })
+    .collect()
+}
+
+/// Pillow's `clip8`: arithmetic-shift the fixed-point accumulator back to the
+/// integer domain (`>> 22`) and clamp to `u8`. Equivalent to PIL's clip lookup
+/// over the reachable accumulator range.
+fn clip8(ss: i64) -> u8 {
+  (ss >> PRECISION_BITS).clamp(0, 255) as u8
+}
+
+/// Element count `a·b·c`, or [`Error::PreprocessAllocation`]
+/// `{ bytes: usize::MAX }` on `usize` overflow — a pathological source geometry
+/// whose working buffer cannot even be represented, let alone allocated.
+fn checked_len3(a: usize, b: usize, c: usize) -> Result<usize, Error> {
+  a.checked_mul(b)
+    .and_then(|ab| ab.checked_mul(c))
+    .ok_or(Error::PreprocessAllocation { bytes: usize::MAX })
+}
+
+/// A zeroed `Vec<u8>` of `len` bytes reserved fallibly (`try_reserve_exact`), so
+/// a pathological source geometry returns [`Error::PreprocessAllocation`]
+/// instead of aborting the process on allocator failure.
+fn alloc_u8(len: usize) -> Result<Vec<u8>, Error> {
+  let mut v = Vec::new();
+  v.try_reserve_exact(len)
+    .map_err(|_| Error::PreprocessAllocation { bytes: len })?;
+  v.resize(len, 0);
+  Ok(v)
+}
+
+/// PIL-parity antialiased-bilinear resample in the **uint8 domain** (Pillow
+/// `Resample.c`, `PRECISION_BITS = 22`): per pass, [`precompute_coeffs`] taps
+/// are quantized to 22-bit fixed point, accumulated over `u8` taps with a
+/// `1 << 21` rounding offset, then shifted (`>> 22`) and clamped back to `u8` —
+/// **including the `u8` horizontal intermediate between the two passes**. This
+/// is the image path of the SigLIP2 processor (resize on `u8`, then
+/// rescale+normalize); the per-pass rounding is part of the reference semantics
+/// and is what the `f64` kernel cannot emulate.
+///
+/// The accumulator is `i64`; PIL relies on `ss ≤ 2²¹ + 255·(2²² + ksize/2) ≈
+/// 1.07e9 < i32::MAX` holding, and `i64` gives the identical result while
+/// immunizing debug-overflow. The src-dependent horizontal intermediate is
+/// sized with [`checked_len3`] and reserved with [`alloc_u8`] (fallible), so a
+/// pathological geometry returns a typed error rather than aborting.
+///
+/// # Errors
+/// [`Error::PreprocessAllocation`] if a working buffer's size overflows `usize`
+/// or cannot be reserved.
+pub(crate) fn resize_bilinear_antialias_u8(
+  src: &[u8],
+  src_h: usize,
+  src_w: usize,
+  channels: usize,
+  dst_h: usize,
+  dst_w: usize,
+) -> Result<Vec<u8>, Error> {
+  const OFFSET: i64 = 1 << (PRECISION_BITS - 1);
+
+  // Horizontal pass: (src_h, src_w, C) → (src_h, dst_w, C), u8 intermediate.
+  let wc = quantize_coeffs_8bpc(&precompute_coeffs(src_w, dst_w));
+  let mut tmp = alloc_u8(checked_len3(src_h, dst_w, channels)?)?;
+  for y in 0..src_h {
+    for (ox, (start, weights)) in wc.iter().enumerate() {
+      for c in 0..channels {
+        let mut ss: i64 = OFFSET;
+        for (k, &wk) in weights.iter().enumerate() {
+          ss += i64::from(src[(y * src_w + start + k) * channels + c]) * i64::from(wk);
+        }
+        tmp[(y * dst_w + ox) * channels + c] = clip8(ss);
+      }
+    }
+  }
+
+  // Vertical pass: (src_h, dst_w, C) → (dst_h, dst_w, C).
+  let hc = quantize_coeffs_8bpc(&precompute_coeffs(src_h, dst_h));
+  let mut out = alloc_u8(checked_len3(dst_h, dst_w, channels)?)?;
+  for (oy, (start, weights)) in hc.iter().enumerate() {
+    for x in 0..dst_w {
+      for c in 0..channels {
+        let mut ss: i64 = OFFSET;
+        for (k, &wk) in weights.iter().enumerate() {
+          ss += i64::from(tmp[((start + k) * dst_w + x) * channels + c]) * i64::from(wk);
+        }
+        out[(oy * dst_w + x) * channels + c] = clip8(ss);
+      }
+    }
+  }
+  Ok(out)
+}
+
+/// Rescale + normalize one `u8` pixel channel to `((v/255) − 0.5)/0.5 ∈ [−1, 1]`
+/// — the SigLIP2 processor's `do_rescale` + `do_normalize` (mean `0.5`, std
+/// `0.5`). Mirrors the reference dtype order: multiply the `u8` by the `f64`
+/// rescale factor, cast the product to `f32`, then normalize in `f32`.
+pub(crate) fn normalize_u8(v: u8) -> f32 {
+  ((f64::from(v) * RESCALE_FACTOR_F64) as f32 - IMAGE_MEAN) / IMAGE_STD
 }
 
 /// Reshape a resized+normalized `(grid_h·PATCH_SIZE, grid_w·PATCH_SIZE, 3)`
@@ -302,9 +434,18 @@ pub(crate) fn parse_base_pos_grid(bytes: &[u8]) -> Result<Vec<f32>, Error> {
 
 /// Lift the base `16×16×768` position grid to the `(grid_h, grid_w)` patch grid
 /// and flatten to the `[budget, 768]` `position_embeddings` input: resize the
-/// grid with the shared antialiased-bilinear kernel, take its row-major
+/// grid with the f64 antialiased-bilinear kernel, take its row-major
 /// `(grid_h·grid_w, 768)` flattening (the resize already emits that layout), and
 /// zero-pad the remaining `budget − grid_h·grid_w` rows.
+///
+/// Pad rows are **zero-filled — a deliberate deviation** from transformers
+/// `resize_positional_embeddings`, which fills them with the first resized row
+/// (an artifact of its `torch.empty` initialization). Pad positions are
+/// attention-masked in the encoder and the pooling head (additive `−1e4` →
+/// exactly zero softmax weight), so the model output is exactly invariant to the
+/// fill; zero is chosen because it is validatable and matches the pixel-pad
+/// convention. Wave C compares the lifted real rows against the reference and
+/// asserts the pad rows zero.
 ///
 /// `base_grid` must be `POS_EMBED_ELEMS` long (as [`parse_base_pos_grid`]
 /// returns) and `grid_h · grid_w ≤ budget` (the budget solver guarantees it;
@@ -350,16 +491,18 @@ pub(crate) struct VisionInputs {
 
 /// The full model-free NaFlex image pipeline: decoded RGB8 in, the three vision-
 /// graph input tensors out. Fits the image to the patch `budget`, resizes it
-/// with the antialiased-bilinear kernel to `(grid·PATCH_SIZE)` pixels, rescale+
-/// normalizes, patchifies to `pixel_values` + `attention_mask`, and lifts the
-/// base position grid to `position_embeddings`.
+/// with the uint8 PIL-parity antialiased-bilinear kernel to `(grid·PATCH_SIZE)`
+/// pixels, rescale+normalizes, patchifies to `pixel_values` + `attention_mask`,
+/// and lifts the base position grid to `position_embeddings`.
 ///
 /// `rgb` is row-major RGB-interleaved (`width · height · 3`, as a validated
 /// [`crate::embeddings::siglip::Rgb8Image`] guarantees); `base_grid` is the
 /// parsed `POS_EMBED_ELEMS` base position grid.
 ///
 /// # Errors
-/// [`Error::PatchCount`] if the solved grid exceeds `budget` (a solver bug).
+/// [`Error::PatchCount`] if the solved grid exceeds `budget` (a solver bug);
+/// [`Error::PreprocessAllocation`] if a resize working buffer cannot be sized or
+/// reserved (pathological source geometry).
 pub(crate) fn preprocess_image(
   rgb: &[u8],
   width: usize,
@@ -369,16 +512,15 @@ pub(crate) fn preprocess_image(
 ) -> Result<VisionInputs, Error> {
   let (grid_h, grid_w) = fit_to_patch_budget(height, width, PATCH_SIZE, budget);
 
-  // Decode to f32 [0, 255] in (H, W, C) row-major (the Rgb8Image layout).
-  let img_f32: Vec<f32> = rgb.iter().map(|&b| b as f32).collect();
-
-  // Resize (on 0..255 floats), then rescale+normalize — the processor's order.
+  // Resize in the u8 domain (PIL-parity fixed-point kernel), then
+  // rescale+normalize to f32 — the SigLIP2 processor's order AND dtype (it
+  // resizes the u8 image, rounding each pass to u8, then casts to f32). No
+  // whole-image f32 buffer is materialized; the only src-dependent allocation is
+  // the kernel's fallibly-reserved u8 intermediate.
   let dst_h = grid_h * PATCH_SIZE;
   let dst_w = grid_w * PATCH_SIZE;
-  let mut resized = resize_bilinear_antialias(&img_f32, height, width, CHANNELS, dst_h, dst_w);
-  for v in &mut resized {
-    *v = normalize_pixel(*v);
-  }
+  let resized_u8 = resize_bilinear_antialias_u8(rgb, height, width, CHANNELS, dst_h, dst_w)?;
+  let resized: Vec<f32> = resized_u8.iter().map(|&v| normalize_u8(v)).collect();
 
   let (pixel_values, attention_mask) = patchify(&resized, grid_h, grid_w, budget)?;
   let position_embeddings = lift_position_embeddings(base_grid, grid_h, grid_w, budget);

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
@@ -45,9 +45,10 @@ pub(crate) const PATCH_SIZE: usize = 16;
 pub(crate) const CHANNELS: usize = 3;
 
 /// Flattened per-patch dimension `CHANNELS · PATCH_SIZE · PATCH_SIZE = 3·16·16 =
-/// 768` — the `pixel_values` inner dimension. Coincides with [`EMBEDDING_DIM`]
-/// for `base-patch16`, but is a distinct quantity.
-pub(crate) const PATCH_DIM: usize = CHANNELS * PATCH_SIZE * PATCH_SIZE;
+/// 768` — the `pixel_values` inner dimension: a [`crate::embeddings::siglip::PreprocessedImage`]
+/// carries `max_num_patches · PATCH_DIM` pixel values. Coincides with
+/// [`EMBEDDING_DIM`] for `base-patch16`, but is a distinct quantity.
+pub const PATCH_DIM: usize = CHANNELS * PATCH_SIZE * PATCH_SIZE;
 
 /// Side of the base position-embedding grid: the model's `num_patches = 256`
 /// position table reshaped to `16×16` (per the probe). Architecture constant.

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
@@ -102,7 +102,7 @@ fn budget_solver_extreme_aspect_clamps_short_side_to_one_patch() {
 fn resize_identity_is_exact() {
   // 2×2, three channels, distinct values.
   let src: Vec<f32> = (0..2 * 2 * 3).map(|i| i as f32).collect();
-  let out = resize_bilinear_antialias(&src, 2, 2, 3, 2, 2);
+  let out = resize_bilinear_antialias(&src, 2, 2, 3, 2, 2).expect("identity resize");
   assert_eq!(out, src);
 }
 
@@ -110,12 +110,12 @@ fn resize_identity_is_exact() {
 #[test]
 fn resize_of_constant_field_is_constant() {
   let src = vec![0.375f32; 3 * 5 * 2]; // 3×5, 2 channels
-  let up = resize_bilinear_antialias(&src, 3, 5, 2, 7, 9);
+  let up = resize_bilinear_antialias(&src, 3, 5, 2, 7, 9).expect("upscale");
   assert!(
     up.iter().all(|&v| (v - 0.375).abs() <= 1e-6),
     "upscale drifted"
   );
-  let down = resize_bilinear_antialias(&src, 3, 5, 2, 2, 2);
+  let down = resize_bilinear_antialias(&src, 3, 5, 2, 2, 2).expect("downscale");
   assert!(
     down.iter().all(|&v| (v - 0.375).abs() <= 1e-6),
     "downscale drifted"
@@ -127,7 +127,7 @@ fn resize_of_constant_field_is_constant() {
 /// interior).
 #[test]
 fn resize_upscale_matches_hand_computed_bilinear() {
-  let out = resize_bilinear_antialias(&[0.0, 1.0], 1, 2, 1, 1, 4);
+  let out = resize_bilinear_antialias(&[0.0, 1.0], 1, 2, 1, 1, 4).expect("upscale resize");
   assert_eq!(out, vec![0.0, 0.25, 0.75, 1.0]);
 }
 
@@ -138,7 +138,7 @@ fn resize_upscale_matches_hand_computed_bilinear() {
 fn resize_checker_upscale_matches_hand_computed_surface() {
   // [[0,1],[1,0]] row-major, single channel.
   let src = [0.0f32, 1.0, 1.0, 0.0];
-  let out = resize_bilinear_antialias(&src, 2, 2, 1, 4, 4);
+  let out = resize_bilinear_antialias(&src, 2, 2, 1, 4, 4).expect("checker upscale");
   let at = |r: usize, c: usize| out[r * 4 + c];
   // Corners replicate.
   assert_eq!(
@@ -166,7 +166,8 @@ fn resize_checker_upscale_matches_hand_computed_surface() {
 /// (a non-antialiased 2-tap bilinear would just subsample to `[0, 255]`).
 #[test]
 fn resize_antialias_downscale_is_symmetric_lowpass() {
-  let out = resize_bilinear_antialias(&[0.0, 0.0, 255.0, 255.0], 1, 4, 1, 1, 2);
+  let out = resize_bilinear_antialias(&[0.0, 0.0, 255.0, 255.0], 1, 4, 1, 1, 2)
+    .expect("antialias downscale");
   assert!(out[0] < out[1], "must be monotonic increasing");
   assert!(
     (out[0] + out[1] - 255.0).abs() <= 1e-3,
@@ -185,7 +186,7 @@ fn resize_antialias_downscale_is_symmetric_lowpass() {
 #[test]
 fn resize_keeps_channels_independent() {
   let src = [0.0f32, 10.0, 20.0, 40.0, 50.0, 60.0]; // 1×2, RGB
-  let out = resize_bilinear_antialias(&src, 1, 2, 3, 1, 4);
+  let out = resize_bilinear_antialias(&src, 1, 2, 3, 1, 4).expect("channel resize");
   // Reconstruct expected per channel.
   let up1d = |a: f32, b: f32| [a, 0.75 * a + 0.25 * b, 0.25 * a + 0.75 * b, b];
   for c in 0..3 {
@@ -207,7 +208,7 @@ fn resize_keeps_channels_independent() {
 fn resize_preserves_vertical_constancy() {
   // 4×2×1 with all rows == [3.0, 7.0].
   let src = [3.0f32, 7.0, 3.0, 7.0, 3.0, 7.0, 3.0, 7.0];
-  let out = resize_bilinear_antialias(&src, 4, 2, 1, 2, 2); // 2×2
+  let out = resize_bilinear_antialias(&src, 4, 2, 1, 2, 2).expect("height resize"); // 2×2
   assert!((out[0] - out[2]).abs() <= 1e-6, "column 0 not constant");
   assert!((out[1] - out[3]).abs() <= 1e-6, "column 1 not constant");
 }
@@ -224,8 +225,9 @@ fn resize_u8_identity_is_exact() {
 }
 
 /// Any constant field stays exactly constant under up- and down-scale: the
-/// quantized weight sum is within `ksize/2` of `2²²`, so `c·δ < 2²¹` for every
-/// reachable `ksize` and the offset truncates back to `c`.
+/// quantized weight sum is within `ksize/2` of `2²²`, so `c·δ < 2²¹` for this
+/// test's geometries (the margin holds while `ksize < 16448`) and the offset
+/// truncates back to `c`.
 #[test]
 fn resize_u8_constant_field_is_constant() {
   let src = vec![123u8; 5 * 7 * 3]; // 5×7, 3 channels
@@ -280,11 +282,31 @@ fn resize_u8_per_pass_rounding_discriminates_from_float() {
 }
 
 /// Pathologically large source dims return a typed
-/// [`Error::PreprocessAllocation`] from the `checked_mul` sizing arm — no panic,
-/// no abort. (The `try_reserve` arm is not portably forcible.)
+/// [`Error::PreprocessAllocation`] from [`checked_len3`]'s `checked_mul`
+/// working-buffer sizing arm — no panic, no abort. (The `try_reserve` arm is
+/// not portably forcible.)
 #[test]
 fn resize_u8_rejects_overflowing_geometry() {
   match resize_bilinear_antialias_u8(&[0u8; 12], usize::MAX / 2, 2, 3, 2, 2) {
+    Err(Error::PreprocessAllocation { bytes }) => assert_eq!(bytes, usize::MAX),
+    other => panic!("expected PreprocessAllocation, got {other:?}"),
+  }
+}
+
+/// A pathologically large *source* extent trips the coefficient-table
+/// representability pre-guard inside [`precompute_coeffs`] (the horizontal
+/// axis' `out·(2⌈support⌉+1)` element count overflows `usize`), returning a
+/// typed [`Error::PreprocessAllocation`] before any tap is indexed — no panic,
+/// no abort. This is the coefficient-table arm, distinct from the working-buffer
+/// [`checked_len3`] arm above. (The `try_reserve` arms are not portably
+/// forcible.)
+#[test]
+fn resize_u8_rejects_coeff_table_overflow() {
+  // src_w = usize::MAX/2, dst_w = 16 ⇒ support ≈ 2⁵⁹, so 2⌈support⌉+1 = 2⁶⁰+1
+  // and 16·(2⁶⁰+1) overflows usize. precompute_coeffs(src_w, dst_w) is the u8
+  // kernel's first action, so the guard fires before any buffer or src indexing;
+  // the tiny src is never read.
+  match resize_bilinear_antialias_u8(&[0u8; 12], 2, usize::MAX / 2, 3, 2, 16) {
     Err(Error::PreprocessAllocation { bytes }) => assert_eq!(bytes, usize::MAX),
     other => panic!("expected PreprocessAllocation, got {other:?}"),
   }
@@ -325,7 +347,8 @@ fn preprocess_image_pixel_values_come_from_u8_resize() {
   // kernel for this source, so preprocess_image is provably off the old float
   // path.
   let rgb_f32: Vec<f32> = rgb.iter().map(|&b| f32::from(b)).collect();
-  let float_resized = resize_bilinear_antialias(&rgb_f32, 2, 2, CHANNELS, 16, 16);
+  let float_resized =
+    resize_bilinear_antialias(&rgb_f32, 2, 2, CHANNELS, 16, 16).expect("float resize");
   let float_u8: Vec<u8> = float_resized
     .iter()
     .map(|&v| v.round().clamp(0.0, 255.0) as u8)
@@ -486,7 +509,7 @@ fn lift_position_embeddings_flattens_and_zero_pads() {
   let grid_h = 3;
   let grid_w = 4; // 12 real patches
   let budget = 20;
-  let lifted = lift_position_embeddings(&base, grid_h, grid_w, budget);
+  let lifted = lift_position_embeddings(&base, grid_h, grid_w, budget).expect("lift");
   assert_eq!(lifted.len(), budget * EMBEDDING_DIM);
 
   let n_real = grid_h * grid_w;
@@ -519,7 +542,7 @@ fn lift_position_embeddings_row_order_matches_patch_order() {
   }
   // Identity grid (16×16) → resize is exact, one position row per cell.
   let budget = POS_GRID_SIDE * POS_GRID_SIDE + 5;
-  let lifted = lift_position_embeddings(&base, POS_GRID_SIDE, POS_GRID_SIDE, budget);
+  let lifted = lift_position_embeddings(&base, POS_GRID_SIDE, POS_GRID_SIDE, budget).expect("lift");
   for gy in 0..POS_GRID_SIDE {
     for gx in 0..POS_GRID_SIDE {
       let row = gy * POS_GRID_SIDE + gx;

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
@@ -212,15 +212,140 @@ fn resize_preserves_vertical_constancy() {
   assert!((out[1] - out[3]).abs() <= 1e-6, "column 1 not constant");
 }
 
+// ── E3: uint8 PIL-parity resize kernel (fixed-point oracles) ──────────────────
+
+/// Identity dims return the input bytes exactly: each output is a single
+/// unit-weight tap, and the `1 << 21` offset truncates back to the input value.
+#[test]
+fn resize_u8_identity_is_exact() {
+  let src = [17u8, 200, 3, 250, 9, 128, 44, 71, 255]; // 3×3, 1 channel
+  let out = resize_bilinear_antialias_u8(&src, 3, 3, 1, 3, 3).expect("resize");
+  assert_eq!(out, src);
+}
+
+/// Any constant field stays exactly constant under up- and down-scale: the
+/// quantized weight sum is within `ksize/2` of `2²²`, so `c·δ < 2²¹` for every
+/// reachable `ksize` and the offset truncates back to `c`.
+#[test]
+fn resize_u8_constant_field_is_constant() {
+  let src = vec![123u8; 5 * 7 * 3]; // 5×7, 3 channels
+  let up = resize_bilinear_antialias_u8(&src, 5, 7, 3, 9, 4).expect("upscale");
+  assert!(
+    up.iter().all(|&v| v == 123),
+    "upscale drifted from constant"
+  );
+  let down = resize_bilinear_antialias_u8(&src, 5, 7, 3, 2, 2).expect("downscale");
+  assert!(
+    down.iter().all(|&v| v == 123),
+    "downscale drifted from constant"
+  );
+}
+
+/// A 2×2 checker `[[0,255],[255,0]]` upscaled to 4×4 matches the hand-derived
+/// Pillow 12.3.0 fixed-point grid EXACTLY (2→4 weights `[1]`, `[.75,.25]`,
+/// `[.25,.75]`, `[1]`; quantized `[4194304]`, `[3145728,1048576]`, …).
+#[test]
+fn resize_u8_matches_hand_computed_pil_grid_checker() {
+  let src = [0u8, 255, 255, 0];
+  let out = resize_bilinear_antialias_u8(&src, 2, 2, 1, 4, 4).expect("resize");
+  #[rustfmt::skip]
+  let expected: [u8; 16] = [
+      0,  64, 191, 255,
+     64,  96, 159, 191,
+    191, 159,  96,  64,
+    255, 191,  64,   0,
+  ];
+  assert_eq!(out, expected);
+}
+
+/// A 2×2 `[[0,1],[255,255]]` upscaled to 4×4 matches the hand-derived grid, with
+/// the discriminant cells `[1][2] = 65` and `[2][2] = 192`. A float pipeline
+/// rounded once at the end yields 64 and 191 there (`0.75·0.75 + 0.25·255 =
+/// 64.3125`; `0.25·0.75 + 0.75·255 = 191.4375`), so these cells pin the uint8
+/// per-pass (u8 intermediate) rounding as non-vacuous.
+#[test]
+fn resize_u8_per_pass_rounding_discriminates_from_float() {
+  let src = [0u8, 1, 255, 255];
+  let out = resize_bilinear_antialias_u8(&src, 2, 2, 1, 4, 4).expect("resize");
+  #[rustfmt::skip]
+  let expected: [u8; 16] = [
+      0,   0,   1,   1,
+     64,  64,  65,  65,
+    191, 191, 192, 192,
+    255, 255, 255, 255,
+  ];
+  assert_eq!(out, expected);
+  // Cells [1][2] and [2][2] (indices 6 and 10) are the float-vs-uint8 tell.
+  assert_eq!((out[6], out[10]), (65, 192));
+}
+
+/// Pathologically large source dims return a typed
+/// [`Error::PreprocessAllocation`] from the `checked_mul` sizing arm — no panic,
+/// no abort. (The `try_reserve` arm is not portably forcible.)
+#[test]
+fn resize_u8_rejects_overflowing_geometry() {
+  match resize_bilinear_antialias_u8(&[0u8; 12], usize::MAX / 2, 2, 3, 2, 2) {
+    Err(Error::PreprocessAllocation { bytes }) => assert_eq!(bytes, usize::MAX),
+    other => panic!("expected PreprocessAllocation, got {other:?}"),
+  }
+}
+
+/// `preprocess_image` routes pixels through the uint8 kernel + [`normalize_u8`],
+/// NOT the float path. Budget 1 makes the whole image a single 16×16 patch, so
+/// the real patch row equals `normalize_u8` of the u8-resized bytes exactly; and
+/// the u8 resize provably differs from a float-then-round resize for this source
+/// (the per-pass rounding), so the routing is observable, not vacuous.
+#[test]
+fn preprocess_image_pixel_values_come_from_u8_resize() {
+  // src pattern [[0,1],[255,255]] replicated on all 3 channels — this diverges
+  // from a float resize under 2→16 (the per-pass u8 rounding).
+  let pattern = [0u8, 1, 255, 255];
+  let mut rgb = vec![0u8; 2 * 2 * CHANNELS];
+  for (px, &v) in pattern.iter().enumerate() {
+    for c in 0..CHANNELS {
+      rgb[px * CHANNELS + c] = v;
+    }
+  }
+  let base = vec![0.0f32; POS_EMBED_ELEMS];
+  let out = preprocess_image(&rgb, 2, 2, &base, 1).expect("preprocess");
+  assert_eq!(out.grid, (1, 1), "budget 1 → single-patch grid");
+
+  // The single real patch is normalize_u8 of the u8-resized image, exactly.
+  let resized_u8 = resize_bilinear_antialias_u8(&rgb, 2, 2, CHANNELS, 16, 16).expect("resize");
+  assert_eq!(resized_u8.len(), 16 * 16 * CHANNELS);
+  for (k, &v) in resized_u8.iter().enumerate() {
+    assert_eq!(
+      out.pixel_values[k],
+      normalize_u8(v),
+      "pixel_values[{k}] must be normalize_u8 of the u8-resized byte"
+    );
+  }
+
+  // Non-vacuity: a float resize rounded to u8 diverges from the per-pass u8
+  // kernel for this source, so preprocess_image is provably off the old float
+  // path.
+  let rgb_f32: Vec<f32> = rgb.iter().map(|&b| f32::from(b)).collect();
+  let float_resized = resize_bilinear_antialias(&rgb_f32, 2, 2, CHANNELS, 16, 16);
+  let float_u8: Vec<u8> = float_resized
+    .iter()
+    .map(|&v| v.round().clamp(0.0, 255.0) as u8)
+    .collect();
+  assert!(
+    resized_u8.iter().zip(&float_u8).any(|(&u, &f)| u != f),
+    "uint8 per-pass resize must differ from a float-then-round resize here"
+  );
+}
+
 // ── A7: normalize + patchify + mask ──────────────────────────────────────────
 
-/// The rescale+normalize maps the pixel range `[0, 255]` onto `[-1, 1]` at the
-/// pinned constants `((x/255) − 0.5)/0.5`.
+/// The rescale+normalize maps the u8 range `[0, 255]` onto `[-1, 1]` at the
+/// pinned constants `((v/255) − 0.5)/0.5`: the endpoints are exact and the
+/// midpoint is near zero.
 #[test]
-fn normalize_pixel_maps_range_to_unit_interval() {
-  assert!((normalize_pixel(0.0) - (-1.0)).abs() <= 1e-6);
-  assert!((normalize_pixel(255.0) - 1.0).abs() <= 1e-6);
-  assert!(normalize_pixel(127.5).abs() <= 1e-6);
+fn normalize_u8_maps_range_to_unit_interval() {
+  assert_eq!(normalize_u8(0), -1.0);
+  assert_eq!(normalize_u8(255), 1.0);
+  assert!(normalize_u8(128).abs() < 0.01);
 }
 
 /// Patchify places each pixel at the exact `(patch_row, patch_col)` × `(py, px,

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
@@ -1,0 +1,476 @@
+use super::*;
+
+const P: usize = 512;
+
+// ── A6: budget solver ────────────────────────────────────────────────────────
+
+/// The one fully-known real oracle pair: the probe's 320×240 image
+/// (`spatial_shapes = (19, 26)` at the 512 budget). `320×240` is W×H, so
+/// `image_height = 240`, `image_width = 320`.
+#[test]
+fn budget_solver_matches_known_320x240_oracle() {
+  assert_eq!(fit_to_patch_budget(240, 320, PATCH_SIZE, P), (19, 26));
+}
+
+/// A square image scales uniformly to the largest square grid fitting the
+/// budget: `⌊√512⌋ = 22` (`22² = 484 ≤ 512`, `23² = 529 > 512`).
+#[test]
+fn budget_solver_square_image_fills_the_square_grid() {
+  assert_eq!(fit_to_patch_budget(512, 512, PATCH_SIZE, P), (22, 22));
+  // Absolute size is (near-)irrelevant — a smaller square lands on the same grid.
+  assert_eq!(fit_to_patch_budget(64, 64, PATCH_SIZE, P), (22, 22));
+}
+
+/// The probe's eight measured `aspect → spatial_shapes` rows (P = 512), the real
+/// oracle already recorded in the conversion probe. Feeding representative
+/// dimensions at each aspect (long side 640, the COCO norm) reproduces every
+/// measured `(h_p, w_p)` grid EXACTLY — a cross-check of the port against
+/// measured NaFlex truth. `aspect = width / height`; a portrait (`< 1`) has the
+/// long side on height, a landscape (`≥ 1`) on width.
+#[test]
+fn budget_solver_reproduces_probe_aspect_table() {
+  // (image_height, image_width, expected grid_h, grid_w)
+  let rows: &[(usize, usize, usize, usize)] = &[
+    (640, 425, 28, 18), // aspect 0.664
+    (640, 480, 26, 19), // aspect 0.750
+    (640, 586, 23, 22), // aspect 0.916
+    (483, 640, 19, 26), // aspect 1.325
+    (480, 640, 19, 26), // aspect 1.333
+    (427, 640, 18, 27), // aspect 1.499
+    (426, 640, 18, 28), // aspect 1.502
+  ];
+  for &(h, w, eh, ew) in rows {
+    assert_eq!(
+      fit_to_patch_budget(h, w, PATCH_SIZE, P),
+      (eh, ew),
+      "budget solver diverged from the probe oracle for {h}×{w}"
+    );
+  }
+}
+
+/// Budget + maximality invariants across a spread of shapes: the grid always
+/// fits (`h_p·w_p ≤ P`), never degenerates (`≥ 1` per axis), and is maximal —
+/// growing BOTH axes by one patch would exceed the budget.
+#[test]
+fn budget_solver_respects_budget_and_is_maximal() {
+  for &(h, w) in &[
+    (240, 320),
+    (640, 425),
+    (512, 512),
+    (100, 3000),
+    (1000, 1000),
+    (37, 91),
+    (640, 587),
+  ] {
+    let (hp, wp) = fit_to_patch_budget(h, w, PATCH_SIZE, P);
+    assert!(hp >= 1 && wp >= 1, "{h}×{w} degenerate grid ({hp},{wp})");
+    assert!(hp * wp <= P, "{h}×{w} exceeds budget: {hp}·{wp}");
+    assert!(
+      (hp + 1) * (wp + 1) > P,
+      "{h}×{w} not maximal: ({}+1)·({}+1) ≤ {P}",
+      hp,
+      wp
+    );
+  }
+}
+
+/// The solver is (near-)scale-invariant: the same aspect ratio at different
+/// absolute sizes lands on the same grid (the probe measured the small 320×240
+/// and a full-size 1.333 image onto the identical `(19, 26)`).
+#[test]
+fn budget_solver_is_scale_invariant_for_a_fixed_aspect() {
+  let g = fit_to_patch_budget(240, 320, PATCH_SIZE, P);
+  assert_eq!(g, (19, 26));
+  assert_eq!(fit_to_patch_budget(480, 640, PATCH_SIZE, P), g);
+  assert_eq!(fit_to_patch_budget(120, 160, PATCH_SIZE, P), g);
+}
+
+/// An extreme aspect ratio clamps the short side to a single patch (the
+/// `max(patch, …)` floor) while the long side absorbs the budget.
+#[test]
+fn budget_solver_extreme_aspect_clamps_short_side_to_one_patch() {
+  let (hp, wp) = fit_to_patch_budget(16, 16_000, PATCH_SIZE, P);
+  assert_eq!(hp, 1, "the 1-patch short-side clamp must hold");
+  assert!(wp >= 1 && hp * wp <= P, "grid ({hp},{wp}) invalid");
+}
+
+// ── A8: antialiased-bilinear resize kernel ───────────────────────────────────
+
+/// Identity resize (`out == in`) is exact per element and per channel — the
+/// coefficient at each output is a single unit weight.
+#[test]
+fn resize_identity_is_exact() {
+  // 2×2, three channels, distinct values.
+  let src: Vec<f32> = (0..2 * 2 * 3).map(|i| i as f32).collect();
+  let out = resize_bilinear_antialias(&src, 2, 2, 3, 2, 2);
+  assert_eq!(out, src);
+}
+
+/// A constant field stays constant under any resize (weights sum to 1).
+#[test]
+fn resize_of_constant_field_is_constant() {
+  let src = vec![0.375f32; 3 * 5 * 2]; // 3×5, 2 channels
+  let up = resize_bilinear_antialias(&src, 3, 5, 2, 7, 9);
+  assert!(
+    up.iter().all(|&v| (v - 0.375).abs() <= 1e-6),
+    "upscale drifted"
+  );
+  let down = resize_bilinear_antialias(&src, 3, 5, 2, 2, 2);
+  assert!(
+    down.iter().all(|&v| (v - 0.375).abs() <= 1e-6),
+    "downscale drifted"
+  );
+}
+
+/// Upscale `[0, 1]` (2→4) matches the hand-computed align-corners=false bilinear
+/// `[0, 0.25, 0.75, 1.0]` EXACTLY (edge replication at the ends, quarter steps
+/// interior).
+#[test]
+fn resize_upscale_matches_hand_computed_bilinear() {
+  let out = resize_bilinear_antialias(&[0.0, 1.0], 1, 2, 1, 1, 4);
+  assert_eq!(out, vec![0.0, 0.25, 0.75, 1.0]);
+}
+
+/// A 2×2 checker upscaled to 4×4 matches the hand-computed separable bilinear
+/// surface: corners replicate the source, the interior 2×2 block is the
+/// symmetric `{0.375, 0.625}` blend.
+#[test]
+fn resize_checker_upscale_matches_hand_computed_surface() {
+  // [[0,1],[1,0]] row-major, single channel.
+  let src = [0.0f32, 1.0, 1.0, 0.0];
+  let out = resize_bilinear_antialias(&src, 2, 2, 1, 4, 4);
+  let at = |r: usize, c: usize| out[r * 4 + c];
+  // Corners replicate.
+  assert_eq!(
+    (at(0, 0), at(0, 3), at(3, 0), at(3, 3)),
+    (0.0, 1.0, 1.0, 0.0)
+  );
+  // Interior 2×2 block.
+  for (r, c, want) in [
+    (1, 1, 0.375f32),
+    (1, 2, 0.625),
+    (2, 1, 0.625),
+    (2, 2, 0.375),
+  ] {
+    assert!(
+      (at(r, c) - want).abs() <= 1e-6,
+      "checker[{r}][{c}] = {}",
+      at(r, c)
+    );
+  }
+}
+
+/// Antialiased downscale of a step edge `[0,0,255,255]` (4→2) low-passes
+/// symmetrically: the two outputs are mirror images summing to the full range
+/// (`v` and `255 − v`), and monotonic — proving the triangle support widened
+/// (a non-antialiased 2-tap bilinear would just subsample to `[0, 255]`).
+#[test]
+fn resize_antialias_downscale_is_symmetric_lowpass() {
+  let out = resize_bilinear_antialias(&[0.0, 0.0, 255.0, 255.0], 1, 4, 1, 1, 2);
+  assert!(out[0] < out[1], "must be monotonic increasing");
+  assert!(
+    (out[0] + out[1] - 255.0).abs() <= 1e-3,
+    "must be symmetric around 127.5"
+  );
+  // The edge is smoothed (not a hard subsample to 0 / 255).
+  assert!(
+    out[0] > 1.0 && out[1] < 254.0,
+    "antialias must low-pass the edge"
+  );
+}
+
+/// Channels are resampled independently — one channel's values never bleed into
+/// another. Two RGB pixels `[(0,10,20),(40,50,60)]` upscaled 2→4 give each
+/// channel its own 1D upscale (`[v0, .75v0+.25v1, .25v0+.75v1, v1]`).
+#[test]
+fn resize_keeps_channels_independent() {
+  let src = [0.0f32, 10.0, 20.0, 40.0, 50.0, 60.0]; // 1×2, RGB
+  let out = resize_bilinear_antialias(&src, 1, 2, 3, 1, 4);
+  // Reconstruct expected per channel.
+  let up1d = |a: f32, b: f32| [a, 0.75 * a + 0.25 * b, 0.25 * a + 0.75 * b, b];
+  for c in 0..3 {
+    let want = up1d(src[c], src[3 + c]);
+    for x in 0..4 {
+      assert!(
+        (out[x * 3 + c] - want[x]).abs() <= 1e-6,
+        "channel {c} pixel {x}: {} != {}",
+        out[x * 3 + c],
+        want[x]
+      );
+    }
+  }
+}
+
+/// Separability sanity: a vertically-constant image (identical rows) stays
+/// vertically constant after a height resize, since each column is constant.
+#[test]
+fn resize_preserves_vertical_constancy() {
+  // 4×2×1 with all rows == [3.0, 7.0].
+  let src = [3.0f32, 7.0, 3.0, 7.0, 3.0, 7.0, 3.0, 7.0];
+  let out = resize_bilinear_antialias(&src, 4, 2, 1, 2, 2); // 2×2
+  assert!((out[0] - out[2]).abs() <= 1e-6, "column 0 not constant");
+  assert!((out[1] - out[3]).abs() <= 1e-6, "column 1 not constant");
+}
+
+// ── A7: normalize + patchify + mask ──────────────────────────────────────────
+
+/// The rescale+normalize maps the pixel range `[0, 255]` onto `[-1, 1]` at the
+/// pinned constants `((x/255) − 0.5)/0.5`.
+#[test]
+fn normalize_pixel_maps_range_to_unit_interval() {
+  assert!((normalize_pixel(0.0) - (-1.0)).abs() <= 1e-6);
+  assert!((normalize_pixel(255.0) - 1.0).abs() <= 1e-6);
+  assert!(normalize_pixel(127.5).abs() <= 1e-6);
+}
+
+/// Patchify places each pixel at the exact `(patch_row, patch_col)` × `(py, px,
+/// channel)` slot: a synthetic image whose every pixel channel encodes its own
+/// `(y, x, c)` coordinate must land where the reshape says. A transpose or
+/// off-by-one in the flatten order relocates values and reds this.
+#[test]
+fn patchify_places_pixels_at_exact_slots() {
+  let grid_h = 2;
+  let grid_w = 3;
+  let img_h = grid_h * PATCH_SIZE;
+  let img_w = grid_w * PATCH_SIZE;
+  // Distinguishable encoding: value = (y*10000 + x*10 + c) as f32.
+  let mut img = vec![0.0f32; img_h * img_w * CHANNELS];
+  for y in 0..img_h {
+    for x in 0..img_w {
+      for c in 0..CHANNELS {
+        img[(y * img_w + x) * CHANNELS + c] = (y * 10_000 + x * 10 + c) as f32;
+      }
+    }
+  }
+  let budget = 10;
+  let (pixel_values, mask) = patchify(&img, grid_h, grid_w, budget).expect("patchify");
+  assert_eq!(pixel_values.len(), budget * PATCH_DIM);
+  assert_eq!(mask.len(), budget);
+
+  // Verify the full reshape by re-deriving each slot's expected source pixel.
+  for ph in 0..grid_h {
+    for pw in 0..grid_w {
+      let row = ph * grid_w + pw;
+      let mut k = 0;
+      for py in 0..PATCH_SIZE {
+        for px in 0..PATCH_SIZE {
+          for c in 0..CHANNELS {
+            let y = ph * PATCH_SIZE + py;
+            let x = pw * PATCH_SIZE + px;
+            let want = (y * 10_000 + x * 10 + c) as f32;
+            assert_eq!(
+              pixel_values[row * PATCH_DIM + k],
+              want,
+              "slot (ph={ph},pw={pw},py={py},px={px},c={c}) misplaced"
+            );
+            k += 1;
+          }
+        }
+      }
+    }
+  }
+}
+
+/// The mask marks exactly the `grid_h·grid_w` real patches `1.0` and zero-pads
+/// the rest; the padded `pixel_values` rows are bitwise zero.
+#[test]
+fn patchify_mask_and_padding_are_correct() {
+  let grid_h = 2;
+  let grid_w = 3; // 6 real patches
+  let img = vec![0.5f32; (grid_h * PATCH_SIZE) * (grid_w * PATCH_SIZE) * CHANNELS];
+  let budget = 8;
+  let (pixel_values, mask) = patchify(&img, grid_h, grid_w, budget).expect("patchify");
+
+  let n_real = grid_h * grid_w;
+  assert_eq!(
+    mask.iter().sum::<f32>(),
+    n_real as f32,
+    "mask must count real patches"
+  );
+  assert!(
+    mask[..n_real].iter().all(|&m| m == 1.0),
+    "real patches masked 1.0"
+  );
+  assert!(
+    mask[n_real..].iter().all(|&m| m == 0.0),
+    "pad patches masked 0.0"
+  );
+  // Pad rows are bitwise zero.
+  assert!(
+    pixel_values[n_real * PATCH_DIM..].iter().all(|&v| v == 0.0),
+    "padded pixel rows must be zero"
+  );
+}
+
+/// Patchify defensively rejects a grid larger than the budget with a typed
+/// error (never an out-of-bounds write).
+#[test]
+fn patchify_rejects_grid_over_budget() {
+  let grid_h = 3;
+  let grid_w = 3; // 9 patches
+  let img = vec![0.0f32; (grid_h * PATCH_SIZE) * (grid_w * PATCH_SIZE) * CHANNELS];
+  match patchify(&img, grid_h, grid_w, 8) {
+    Err(Error::PatchCount { got: 9, max: 8 }) => {}
+    other => panic!("expected PatchCount, got {other:?}"),
+  }
+}
+
+// ── A9: position-embedding grid (parse + lift + pad) ──────────────────────────
+
+/// The raw sidecar length is hard-validated to the exact `16·16·768·4` byte
+/// count; a short/long file is rejected, a correct one parses to
+/// `POS_EMBED_ELEMS` little-endian f32.
+#[test]
+fn parse_base_pos_grid_validates_exact_byte_length() {
+  assert_eq!(POS_EMBED_BYTES, 16 * 16 * 768 * 4);
+  assert_eq!(POS_EMBED_BYTES, 786_432);
+
+  let good = vec![0u8; POS_EMBED_BYTES];
+  let grid = parse_base_pos_grid(&good).expect("exact length parses");
+  assert_eq!(grid.len(), POS_EMBED_ELEMS);
+
+  match parse_base_pos_grid(&[0u8; 16]) {
+    Err(Error::PosEmbedLength { got: 16, expected }) => assert_eq!(expected, POS_EMBED_BYTES),
+    other => panic!("expected PosEmbedLength, got {other:?}"),
+  }
+  let long = vec![0u8; POS_EMBED_BYTES + 4];
+  assert!(matches!(
+    parse_base_pos_grid(&long),
+    Err(Error::PosEmbedLength { .. })
+  ));
+}
+
+/// Round-trip: a known little-endian f32 pattern parses back to those floats.
+#[test]
+fn parse_base_pos_grid_decodes_little_endian_f32() {
+  let mut bytes = vec![0u8; POS_EMBED_BYTES];
+  bytes[0..4].copy_from_slice(&1.5f32.to_le_bytes());
+  bytes[4..8].copy_from_slice(&(-2.25f32).to_le_bytes());
+  let grid = parse_base_pos_grid(&bytes).expect("parse");
+  assert_eq!(grid[0], 1.5);
+  assert_eq!(grid[1], -2.25);
+}
+
+/// The lift resizes the base grid to the patch grid, flattens row-major, and
+/// zero-pads to `[budget, EMBEDDING_DIM]`. A constant base grid resizes to the
+/// same constant on every real patch row, with the pad rows bitwise zero — this
+/// pins the flatten + pad plumbing (the resize kernel itself is covered above).
+#[test]
+fn lift_position_embeddings_flattens_and_zero_pads() {
+  let base = vec![0.7f32; POS_EMBED_ELEMS]; // constant grid
+  let grid_h = 3;
+  let grid_w = 4; // 12 real patches
+  let budget = 20;
+  let lifted = lift_position_embeddings(&base, grid_h, grid_w, budget);
+  assert_eq!(lifted.len(), budget * EMBEDDING_DIM);
+
+  let n_real = grid_h * grid_w;
+  // Real rows: resize of a constant grid is the same constant.
+  assert!(
+    lifted[..n_real * EMBEDDING_DIM]
+      .iter()
+      .all(|&v| (v - 0.7).abs() <= 1e-6),
+    "real position rows must carry the resized (constant) grid"
+  );
+  // Pad rows: bitwise zero.
+  assert!(
+    lifted[n_real * EMBEDDING_DIM..].iter().all(|&v| v == 0.0),
+    "padded position rows must be zero"
+  );
+}
+
+/// The lift's per-patch row layout matches patchify's: distinct base-grid rows
+/// land on distinct position rows in `(grid_row, grid_col)` order. An identity
+/// resize (`grid == POS_GRID_SIDE`) makes the mapping exact, so a per-row
+/// signature proves alignment with the patch order.
+#[test]
+fn lift_position_embeddings_row_order_matches_patch_order() {
+  // Give each base-grid cell a per-cell signature in channel 0.
+  let mut base = vec![0.0f32; POS_EMBED_ELEMS];
+  for gy in 0..POS_GRID_SIDE {
+    for gx in 0..POS_GRID_SIDE {
+      base[(gy * POS_GRID_SIDE + gx) * EMBEDDING_DIM] = (gy * 100 + gx) as f32;
+    }
+  }
+  // Identity grid (16×16) → resize is exact, one position row per cell.
+  let budget = POS_GRID_SIDE * POS_GRID_SIDE + 5;
+  let lifted = lift_position_embeddings(&base, POS_GRID_SIDE, POS_GRID_SIDE, budget);
+  for gy in 0..POS_GRID_SIDE {
+    for gx in 0..POS_GRID_SIDE {
+      let row = gy * POS_GRID_SIDE + gx;
+      assert_eq!(
+        lifted[row * EMBEDDING_DIM],
+        (gy * 100 + gx) as f32,
+        "position row {row} misaligned with patch order"
+      );
+    }
+  }
+}
+
+// ── A6–A10: full model-free image pipeline (preprocess_image) ─────────────────
+
+/// A synthetic decoded RGB image (row-major, RGB-interleaved u8) with a
+/// deterministic gradient.
+fn synthetic_rgb(width: usize, height: usize) -> Vec<u8> {
+  let mut data = vec![0u8; width * height * CHANNELS];
+  for y in 0..height {
+    for x in 0..width {
+      let base = (y * width + x) * CHANNELS;
+      data[base] = ((x * 255) / width.max(1)) as u8;
+      data[base + 1] = ((y * 255) / height.max(1)) as u8;
+      data[base + 2] = ((x + y) % 256) as u8;
+    }
+  }
+  data
+}
+
+/// The full pipeline yields the three graph tensors at the budget's shapes, with
+/// the mask counting exactly the solved grid's real patches and normalized
+/// pixels inside `[-1, 1]`.
+#[test]
+fn preprocess_image_produces_budget_shaped_tensors() {
+  let (w, h) = (320usize, 240usize);
+  let base = vec![0.1f32; POS_EMBED_ELEMS];
+  let rgb = synthetic_rgb(w, h);
+  let out = preprocess_image(&rgb, w, h, &base, P).expect("preprocess");
+
+  assert_eq!(out.grid, (19, 26), "grid must match the 320×240 oracle");
+  assert_eq!(out.pixel_values.len(), P * PATCH_DIM);
+  assert_eq!(out.attention_mask.len(), P);
+  assert_eq!(out.position_embeddings.len(), P * EMBEDDING_DIM);
+
+  let n_real = out.grid.0 * out.grid.1;
+  assert_eq!(out.attention_mask.iter().sum::<f32>(), n_real as f32);
+  assert!(
+    out.pixel_values.iter().all(|&v| (-1.0..=1.0).contains(&v)),
+    "normalized pixels must lie in [-1, 1]"
+  );
+  // Pad regions of both pixel_values and position_embeddings are zero.
+  assert!(
+    out.pixel_values[n_real * PATCH_DIM..]
+      .iter()
+      .all(|&v| v == 0.0)
+  );
+  assert!(
+    out.position_embeddings[n_real * EMBEDDING_DIM..]
+      .iter()
+      .all(|&v| v == 0.0)
+  );
+}
+
+/// The pipeline is deterministic — the same image yields byte-identical tensors
+/// across runs (the hermetic determinism evidence).
+#[test]
+fn preprocess_image_is_deterministic() {
+  let (w, h) = (200usize, 150usize);
+  let base: Vec<f32> = (0..POS_EMBED_ELEMS)
+    .map(|i| (i % 97) as f32 * 0.01)
+    .collect();
+  let rgb = synthetic_rgb(w, h);
+  let a = preprocess_image(&rgb, w, h, &base, P).expect("a");
+  let b = preprocess_image(&rgb, w, h, &base, P).expect("b");
+  assert_eq!(a.grid, b.grid);
+  assert_eq!(a.pixel_values, b.pixel_values);
+  assert_eq!(a.attention_mask, b.attention_mask);
+  assert_eq!(a.position_embeddings, b.position_embeddings);
+}

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
@@ -622,3 +622,76 @@ fn preprocess_image_is_deterministic() {
   assert_eq!(a.attention_mask, b.attention_mask);
   assert_eq!(a.position_embeddings, b.position_embeddings);
 }
+
+// ── Image-axis bound ─────────────────────────────────────────────────────────
+
+/// Wide over-bound strip: a valid `Rgb8Image` geometry one past
+/// [`MAX_IMAGE_AXIS`] is rejected, typed, before any resize allocation.
+#[test]
+fn preprocess_rejects_width_over_axis_bound() {
+  let w = MAX_IMAGE_AXIS + 1;
+  let rgb = vec![0u8; w * 3];
+  let base = vec![0.0f32; POS_EMBED_ELEMS];
+  let err = preprocess_image(&rgb, w, 1, &base, P).unwrap_err();
+  assert!(matches!(err, Error::ImageDimensions { width, height } if width == w && height == 1));
+}
+
+/// Tall twin — the worse unbounded orientation (the horizontal pass would
+/// materialize a `src_h · dst_w · 3` intermediate, ~805 MB at 16.7M px).
+#[test]
+fn preprocess_rejects_height_over_axis_bound() {
+  let h = MAX_IMAGE_AXIS + 1;
+  let rgb = vec![0u8; h * 3];
+  let base = vec![0.0f32; POS_EMBED_ELEMS];
+  let err = preprocess_image(&rgb, 1, h, &base, P).unwrap_err();
+  assert!(matches!(err, Error::ImageDimensions { width, height } if width == 1 && height == h));
+}
+
+/// The Pillow `f32`-box divergence zone is unreachable: Pillow rounds the
+/// extent through `float box[4]` (`16 777 219 → 16 777 220.0f32`, first
+/// inexact integer `2²⁴ + 1`), so above `2²⁴` its coefficients diverge from
+/// exact-`f64` ones (quantized tables differ; a crafted 0/255 pattern flips
+/// output bytes). The axis bound rejects such extents long before the kernel
+/// runs, keeping the uint8 kernel's bit-exact contract honest over the whole
+/// accepted domain.
+#[test]
+fn preprocess_rejects_pillow_f32_inexact_extent() {
+  let w = 16_777_219usize; // ~50 MB transient buffer; freed at test end
+  let rgb = vec![0u8; w * 3];
+  let base = vec![0.0f32; POS_EMBED_ELEMS];
+  let err = preprocess_image(&rgb, w, 1, &base, P).unwrap_err();
+  assert!(matches!(err, Error::ImageDimensions { width, height } if width == w && height == 1));
+}
+
+/// The boundary panorama IS accepted: `MAX_IMAGE_AXIS × 1` (the largest
+/// accepted wide strip) preprocesses to a valid bundle with bounded tables
+/// (≈ 17 MB f64 peak per axis).
+#[test]
+fn preprocess_accepts_axis_bound_wide_panorama() {
+  let rgb = vec![127u8; MAX_IMAGE_AXIS * 3];
+  let base = vec![0.0f32; POS_EMBED_ELEMS];
+  let out = preprocess_image(&rgb, MAX_IMAGE_AXIS, 1, &base, P).unwrap();
+  let (gh, gw) = out.grid;
+  assert_eq!(gh, 1);
+  assert!((1..=P).contains(&gw));
+  assert_eq!(out.pixel_values.len(), P * PATCH_DIM);
+  assert_eq!(out.attention_mask.len(), P);
+  let real = out.attention_mask.iter().filter(|&&m| m == 1.0).count();
+  assert_eq!(real, gh * gw);
+}
+
+/// Tall boundary twin: `1 × MAX_IMAGE_AXIS` — exercises the bounded worst-case
+/// horizontal intermediate (`MAX_IMAGE_AXIS · 16 · 3 ≈ 50 MB`) end to end.
+#[test]
+fn preprocess_accepts_axis_bound_tall_strip() {
+  let rgb = vec![127u8; MAX_IMAGE_AXIS * 3];
+  let base = vec![0.0f32; POS_EMBED_ELEMS];
+  let out = preprocess_image(&rgb, 1, MAX_IMAGE_AXIS, &base, P).unwrap();
+  let (gh, gw) = out.grid;
+  assert_eq!(gw, 1);
+  assert!((1..=P).contains(&gh));
+  assert_eq!(out.pixel_values.len(), P * PATCH_DIM);
+  assert_eq!(out.attention_mask.len(), P);
+  let real = out.attention_mask.iter().filter(|&&m| m == 1.0).count();
+  assert_eq!(real, gh * gw);
+}

--- a/crates/coremlit/src/embeddings/siglip/image/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/tests.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+// ── A5: Rgb8Image geometry validation ────────────────────────────────────────
+
+#[test]
+fn rgb8_image_accepts_valid_geometry_and_exposes_dims() {
+  let data = vec![7u8; 4 * 3 * 3]; // 4×3 RGB
+  let img = Rgb8Image::new(&data, 4, 3).expect("valid");
+  assert_eq!(img.width(), 4);
+  assert_eq!(img.height(), 3);
+  assert_eq!(img.data().len(), 4 * 3 * 3);
+  // The borrowed view round-trips the exact bytes.
+  assert_eq!(img.data(), data.as_slice());
+}
+
+#[test]
+fn rgb8_image_rejects_zero_width() {
+  let data: Vec<u8> = Vec::new();
+  match Rgb8Image::new(&data, 0, 3) {
+    Err(Error::ImageDimensions {
+      width: 0,
+      height: 3,
+    }) => {}
+    other => panic!("expected ImageDimensions, got {other:?}"),
+  }
+}
+
+#[test]
+fn rgb8_image_rejects_zero_height() {
+  let data: Vec<u8> = Vec::new();
+  match Rgb8Image::new(&data, 4, 0) {
+    Err(Error::ImageDimensions {
+      width: 4,
+      height: 0,
+    }) => {}
+    other => panic!("expected ImageDimensions, got {other:?}"),
+  }
+}
+
+#[test]
+fn rgb8_image_rejects_length_mismatch() {
+  let data = vec![0u8; 4 * 3 * 3 - 1]; // one byte short
+  match Rgb8Image::new(&data, 4, 3) {
+    Err(Error::ImageDataLength { got, expected }) => {
+      assert_eq!(got, 4 * 3 * 3 - 1);
+      assert_eq!(expected, 4 * 3 * 3);
+    }
+    other => panic!("expected ImageDataLength, got {other:?}"),
+  }
+}
+
+#[test]
+fn rgb8_image_rejects_size_overflow() {
+  // width·height·3 overflows usize; data length is irrelevant to the overflow.
+  let data = [0u8; 1];
+  match Rgb8Image::new(&data, usize::MAX, 2) {
+    Err(Error::ImageDimensions { .. }) => {}
+    other => panic!("expected ImageDimensions on overflow, got {other:?}"),
+  }
+}
+
+// ── A4: options ──────────────────────────────────────────────────────────────
+
+#[test]
+fn options_default_equals_new_and_is_cpu_and_gpu() {
+  assert_eq!(ImageEmbedderOptions::default(), ImageEmbedderOptions::new());
+  assert_eq!(ImageEmbedderOptions::new().compute(), DEFAULT_IMAGE_COMPUTE);
+  // D1: the floor-holding default is CpuAndGpu, NOT All.
+  assert_eq!(DEFAULT_IMAGE_COMPUTE, ComputeUnits::CpuAndGpu);
+}
+
+#[test]
+fn options_with_and_set_compute() {
+  let opts = ImageEmbedderOptions::new().with_compute(ComputeUnits::All);
+  assert_eq!(opts.compute(), ComputeUnits::All);
+  let mut opts = ImageEmbedderOptions::new();
+  opts.set_compute(ComputeUnits::CpuOnly);
+  assert_eq!(opts.compute(), ComputeUnits::CpuOnly);
+}
+
+#[test]
+fn describe_renders_shape_and_dtype() {
+  assert_eq!(
+    describe(&[1, 512, 768], Some(DataType::F32)),
+    "[1, 512, 768] float32"
+  );
+  assert_eq!(describe(&[1, 512], None), "[1, 512] none");
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn options_serde_roundtrip() {
+  let opts = ImageEmbedderOptions::new().with_compute(ComputeUnits::CpuAndNeuralEngine);
+  let json = serde_json::to_string(&opts).unwrap();
+  assert!(json.contains("cpu_and_neural_engine"), "serialized: {json}");
+  let back: ImageEmbedderOptions = serde_json::from_str(&json).unwrap();
+  assert_eq!(back, opts);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn options_serde_defaults_missing_compute_to_the_module_default() {
+  // A missing `compute` field defaults to DEFAULT_IMAGE_COMPUTE (serde default).
+  let back: ImageEmbedderOptions = serde_json::from_str("{}").unwrap();
+  assert_eq!(back, ImageEmbedderOptions::new());
+}

--- a/crates/coremlit/src/embeddings/siglip/image/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/tests.rs
@@ -104,3 +104,246 @@ fn options_serde_defaults_missing_compute_to_the_module_default() {
   let back: ImageEmbedderOptions = serde_json::from_str("{}").unwrap();
   assert_eq!(back, ImageEmbedderOptions::new());
 }
+
+// ── embed_preprocessed: PreprocessedImage validation ─────────────────────────
+
+/// A well-formed padded bundle at budget `p` with `n_real` real patches: real
+/// rows filled with `0.5`, pad rows zero, exact binary prefix mask.
+fn bundle(p: usize, n_real: usize) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+  let mut pixel_values = vec![0.0f32; p * PATCH_DIM];
+  let mut position_embeddings = vec![0.0f32; p * EMBEDDING_DIM];
+  let mut attention_mask = vec![0.0f32; p];
+  pixel_values[..n_real * PATCH_DIM].fill(0.5);
+  position_embeddings[..n_real * EMBEDDING_DIM].fill(0.5);
+  attention_mask[..n_real].fill(1.0);
+  (pixel_values, position_embeddings, attention_mask)
+}
+
+#[test]
+fn preprocessed_image_accepts_well_formed_bundle() {
+  let (px, pos, mask) = bundle(4, 3);
+  let pre = PreprocessedImage::try_new(px, pos, mask, 4).expect("well-formed bundle");
+  assert_eq!(pre.max_num_patches(), 4);
+  assert_eq!(pre.pixel_values().len(), 4 * PATCH_DIM);
+  assert_eq!(pre.position_embeddings().len(), 4 * EMBEDDING_DIM);
+  assert_eq!(pre.attention_mask(), &[1.0, 1.0, 1.0, 0.0]);
+}
+
+#[test]
+fn preprocessed_image_accepts_full_budget_bundle() {
+  // No pad rows — exercises the empty pad-scan edge.
+  let (px, pos, mask) = bundle(4, 4);
+  PreprocessedImage::try_new(px, pos, mask, 4).expect("full-budget bundle");
+}
+
+#[test]
+fn preprocessed_image_accepts_negative_zero_mask_pad() {
+  let (px, pos, mut mask) = bundle(4, 3);
+  mask[3] = -0.0; // IEEE `-0.0 == 0.0`: documents the accepted edge.
+  PreprocessedImage::try_new(px, pos, mask, 4).expect("negative-zero pad accepted");
+}
+
+#[test]
+fn preprocessed_image_rejects_zero_budget() {
+  match PreprocessedImage::try_new(vec![], vec![], vec![], 0) {
+    Err(Error::PreprocessedPatchBudget { max_num_patches: 0 }) => {}
+    other => panic!("expected PreprocessedPatchBudget, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_overflowing_budget() {
+  // The budget guard runs before any multiplication, so this must not
+  // panic/overflow in debug.
+  match PreprocessedImage::try_new(vec![], vec![], vec![], usize::MAX) {
+    Err(Error::PreprocessedPatchBudget { .. }) => {}
+    other => panic!("expected PreprocessedPatchBudget, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_wrong_pixel_values_length() {
+  let (mut px, pos, mask) = bundle(4, 3);
+  px.pop();
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedLength {
+      feature: "pixel_values",
+      got,
+      expected,
+    }) => {
+      assert_eq!(got, 4 * PATCH_DIM - 1);
+      assert_eq!(expected, 4 * PATCH_DIM);
+    }
+    other => panic!("expected PreprocessedLength, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_wrong_position_embeddings_length() {
+  let (px, mut pos, mask) = bundle(4, 3);
+  pos.push(0.0);
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedLength {
+      feature: "position_embeddings",
+      got,
+      expected,
+    }) => {
+      assert_eq!(got, 4 * EMBEDDING_DIM + 1);
+      assert_eq!(expected, 4 * EMBEDDING_DIM);
+    }
+    other => panic!("expected PreprocessedLength, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_wrong_mask_length() {
+  let (px, pos, _mask) = bundle(4, 3);
+  let mask = vec![0.0f32; 5]; // length 5 at budget 4
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedLength {
+      feature: "attention_mask",
+      got: 5,
+      expected: 4,
+    }) => {}
+    other => panic!("expected PreprocessedLength, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_non_finite_pixel_values() {
+  let (mut px, pos, mask) = bundle(4, 3);
+  px[10] = f32::NAN;
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedNonFinite {
+      feature: "pixel_values",
+      index: 10,
+    }) => {}
+    other => panic!("expected PreprocessedNonFinite, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_non_finite_position_embeddings() {
+  let (px, mut pos, mask) = bundle(4, 3);
+  pos[0] = f32::NEG_INFINITY;
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedNonFinite {
+      feature: "position_embeddings",
+      index: 0,
+    }) => {}
+    other => panic!("expected PreprocessedNonFinite, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_classifies_nan_mask_as_mask_value() {
+  // A NaN mask entry is a MaskValue, not NonFinite: the mask never enters the
+  // finiteness scan; its exact-binary domain check subsumes finiteness.
+  let (px, pos, mut mask) = bundle(4, 3);
+  mask[1] = f32::NAN;
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedMaskValue { index: 1, value }) => assert!(value.is_nan()),
+    other => panic!("expected PreprocessedMaskValue, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_mask_value_outside_domain() {
+  let (px, pos, mut mask) = bundle(4, 3);
+  mask[1] = 0.5;
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedMaskValue { index: 1, value }) => assert_eq!(value, 0.5),
+    other => panic!("expected PreprocessedMaskValue, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_mask_one_after_zero() {
+  // Mask `1.0` after a `0.0` — the mask check precedes the pad-row check, so the
+  // tensor content is irrelevant.
+  let (px, pos, _mask) = bundle(4, 3);
+  let mask = vec![1.0, 0.0, 1.0, 0.0];
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedMaskOrder { index: 2 }) => {}
+    other => panic!("expected PreprocessedMaskOrder, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_all_pad_mask() {
+  // All-zero tensors + all-zero mask at budget 4 (`bundle(4, 0)`).
+  let (px, pos, mask) = bundle(4, 0);
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedMaskEmpty) => {}
+    other => panic!("expected PreprocessedMaskEmpty, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_nonzero_pixel_pad_row() {
+  let (mut px, pos, mask) = bundle(4, 3);
+  px[3 * PATCH_DIM + 5] = 0.25; // a nonzero value inside the masked pad row
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedPadNonZero {
+      feature: "pixel_values",
+      index,
+    }) => assert_eq!(index, 3 * PATCH_DIM + 5),
+    other => panic!("expected PreprocessedPadNonZero, got {other:?}"),
+  }
+}
+
+#[test]
+fn preprocessed_image_rejects_nonzero_position_embedding_pad_row() {
+  let (px, mut pos, mask) = bundle(4, 3);
+  pos[3 * EMBEDDING_DIM] = 1e-3; // first element of the masked pad row
+  match PreprocessedImage::try_new(px, pos, mask, 4) {
+    Err(Error::PreprocessedPadNonZero {
+      feature: "position_embeddings",
+      index,
+    }) => assert_eq!(index, 3 * EMBEDDING_DIM),
+    other => panic!("expected PreprocessedPadNonZero, got {other:?}"),
+  }
+}
+
+#[test]
+fn check_patch_budget_accepts_equal_and_rejects_mismatch() {
+  check_patch_budget(512, 512).expect("equal budgets accepted");
+  match check_patch_budget(256, 512) {
+    Err(Error::PatchBudgetMismatch {
+      input: 256,
+      model: 512,
+    }) => {}
+    other => panic!("expected PatchBudgetMismatch, got {other:?}"),
+  }
+}
+
+#[test]
+fn internal_pipeline_output_passes_public_validation() {
+  use super::preprocess::{POS_EMBED_ELEMS, preprocess_image};
+  // The internal NaFlex pipeline's outputs must satisfy the public validator —
+  // the exact contract `embed`'s trusted `from_pipeline` path relies on.
+  let v = preprocess_image(
+    &[128u8; 8 * 8 * 3],
+    8,
+    8,
+    &vec![0.0f32; POS_EMBED_ELEMS],
+    512,
+  )
+  .expect("preprocess");
+  let real = v.grid.0 * v.grid.1;
+  let ones = v.attention_mask.iter().filter(|&&m| m == 1.0).count();
+  assert_eq!(ones, real, "mask real-count equals the resolved grid");
+  PreprocessedImage::try_new(v.pixel_values, v.position_embeddings, v.attention_mask, 512)
+    .expect("pipeline output passes public validation");
+}
+
+#[test]
+fn preprocessed_image_debug_is_compact() {
+  let (px, pos, mask) = bundle(4, 3);
+  let pre = PreprocessedImage::try_new(px, pos, mask, 4).expect("well-formed");
+  let debug = format!("{pre:?}");
+  assert!(debug.contains("max_num_patches"), "{debug}");
+  assert!(debug.contains("num_real_patches: 3"), "{debug}");
+  // Tensors are elided (`finish_non_exhaustive` renders `..`).
+  assert!(!debug.contains("pixel_values"), "{debug}");
+}

--- a/crates/coremlit/src/embeddings/siglip/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/mod.rs
@@ -28,6 +28,11 @@
 //! `pixel_values` contract at load ([`ImageEmbedder::max_num_patches`]), never a
 //! code constant, so a 256/1024 tier is a drop-in artifact.
 //!
+//! Callers who reproduce the exact NaFlex pipeline offline can bypass the
+//! in-crate preprocessing via [`ImageEmbedder::embed_preprocessed`]
+//! ([`PreprocessedImage`]); [`ImageEmbedder::preprocess`] is the pipeline's
+//! public producer, and [`ImageEmbedder::embed`] remains the safe default.
+//!
 //! # Text: single-input, full-window
 //!
 //! The SigLIP text graph takes **only** `input_ids` (`[1, T]`) — no attention
@@ -93,7 +98,9 @@ mod compute_units_serde;
 
 pub use embedding::Embedding;
 pub use error::Error;
-pub use image::{DEFAULT_IMAGE_COMPUTE, ImageEmbedder, ImageEmbedderOptions, Rgb8Image};
+pub use image::{
+  DEFAULT_IMAGE_COMPUTE, ImageEmbedder, ImageEmbedderOptions, PreprocessedImage, Rgb8Image,
+};
 pub use text::{DEFAULT_TEXT_COMPUTE, TextEmbedder, TextEmbedderOptions};
 
 /// Bytes of the bundled SigLIP 2 Gemma `tokenizer.json` compiled into the crate.

--- a/crates/coremlit/src/embeddings/siglip/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/mod.rs
@@ -1,0 +1,191 @@
+//! Native CoreML **SigLIP 2** (`siglip2-base-patch16-naflex`) inference: a NaFlex
+//! vision encoder and a Gemma-tokenized text encoder that project into a shared
+//! 768-dim joint embedding space, plus zero-shot cross-modal ranking
+//! ([`rank`]).
+//!
+//! A decoded [`Rgb8Image`] in, a unit-norm 768-d [`Embedding`] out
+//! ([`ImageEmbedder::embed`]); a `&str` in, the same [`Embedding`] out
+//! ([`TextEmbedder::embed`]). Both towers share ONE [`Embedding`] type (a single
+//! joint space), so an image and a caption are directly comparable by cosine.
+//!
+//! Design spec: `docs/superpowers/specs/2026-07-19-siglip-design.md` (GREENLIT,
+//! dual-placement, end-user-decides).
+//!
+//! macOS only (built on [`crate`]).
+//!
+//! # NaFlex: native aspect-ratio patching (no windowing)
+//!
+//! Unlike a fixed-resolution ViT, NaFlex resizes each image to an
+//! aspect-preserving grid that fills a fixed **patch budget** `P` (the shipped
+//! tier is 512), so no tiling/windowing is needed. The host-side preprocessing
+//! (the private `image::preprocess` port) is pure Rust: an aspect-preserving
+//! budget solver, an antialiased-bilinear resize, rescale+normalize, patchify
+//! into `[1, P, 768]` `pixel_values` + `[1, P]` `attention_mask`, and — the
+//! port's central step — the **position-embedding lift**: the base `16×16×768`
+//! grid is resized per image and passed as the `[1, P, 768]` `position_embeddings`
+//! input (the in-graph resize does not convert to a single static CoreML graph,
+//! so it is lifted host-side). `P` is resolved from the loaded model's
+//! `pixel_values` contract at load ([`ImageEmbedder::max_num_patches`]), never a
+//! code constant, so a 256/1024 tier is a drop-in artifact.
+//!
+//! # Text: single-input, full-window
+//!
+//! The SigLIP text graph takes **only** `input_ids` (`[1, T]`) — no attention
+//! mask (canonical SigLIP attends every position) — and pools the final
+//! position. The module builds a fixed `[1, T]` padded window whose pad id and
+//! side are semantically load-bearing and are pinned by the committed goldens.
+//! `T` is resolved from the loaded model at load ([`TextEmbedder::max_tokens`]).
+//!
+//! # Model artifacts
+//!
+//! The CoreML graphs (one fp16 artifact per tower) and the base position-grid
+//! sidecar (`pos_embed_16x16x768.f32le.bin`) are distributed on the Hugging Face
+//! Hub at `FinDIT-Studio/siglip2-naflex-coreml`, under the `512`-tier path
+//! prefix, converted from
+//! [`google/siglip2-base-patch16-naflex`](https://huggingface.co/google/siglip2-base-patch16-naflex)
+//! (**Apache-2.0**; see the crate `NOTICE`). They are gitignored dev-time
+//! downloads under `Models/siglip2-naflex/` (overridable via
+//! `SIGLIP_TEST_MODELS`); their immutable revision, per-file SHA-256, and I/O
+//! contract are pinned by `tests/siglip/model_io.rs` / `tests/siglip/text_model_io.rs`
+//! once the owner stages the conversion (the conversion runbook in the port
+//! plan).
+//!
+//! # Rust front-end around fp16 CoreML graphs
+//!
+//! Each graph emits the **pre-normalization** joint embedding; this module
+//! applies the final L2 normalization in Rust (keeping the fp16 rsqrt-guard class
+//! out of the graphs, the workspace convention).
+//!
+//! # Committed-golden oracle (no ort)
+//!
+//! Parity is scored against **committed transformers-fp32 fixtures**
+//! (`tests/siglip/fixtures/goldens/`), never a live ONNX crate — the granite "no
+//! ort anywhere, not even dev" rule. There is no `siglip-oracle` feature.
+//!
+//! # Compute placement (measured, never marketed)
+//!
+//! Placement is characterized, not asserted (`tests/siglip/placement.rs`). The
+//! per-tower defaults are **measure-then-pin** [`crate::ComputeUnits::CpuAndGpu`]
+//! (see [`DEFAULT_IMAGE_COMPUTE`] / [`DEFAULT_TEXT_COMPUTE`]): the vision graph is
+//! ~99% ANE-preferred yet its fp16-on-ANE parity is below the committed floor, so
+//! the floor-holding GPU path is the default; the text graph's ANE compile fails,
+//! so it runs on the GPU regardless. Both stay overridable per tower via
+//! `with_compute` / `set_compute`; the GPU parity is granite-class (vision
+//! 0.999959, text 0.999998).
+//!
+//! # Construct once, reuse, prewarm
+//!
+//! Construct each embedder once and **reuse** it: it loads its CoreML model at
+//! construction and runs `&self` inference (no per-call load). Call
+//! [`ImageEmbedder::prewarm`] / [`TextEmbedder::prewarm`] once after construction
+//! and before serving to absorb the first-inference graph specialization, so the
+//! first real request is warm.
+
+pub mod embedding;
+pub mod error;
+pub mod image;
+pub mod text;
+
+#[cfg(feature = "serde")]
+mod compute_units_serde;
+
+pub use embedding::Embedding;
+pub use error::Error;
+pub use image::{DEFAULT_IMAGE_COMPUTE, ImageEmbedder, ImageEmbedderOptions, Rgb8Image};
+pub use text::{DEFAULT_TEXT_COMPUTE, TextEmbedder, TextEmbedderOptions};
+
+/// Bytes of the bundled SigLIP 2 Gemma `tokenizer.json` compiled into the crate.
+///
+/// This is the tokenizer from the source model repo
+/// [`google/siglip2-base-patch16-naflex`](https://huggingface.co/google/siglip2-base-patch16-naflex),
+/// the exact revision that produces the committed token-id goldens (proven
+/// byte-correct by `tests/siglip/tokenizer_identity.rs`). Exposed for callers who
+/// construct [`TextEmbedder`] via [`TextEmbedder::from_memory`]; the
+/// [`TextEmbedder::load`] / [`TextEmbedder::from_file`] constructors use it
+/// directly.
+///
+/// NOTE: the committed `assets/tokenizer.json` is a small **placeholder** until
+/// the owner stages the source-revision Gemma bytes (the golden-generation step
+/// of the port plan); the SHA / identity pin in `tests/siglip/tokenizer_identity.rs`
+/// is what forces the real artifact in.
+pub const BUNDLED_TOKENIZER: &[u8] = include_bytes!("assets/tokenizer.json");
+
+/// A candidate paired with its precomputed [`Embedding`] — the input unit to
+/// [`rank`]. Borrowing keeps ranking allocation-free and lets the label flow
+/// straight into the returned [`Ranked`].
+#[derive(Debug, Clone, Copy)]
+pub struct Candidate<'a> {
+  label: &'a str,
+  embedding: &'a Embedding,
+}
+
+impl<'a> Candidate<'a> {
+  /// Pair `label` with its precomputed embedding (an image's or a text's — both
+  /// towers share the joint space).
+  pub const fn new(label: &'a str, embedding: &'a Embedding) -> Self {
+    Self { label, embedding }
+  }
+
+  /// The candidate label.
+  #[inline]
+  pub const fn label(&self) -> &'a str {
+    self.label
+  }
+
+  /// The candidate's precomputed embedding.
+  #[inline]
+  pub const fn embedding(&self) -> &'a Embedding {
+    self.embedding
+  }
+}
+
+/// One ranked candidate, borrowing its label from the [`Candidate`] it came
+/// from, scored by cosine against the query.
+#[derive(Debug, Clone, Copy)]
+pub struct Ranked<'a> {
+  label: &'a str,
+  score: f32,
+}
+
+impl<'a> Ranked<'a> {
+  /// The ranked label.
+  #[inline]
+  pub const fn label(&self) -> &'a str {
+    self.label
+  }
+
+  /// The cosine score against the query, in roughly `[-1, 1]`.
+  #[inline]
+  pub const fn score(&self) -> f32 {
+    self.score
+  }
+}
+
+/// Rank `candidates` against a `query` [`Embedding`] by cosine, descending.
+///
+/// Cross-modal: the `query` can be an image and the `candidates` texts (zero-shot
+/// classification / retrieval), or vice versa — both towers share the joint
+/// space. The score is the raw cosine (v1 ships cosine/rank only; the checkpoint's
+/// `logit_scale`/`logit_bias` sigmoid scoring is recorded in the artifact
+/// metadata for a future `score()`). Ties keep input order (the sort is stable);
+/// an empty `candidates` yields an empty vec.
+#[must_use]
+pub fn rank<'a>(query: &Embedding, candidates: &[Candidate<'a>]) -> Vec<Ranked<'a>> {
+  let mut out: Vec<Ranked<'a>> = candidates
+    .iter()
+    .map(|c| Ranked {
+      label: c.label(),
+      score: query.cosine(c.embedding()),
+    })
+    .collect();
+  // Descending by score; `sort_by` is stable, so ties keep input order.
+  out.sort_by(|x, y| {
+    y.score
+      .partial_cmp(&x.score)
+      .unwrap_or(std::cmp::Ordering::Equal)
+  });
+  out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coremlit/src/embeddings/siglip/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/mod.rs
@@ -32,9 +32,11 @@
 //!
 //! The SigLIP text graph takes **only** `input_ids` (`[1, T]`) — no attention
 //! mask (canonical SigLIP attends every position) — and pools the final
-//! position. The module builds a fixed `[1, T]` padded window whose pad id and
-//! side are semantically load-bearing and are pinned by the committed goldens.
-//! `T` is resolved from the loaded model at load ([`TextEmbedder::max_tokens`]).
+//! position. Text is lowercased before tokenization (SigLIP2 convention;
+//! checkpoint `do_lower_case: true`; mirrors transformers `Siglip2Tokenizer`).
+//! The module builds a fixed `[1, T]` padded window whose pad id and side are
+//! semantically load-bearing and are pinned by the committed goldens. `T` is
+//! resolved from the loaded model at load ([`TextEmbedder::max_tokens`]).
 //!
 //! # Model artifacts
 //!
@@ -107,7 +109,10 @@ pub use text::{DEFAULT_TEXT_COMPUTE, TextEmbedder, TextEmbedderOptions};
 /// NOTE: the committed `assets/tokenizer.json` is a small **placeholder** until
 /// the owner stages the source-revision Gemma bytes (the golden-generation step
 /// of the port plan); the SHA / identity pin in `tests/siglip/tokenizer_identity.rs`
-/// is what forces the real artifact in.
+/// is what forces the real artifact in, and [`TextEmbedder::load`] /
+/// [`TextEmbedder::from_memory`] fail closed on it
+/// ([`Error::TokenizerPlaceholder`]) so it can never silently produce
+/// meaningless embeddings.
 pub const BUNDLED_TOKENIZER: &[u8] = include_bytes!("assets/tokenizer.json");
 
 /// A candidate paired with its precomputed [`Embedding`] — the input unit to

--- a/crates/coremlit/src/embeddings/siglip/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/tests.rs
@@ -1,0 +1,78 @@
+use super::*;
+use crate::embeddings::siglip::embedding::EMBEDDING_DIM;
+
+/// A unit embedding with all mass on component `i`.
+fn axis(i: usize) -> Embedding {
+  let mut s = [0.0f32; EMBEDDING_DIM];
+  s[i] = 1.0;
+  Embedding::from_slice_normalizing(&s).expect("unit")
+}
+
+/// A unit embedding blended between axes 0 and 1 (weight `w` on axis 0).
+fn blend(w: f32) -> Embedding {
+  let mut s = [0.0f32; EMBEDDING_DIM];
+  s[0] = w;
+  s[1] = 1.0 - w;
+  Embedding::from_slice_normalizing(&s).expect("unit")
+}
+
+#[test]
+fn rank_orders_by_cosine_descending() {
+  let query = axis(0);
+  let near = blend(0.9); // close to axis 0
+  let mid = blend(0.5);
+  let far = axis(1); // orthogonal to the query
+  let candidates = [
+    Candidate::new("far", &far),
+    Candidate::new("near", &near),
+    Candidate::new("mid", &mid),
+  ];
+  let ranked = rank(&query, &candidates);
+  assert_eq!(
+    ranked.iter().map(Ranked::label).collect::<Vec<_>>(),
+    vec!["near", "mid", "far"]
+  );
+  // Scores are descending and are the query↔candidate cosines.
+  assert!(ranked[0].score() >= ranked[1].score());
+  assert!(ranked[1].score() >= ranked[2].score());
+  assert!((ranked[0].score() - query.cosine(&near)).abs() <= 1e-6);
+}
+
+#[test]
+fn rank_is_stable_on_ties() {
+  let query = axis(0);
+  let a = blend(0.7);
+  let b = blend(0.7); // identical score to `a`
+  let candidates = [Candidate::new("a", &a), Candidate::new("b", &b)];
+  let ranked = rank(&query, &candidates);
+  // Equal scores keep input order (stable sort).
+  assert_eq!(
+    ranked.iter().map(Ranked::label).collect::<Vec<_>>(),
+    vec!["a", "b"]
+  );
+}
+
+#[test]
+fn rank_empty_candidates_is_empty() {
+  let query = axis(0);
+  assert!(rank(&query, &[]).is_empty());
+}
+
+#[test]
+fn rank_query_matches_its_identical_candidate_top1() {
+  // Cross-modal shape: a "text" query ranks its matching "image" first.
+  let image_a = blend(0.8);
+  let image_b = blend(0.2);
+  let query = blend(0.8); // identical to image_a
+  let candidates = [
+    Candidate::new("image_b", &image_b),
+    Candidate::new("image_a", &image_a),
+  ];
+  let ranked = rank(&query, &candidates);
+  assert_eq!(
+    ranked[0].label(),
+    "image_a",
+    "identical embedding ranks top-1"
+  );
+  assert!((ranked[0].score() - 1.0).abs() <= 1e-5, "self-cosine ≈ 1");
+}

--- a/crates/coremlit/src/embeddings/siglip/text/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/text/mod.rs
@@ -1,6 +1,9 @@
 //! The siglip [`TextEmbedder`]: the bundled Gemma tokenizer around the fp16
 //! CoreML text graph, with L2 normalization applied in Rust.
 //!
+//! Text is lowercased before tokenization (the SigLIP2 training convention;
+//! checkpoint `do_lower_case: true`), mirroring transformers `Siglip2Tokenizer`.
+//!
 //! Unlike `granite`/`clap`, the SigLIP text graph takes **only** `input_ids`
 //! (`[1, T]` int32) — the processor emits no attention mask (canonical SigLIP
 //! attends all `T` positions) and the tower pools the final position. Because
@@ -12,7 +15,10 @@
 use std::path::Path;
 
 use crate::{ComputeUnits, DataType, Model, ModelDescription, MultiArray};
-use tokenizers::{Tokenizer, TruncationDirection, TruncationParams, TruncationStrategy};
+use tokenizers::{
+  Tokenizer, TruncationDirection, TruncationParams, TruncationStrategy,
+  normalizers::{Lowercase, NormalizerWrapper, Sequence as NormalizerSequence},
+};
 
 use crate::embeddings::siglip::{
   embedding::{EMBEDDING_DIM, Embedding, check_finite_output},
@@ -25,6 +31,32 @@ use crate::embeddings::siglip::{
 mod names {
   pub const INPUT_IDS: &str = "input_ids";
   pub const TEXT_FEATURES: &str = "text_features";
+}
+
+/// Sentinel embedded in the Wave-A placeholder `assets/tokenizer.json`; the real
+/// source-revision Gemma artifact cannot contain it. Kept after Wave B as a
+/// regression guard against re-committing the placeholder.
+const PLACEHOLDER_SENTINEL: &[u8] =
+  b"PLACEHOLDER_REPLACE_WITH_SOURCE_REVISION_GEMMA_TOKENIZER_IN_WAVE_B";
+
+/// Fails closed if `bytes` is the build-time placeholder tokenizer, whose vocab
+/// maps every ordinary word to `<pad>` (so embedding with it would silently
+/// yield meaningless vectors). Called before any tokenizer parse or model load
+/// so the failure is deterministic and hermetically testable.
+///
+/// # Errors
+/// [`Error::TokenizerPlaceholder`] if `bytes` carries the placeholder sentinel.
+fn ensure_not_placeholder(bytes: &[u8]) -> Result<()> {
+  // The real Gemma artifact is tens of MB; only a small file can be the
+  // placeholder, so the scan is skipped once the real bytes are staged.
+  if bytes.len() < 1_000_000
+    && bytes
+      .windows(PLACEHOLDER_SENTINEL.len())
+      .any(|w| w == PLACEHOLDER_SENTINEL)
+  {
+    return Err(Error::TokenizerPlaceholder);
+  }
+  Ok(())
 }
 
 /// Default [`TextEmbedderOptions::compute`]: [`ComputeUnits::CpuAndGpu`] — the
@@ -114,7 +146,8 @@ pub(crate) enum PadSide {
 /// siglip text embedder: a `&str` in, a unit-norm 768-d [`Embedding`] out — the
 /// same joint-space [`Embedding`] the image tower emits.
 ///
-/// Tokenizes with the bundled Gemma tokenizer (truncation `LongestFirst` at the
+/// Lowercases the text (SigLIP2 convention; checkpoint `do_lower_case: true`),
+/// tokenizes with the bundled Gemma tokenizer (truncation `LongestFirst` at the
 /// resolved window `T`, the tokenizer's own padding disabled), builds the fixed
 /// `[1, T]` padded window (side/id per D6), runs the single-input fp16 CoreML
 /// graph, and L2-normalizes the pre-normalization projection.
@@ -141,8 +174,11 @@ impl TextEmbedder {
   /// validates the I/O contract against the metadata at load.
   ///
   /// # Errors
-  /// As [`Self::from_files`] (with the bundled tokenizer bytes).
+  /// [`Error::TokenizerPlaceholder`] if the bundled `tokenizer.json` is still the
+  /// build-time placeholder (fails closed before any I/O); otherwise as
+  /// [`Self::from_files`] (with the bundled tokenizer bytes).
   pub fn load(model_path: impl AsRef<Path>, options: TextEmbedderOptions) -> Result<Self> {
+    ensure_not_placeholder(crate::embeddings::siglip::BUNDLED_TOKENIZER)?;
     let tokenizer = Tokenizer::from_bytes(crate::embeddings::siglip::BUNDLED_TOKENIZER)
       .map_err(Error::TokenizerLoad)?;
     Self::from_parts(model_path, tokenizer, options)
@@ -157,7 +193,10 @@ impl TextEmbedder {
     Self::load(model_path, TextEmbedderOptions::new())
   }
 
-  /// Loads the model and a `tokenizer.json` from separate file paths.
+  /// Loads the model and a `tokenizer.json` from separate file paths. The
+  /// caller-supplied file is deliberately NOT placeholder-checked — a
+  /// caller-chosen tokenizer is the caller's contract; the placeholder ships
+  /// only as the bundled bytes that [`Self::load`] / [`Self::from_memory`] guard.
   ///
   /// # Errors
   /// [`Error::Load`] if CoreML rejects the model / [`Error::ContractMismatch`]
@@ -177,12 +216,15 @@ impl TextEmbedder {
   /// Loads the model from a path and the tokenizer from caller-supplied bytes.
   ///
   /// # Errors
-  /// As [`Self::from_files`].
+  /// [`Error::TokenizerPlaceholder`] if `tokenizer_json_bytes` is the build-time
+  /// placeholder (e.g. the current [`crate::embeddings::siglip::BUNDLED_TOKENIZER`];
+  /// fails closed before any I/O); otherwise as [`Self::from_files`].
   pub fn from_memory(
     model_path: impl AsRef<Path>,
     tokenizer_json_bytes: &[u8],
     options: TextEmbedderOptions,
   ) -> Result<Self> {
+    ensure_not_placeholder(tokenizer_json_bytes)?;
     let tokenizer = Tokenizer::from_bytes(tokenizer_json_bytes).map_err(Error::TokenizerLoad)?;
     Self::from_parts(model_path, tokenizer, options)
   }
@@ -215,10 +257,10 @@ impl TextEmbedder {
     self.max_tokens
   }
 
-  /// The fixed `[T]` **padded** `input_ids` window for `text` (post-truncation,
-  /// then padded to `T` on the pinned side with the pad id) — the exact sequence
-  /// fed to the graph, and the one the Wave B token-identity gate compares
-  /// byte-for-byte against the committed goldens.
+  /// The fixed `[T]` **padded** `input_ids` window for `text` (lowercased, then
+  /// post-truncation, then padded to `T` on the pinned side with the pad id) —
+  /// the exact sequence fed to the graph, and the one the Wave B token-identity
+  /// gate compares byte-for-byte against the committed goldens.
   ///
   /// This deliberately differs from `granite::token_ids` (which returns the
   /// UNPADDED ids): SigLIP attends every position and pools the final one, so the
@@ -345,13 +387,29 @@ fn resolve_text_window(description: &ModelDescription) -> Result<usize> {
   Ok(t)
 }
 
-/// Overrides the loaded tokenizer's truncation and padding policy to this
-/// module's fixed-window contract: `LongestFirst` truncation at `max_tokens`,
+/// Overrides the loaded tokenizer's normalization, truncation, and padding
+/// policy to this module's fixed-window contract: a `Lowercase` normalizer
+/// composed ahead of the loaded one, `LongestFirst` truncation at `max_tokens`,
 /// stride 0, right direction (the export window is a hard model constraint), and
 /// the tokenizer's own padding DISABLED — the module builds its own padded
 /// window in [`build_window`] on the pinned side (D6), so an inherited padding
 /// policy must not leak into the ids.
 fn configure_tokenizer(tokenizer: &mut Tokenizer, max_tokens: usize) -> Result<()> {
+  // SigLIP2 lowercases text before tokenization (checkpoint tokenizer_config
+  // `do_lower_case: true`; transformers `Siglip2Tokenizer` composes
+  // `normalizers.Lowercase()` ahead of the loaded tokenizer.json normalizer).
+  // `Lowercase` here IS the same Rust implementation the Python reference calls.
+  // Unlike upstream's defensive `is not None` guard, the composition applies
+  // even when the loaded file carries no normalizer — the lowercase contract is
+  // the module's, not the file's. Special/added tokens are matched before
+  // normalization, so this cannot corrupt them.
+  let lowercased: NormalizerWrapper = match tokenizer.get_normalizer() {
+    Some(existing) => NormalizerSequence::new(vec![Lowercase.into(), existing.clone()]).into(),
+    None => Lowercase.into(),
+  };
+  tokenizer
+    .with_normalizer(Some(lowercased))
+    .map_err(Error::TokenizerConfig)?;
   tokenizer
     .with_truncation(Some(TruncationParams {
       max_length: max_tokens,

--- a/crates/coremlit/src/embeddings/siglip/text/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/text/mod.rs
@@ -1,0 +1,422 @@
+//! The siglip [`TextEmbedder`]: the bundled Gemma tokenizer around the fp16
+//! CoreML text graph, with L2 normalization applied in Rust.
+//!
+//! Unlike `granite`/`clap`, the SigLIP text graph takes **only** `input_ids`
+//! (`[1, T]` int32) — the processor emits no attention mask (canonical SigLIP
+//! attends all `T` positions) and the tower pools the final position. Because
+//! every position is attended and the pooled token is positional, the pad id AND
+//! pad side are semantically load-bearing (D6); the built window is compared
+//! byte-for-byte against the committed goldens by the Wave B token-identity gate,
+//! which pins them empirically.
+
+use std::path::Path;
+
+use crate::{ComputeUnits, DataType, Model, ModelDescription, MultiArray};
+use tokenizers::{Tokenizer, TruncationDirection, TruncationParams, TruncationStrategy};
+
+use crate::embeddings::siglip::{
+  embedding::{EMBEDDING_DIM, Embedding, check_finite_output},
+  error::{Error, Result},
+};
+
+/// Declared feature names on the siglip text `.mlmodelc` (pinned by
+/// `tests/siglip/text_model_io.rs`). There is deliberately no `attention_mask`
+/// — the graph has a single input.
+mod names {
+  pub const INPUT_IDS: &str = "input_ids";
+  pub const TEXT_FEATURES: &str = "text_features";
+}
+
+/// Default [`TextEmbedderOptions::compute`]: [`ComputeUnits::CpuAndGpu`] — the
+/// measured floor-holding placement.
+///
+/// The conversion probe measured the text tower's whole-graph ANE compile as
+/// **failing** (`ANECCompile() FAILED`), so CoreML runs it on the GPU regardless;
+/// forcing [`ComputeUnits::CpuAndNeuralEngine`] is **7–10× slower** (58.5 ms vs
+/// 6.0 ms at batch 1) as it re-attempts the failing compile on every load. On the
+/// GPU the fp16 parity is granite-class (**0.999998**). `CpuAndGpu` pins the
+/// floor-holding GPU path and skips the ANE-dispatch cost (mirroring `clap`'s
+/// measure-then-pin `text` default). Every unit stays selectable via
+/// [`TextEmbedderOptions::with_compute`] / [`TextEmbedderOptions::set_compute`];
+/// placement is characterized, not asserted (`tests/siglip/placement.rs`).
+pub const DEFAULT_TEXT_COMPUTE: ComputeUnits = ComputeUnits::CpuAndGpu;
+
+#[cfg(feature = "serde")]
+fn default_text_compute() -> ComputeUnits {
+  DEFAULT_TEXT_COMPUTE
+}
+
+/// Construction options for [`TextEmbedder`] (rust-options-pattern): a single
+/// `compute` knob with one source of truth shared by `const new`/`Default`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TextEmbedderOptions {
+  #[cfg_attr(
+    feature = "serde",
+    serde(
+      default = "default_text_compute",
+      with = "crate::embeddings::siglip::compute_units_serde"
+    )
+  )]
+  compute: ComputeUnits,
+}
+
+impl Default for TextEmbedderOptions {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl TextEmbedderOptions {
+  /// Options matching the module default: [`DEFAULT_TEXT_COMPUTE`].
+  pub const fn new() -> Self {
+    Self {
+      compute: DEFAULT_TEXT_COMPUTE,
+    }
+  }
+
+  /// Which hardware CoreML may schedule the text graph on.
+  #[inline]
+  pub const fn compute(&self) -> ComputeUnits {
+    self.compute
+  }
+
+  /// Builder form of [`Self::set_compute`].
+  #[must_use]
+  #[inline]
+  pub const fn with_compute(mut self, compute: ComputeUnits) -> Self {
+    self.set_compute(compute);
+    self
+  }
+
+  /// Sets [`Self::compute`] in place.
+  #[inline]
+  pub const fn set_compute(&mut self, compute: ComputeUnits) -> &mut Self {
+    self.compute = compute;
+    self
+  }
+}
+
+/// Which side of the fixed window the padding occupies. SigLIP's final-position
+/// pooling makes this semantically load-bearing (D6); the concrete value is
+/// pinned empirically by the Wave B token-identity goldens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PadSide {
+  /// Real tokens occupy the prefix; pads fill the suffix.
+  Right,
+  /// Pads fill the prefix; real tokens occupy the suffix. Reserved for the
+  /// Wave B pinned convention (production currently pads [`PadSide::Right`]);
+  /// exercised by the hermetic `build_window` tests.
+  #[allow(dead_code)]
+  Left,
+}
+
+/// siglip text embedder: a `&str` in, a unit-norm 768-d [`Embedding`] out — the
+/// same joint-space [`Embedding`] the image tower emits.
+///
+/// Tokenizes with the bundled Gemma tokenizer (truncation `LongestFirst` at the
+/// resolved window `T`, the tokenizer's own padding disabled), builds the fixed
+/// `[1, T]` padded window (side/id per D6), runs the single-input fp16 CoreML
+/// graph, and L2-normalizes the pre-normalization projection.
+#[derive(Debug)]
+pub struct TextEmbedder {
+  model: Model,
+  tokenizer: Tokenizer,
+  /// Padding token id for the fixed-length window. SigLIP attends every position
+  /// and pools the final one, so this is semantically load-bearing (D6);
+  /// resolved from the tokenizer's `<pad>` at load, else `0`. Pinned by the
+  /// Wave B token-identity goldens.
+  pad_id: i32,
+  /// Padding side for the fixed-length window (D6). Provisionally [`PadSide::Right`];
+  /// pinned by the Wave B token-identity goldens.
+  pad_side: PadSide,
+  /// The text window length `T` resolved from the loaded model's `input_ids [1,
+  /// T]` contract (D2 — never a code constant).
+  max_tokens: usize,
+}
+
+impl TextEmbedder {
+  /// Loads the text `.mlmodelc` from `model_path` with the bundled tokenizer and
+  /// custom `options` — the primary constructor. Resolves the window `T` and
+  /// validates the I/O contract against the metadata at load.
+  ///
+  /// # Errors
+  /// As [`Self::from_files`] (with the bundled tokenizer bytes).
+  pub fn load(model_path: impl AsRef<Path>, options: TextEmbedderOptions) -> Result<Self> {
+    let tokenizer = Tokenizer::from_bytes(crate::embeddings::siglip::BUNDLED_TOKENIZER)
+      .map_err(Error::TokenizerLoad)?;
+    Self::from_parts(model_path, tokenizer, options)
+  }
+
+  /// Loads the text `.mlmodelc` from `model_path` using the bundled tokenizer and
+  /// [`TextEmbedderOptions::new`].
+  ///
+  /// # Errors
+  /// As [`Self::from_files`].
+  pub fn from_file(model_path: impl AsRef<Path>) -> Result<Self> {
+    Self::load(model_path, TextEmbedderOptions::new())
+  }
+
+  /// Loads the model and a `tokenizer.json` from separate file paths.
+  ///
+  /// # Errors
+  /// [`Error::Load`] if CoreML rejects the model / [`Error::ContractMismatch`]
+  /// if its I/O contract mismatches; [`Error::TokenizerLoad`] if the tokenizer
+  /// JSON is unreadable/invalid; [`Error::TokenizerConfig`] if truncation cannot
+  /// be configured.
+  pub fn from_files(
+    model_path: impl AsRef<Path>,
+    tokenizer_json_path: impl AsRef<Path>,
+    options: TextEmbedderOptions,
+  ) -> Result<Self> {
+    let tokenizer =
+      Tokenizer::from_file(tokenizer_json_path.as_ref()).map_err(Error::TokenizerLoad)?;
+    Self::from_parts(model_path, tokenizer, options)
+  }
+
+  /// Loads the model from a path and the tokenizer from caller-supplied bytes.
+  ///
+  /// # Errors
+  /// As [`Self::from_files`].
+  pub fn from_memory(
+    model_path: impl AsRef<Path>,
+    tokenizer_json_bytes: &[u8],
+    options: TextEmbedderOptions,
+  ) -> Result<Self> {
+    let tokenizer = Tokenizer::from_bytes(tokenizer_json_bytes).map_err(Error::TokenizerLoad)?;
+    Self::from_parts(model_path, tokenizer, options)
+  }
+
+  fn from_parts(
+    model_path: impl AsRef<Path>,
+    mut tokenizer: Tokenizer,
+    options: TextEmbedderOptions,
+  ) -> Result<Self> {
+    let model = Model::load(model_path, options.compute())?;
+    let max_tokens = resolve_text_window(model.description())?;
+    configure_tokenizer(&mut tokenizer, max_tokens)?;
+    let pad_id = tokenizer
+      .token_to_id("<pad>")
+      .and_then(|id| i32::try_from(id).ok())
+      .unwrap_or(0);
+    Ok(Self {
+      model,
+      tokenizer,
+      pad_id,
+      pad_side: PadSide::Right,
+      max_tokens,
+    })
+  }
+
+  /// The text window length `T` this model was converted at — resolved from the
+  /// loaded `input_ids [1, T]` contract (D2), not a code constant.
+  #[inline]
+  pub const fn max_tokens(&self) -> usize {
+    self.max_tokens
+  }
+
+  /// The fixed `[T]` **padded** `input_ids` window for `text` (post-truncation,
+  /// then padded to `T` on the pinned side with the pad id) — the exact sequence
+  /// fed to the graph, and the one the Wave B token-identity gate compares
+  /// byte-for-byte against the committed goldens.
+  ///
+  /// This deliberately differs from `granite::token_ids` (which returns the
+  /// UNPADDED ids): SigLIP attends every position and pools the final one, so the
+  /// pad positions are part of the semantic input and belong in the window (D6).
+  ///
+  /// # Errors
+  /// [`Error::EmptyText`] if `text` is empty; [`Error::Tokenize`] on a tokenizer
+  /// failure; [`Error::TokenCount`] if the tokenized input exceeds the window
+  /// (defensive — truncation caps it); [`Error::TokenIdRange`] if a token id is
+  /// out of `int32` range.
+  pub fn token_ids(&self, text: &str) -> Result<Vec<i32>> {
+    if text.is_empty() {
+      return Err(Error::EmptyText);
+    }
+    let encoding = self.tokenizer.encode(text, true).map_err(Error::Tokenize)?;
+    build_window(
+      encoding.get_ids(),
+      self.pad_id,
+      self.pad_side,
+      self.max_tokens,
+    )
+  }
+
+  /// Embeds one text into a unit-norm [`Embedding`].
+  ///
+  /// # Errors
+  /// [`Error::EmptyText`] if `text` is empty; [`Error::Tokenize`] on a tokenizer
+  /// failure; [`Error::TokenCount`] / [`Error::TokenIdRange`] on a window guard;
+  /// [`Error::Tensor`] / [`Error::Prediction`] on a tensor or CoreML failure;
+  /// [`Error::OutputShape`] if the predicted `text_features` shape diverges from
+  /// `[1, `[`EMBEDDING_DIM`]`]`; [`Error::NonFiniteOutput`] if the model output
+  /// has a NaN/infinite component — model corruption, classified apart from a
+  /// caller's own non-finite embedding data ([`Error::NonFiniteEmbedding`]);
+  /// [`Error::EmbeddingZero`] if the (finite) projection has zero magnitude.
+  pub fn embed(&self, text: &str) -> Result<Embedding> {
+    let ids = self.token_ids(text)?;
+    let ids_tensor = MultiArray::from_slice(&[1, self.max_tokens], &ids)?;
+    // Single input: no attention_mask (the SigLIP text graph has none).
+    let mut outputs = self
+      .model
+      .predict_with(&[(names::INPUT_IDS, &ids_tensor)])?;
+    let feats =
+      outputs
+        .take(names::TEXT_FEATURES)
+        .ok_or_else(|| crate::PredictionError::MissingOutput {
+          name: names::TEXT_FEATURES.to_string(),
+        })?;
+    if feats.shape() != [1, EMBEDDING_DIM] {
+      return Err(Error::OutputShape {
+        got: feats.shape().to_vec(),
+        expected: vec![1, EMBEDDING_DIM],
+      });
+    }
+
+    let mut row = [0.0f32; EMBEDDING_DIM];
+    feats.copy_into::<f32>(&mut row)?;
+    // Classify a NaN/∞ the CoreML runtime produced as model-output corruption
+    // (`NonFiniteOutput`) before it reaches `from_slice_normalizing`.
+    check_finite_output(&row)?;
+    Embedding::from_slice_normalizing(&row)
+  }
+
+  /// Runs one throwaway [`Self::embed`] to fully specialize the prediction path,
+  /// so the first user-facing request is warm. Construction pays the model load;
+  /// this pays the first prediction's graph specialization. Then **reuse** this
+  /// same embedder for every request (it is `&self`).
+  ///
+  /// # Errors
+  /// As [`Self::embed`] (the warm-up query is a fixed non-empty string, so the
+  /// empty-text path cannot fire); a failure surfaces a broken model at prewarm
+  /// time rather than on the first request.
+  pub fn prewarm(&self) -> Result<()> {
+    self.embed("warmup")?;
+    Ok(())
+  }
+}
+
+/// Resolves the text window `T` from the loaded model's `input_ids [1, T]`
+/// contract (D2) and validates the `text_features [1, 768]` output. The
+/// exact-input-SET assertion (that `input_ids` is the ONLY input — no
+/// `attention_mask`) is the Wave C `tests/siglip/text_model_io.rs` gate.
+fn resolve_text_window(description: &ModelDescription) -> Result<usize> {
+  let ids_expected = "[1, T] int32";
+  let input = description
+    .input(names::INPUT_IDS)
+    .ok_or_else(|| Error::ContractMismatch {
+      feature: names::INPUT_IDS,
+      expected: ids_expected.to_string(),
+      actual: "missing".to_string(),
+    })?;
+  let shape = input.shape();
+  if shape.len() != 2 || shape[0] != 1 || input.data_type() != Some(DataType::I32) {
+    return Err(Error::ContractMismatch {
+      feature: names::INPUT_IDS,
+      expected: ids_expected.to_string(),
+      actual: describe(shape, input.data_type()),
+    });
+  }
+  let t = shape[1];
+  if t == 0 {
+    return Err(Error::ContractMismatch {
+      feature: names::INPUT_IDS,
+      expected: ids_expected.to_string(),
+      actual: describe(shape, input.data_type()),
+    });
+  }
+
+  let out_expected = format!("[1, {EMBEDDING_DIM}] float32");
+  let output = description
+    .output(names::TEXT_FEATURES)
+    .ok_or_else(|| Error::ContractMismatch {
+      feature: names::TEXT_FEATURES,
+      expected: out_expected.clone(),
+      actual: "missing".to_string(),
+    })?;
+  if output.shape() != [1, EMBEDDING_DIM] || output.data_type() != Some(DataType::F32) {
+    return Err(Error::ContractMismatch {
+      feature: names::TEXT_FEATURES,
+      expected: out_expected,
+      actual: describe(output.shape(), output.data_type()),
+    });
+  }
+
+  Ok(t)
+}
+
+/// Overrides the loaded tokenizer's truncation and padding policy to this
+/// module's fixed-window contract: `LongestFirst` truncation at `max_tokens`,
+/// stride 0, right direction (the export window is a hard model constraint), and
+/// the tokenizer's own padding DISABLED — the module builds its own padded
+/// window in [`build_window`] on the pinned side (D6), so an inherited padding
+/// policy must not leak into the ids.
+fn configure_tokenizer(tokenizer: &mut Tokenizer, max_tokens: usize) -> Result<()> {
+  tokenizer
+    .with_truncation(Some(TruncationParams {
+      max_length: max_tokens,
+      strategy: TruncationStrategy::LongestFirst,
+      stride: 0,
+      direction: TruncationDirection::Right,
+    }))
+    .map_err(Error::TokenizerConfig)?;
+  tokenizer.with_padding(None);
+  Ok(())
+}
+
+/// Builds the fixed `[max_tokens]` padded `input_ids` window from the real token
+/// `ids`: the real tokens occupy the prefix (`Right` pad) or suffix (`Left` pad),
+/// and the remainder is filled with `pad_id`. Returns the full padded window (D6
+/// — SigLIP attends and pools over pads, so they are part of the input).
+///
+/// [`configure_tokenizer`] forces truncation and disables the tokenizer's own
+/// padding, so `ids` is already within the window; this still returns a typed
+/// [`Error`] rather than panicking should that contract be violated.
+///
+/// # Errors
+/// [`Error::TokenCount`] if `ids` exceeds `max_tokens`; [`Error::TokenIdRange`]
+/// if a token id does not fit the model's `int32` `input_ids` tensor.
+fn build_window(
+  ids: &[u32],
+  pad_id: i32,
+  pad_side: PadSide,
+  max_tokens: usize,
+) -> Result<Vec<i32>> {
+  if ids.len() > max_tokens {
+    return Err(Error::TokenCount {
+      got: ids.len(),
+      max: max_tokens,
+    });
+  }
+  let mut window = vec![pad_id; max_tokens];
+  let offset = match pad_side {
+    PadSide::Right => 0,
+    PadSide::Left => max_tokens - ids.len(),
+  };
+  for (i, &id) in ids.iter().enumerate() {
+    window[offset + i] = i32::try_from(id).map_err(|_| Error::TokenIdRange { id })?;
+  }
+  Ok(window)
+}
+
+/// Test-only seam: the module's actual tokenizer configuration, without loading
+/// a CoreML model — so `tests` can exercise the real tokenization path
+/// hermetically with a caller-supplied tokenizer and window `T`.
+#[cfg(test)]
+pub(crate) fn configured_tokenizer_from_bytes(
+  bytes: &[u8],
+  max_tokens: usize,
+) -> Result<Tokenizer> {
+  let mut tokenizer = Tokenizer::from_bytes(bytes).map_err(Error::TokenizerLoad)?;
+  configure_tokenizer(&mut tokenizer, max_tokens)?;
+  Ok(tokenizer)
+}
+
+/// Human-readable `shape dtype` rendering for [`Error::ContractMismatch`].
+fn describe(shape: &[usize], dtype: Option<DataType>) -> String {
+  let dtype = dtype.map_or("none", |d| d.as_str());
+  format!("{shape:?} {dtype}")
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coremlit/src/embeddings/siglip/text/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/text/tests.rs
@@ -144,3 +144,123 @@ fn configured_tokenizer_truncates_to_window_and_disables_padding() {
   let window = build_window(&short, 0, PadSide::Right, max_tokens).expect("window");
   assert_eq!(window, vec![1i32, 2, 0, 0]);
 }
+
+// ── E1: fail-closed placeholder tokenizer ─────────────────────────────────────
+
+/// `load` and `from_memory` reject the shipping placeholder `tokenizer.json`
+/// with [`Error::TokenizerPlaceholder`] BEFORE any I/O — a nonexistent model
+/// path proves the guard fires ahead of `Model::load` (else the error would be
+/// [`Error::Load`]).
+///
+/// Wave B note: when the real Gemma bytes replace the placeholder,
+/// `ensure_not_placeholder(BUNDLED_TOKENIZER)` becomes `Ok` and both
+/// constructors proceed to `Error::Load` on the nonexistent path — this test's
+/// two assertions flip accordingly (tracked in the port plan's Wave B flip list).
+#[test]
+fn load_and_from_memory_fail_closed_on_placeholder() {
+  let bundled = crate::embeddings::siglip::BUNDLED_TOKENIZER;
+  match TextEmbedder::load("/nonexistent/model.mlmodelc", TextEmbedderOptions::new()) {
+    Err(Error::TokenizerPlaceholder) => {}
+    other => panic!("expected TokenizerPlaceholder from load, got {other:?}"),
+  }
+  match TextEmbedder::from_memory(
+    "/nonexistent/model.mlmodelc",
+    bundled,
+    TextEmbedderOptions::new(),
+  ) {
+    Err(Error::TokenizerPlaceholder) => {}
+    other => panic!("expected TokenizerPlaceholder from from_memory, got {other:?}"),
+  }
+}
+
+/// The guard is a placeholder sentinel scan, not a blanket reject: a small
+/// non-placeholder tokenizer (the length fast-path is an optimization, not a
+/// semantic) passes.
+#[test]
+fn placeholder_guard_accepts_real_tokenizer_bytes() {
+  assert!(ensure_not_placeholder(TINY_TOKENIZER.as_bytes()).is_ok());
+}
+
+// ── E2: lowercase composition (mixed-case oracles) ────────────────────────────
+
+/// A tiny WordLevel tokenizer whose vocab carries BOTH a lowercase and an
+/// uppercase entry for the same letter — proves the composed `Lowercase`
+/// normalizer runs before the model lookup (the uppercase id is never chosen).
+const CASE_COLLISION_TOKENIZER: &str = r#"{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [],
+  "normalizer": null,
+  "pre_tokenizer": { "type": "Whitespace" },
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "WordLevel",
+    "vocab": { "<pad>": 0, "a": 1, "b": 2, "A": 6 },
+    "unk_token": "<pad>"
+  }
+}"#;
+
+/// A tiny WordLevel tokenizer carrying its OWN `Replace` normalizer (`x` → `a`).
+/// Composing `Lowercase` AHEAD of it turns `X` into `x` into `a`; composing it
+/// AFTER would leave `X` unmatched — so the encoded id discriminates the order.
+const REPLACE_NORMALIZER_TOKENIZER: &str = r#"{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [],
+  "normalizer": { "type": "Replace", "pattern": { "String": "x" }, "content": "a" },
+  "pre_tokenizer": { "type": "Whitespace" },
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "WordLevel",
+    "vocab": { "<pad>": 0, "a": 1, "b": 2 },
+    "unk_token": "<pad>"
+  }
+}"#;
+
+/// The configured tokenizer lowercases before the model lookup: mixed-case
+/// `"A B"` encodes to the lowercase ids `[1, 2]`. Non-vacuity: `TINY_TOKENIZER`
+/// carries NO normalizer, so without the composition `A`/`B` are out-of-vocab
+/// and fall to the `<pad>` unk (`[0, 0]`) — the mixed-case oracle is sharp.
+/// (Covers the `None`-normalizer arm of the composition.)
+#[test]
+fn configured_tokenizer_lowercases_before_lookup() {
+  let tok =
+    configured_tokenizer_from_bytes(TINY_TOKENIZER.as_bytes(), 8).expect("configure tokenizer");
+  let ids = tok.encode("A B", false).expect("encode").get_ids().to_vec();
+  assert_eq!(
+    ids,
+    vec![1u32, 2],
+    "mixed case must lowercase to [a, b] ids"
+  );
+}
+
+/// With both `"a"` and `"A"` in the vocab, `"A"` still resolves to the lowercase
+/// id `1` (never the uppercase `6`) — the normalizer runs before the lookup.
+#[test]
+fn configured_tokenizer_prefers_lowercase_vocab_entry() {
+  let tok = configured_tokenizer_from_bytes(CASE_COLLISION_TOKENIZER.as_bytes(), 8)
+    .expect("configure tokenizer");
+  let ids = tok.encode("A", false).expect("encode").get_ids().to_vec();
+  assert_eq!(ids, vec![1u32], "must pick the lowercase entry, not id 6");
+}
+
+/// `Lowercase` is composed AHEAD of the loaded normalizer, and the loaded
+/// normalizer is preserved (not clobbered): `"X b"` lowercases to `"x b"`, then
+/// the loaded `Replace` maps `x` → `a`, giving `[1, 2]`. Composed the other way,
+/// `X` never reaches `Replace` and would fall to unk `[0, 2]` — so this pins the
+/// ordering.
+#[test]
+fn configured_tokenizer_composes_ahead_of_existing_normalizer() {
+  let tok = configured_tokenizer_from_bytes(REPLACE_NORMALIZER_TOKENIZER.as_bytes(), 8)
+    .expect("configure tokenizer");
+  let ids = tok.encode("X b", false).expect("encode").get_ids().to_vec();
+  assert_eq!(
+    ids,
+    vec![1u32, 2],
+    "Lowercase must run before the loaded Replace normalizer"
+  );
+}

--- a/crates/coremlit/src/embeddings/siglip/text/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/text/tests.rs
@@ -1,0 +1,146 @@
+use super::*;
+
+// ── A4: options ──────────────────────────────────────────────────────────────
+
+#[test]
+fn options_default_equals_new_and_is_cpu_and_gpu() {
+  assert_eq!(TextEmbedderOptions::default(), TextEmbedderOptions::new());
+  assert_eq!(TextEmbedderOptions::new().compute(), DEFAULT_TEXT_COMPUTE);
+  assert_eq!(DEFAULT_TEXT_COMPUTE, ComputeUnits::CpuAndGpu);
+}
+
+#[test]
+fn options_with_and_set_compute() {
+  let opts = TextEmbedderOptions::new().with_compute(ComputeUnits::CpuAndNeuralEngine);
+  assert_eq!(opts.compute(), ComputeUnits::CpuAndNeuralEngine);
+  let mut opts = TextEmbedderOptions::new();
+  opts.set_compute(ComputeUnits::CpuOnly);
+  assert_eq!(opts.compute(), ComputeUnits::CpuOnly);
+}
+
+#[test]
+fn describe_renders_shape_and_dtype() {
+  assert_eq!(describe(&[1, 64], Some(DataType::I32)), "[1, 64] int32");
+  assert_eq!(describe(&[1, 768], None), "[1, 768] none");
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn options_serde_roundtrip() {
+  let opts = TextEmbedderOptions::new().with_compute(ComputeUnits::All);
+  let json = serde_json::to_string(&opts).unwrap();
+  assert!(json.contains("all"), "serialized: {json}");
+  let back: TextEmbedderOptions = serde_json::from_str(&json).unwrap();
+  assert_eq!(back, opts);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn options_serde_defaults_missing_compute() {
+  let back: TextEmbedderOptions = serde_json::from_str("{}").unwrap();
+  assert_eq!(back, TextEmbedderOptions::new());
+}
+
+// ── A10/A11: build_window (hermetic; the fixed padded-window contract) ────────
+
+const T: usize = 64;
+
+#[test]
+fn build_window_right_pad_places_prefix_and_pads_suffix() {
+  let ids = [10u32, 20, 30];
+  let w = build_window(&ids, 7, PadSide::Right, T).expect("window");
+  assert_eq!(w.len(), T);
+  assert_eq!(&w[..3], &[10i32, 20, 30]);
+  assert!(w[3..].iter().all(|&x| x == 7), "suffix must be pad_id");
+}
+
+#[test]
+fn build_window_left_pad_places_suffix_and_pads_prefix() {
+  let ids = [10u32, 20, 30];
+  let w = build_window(&ids, 7, PadSide::Left, T).expect("window");
+  assert_eq!(w.len(), T);
+  assert!(w[..T - 3].iter().all(|&x| x == 7), "prefix must be pad_id");
+  assert_eq!(&w[T - 3..], &[10i32, 20, 30]);
+}
+
+#[test]
+fn build_window_full_window_has_no_pad() {
+  let ids: Vec<u32> = (0..T as u32).collect();
+  let w_right = build_window(&ids, 7, PadSide::Right, T).expect("full window");
+  let w_left = build_window(&ids, 7, PadSide::Left, T).expect("full window");
+  // A full window is identical regardless of pad side (no pad positions).
+  let expected: Vec<i32> = (0..T as i32).collect();
+  assert_eq!(w_right, expected);
+  assert_eq!(w_left, expected);
+}
+
+#[test]
+fn build_window_rejects_overlong_ids_with_typed_error() {
+  let overlong = vec![1u32; T + 1];
+  match build_window(&overlong, 0, PadSide::Right, T) {
+    Err(Error::TokenCount { got, max }) => {
+      assert_eq!(got, T + 1);
+      assert_eq!(max, T);
+    }
+    other => panic!("expected TokenCount, got {other:?}"),
+  }
+}
+
+#[test]
+fn build_window_rejects_out_of_range_token_id() {
+  match build_window(&[u32::MAX], 0, PadSide::Right, T) {
+    Err(Error::TokenIdRange { id }) => assert_eq!(id, u32::MAX),
+    other => panic!("expected TokenIdRange, got {other:?}"),
+  }
+}
+
+// ── A11: tokenizer seam (hermetic; a caller-supplied synthetic tokenizer) ─────
+
+/// A minimal valid WordLevel `tokenizer.json` — enough to exercise the module's
+/// truncation/padding configuration seam without the (Wave-B-staged) bundled
+/// Gemma tokenizer.
+const TINY_TOKENIZER: &str = r#"{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [],
+  "normalizer": null,
+  "pre_tokenizer": { "type": "Whitespace" },
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "WordLevel",
+    "vocab": { "<pad>": 0, "a": 1, "b": 2, "c": 3, "d": 4, "e": 5 },
+    "unk_token": "<pad>"
+  }
+}"#;
+
+/// The configured tokenizer seam applies this module's truncation (`LongestFirst`
+/// at the resolved `T`) and disables the tokenizer's own padding — so an
+/// over-length input truncates to exactly `T` real ids (which `build_window`
+/// then pads), regardless of what policy the tokenizer carried.
+#[test]
+fn configured_tokenizer_truncates_to_window_and_disables_padding() {
+  let max_tokens = 4;
+  let tok = configured_tokenizer_from_bytes(TINY_TOKENIZER.as_bytes(), max_tokens)
+    .expect("configure tiny tokenizer");
+  // 8 whitespace tokens; truncation must cap the encoding at 4.
+  let ids = tok
+    .encode("a b c d e a b c", false)
+    .expect("encode")
+    .get_ids()
+    .to_vec();
+  assert_eq!(ids.len(), max_tokens, "must truncate to the window");
+  // Padding disabled: a short input is NOT padded by the tokenizer (the module
+  // owns the fixed-window pad).
+  let short = tok.encode("a b", false).expect("encode").get_ids().to_vec();
+  assert_eq!(
+    short,
+    vec![1u32, 2],
+    "short input stays unpadded by the tokenizer"
+  );
+
+  // The module then pads the short ids into the fixed window.
+  let window = build_window(&short, 0, PadSide::Right, max_tokens).expect("window");
+  assert_eq!(window, vec![1i32, 2, 0, 0]);
+}

--- a/crates/coremlit/tests/feature_map.rs
+++ b/crates/coremlit/tests/feature_map.rs
@@ -77,6 +77,7 @@ fn expected_features() -> Vec<(&'static str, Vec<&'static str>)> {
       "granite",
       vec!["dep:tokenizers", "dep:windit", "windit/text"],
     ),
+    ("siglip", vec!["dep:tokenizers"]),
   ]
 }
 
@@ -110,8 +111,9 @@ const INTENDED_CI_COMBOS: &[&str] = &[
   "clap",
   "clap-oracle",
   "granite",
-  "whisper,align,speaker,vad,clap,granite,serde,tracing,nl-recognizer",
-  "whisper,align-oracle,speaker-oracle,vad-bundled,clap-oracle,granite,serde,tracing,nl-recognizer",
+  "siglip",
+  "whisper,align,speaker,vad,clap,granite,siglip,serde,tracing,nl-recognizer",
+  "whisper,align-oracle,speaker-oracle,vad-bundled,clap-oracle,granite,siglip,serde,tracing,nl-recognizer",
 ];
 
 /// The text of the `[features]` table (its lines, blank/comment lines included).
@@ -409,8 +411,9 @@ const DOCTORED_MATRIX: &str = r#"
           - "clap"
           - "clap-oracle"
           - "granite"
-          - "whisper,align,speaker,vad,clap,granite,serde,tracing,nl-recognizer"
-          - "whisper,align-oracle,speaker-oracle,vad-bundled,clap-oracle,granite,serde,tracing,nl-recognizer"
+          - "siglip"
+          - "whisper,align,speaker,vad,clap,granite,siglip,serde,tracing,nl-recognizer"
+          - "whisper,align-oracle,speaker-oracle,vad-bundled,clap-oracle,granite,siglip,serde,tracing,nl-recognizer"
     steps:
       - uses: actions/checkout@v7
 "#;

--- a/crates/coremlit/tests/siglip/common/mod.rs
+++ b/crates/coremlit/tests/siglip/common/mod.rs
@@ -1,0 +1,280 @@
+//! Shared helpers for the siglip embedding tests.
+//!
+//! Two data sources, kept distinct:
+//!
+//! - **Committed goldens** (`tests/siglip/fixtures/goldens/`) — the in-tree
+//!   transformers-fp32 oracle (per-image + per-text unit-normalized embeddings,
+//!   the padded token windows, and small preprocessing oracles) plus the CC0
+//!   corpus PNGs. Read hermetically; no model, no network. Staged by the port
+//!   plan's golden-generation step (Wave B).
+//! - **CoreML artifacts** (`siglip2_vision_512.mlmodelc`, `siglip2_text_64.mlmodelc`,
+//!   and `pos_embed_16x16x768.f32le.bin`) — gitignored dev-time downloads from
+//!   `FinDIT-Studio/siglip2-naflex-coreml` under `Models/siglip2-naflex/`
+//!   (overridable via `SIGLIP_TEST_MODELS`). Model-gated tests are `#[ignore]` by
+//!   default and run only when the owner stages the conversion (Wave C).
+
+use std::path::{Path, PathBuf};
+
+/// The HF revision (commit SHA) of `FinDIT-Studio/siglip2-naflex-coreml` the
+/// model artifacts and their per-file SHA-256 pins are recorded at. Pinned by
+/// the conversion runbook's upload step (Wave C / U2); a placeholder until then.
+#[allow(dead_code)]
+pub const SIGLIP_REVISION: &str = "<pending conversion upload (Wave C / runbook U2)>";
+
+/// Directory containing the downloaded siglip CoreML artifact tree.
+///
+/// Overridable via `SIGLIP_TEST_MODELS`; otherwise
+/// `<workspace>/Models/siglip2-naflex` — gitignored, fetched dev-time (mirrors
+/// the `EMBEDKIT_TEST_MODELS` / `CLAPKIT_TEST_MODELS` conventions).
+#[allow(dead_code)]
+pub fn models_dir() -> PathBuf {
+  std::env::var_os("SIGLIP_TEST_MODELS").map_or_else(
+    || {
+      PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("Models")
+        .join("siglip2-naflex")
+    },
+    PathBuf::from,
+  )
+}
+
+/// The 512-tier bundle's parent directory
+/// (`.../siglip2-base-patch16-naflex-512`), which holds the `.mlmodelc` bundles,
+/// the pos-emb sidecar, and `CHECKSUMS.sha256`.
+#[allow(dead_code)]
+pub fn model_root() -> PathBuf {
+  models_dir().join("siglip2-base-patch16-naflex-512")
+}
+
+/// Path to the compiled vision encoder, `siglip2_vision_512.mlmodelc`.
+#[allow(dead_code)]
+pub fn vision_model_path() -> PathBuf {
+  model_root().join("siglip2_vision_512.mlmodelc")
+}
+
+/// Path to the compiled text encoder, `siglip2_text_64.mlmodelc`.
+#[allow(dead_code)]
+pub fn text_model_path() -> PathBuf {
+  model_root().join("siglip2_text_64.mlmodelc")
+}
+
+/// Path to the base position-grid sidecar, `pos_embed_16x16x768.f32le.bin`.
+#[allow(dead_code)]
+pub fn pos_embed_path() -> PathBuf {
+  model_root().join("pos_embed_16x16x768.f32le.bin")
+}
+
+/// Absolute path to a committed fixture under `crates/coremlit/tests/siglip/fixtures`.
+#[allow(dead_code)]
+pub fn fixture_path(relative: &str) -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    .join("tests")
+    .join("siglip")
+    .join("fixtures")
+    .join(relative)
+}
+
+/// One committed golden IMAGE entry: geometry, the measured `spatial_shapes`
+/// grid, its matched caption id, and the transformers-fp32 **unit-normalized**
+/// 768-d embedding.
+#[derive(Debug, serde::Deserialize)]
+#[allow(dead_code)]
+pub struct ImageGolden {
+  /// Stable per-entry id.
+  pub id: String,
+  /// Corpus-relative PNG path (`images/<id>.png`).
+  pub file: String,
+  /// Source URL (provenance).
+  pub source: String,
+  /// Redistributable license (CC0 / public-domain / owner-authored).
+  pub license: String,
+  /// Decoded image width in pixels.
+  pub width: usize,
+  /// Decoded image height in pixels.
+  pub height: usize,
+  /// The measured `(grid_h, grid_w)` patch grid at the 512 budget.
+  pub spatial_shapes: [usize; 2],
+  /// The matched caption's `TextGolden::id`.
+  pub caption_id: String,
+  /// The transformers-fp32 unit-normalized 768-d image embedding.
+  pub embedding: Vec<f32>,
+}
+
+/// One committed golden TEXT entry: the raw text, the EXACT padded `[T]` token
+/// window (side/id load-bearing, D6), the real-token count, and the
+/// transformers-fp32 **unit-normalized** 768-d embedding.
+#[derive(Debug, serde::Deserialize)]
+#[allow(dead_code)]
+pub struct TextGolden {
+  /// Stable per-entry id.
+  pub id: String,
+  /// The raw input string.
+  pub text: String,
+  /// The processor's EXACT padded token window (length `T`).
+  pub token_ids_padded: Vec<i32>,
+  /// Real (non-pad) token count.
+  pub n_real: usize,
+  /// The transformers-fp32 unit-normalized 768-d text embedding.
+  pub embedding: Vec<f32>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[allow(dead_code)]
+struct Corpus {
+  images: Vec<ImageGolden>,
+  texts: Vec<TextGolden>,
+}
+
+/// Load the committed golden corpus (images + texts). Hermetic — reads the
+/// in-tree fixture, never `Models/`. (Staged by Wave B; until then the fixture
+/// is absent and only the model-gated / goldens-gated tests that call this are
+/// affected — they are `#[ignore]`d.)
+#[allow(dead_code)]
+pub fn golden_corpus() -> (Vec<ImageGolden>, Vec<TextGolden>) {
+  let path = fixture_path("goldens/corpus.json");
+  let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+  let corpus: Corpus =
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+  (corpus.images, corpus.texts)
+}
+
+/// Lowercase-hex SHA-256 of a byte slice.
+#[allow(dead_code)]
+pub fn sha256_hex(bytes: &[u8]) -> String {
+  use sha2::{Digest, Sha256};
+  Sha256::digest(bytes)
+    .iter()
+    .map(|b| format!("{b:02x}"))
+    .collect()
+}
+
+/// Lowercase-hex SHA-256 of a file's contents.
+#[allow(dead_code)]
+pub fn sha256_file(path: &Path) -> String {
+  let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+  sha256_hex(&bytes)
+}
+
+/// Cosine of two equal-length finite vectors — FAIL-CLOSED (the #30 lesson):
+/// panics on a length mismatch or any non-finite component rather than returning
+/// a silently-wrong scalar.
+#[allow(dead_code)]
+pub fn cosine_checked(a: &[f32], b: &[f32]) -> f32 {
+  assert_eq!(a.len(), b.len(), "cosine operands differ in length");
+  assert!(!a.is_empty(), "cosine of empty vectors is undefined");
+  let mut dot = 0.0f64;
+  let mut na = 0.0f64;
+  let mut nb = 0.0f64;
+  for (i, (&x, &y)) in a.iter().zip(b.iter()).enumerate() {
+    assert!(x.is_finite(), "left operand non-finite at {i}");
+    assert!(y.is_finite(), "right operand non-finite at {i}");
+    dot += (x as f64) * (y as f64);
+    na += (x as f64) * (x as f64);
+    nb += (y as f64) * (y as f64);
+  }
+  assert!(na > 0.0 && nb > 0.0, "cosine of a zero vector is undefined");
+  (dot / (na.sqrt() * nb.sqrt())) as f32
+}
+
+/// Recursively collects the forward-slash relative path of every FILE under
+/// `dir` into `out`. Pure path enumeration — hermetically testable without real
+/// model bytes. OS-generated sidecars (AppleDouble `._*`, `.DS_Store`) are
+/// skipped: CoreML's loader never reads them, so excluding them cannot mask a
+/// functional change, whereas keeping them would false-fail the exact-set gate.
+#[allow(dead_code)]
+pub fn collect_files_rel(dir: &Path, prefix: &str, out: &mut Vec<String>) {
+  let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {dir:?}: {e}"));
+  for entry in entries {
+    let entry = entry.unwrap_or_else(|e| panic!("dir entry under {dir:?}: {e}"));
+    let name = entry.file_name().to_string_lossy().into_owned();
+    if name.starts_with("._") || name == ".DS_Store" {
+      continue;
+    }
+    let rel = if prefix.is_empty() {
+      name
+    } else {
+      format!("{prefix}/{name}")
+    };
+    let file_type = entry
+      .file_type()
+      .unwrap_or_else(|e| panic!("file_type {:?}: {e}", entry.path()));
+    if file_type.is_dir() {
+      collect_files_rel(&entry.path(), &rel, out);
+    } else {
+      out.push(rel);
+    }
+  }
+}
+
+/// Assert that the compiled-model bundle at `dir` matches an EXACT pinned
+/// manifest (`(relative_path, sha256)` list): the discovered file set must EQUAL
+/// the pinned key set (so a missing OR an added artifact both red), and each
+/// file's SHA-256 must equal its pinned value. `std`-only recursive walk;
+/// forward-slash relative keys.
+#[allow(dead_code)]
+pub fn assert_exact_sha_manifest(dir: &Path, cases: &[(&str, &str)]) {
+  use std::collections::BTreeSet;
+
+  let mut found = Vec::new();
+  collect_files_rel(dir, "", &mut found);
+  let on_disk: BTreeSet<String> = found.into_iter().collect();
+  let pinned: BTreeSet<String> = cases.iter().map(|(rel, _)| (*rel).to_owned()).collect();
+
+  if on_disk != pinned {
+    let missing: Vec<&String> = pinned.difference(&on_disk).collect();
+    let extra: Vec<&String> = on_disk.difference(&pinned).collect();
+    panic!(
+      "artifact manifest mismatch under {dir:?}:\n  \
+       missing (pinned but not on disk): {missing:?}\n  \
+       extra (on disk but not pinned): {extra:?}\n  \
+       if the bundle changed intentionally, update the pinned `cases` list AND \
+       the doc SHA table"
+    );
+  }
+
+  for (relative, expected) in cases {
+    let actual = sha256_file(&dir.join(relative));
+    assert_eq!(
+      &actual, expected,
+      "sha256 drift on artifact {relative} under {dir:?}"
+    );
+  }
+}
+
+/// Decode a committed corpus PNG to interleaved RGB8 `(bytes, width, height)`
+/// via the `png` dev-dep — the sans-I/O crate takes decoded RGB, so decoding is
+/// the test's job. Accepts 8-bit RGB or RGBA (alpha dropped).
+#[allow(dead_code)]
+pub fn decode_png_rgb8(path: &Path) -> (Vec<u8>, usize, usize) {
+  let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {path:?}: {e}"));
+  let mut reader = png::Decoder::new(file)
+    .read_info()
+    .unwrap_or_else(|e| panic!("read png header {path:?}: {e}"));
+  let mut buf = vec![0u8; reader.output_buffer_size()];
+  let info = reader
+    .next_frame(&mut buf)
+    .unwrap_or_else(|e| panic!("decode png {path:?}: {e}"));
+  assert_eq!(
+    info.bit_depth,
+    png::BitDepth::Eight,
+    "corpus PNGs must be 8-bit ({path:?})"
+  );
+  let (w, h) = (info.width as usize, info.height as usize);
+  let rgb: Vec<u8> = match info.color_type {
+    png::ColorType::Rgb => buf[..info.buffer_size()].to_vec(),
+    png::ColorType::Rgba => buf[..info.buffer_size()]
+      .as_chunks::<4>()
+      .0
+      .iter()
+      .flat_map(|p| [p[0], p[1], p[2]])
+      .collect(),
+    other => panic!("unsupported PNG color type {other:?} for {path:?} (need RGB/RGBA)"),
+  };
+  assert_eq!(
+    rgb.len(),
+    w * h * 3,
+    "decoded RGB length mismatch for {path:?}"
+  );
+  (rgb, w, h)
+}

--- a/crates/coremlit/tests/siglip/e2e.rs
+++ b/crates/coremlit/tests/siglip/e2e.rs
@@ -1,0 +1,29 @@
+//! End-to-end cross-modal ranking + prewarm smoke.
+//!
+//! # Status: Wave C shell (model-gated)
+//!
+//! `#[ignore]`d until the conversion is staged (`SIGLIP_TEST_MODELS`) and the
+//! corpus committed (Wave B). Wave C loads both towers (defaults), embeds every
+//! corpus image + caption, and asserts each caption ranks its own image top-1
+//! (via `siglip::rank`, GPU arm), exercises `prewarm`, and one `from_memory`
+//! construction path.
+
+mod common;
+
+use coremlit::embeddings::siglip::{ImageEmbedder, TextEmbedder};
+
+/// Each caption ranks its matched image top-1 (cross-modal retrieval), on the
+/// default `CpuAndGpu` arm. Wave C implements against the staged models + corpus.
+#[test]
+#[ignore = "requires staged siglip models + committed corpus — Wave C"]
+fn each_caption_ranks_its_image_top1() {
+  let image = ImageEmbedder::from_files(common::vision_model_path(), common::pos_embed_path())
+    .expect("load vision");
+  let text = TextEmbedder::from_file(common::text_model_path()).expect("load text");
+  image.prewarm().expect("prewarm vision");
+  text.prewarm().expect("prewarm text");
+  let (_images, _texts) = common::golden_corpus();
+  // Wave C: embed corpus images (decode_png_rgb8 → Rgb8Image → image.embed) and
+  //         captions (text.embed), then siglip::rank each caption over the images
+  //         and assert its matched image is top-1.
+}

--- a/crates/coremlit/tests/siglip/e2e.rs
+++ b/crates/coremlit/tests/siglip/e2e.rs
@@ -27,3 +27,30 @@ fn each_caption_ranks_its_image_top1() {
   //         captions (text.embed), then siglip::rank each caption over the images
   //         and assert its matched image is top-1.
 }
+
+/// `embed(img)` and `embed_preprocessed(preprocess(img))` agree: `embed` routes
+/// through `embed_preprocessed` by construction, so the two calls feed
+/// byte-identical tensors to CoreML and the tolerance only absorbs run-to-run
+/// prediction jitter (tighten toward 0.0 if Wave C measures bit-stability on
+/// the pinned GPU arm). Also round-trips the pipeline's bundle through the
+/// public validator at the model's real budget.
+#[test]
+#[ignore = "requires staged siglip models + committed corpus — Wave C"]
+fn embed_preprocessed_matches_embed_identity() {
+  let _embedder = ImageEmbedder::from_files(common::vision_model_path(), common::pos_embed_path())
+    .expect("load vision");
+  // Wave C: decode one corpus PNG → Rgb8Image `img`, then:
+  //   let a = embedder.embed(img).expect("embed");
+  //   let pre = embedder.preprocess(img).expect("preprocess");
+  //   let b = embedder.embed_preprocessed(&pre).expect("embed_preprocessed");
+  //   assert!(a.is_close(&b, 1e-6));
+  //   assert!(
+  //     PreprocessedImage::try_new(
+  //       pre.pixel_values().to_vec(),
+  //       pre.position_embeddings().to_vec(),
+  //       pre.attention_mask().to_vec(),
+  //       embedder.max_num_patches(),
+  //     )
+  //     .is_ok()
+  //   );
+}

--- a/crates/coremlit/tests/siglip/model_io.rs
+++ b/crates/coremlit/tests/siglip/model_io.rs
@@ -1,0 +1,117 @@
+//! Ground-truth introspection + provenance pins for the siglip VISION artifact
+//! `siglip2_vision_512.mlmodelc` and the base position-grid sidecar.
+//!
+//! # Status: Wave C shell (model-gated)
+//!
+//! The I/O + exact-SHA gates below are `#[ignore]`d until the owner stages the
+//! conversion under `Models/siglip2-naflex/` (`SIGLIP_TEST_MODELS`) per the port
+//! plan's conversion runbook, at which point the pinned SHA manifest
+//! (`ARTIFACT_SHA256`, the sidecar SHA) is filled from `CHECKSUMS.sha256` at the
+//! recorded revision. The contract mirrors the plan's §0 table:
+//! `pixel_values` f32 `[1, P, 768]` + `position_embeddings` f32 `[1, P, 768]` +
+//! `attention_mask` f32 `[1, P]` → `image_features` f32 `[1, 768]`.
+//!
+//! The sidecar-filter non-vacuity test IS hermetic (no model) and runs now.
+
+mod common;
+
+use std::collections::BTreeSet;
+
+use coremlit::{ComputeUnits, DataType, Model, embeddings::siglip::embedding::EMBEDDING_DIM};
+
+/// Vision `.mlmodelc` per-file SHA-256, EXACTLY enumerated (the #30 pattern).
+/// Pinned from `CHECKSUMS.sha256` at `common::SIGLIP_REVISION` — filled when the
+/// conversion is staged (Wave C).
+const ARTIFACT_SHA256: &[(&str, &str)] = &[
+  // ("coremldata.bin", "<sha256 — Wave C>"),
+  // ("model.mil", "<sha256 — Wave C>"),
+  // ("weights/weight.bin", "<sha256 — Wave C>"),
+];
+
+/// Vision graph I/O contract (§0): resolves `P` from `pixel_values [1, P, 768]`
+/// and cross-checks `position_embeddings`, `attention_mask`, and the exact input
+/// SET against it. Wave C: extend with the exact-SHA manifest.
+#[test]
+#[ignore = "requires staged siglip vision model (SIGLIP_TEST_MODELS) — Wave C"]
+fn vision_io_matches_spec() {
+  let model = Model::load(common::vision_model_path(), ComputeUnits::CpuOnly).unwrap();
+  let d = model.description();
+
+  let pv = d.input("pixel_values").expect("pixel_values input");
+  assert_eq!(pv.shape()[0], 1, "pixel_values batch");
+  assert_eq!(pv.shape()[2], 768, "pixel_values patch_dim = 3·16·16");
+  assert_eq!(pv.data_type(), Some(DataType::F32));
+  let p = pv.shape()[1];
+  assert!(p >= 1, "resolved patch budget P must be positive");
+
+  let pe = d
+    .input("position_embeddings")
+    .expect("position_embeddings input");
+  assert_eq!(pe.shape(), &[1, p, EMBEDDING_DIM]);
+  assert_eq!(pe.data_type(), Some(DataType::F32));
+
+  let mask = d.input("attention_mask").expect("attention_mask input");
+  assert_eq!(mask.shape(), &[1, p]);
+  // Note: the NaFlex mask input is f32 (not int32) — the §0 contract.
+  assert_eq!(mask.data_type(), Some(DataType::F32));
+
+  let input_names: BTreeSet<&str> = d.inputs().iter().map(|f| f.name()).collect();
+  assert_eq!(
+    input_names,
+    BTreeSet::from(["pixel_values", "position_embeddings", "attention_mask"]),
+    "vision must declare exactly these three inputs"
+  );
+
+  let out = d.output("image_features").expect("image_features output");
+  assert_eq!(out.shape(), &[1, EMBEDDING_DIM]);
+  assert_eq!(out.data_type(), Some(DataType::F32));
+}
+
+/// Exact-SHA manifest for the vision bundle + the pos-emb sidecar. Wave C fills
+/// `ARTIFACT_SHA256` and the sidecar SHA from `CHECKSUMS.sha256`.
+#[test]
+#[ignore = "requires staged siglip vision model (SIGLIP_TEST_MODELS) — Wave C"]
+fn vision_artifact_bytes_match_pinned_sha256() {
+  common::assert_exact_sha_manifest(&common::vision_model_path(), ARTIFACT_SHA256);
+  // Wave C: pin the pos-emb sidecar SHA (common::sha256_file(&common::pos_embed_path())).
+}
+
+/// Hermetic non-vacuity proof for [`common::collect_files_rel`]'s sidecar filter
+/// (no staged model needed): AppleDouble `._*` / `.DS_Store` are dropped at every
+/// depth, while a real unpinned extra still surfaces to the exact-set gate.
+#[test]
+fn collect_files_rel_skips_sidecars_but_surfaces_real_extras() {
+  let tmp = tempfile::tempdir().expect("temp dir");
+  let bundle = tmp.path().join("siglip2_vision_512.mlmodelc");
+  std::fs::create_dir_all(bundle.join("weights")).expect("mkdir weights");
+
+  std::fs::write(bundle.join("model.mil"), b"mil").expect("write model.mil");
+  std::fs::write(bundle.join("weights/weight.bin"), b"w").expect("write weight.bin");
+  std::fs::write(bundle.join("._model.mil"), b"ad").expect("write ._model.mil");
+  std::fs::write(bundle.join(".DS_Store"), b"ds").expect("write .DS_Store");
+  std::fs::write(bundle.join("weights/._weight.bin"), b"ad").expect("write nested ._");
+  std::fs::write(bundle.join("rogue.bin"), b"x").expect("write rogue.bin");
+
+  let mut found = Vec::new();
+  common::collect_files_rel(&bundle, "", &mut found);
+  let discovered: BTreeSet<String> = found.into_iter().collect();
+
+  assert_eq!(
+    discovered,
+    BTreeSet::from([
+      "model.mil".to_string(),
+      "rogue.bin".to_string(),
+      "weights/weight.bin".to_string(),
+    ]),
+    "discovery must exclude `._*`/.DS_Store sidecars and keep every real file"
+  );
+
+  let pinned: BTreeSet<String> =
+    BTreeSet::from(["model.mil".to_string(), "weights/weight.bin".to_string()]);
+  let extras: Vec<String> = discovered.difference(&pinned).cloned().collect();
+  assert_eq!(
+    extras,
+    vec!["rogue.bin".to_string()],
+    "a real unpinned extra must still surface (not be blanket-suppressed)"
+  );
+}

--- a/crates/coremlit/tests/siglip/parity_embed.rs
+++ b/crates/coremlit/tests/siglip/parity_embed.rs
@@ -1,0 +1,33 @@
+//! The siglip parity SHIP GATE — CoreML embeddings vs the committed
+//! transformers-fp32 goldens, per compute unit.
+//!
+//! # Status: Wave C shell (model-gated)
+//!
+//! `#[ignore]`d until the owner stages the conversion (`SIGLIP_TEST_MODELS`) and
+//! the committed goldens (Wave B). Wave C measures on this machine and pins the
+//! bands (§7): the `CpuAndGpu` arm is THE GATE (floor never below 0.99917;
+//! expected pin ≈ 0.9998 — probe worst 0.999959 vision / 0.999998 text), with the
+//! ANE / CpuOnly arms CHARACTERIZED (not floor-gated — the ANE misses the floor
+//! by design). Non-vacuity mutations: zeroed `position_embeddings` (proves the
+//! pos-emb lift is load-bearing), mask off-by-one, rotated output slice.
+
+mod common;
+
+/// The `CpuAndGpu` GATE: worst-corpus cosine vs the fp32 goldens holds the floor.
+/// Wave C measures and pins the two-sided band.
+#[test]
+#[ignore = "requires staged siglip models + committed goldens — Wave C"]
+fn cpu_and_gpu_arm_holds_the_parity_floor() {
+  let (_images, _texts) = common::golden_corpus();
+  // Wave C: embed each corpus image/text on CpuAndGpu, cosine vs golden
+  //         (common::cosine_checked), assert worst >= pinned floor (>= 0.99917).
+}
+
+/// Non-vacuity: zeroing `position_embeddings` (the port's central novel step)
+/// must collapse vision parity far below the floor. Wave C implements the
+/// raw-pipeline mutation harness.
+#[test]
+#[ignore = "requires staged siglip models + committed goldens — Wave C"]
+fn zeroed_position_embeddings_break_the_gate() {
+  // Wave C: prove the pos-emb lift is load-bearing.
+}

--- a/crates/coremlit/tests/siglip/placement.rs
+++ b/crates/coremlit/tests/siglip/placement.rs
@@ -1,0 +1,31 @@
+//! Compute-placement characterization (measured, never marketed).
+//!
+//! # Status: Wave C shell (model-gated)
+//!
+//! `#[ignore]`d until the conversion is staged (`SIGLIP_TEST_MODELS`). Wave C
+//! records, per tower × `{CpuOnly, CpuAndGpu, CpuAndNeuralEngine, All}`, the
+//! cross-unit cosine vs the `CpuAndGpu` reference and vs the goldens (§7 arm
+//! table). The `All` arm closes D1: record which device the planner picks for
+//! vision under `All`; if it is GPU-identical and floor-holding the owner may
+//! flip [`DEFAULT_IMAGE_COMPUTE`] to `All` — with the measurement in hand.
+
+mod common;
+
+use coremlit::ComputeUnits;
+
+/// Characterize each placement arm's agreement with the `CpuAndGpu` reference
+/// (and the goldens). Wave C measures and records the bands.
+#[test]
+#[ignore = "requires staged siglip models (SIGLIP_TEST_MODELS) — Wave C"]
+fn placement_arms_are_characterized() {
+  let _dir = common::model_root();
+  for _unit in [
+    ComputeUnits::CpuOnly,
+    ComputeUnits::CpuAndGpu,
+    ComputeUnits::CpuAndNeuralEngine,
+    ComputeUnits::All,
+  ] {
+    // Wave C: embed the corpus per unit, record cosine vs the CpuAndGpu reference
+    //         and vs the goldens; note the `All`-arm vision dispatch device (D1).
+  }
+}

--- a/crates/coremlit/tests/siglip/preprocess.rs
+++ b/crates/coremlit/tests/siglip/preprocess.rs
@@ -36,5 +36,11 @@ fn full_tensor_parity_against_staged_npy() {
   let _dir = common::models_dir();
   // Wave C: for each corpus image, decode PNG (common::decode_png_rgb8), run the
   //         ImageEmbedder preprocessing, compare pixel_values/mask/pos-emb to the
-  //         staged `.npy`; exact mask equality; pad rows bitwise zero.
+  //         staged `.npy`. Exact mask equality; pixel_values exact against the
+  //         slow-processor (use_fast=False, pillow 12.3.0) fixture on the u8
+  //         resize. For position_embeddings, compare the lifted REAL rows
+  //         (`.. h_p·w_p`) to the fixture but assert the pad rows bitwise zero
+  //         against the coremlit contract — the reference fills them with
+  //         resized[0] (masked, output-invariant), so canonicalize/exclude the
+  //         pad rows rather than comparing them to the raw dump.
 }

--- a/crates/coremlit/tests/siglip/preprocess.rs
+++ b/crates/coremlit/tests/siglip/preprocess.rs
@@ -1,0 +1,40 @@
+//! NaFlex preprocessing parity gates.
+//!
+//! # Status: Wave B/C shells
+//!
+//! The pure preprocessing MATH (budget solver against the probe's `spatial_shapes`
+//! oracle, antialiased resize, patchify/mask, pos-emb lift, determinism) is
+//! proven HERMETICALLY in the in-lib unit tests
+//! (`src/embeddings/siglip/image/preprocess/tests.rs`, in the default
+//! `cargo test --features siglip`). This integration file holds the
+//! oracle-fixture-gated arms:
+//!
+//! - **Wave B** — the committed small-oracle cases (`fixtures/goldens/preprocess.json`):
+//!   resize vs torch-oracle arrays, the `(H,W)→(h_p,w_p)` budget table (exact),
+//!   a tiny patchify tensor, and the normalize constants.
+//! - **Wave C** — full-tensor parity: the Rust `pixel_values`/`attention_mask`/
+//!   `position_embeddings` vs the staged per-image `.npy` fixtures (via `npyz`),
+//!   exact mask equality, bitwise-zero pad rows.
+
+mod common;
+
+/// Small committed oracles: resize / budget-table / patchify / normalize vs the
+/// torch-generated `preprocess.json`. Wave B implements against the staged file.
+#[test]
+#[ignore = "requires committed preprocess small-oracles (fixtures/goldens/preprocess.json) — Wave B"]
+fn small_oracles_match_committed_torch_reference() {
+  let _oracle = common::fixture_path("goldens/preprocess.json");
+  // Wave B: parse and compare (tolerance measured-then-pinned ~1e-6-class for the
+  // resize; exact for the budget table and patchify).
+}
+
+/// Full-tensor parity of the Rust NaFlex tensors against the staged per-image
+/// `.npy` fixtures. Wave C implements against `SIGLIP_TEST_MODELS`.
+#[test]
+#[ignore = "requires staged siglip preprocessing fixtures (SIGLIP_TEST_MODELS) — Wave C"]
+fn full_tensor_parity_against_staged_npy() {
+  let _dir = common::models_dir();
+  // Wave C: for each corpus image, decode PNG (common::decode_png_rgb8), run the
+  //         ImageEmbedder preprocessing, compare pixel_values/mask/pos-emb to the
+  //         staged `.npy`; exact mask equality; pad rows bitwise zero.
+}

--- a/crates/coremlit/tests/siglip/text_model_io.rs
+++ b/crates/coremlit/tests/siglip/text_model_io.rs
@@ -1,0 +1,57 @@
+//! Ground-truth introspection + provenance pins for the siglip TEXT artifact
+//! `siglip2_text_64.mlmodelc`.
+//!
+//! # Status: Wave C shell (model-gated)
+//!
+//! `#[ignore]`d until the owner stages the conversion (`SIGLIP_TEST_MODELS`). The
+//! contract (§0): `input_ids` int32 `[1, T]` → `text_features` f32 `[1, 768]`,
+//! and — the SigLIP text specificity — the input SET is EXACTLY `{input_ids}`
+//! (NO `attention_mask`). Wave C fills the exact-SHA manifest.
+
+mod common;
+
+use std::collections::BTreeSet;
+
+use coremlit::{ComputeUnits, DataType, Model, embeddings::siglip::embedding::EMBEDDING_DIM};
+
+/// Text `.mlmodelc` per-file SHA-256, EXACTLY enumerated. Filled from
+/// `CHECKSUMS.sha256` at `common::SIGLIP_REVISION` (Wave C).
+const ARTIFACT_SHA256: &[(&str, &str)] = &[
+  // ("coremldata.bin", "<sha256 — Wave C>"),
+  // ("model.mil", "<sha256 — Wave C>"),
+  // ("weights/weight.bin", "<sha256 — Wave C>"),
+];
+
+/// Text graph I/O contract: resolves `T` from `input_ids [1, T]` int32 and
+/// asserts the input SET is EXACTLY `{input_ids}` (no `attention_mask`).
+#[test]
+#[ignore = "requires staged siglip text model (SIGLIP_TEST_MODELS) — Wave C"]
+fn text_io_matches_spec_and_has_no_attention_mask() {
+  let model = Model::load(common::text_model_path(), ComputeUnits::CpuOnly).unwrap();
+  let d = model.description();
+
+  let ids = d.input("input_ids").expect("input_ids input");
+  assert_eq!(ids.shape()[0], 1, "input_ids batch");
+  assert_eq!(ids.data_type(), Some(DataType::I32));
+  let t = ids.shape()[1];
+  assert!(t >= 1, "resolved window T must be positive");
+
+  // The SigLIP text graph has a SINGLE input — no attention_mask.
+  let input_names: BTreeSet<&str> = d.inputs().iter().map(|f| f.name()).collect();
+  assert_eq!(
+    input_names,
+    BTreeSet::from(["input_ids"]),
+    "text must declare EXACTLY {{input_ids}} — no attention_mask"
+  );
+
+  let out = d.output("text_features").expect("text_features output");
+  assert_eq!(out.shape(), &[1, EMBEDDING_DIM]);
+  assert_eq!(out.data_type(), Some(DataType::F32));
+}
+
+/// Exact-SHA manifest for the text bundle. Wave C fills `ARTIFACT_SHA256`.
+#[test]
+#[ignore = "requires staged siglip text model (SIGLIP_TEST_MODELS) — Wave C"]
+fn text_artifact_bytes_match_pinned_sha256() {
+  common::assert_exact_sha_manifest(&common::text_model_path(), ARTIFACT_SHA256);
+}

--- a/crates/coremlit/tests/siglip/tokenizer_identity.rs
+++ b/crates/coremlit/tests/siglip/tokenizer_identity.rs
@@ -1,0 +1,39 @@
+//! Hermetic tokenizer-identity gate — the proof the bundled SigLIP Gemma
+//! tokenizer is byte-correct and reproduces the committed padded token windows,
+//! with NO model and NO network.
+//!
+//! # Status: Wave B shell (goldens-gated)
+//!
+//! `#[ignore]`d until the golden-generation step stages the source-revision
+//! tokenizer bytes (`src/embeddings/siglip/assets/tokenizer.json`, currently a
+//! placeholder) and the committed corpus (`fixtures/goldens/corpus.json`). Wave B
+//! then pins the tokenizer SHA-256 and asserts every text entry's built PADDED
+//! window (D6 — the full `[T]` window, side/id load-bearing) equals its golden
+//! `token_ids_padded` byte-for-byte, plus a non-vacuity perturbation and a
+//! >64-token truncated entry.
+
+mod common;
+
+use coremlit::embeddings::siglip::BUNDLED_TOKENIZER;
+
+/// The bundled tokenizer is the exact source-revision artifact that cut the
+/// goldens (SHA-256) and is the real multi-megabyte Gemma tokenizer. Wave B pins
+/// the real SHA; today `BUNDLED_TOKENIZER` is a placeholder.
+#[test]
+#[ignore = "requires source-revision Gemma tokenizer + committed goldens — Wave B"]
+fn bundled_tokenizer_matches_pinned_sha256_and_is_real() {
+  let _sha = common::sha256_hex(BUNDLED_TOKENIZER);
+  // Wave B: assert_eq!(_sha, "<source-revision tokenizer.json SHA-256>");
+  //         assert!(BUNDLED_TOKENIZER.len() > 1_000_000, "real Gemma tokenizer");
+}
+
+/// Every committed text entry's built PADDED window equals its golden
+/// `token_ids_padded` exactly (D6). Wave B implements against the staged corpus.
+#[test]
+#[ignore = "requires source-revision Gemma tokenizer + committed goldens — Wave B"]
+fn every_corpus_text_builds_its_golden_padded_window() {
+  let (_images, _texts) = common::golden_corpus();
+  // Wave B: for each text, TextEmbedder-configured tokenizer + build_window ==
+  //         entry.token_ids_padded exactly; include a >64-token (truncated) and
+  //         a MixedCase entry; one-token perturbation must differ (non-vacuity).
+}


### PR DESCRIPTION
## Summary

Adds the **hermetic (model-free) Wave A** of `coremlit::embeddings::siglip` — the SigLIP 2 `siglip2-base-patch16-naflex` dual-tower image+text embedding core into a shared 768-dim joint space, mirroring the granite/clap module conventions. This is the scaffold + all model-independent logic; the model-gated inference paths are deferred to Waves B/C (see below).

**In this PR (A1–A12):**
- `Embedding` `[f32; 768]` with granite's constructor/cosine/normalization surface; sans-I/O `Rgb8Image` seam; cross-modal `rank()`.
- `ImageEmbedderOptions` / `TextEmbedderOptions` — both towers default to **`CpuAndGpu`** (the measured floor-holding compute arm, not `All`), private fields, granite-style serde bridge.
- Full **NaFlex preprocessing** port: aspect-ratio patch-budget solver, antialias-bilinear resize kernel (shared by image + position-embedding lift), rescale+normalize, patchify + f32 attention mask, position-embedding lift. Patch count `P` and text-token count `T` are resolved from the loaded artifact at load time (not hardcoded).
- Text tower's 64-token padded window; dual-tower assembly with load-time contract validation; module docs + re-exports.

**Deferred, owner-gated (NOT in this PR):**
- **Wave B** (tokenizer + preprocessing goldens) and **Wave C** (model-gated parity / placement / e2e) are `#[ignore]`-d, `Models/`-gated shells. They are blocked on the owner staging `Models/siglip2-naflex/` per the conversion runbook and pinning the upstream HF revision. `assets/tokenizer.json` is a clearly-marked placeholder; the Wave-B identity gate forces the real Gemma bytes in.

## Verify status

`fmt=0 clippy=0` (`-D warnings`, all-features) `test=0` `featmap=0` (golden 9/9) `doc=0`. Independently re-run with **no `Models/` present**: 127/131 lib tests green (4 are the model-gated `#[ignore]` shells), doctests incl. both `compile_fail` contracts, ort/onnx-free (`siglip = ["dep:tokenizers"]` only). No regression to whisper/speaker/align/other embeddings.

## Independent review

Fresh independent **Fable 5 review: ACCEPT** (ordinary risk, no blocking findings). The NaFlex budget solver is a bit-faithful port of the transformers reference (reproduces all 8 measured probe `spatial_shapes` rows incl. the 1.499→(18,27) vs 1.502→(18,28) knife-edge); the resize kernel outputs were hand-derived and pinned; the deferral integrity was confirmed (no model-gated path faked). Two non-blocking follow-ups noted for the Wave B/C fill: harden the deferred shell bodies with a not-implemented panic, and (already corrected in the staging runbook) the pos-emb sidecar is `16·16·768·4 = 786,432` bytes.

Held for owner merge. Incremental — the functional model paths land with Waves B/C after model staging.
