### PR TITLE
refactor(coremlit/siglip): route NaFlex u8 resize through colconv (byte-exact, retire hand-rolled kernel)

### DIFF
--- a/crates/coremlit/Cargo.toml
+++ b/crates/coremlit/Cargo.toml
@@ -104,14 +104,21 @@ granite = ["dep:tokenizers", "dep:windit", "windit/text"]
 # SigLIP 2 (`siglip2-base-patch16-naflex`) dual-tower image+text embeddings on
 # CoreML: a shared 768-dim joint space. A Rust NaFlex vision front-end
 # (aspect-preserving patch-budget solver + antialiased-bilinear resize +
-# position-embedding lift; resize/patchify hand-rolled, no `image`/decoder dep)
-# around two fp16 graphs, plus a bundled Gemma tokenizer (`tokenizers`, shared
-# with `whisper`/`clap`/`granite`), L2-normalized in Rust. NaFlex resizes
-# natively to a fixed patch budget, so no windowing is used. The parity oracle is
-# COMMITTED transformers-fp32 goldens (`tests/siglip/fixtures/goldens/`), never a
-# live ONNX crate — so there is NO `siglip-oracle` feature and NO `ort` in this
-# path. `default = []` pulls none of it.
-siglip = ["dep:tokenizers"]
+# position-embedding lift; the u8 image resize is delegated to `colconv`'s
+# byte-exact PIL-parity q8 resampler, while the patch-budget solver / patchify /
+# pos-emb lift stay hand-rolled — no `image`/decoder dep) around two fp16 graphs,
+# plus a bundled Gemma tokenizer (`tokenizers`, shared with
+# `whisper`/`clap`/`granite`), L2-normalized in Rust. NaFlex resizes natively to
+# a fixed patch budget, so no windowing is used. The parity oracle is COMMITTED
+# transformers-fp32 goldens (`tests/siglip/fixtures/goldens/`), never a live ONNX
+# crate — so there is NO `siglip-oracle` feature and NO `ort` in this path.
+# `default = []` pulls none of it.
+#
+# LICENSE PREREQUISITE (owner-gated, NOT resolved by this change): `colconv` is
+# currently licensed GPL-3.0-or-later; the owner will relicense it permissive
+# (MIT OR Apache-2.0) before this branch merges. It is a flagged merge blocker
+# tracked outside this change, not something wired here.
+siglip = ["dep:tokenizers", "dep:colconv"]
 
 [dependencies]
 # --- core CoreML runtime (always compiled) ---
@@ -255,6 +262,27 @@ textclap = { git = "https://github.com/Findit-AI/textclap", rev = "584f21754337a
 #   windit = { path = "../windit" }
 #
 windit = { git = "https://github.com/findit-studio/windit", rev = "b49888002bcbf4927cf69e83323f15652655eed0", optional = true }
+
+# --- embeddings::siglip image resampler (the `siglip` feature) ---
+# `colconv` supplies the byte-exact PIL-parity q8 image resampler the NaFlex u8
+# resize path delegates to, retiring the former hand-rolled fixed-point kernel.
+# `default-features = false` with EXACTLY `["std", "rgb"]`: `std` gates colconv's
+# `Convert` / `resample` tiers (the `Convert::from(Rgb24Frame).resize_with(
+# Triangle, …).rgb(…).run()` path this crate drives), and `rgb` gates the
+# packed-RGB24 source frame — the `frame` umbrella (every YUV/bayer/xyz format)
+# is NOT needed for the RGB→RGB resize, so it stays off. Transitive deps are
+# pure-Rust and ort-free (`mediaframe`, `derive_more`, `half`, `thiserror`).
+# Rev-pinned to the reviewed colconv HEAD (the asry/diaric/windit convention).
+# CO-DEV against a LOCAL colconv checkout: add an UNCOMMITTED patch to the
+# WORKSPACE ROOT Cargo.toml (never commit it):
+#
+#   [patch."https://github.com/findit-studio/colconv"]
+#   colconv = { path = "../colconv" }
+#
+# LICENSE: colconv is GPL-3.0-or-later today; its owner-gated relicense to
+# MIT OR Apache-2.0 is a merge blocker for this branch (see the `siglip` feature
+# comment above).
+colconv = { git = "https://github.com/findit-studio/colconv", rev = "0e2cef95498bbcbb6f500ce14f2137c38ed66470", default-features = false, features = ["std", "rgb"], optional = true }
 
 [dev-dependencies]
 # Integration tests / benches / examples are external consumers: they link the

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
@@ -11,11 +11,12 @@
 //!    fits `P`.
 //! 2. [`resize_bilinear_antialias_u8`] — the PIL-parity antialiased-bilinear
 //!    image resize in the **uint8 domain** (Pillow `Resample.c` fixed-point:
-//!    22-bit coefficients, per-pass u8 rounding), matching the SigLIP2 processor
-//!    (resize on u8, THEN rescale+normalize). Its sibling f64
-//!    [`resize_bilinear_antialias`] is the position-embedding lift's kernel
-//!    (stage 5), which the reference genuinely computes in float. The u8
-//!    kernel's bit-exactness holds for source axes ≤ [`MAX_IMAGE_AXIS`], which
+//!    22-bit coefficients, per-pass u8 rounding), delegated to [`colconv`]'s
+//!    byte-exact q8 resampler and matching the SigLIP2 processor (resize on u8,
+//!    THEN rescale+normalize). Its sibling f64 [`resize_bilinear_antialias`] is
+//!    the position-embedding lift's kernel (stage 5), which the reference
+//!    genuinely computes in float and which stays native here. The u8 path's
+//!    bit-exactness holds for source axes ≤ [`MAX_IMAGE_AXIS`], which
 //!    [`preprocess_image`] enforces.
 //! 3. [`normalize_u8`] — rescale + normalize `((v/255) − 0.5)/0.5`.
 //! 4. [`patchify`] — reshape the resized+normalized image to `[P, 768]` patch
@@ -62,17 +63,17 @@ pub const PATCH_DIM: usize = CHANNELS * PATCH_SIZE * PATCH_SIZE;
 ///   `precompute_coeffs(int inSize, float in0, float in1, …)` computes
 ///   `scale = (double)(in1 - in0) / outSize`), so the source extent is rounded
 ///   to `f32` before the `f64` coefficient math. Every integer extent `≤ 2²⁴`
-///   is exactly `f32`-representable, making the pure-`f64`
-///   `precompute_coeffs` here bit-identical to Pillow's; from `2²⁴ + 1`
-///   upward Pillow computes with a different extent (`16 777 219 →
-///   16 777 220.0f32`) and the uint8 kernel's bit-exact contract would
-///   silently break. The cap keeps every accepted extent 16× inside the
+///   is exactly `f32`-representable, keeping both colconv's q8 image resampler
+///   and the native `f64` `precompute_coeffs` (the pos-emb lift) bit-identical
+///   to Pillow's; from `2²⁴ + 1` upward Pillow computes with a different extent
+///   (`16 777 219 → 16 777 220.0f32`) and the u8 resize's bit-exact contract
+///   would silently break. The cap keeps every accepted extent 16× inside the
 ///   envelope.
-/// * **Bounded working memory.** The per-axis coefficient tables (`~2·axis`
-///   taps) and the horizontal pass's `u8` intermediate (`src_h · dst_w · 3`
-///   bytes) grow linearly with the accepted axis — hundreds of MB to over a
-///   GB for degenerate strips the budget solver otherwise accepts. Under the
-///   cap the whole resize working set stays ≈ 100 MB even at the boundary.
+/// * **Bounded working memory.** The resize output (`dst_h · dst_w · 3` bytes)
+///   and colconv's streaming working set both grow with the accepted axis — a
+///   degenerate strip the budget solver otherwise accepts could demand
+///   hundreds of MB. Under the cap the whole resize working set stays modest
+///   even at the boundary.
 ///
 /// `2²⁰` px per axis is far beyond any physically decodable image (record
 /// stitched panoramas peak near `8.5 × 10⁵` px on the long axis), so the
@@ -104,12 +105,6 @@ const RESCALE_FACTOR_F64: f64 = 1.0 / 255.0;
 const IMAGE_MEAN: f32 = 0.5;
 /// Per-channel normalization std `0.5` (`image_std`).
 const IMAGE_STD: f32 = 0.5;
-
-/// Fixed-point precision of the uint8 resample coefficients, Pillow's
-/// `PRECISION_BITS = 32 − 8 − 2 = 22` (`Resample.c`): weights are quantized to
-/// `2²²`, accumulated over `u8` taps with a `1 << 21` half-unit rounding offset,
-/// then shifted right by 22 and clamped to `u8`.
-const PRECISION_BITS: u32 = 22;
 
 /// Aspect-preserving patch-budget solver: the largest multiple-of-`patch`
 /// target size whose patch grid `h_p · w_p` fits `budget`, returned as the
@@ -312,148 +307,81 @@ pub(crate) fn resize_bilinear_antialias(
   Ok(out)
 }
 
-/// Quantizes one axis's `f64` resample coefficients to Pillow's 22-bit fixed
-/// point (`normalize_coeffs_8bpc`): `kk = (int)(±0.5 + w·2²²)`, rounding half
-/// away from zero. Bilinear weights are non-negative in practice; the negative
-/// branch mirrors PIL exactly for any residual.
+/// PIL-parity antialiased-bilinear resize of a packed RGB8 image
+/// (`(src_h, src_w, 3)` row-major, RGB-interleaved) to `(dst_h, dst_w, 3)`,
+/// delegated to [`colconv`]'s fixed-point q8 resampler.
 ///
-/// Consumes `coeffs` by value: each entry's `f64` weights vector drops as soon
-/// as its `i32` twin is built, so the two precisions never fully coexist —
-/// the safe-Rust analogue of Pillow's in-place `kk = (INT32 *)prekk` reuse
-/// (`normalize_coeffs_8bpc`).
+/// colconv's `Triangle` (PIL BILINEAR) u8 path reproduces Pillow's 8bpc
+/// `Resample.c` pipeline byte-for-byte — 22-bit coefficients, per-pass `u8`
+/// rounding of the horizontal intermediate — which is exactly the SigLIP2
+/// processor's image-resize semantics (resize on `u8`, THEN rescale+normalize;
+/// the per-pass rounding is part of the reference and is what a pure-`f64`
+/// resize cannot emulate). The byte-exactness is enforced upstream by colconv's
+/// tolerance-0 Pillow golden suite and downstream by this module's committed E3
+/// oracles (`tests.rs`).
 ///
-/// # Errors
-/// [`Error::PreprocessAllocation`] if a quantized coefficient vector cannot be
-/// reserved (the input table is already bounded, so only the reservation can
-/// fail; the quantized values are unchanged from the infallible form).
-fn quantize_coeffs_8bpc(coeffs: Vec<(usize, Vec<f64>)>) -> Result<Vec<(usize, Vec<i32>)>, Error> {
-  let scale = f64::from(1i32 << PRECISION_BITS);
-  let mut out = Vec::new();
-  out
-    .try_reserve_exact(coeffs.len())
-    .map_err(|_| Error::PreprocessAllocation {
-      bytes: coeffs
-        .len()
-        .saturating_mul(core::mem::size_of::<(usize, Vec<i32>)>()),
-    })?;
-  for (start, weights) in coeffs {
-    let mut kk = Vec::new();
-    kk.try_reserve_exact(weights.len())
-      .map_err(|_| Error::PreprocessAllocation {
-        bytes: weights.len().saturating_mul(core::mem::size_of::<i32>()),
-      })?;
-    for &w in &weights {
-      let q = if w < 0.0 {
-        (-0.5 + w * scale) as i32
-      } else {
-        (0.5 + w * scale) as i32
-      };
-      kk.push(q);
-    }
-    out.push((start, kk));
-  }
-  Ok(out)
-}
-
-/// Pillow's `clip8`: arithmetic-shift the fixed-point accumulator back to the
-/// integer domain (`>> 22`) and clamp to `u8`. Equivalent to PIL's clip lookup
-/// over the reachable accumulator range.
-fn clip8(ss: i64) -> u8 {
-  (ss >> PRECISION_BITS).clamp(0, 255) as u8
-}
-
-/// Element count `a·b·c`, or [`Error::PreprocessAllocation`]
-/// `{ bytes: usize::MAX }` on `usize` overflow — a pathological source geometry
-/// whose working buffer cannot even be represented, let alone allocated.
-fn checked_len3(a: usize, b: usize, c: usize) -> Result<usize, Error> {
-  a.checked_mul(b)
-    .and_then(|ab| ab.checked_mul(c))
-    .ok_or(Error::PreprocessAllocation { bytes: usize::MAX })
-}
-
-/// A zeroed `Vec<u8>` of `len` bytes reserved fallibly (`try_reserve_exact`), so
-/// a pathological source geometry returns [`Error::PreprocessAllocation`]
-/// instead of aborting the process on allocator failure.
-fn alloc_u8(len: usize) -> Result<Vec<u8>, Error> {
-  let mut v = Vec::new();
-  v.try_reserve_exact(len)
-    .map_err(|_| Error::PreprocessAllocation { bytes: len })?;
-  v.resize(len, 0);
-  Ok(v)
-}
-
-/// PIL-parity antialiased-bilinear resample in the **uint8 domain** (Pillow
-/// `Resample.c`, `PRECISION_BITS = 22`): per pass, [`precompute_coeffs`] taps
-/// are quantized to 22-bit fixed point, accumulated over `u8` taps with a
-/// `1 << 21` rounding offset, then shifted (`>> 22`) and clamped back to `u8` —
-/// **including the `u8` horizontal intermediate between the two passes**. This
-/// is the image path of the SigLIP2 processor (resize on `u8`, then
-/// rescale+normalize); the per-pass rounding is part of the reference semantics
-/// and is what the `f64` kernel cannot emulate.
-///
-/// The accumulator is `i64`; PIL relies on `ss ≤ 2²¹ + 255·(2²² + ksize/2) ≈
-/// 1.07e9 < i32::MAX` holding, and `i64` gives the identical result while
-/// immunizing debug-overflow. The src-dependent horizontal intermediate is
-/// sized with [`checked_len3`] and reserved with [`alloc_u8`] (fallible), and
-/// the coefficient tables are reserved fallibly by [`precompute_coeffs`] /
-/// [`quantize_coeffs_8bpc`], so a pathological geometry returns a typed error
-/// rather than aborting. A `src` shorter than `src_h·src_w·channels` panics on
-/// an out-of-bounds tap — a caller-internal invariant.
-///
-/// [`quantize_coeffs_8bpc`] consumes its `f64` input table, so the `f64` and
-/// `i32` tables never fully coexist; this fn also drops the horizontal `i32`
-/// table with `drop` before the vertical one is built, so peak coefficient
-/// memory is one table at a time. The only caller, [`preprocess_image`],
-/// bounds `src_h`/`src_w` by [`MAX_IMAGE_AXIS`], which keeps every table and
-/// the horizontal intermediate under ≈ 100 MB and — because every accepted
-/// axis is then exactly `f32`-representable — keeps this kernel inside
-/// Pillow's `float box[4]` exact envelope (see [`MAX_IMAGE_AXIS`]'s doc for
-/// the threshold); the bound is an invariant of the caller, not re-checked
-/// here.
+/// The only caller, [`preprocess_image`], bounds `src_h`/`src_w` by
+/// [`MAX_IMAGE_AXIS`], which keeps every accepted extent exactly
+/// `f32`-representable — inside Pillow's `float box[4]` envelope, so colconv's
+/// coefficient math matches Pillow's (see [`MAX_IMAGE_AXIS`]) — and keeps
+/// colconv's streaming working set small.
 ///
 /// # Errors
-/// [`Error::PreprocessAllocation`] if a working buffer or coefficient table's
-/// size overflows `usize` or cannot be reserved.
+/// [`Error::PreprocessAllocation`] if the output buffer cannot be reserved, a
+/// dimension does not fit colconv's `u32` frame geometry, or colconv rejects the
+/// resize plan — returned instead of aborting the process (`colconv` reserves
+/// fallibly and [`Rgb24Frame::try_new`](colconv::frame::Rgb24Frame::try_new)
+/// validates the geometry rather than panicking). `bytes` is the refused
+/// output-buffer size, or [`usize::MAX`] for a geometry that could never be
+/// represented.
 pub(crate) fn resize_bilinear_antialias_u8(
   src: &[u8],
   src_h: usize,
   src_w: usize,
-  channels: usize,
   dst_h: usize,
   dst_w: usize,
 ) -> Result<Vec<u8>, Error> {
-  const OFFSET: i64 = 1 << (PRECISION_BITS - 1);
+  use colconv::{Convert, frame::Rgb24Frame, resample::Triangle};
 
-  // Horizontal pass: (src_h, src_w, C) → (src_h, dst_w, C), u8 intermediate.
-  let wc = quantize_coeffs_8bpc(precompute_coeffs(src_w, dst_w)?)?;
-  let mut tmp = alloc_u8(checked_len3(src_h, dst_w, channels)?)?;
-  for y in 0..src_h {
-    for (ox, (start, weights)) in wc.iter().enumerate() {
-      for c in 0..channels {
-        let mut ss: i64 = OFFSET;
-        for (k, &wk) in weights.iter().enumerate() {
-          ss += i64::from(src[(y * src_w + start + k) * channels + c]) * i64::from(wk);
-        }
-        tmp[(y * dst_w + ox) * channels + c] = clip8(ss);
-      }
-    }
-  }
-  drop(wc); // horizontal table is dead before the vertical pass builds its own
+  // colconv's frame geometry is `u32`; a source extent that does not fit could
+  // never be represented, let alone allocated. Only reachable through a direct
+  // pathological-geometry call — `preprocess_image` caps both axes by
+  // `MAX_IMAGE_AXIS`, far inside `u32`.
+  let width =
+    u32::try_from(src_w).map_err(|_| Error::PreprocessAllocation { bytes: usize::MAX })?;
+  let height =
+    u32::try_from(src_h).map_err(|_| Error::PreprocessAllocation { bytes: usize::MAX })?;
+  let stride = width
+    .checked_mul(CHANNELS as u32)
+    .ok_or(Error::PreprocessAllocation { bytes: usize::MAX })?;
 
-  // Vertical pass: (src_h, dst_w, C) → (dst_h, dst_w, C).
-  let hc = quantize_coeffs_8bpc(precompute_coeffs(src_h, dst_h)?)?;
-  let mut out = alloc_u8(checked_len3(dst_h, dst_w, channels)?)?;
-  for (oy, (start, weights)) in hc.iter().enumerate() {
-    for x in 0..dst_w {
-      for c in 0..channels {
-        let mut ss: i64 = OFFSET;
-        for (k, &wk) in weights.iter().enumerate() {
-          ss += i64::from(tmp[((start + k) * dst_w + x) * channels + c]) * i64::from(wk);
-        }
-        out[(oy * dst_w + x) * channels + c] = clip8(ss);
-      }
-    }
-  }
+  // Output buffer (`dst_h · dst_w · 3` bytes), reserved fallibly so a
+  // pathological target geometry returns a typed error instead of aborting on
+  // allocator failure.
+  let dst_len = dst_w
+    .checked_mul(dst_h)
+    .and_then(|hw| hw.checked_mul(CHANNELS))
+    .ok_or(Error::PreprocessAllocation { bytes: usize::MAX })?;
+  let mut out = Vec::new();
+  out
+    .try_reserve_exact(dst_len)
+    .map_err(|_| Error::PreprocessAllocation { bytes: dst_len })?;
+  out.resize(dst_len, 0);
+
+  // The tightly-packed RGB24 source frame; `try_new` (not the panicking `new`)
+  // validates dimensions and plane length, returning a typed error on a
+  // pathological direct-call extent.
+  let frame = Rgb24Frame::try_new(src, width, height, stride)
+    .map_err(|_| Error::PreprocessAllocation { bytes: usize::MAX })?;
+
+  // Filtered (windowed-triangle = PIL BILINEAR) resample, any ratio; the sole
+  // fallible call assembles the sink and walks the frame into `out`.
+  Convert::from(&frame)
+    .resize_with(Triangle, dst_w, dst_h)
+    .rgb(&mut out)
+    .run()
+    .map_err(|_| Error::PreprocessAllocation { bytes: usize::MAX })?;
+
   Ok(out)
 }
 
@@ -626,14 +554,14 @@ pub(crate) fn preprocess_image(
 
   let (grid_h, grid_w) = fit_to_patch_budget(height, width, PATCH_SIZE, budget);
 
-  // Resize in the u8 domain (PIL-parity fixed-point kernel), then
+  // Resize in the u8 domain (colconv's PIL-parity q8 resampler), then
   // rescale+normalize to f32 — the SigLIP2 processor's order AND dtype (it
   // resizes the u8 image, rounding each pass to u8, then casts to f32). No
-  // whole-image f32 buffer is materialized; the only src-dependent allocation is
-  // the kernel's fallibly-reserved u8 intermediate.
+  // whole-image f32 buffer is materialized; colconv streams the resize and the
+  // only owned buffer is its fallibly-reserved u8 output.
   let dst_h = grid_h * PATCH_SIZE;
   let dst_w = grid_w * PATCH_SIZE;
-  let resized_u8 = resize_bilinear_antialias_u8(rgb, height, width, CHANNELS, dst_h, dst_w)?;
+  let resized_u8 = resize_bilinear_antialias_u8(rgb, height, width, dst_h, dst_w)?;
   let resized: Vec<f32> = resized_u8.iter().map(|&v| normalize_u8(v)).collect();
 
   let (pixel_values, attention_mask) = patchify(&resized, grid_h, grid_w, budget)?;

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
@@ -169,9 +169,13 @@ fn triangle(t: f64) -> f64 {
 /// bilinear). `align_corners=False` sample centers `(o + 0.5)·scale`. Each entry
 /// is `(start_input_index, normalized_weights)`.
 ///
-/// Image-path callers bound `in_size` by [`MAX_IMAGE_AXIS`], under which this
-/// pure-`f64` extent math coincides bit-for-bit with Pillow's `float box[4]`
-/// semantics (see the const's doc for the threshold).
+/// The sole live caller is the position-embedding lift
+/// ([`lift_position_embeddings`], via [`resize_bilinear_antialias`]), whose
+/// source is the fixed `16×16` base grid ([`POS_GRID_SIDE`]) — the image
+/// resize path uses colconv's `u8` resampler instead
+/// ([`resize_bilinear_antialias_u8`]). `16 ≪ 2²⁴`, so this pure-`f64` extent
+/// math trivially coincides bit-for-bit with Pillow's `float box[4]` semantics
+/// (see [`MAX_IMAGE_AXIS`]'s doc for the threshold).
 ///
 /// # Errors
 /// [`Error::PreprocessAllocation`] if a pathological source extent makes the
@@ -331,9 +335,10 @@ pub(crate) fn resize_bilinear_antialias(
 /// dimension does not fit colconv's `u32` frame geometry, or colconv rejects the
 /// resize plan — returned instead of aborting the process (`colconv` reserves
 /// fallibly and [`Rgb24Frame::try_new`](colconv::frame::Rgb24Frame::try_new)
-/// validates the geometry rather than panicking). `bytes` is the refused
-/// output-buffer size, or [`usize::MAX`] for a geometry that could never be
-/// represented.
+/// validates the geometry rather than panicking). `bytes` is the `dst_h · dst_w
+/// · 3` output-buffer size — representable even when its reservation or
+/// colconv's own resize plan is what actually failed — or [`usize::MAX`] for a
+/// geometry that could never be represented.
 pub(crate) fn resize_bilinear_antialias_u8(
   src: &[u8],
   src_h: usize,
@@ -375,12 +380,16 @@ pub(crate) fn resize_bilinear_antialias_u8(
     .map_err(|_| Error::PreprocessAllocation { bytes: usize::MAX })?;
 
   // Filtered (windowed-triangle = PIL BILINEAR) resample, any ratio; the sole
-  // fallible call assembles the sink and walks the frame into `out`.
+  // fallible call assembles the sink and walks the frame into `out`. `out` is
+  // already sized to `dst_len` (a representable value) at this point, so a
+  // colconv-side plan rejection or internal reservation failure here is
+  // reported at that real size — not aliased onto the `usize::MAX` sentinel,
+  // which is reserved for a geometry that could not be represented at all.
   Convert::from(&frame)
     .resize_with(Triangle, dst_w, dst_h)
     .rgb(&mut out)
     .run()
-    .map_err(|_| Error::PreprocessAllocation { bytes: usize::MAX })?;
+    .map_err(|_| Error::PreprocessAllocation { bytes: dst_len })?;
 
   Ok(out)
 }

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
@@ -213,14 +213,36 @@ fn resize_preserves_vertical_constancy() {
   assert!((out[1] - out[3]).abs() <= 1e-6, "column 1 not constant");
 }
 
-// ── E3: uint8 PIL-parity resize kernel (fixed-point oracles) ──────────────────
+// ── E3: uint8 PIL-parity resize oracles (colconv q8 engine) ───────────────────
+//
+// The u8 resize is delegated to colconv's byte-exact PIL-parity q8 resampler,
+// whose source frame is packed RGB8 (3-channel). The kernel is
+// channel-independent, so a single-channel Pillow oracle grid is driven by
+// replicating it across the three RGB channels and asserting the same grid on
+// each channel — the committed values are unchanged truth (assessment §5.3).
 
-/// Identity dims return the input bytes exactly: each output is a single
-/// unit-weight tap, and the `1 << 21` offset truncates back to the input value.
+/// Replicate a single-channel `u8` pattern across all three RGB channels, the
+/// harness form for driving the RGB8 [`resize_bilinear_antialias_u8`] with a
+/// mono oracle grid.
+fn mono_to_rgb(mono: &[u8]) -> Vec<u8> {
+  let mut rgb = Vec::with_capacity(mono.len() * CHANNELS);
+  for &v in mono {
+    rgb.extend_from_slice(&[v; CHANNELS]);
+  }
+  rgb
+}
+
+/// Extract channel `c` from a packed `(…, 3)` RGB8 buffer as a mono grid.
+fn channel(rgb: &[u8], c: usize) -> Vec<u8> {
+  rgb.iter().skip(c).step_by(CHANNELS).copied().collect()
+}
+
+/// Identity dims (`src == dst`) pass the input bytes through byte-exactly on
+/// every channel — colconv plans a direct copy.
 #[test]
 fn resize_u8_identity_is_exact() {
-  let src = [17u8, 200, 3, 250, 9, 128, 44, 71, 255]; // 3×3, 1 channel
-  let out = resize_bilinear_antialias_u8(&src, 3, 3, 1, 3, 3).expect("resize");
+  let src = mono_to_rgb(&[17u8, 200, 3, 250, 9, 128, 44, 71, 255]); // 3×3
+  let out = resize_bilinear_antialias_u8(&src, 3, 3, 3, 3).expect("resize");
   assert_eq!(out, src);
 }
 
@@ -231,12 +253,12 @@ fn resize_u8_identity_is_exact() {
 #[test]
 fn resize_u8_constant_field_is_constant() {
   let src = vec![123u8; 5 * 7 * 3]; // 5×7, 3 channels
-  let up = resize_bilinear_antialias_u8(&src, 5, 7, 3, 9, 4).expect("upscale");
+  let up = resize_bilinear_antialias_u8(&src, 5, 7, 9, 4).expect("upscale");
   assert!(
     up.iter().all(|&v| v == 123),
     "upscale drifted from constant"
   );
-  let down = resize_bilinear_antialias_u8(&src, 5, 7, 3, 2, 2).expect("downscale");
+  let down = resize_bilinear_antialias_u8(&src, 5, 7, 2, 2).expect("downscale");
   assert!(
     down.iter().all(|&v| v == 123),
     "downscale drifted from constant"
@@ -248,8 +270,8 @@ fn resize_u8_constant_field_is_constant() {
 /// `[.25,.75]`, `[1]`; quantized `[4194304]`, `[3145728,1048576]`, …).
 #[test]
 fn resize_u8_matches_hand_computed_pil_grid_checker() {
-  let src = [0u8, 255, 255, 0];
-  let out = resize_bilinear_antialias_u8(&src, 2, 2, 1, 4, 4).expect("resize");
+  let src = mono_to_rgb(&[0u8, 255, 255, 0]);
+  let out = resize_bilinear_antialias_u8(&src, 2, 2, 4, 4).expect("resize");
   #[rustfmt::skip]
   let expected: [u8; 16] = [
       0,  64, 191, 255,
@@ -257,7 +279,13 @@ fn resize_u8_matches_hand_computed_pil_grid_checker() {
     191, 159,  96,  64,
     255, 191,  64,   0,
   ];
-  assert_eq!(out, expected);
+  for c in 0..CHANNELS {
+    assert_eq!(
+      channel(&out, c),
+      expected,
+      "channel {c} diverged from the PIL grid"
+    );
+  }
 }
 
 /// A 2×2 `[[0,1],[255,255]]` upscaled to 4×4 matches the hand-derived grid, with
@@ -267,8 +295,8 @@ fn resize_u8_matches_hand_computed_pil_grid_checker() {
 /// per-pass (u8 intermediate) rounding as non-vacuous.
 #[test]
 fn resize_u8_per_pass_rounding_discriminates_from_float() {
-  let src = [0u8, 1, 255, 255];
-  let out = resize_bilinear_antialias_u8(&src, 2, 2, 1, 4, 4).expect("resize");
+  let src = mono_to_rgb(&[0u8, 1, 255, 255]);
+  let out = resize_bilinear_antialias_u8(&src, 2, 2, 4, 4).expect("resize");
   #[rustfmt::skip]
   let expected: [u8; 16] = [
       0,   0,   1,   1,
@@ -276,37 +304,38 @@ fn resize_u8_per_pass_rounding_discriminates_from_float() {
     191, 191, 192, 192,
     255, 255, 255, 255,
   ];
-  assert_eq!(out, expected);
-  // Cells [1][2] and [2][2] (indices 6 and 10) are the float-vs-uint8 tell.
-  assert_eq!((out[6], out[10]), (65, 192));
+  for c in 0..CHANNELS {
+    let ch = channel(&out, c);
+    assert_eq!(ch, expected, "channel {c} diverged from the PIL grid");
+    // Cells [1][2] and [2][2] (indices 6 and 10) are the float-vs-uint8 tell.
+    assert_eq!(
+      (ch[6], ch[10]),
+      (65, 192),
+      "channel {c} per-pass discriminant"
+    );
+  }
 }
 
-/// Pathologically large source dims return a typed
-/// [`Error::PreprocessAllocation`] from [`checked_len3`]'s `checked_mul`
-/// working-buffer sizing arm — no panic, no abort. (The `try_reserve` arm is
-/// not portably forcible.)
+/// An over-tall source height that overflows colconv's `u32` frame geometry
+/// returns a typed [`Error::PreprocessAllocation`] `{ bytes: usize::MAX }` — no
+/// panic, no abort — before any resize work. (`preprocess_image` caps both axes
+/// far inside `u32`; this exercises the wrapper's own backstop via a direct
+/// call.)
 #[test]
 fn resize_u8_rejects_overflowing_geometry() {
-  match resize_bilinear_antialias_u8(&[0u8; 12], usize::MAX / 2, 2, 3, 2, 2) {
+  match resize_bilinear_antialias_u8(&[0u8; 12], usize::MAX / 2, 2, 2, 2) {
     Err(Error::PreprocessAllocation { bytes }) => assert_eq!(bytes, usize::MAX),
     other => panic!("expected PreprocessAllocation, got {other:?}"),
   }
 }
 
-/// A pathologically large *source* extent trips the coefficient-table
-/// representability pre-guard inside [`precompute_coeffs`] (the horizontal
-/// axis' `out·(2⌈support⌉+1)` element count overflows `usize`), returning a
-/// typed [`Error::PreprocessAllocation`] before any tap is indexed — no panic,
-/// no abort. This is the coefficient-table arm, distinct from the working-buffer
-/// [`checked_len3`] arm above. (The `try_reserve` arms are not portably
-/// forcible.)
+/// The over-wide twin: a source width that overflows colconv's `u32` frame
+/// geometry is rejected with the same typed [`Error::PreprocessAllocation`]
+/// `{ bytes: usize::MAX }`, before any tap is indexed — no panic, no abort. The
+/// tiny `src` is never read.
 #[test]
-fn resize_u8_rejects_coeff_table_overflow() {
-  // src_w = usize::MAX/2, dst_w = 16 ⇒ support ≈ 2⁵⁹, so 2⌈support⌉+1 = 2⁶⁰+1
-  // and 16·(2⁶⁰+1) overflows usize. precompute_coeffs(src_w, dst_w) is the u8
-  // kernel's first action, so the guard fires before any buffer or src indexing;
-  // the tiny src is never read.
-  match resize_bilinear_antialias_u8(&[0u8; 12], 2, usize::MAX / 2, 3, 2, 16) {
+fn resize_u8_rejects_over_wide_source_extent() {
+  match resize_bilinear_antialias_u8(&[0u8; 12], 2, usize::MAX / 2, 2, 16) {
     Err(Error::PreprocessAllocation { bytes }) => assert_eq!(bytes, usize::MAX),
     other => panic!("expected PreprocessAllocation, got {other:?}"),
   }
@@ -333,7 +362,7 @@ fn preprocess_image_pixel_values_come_from_u8_resize() {
   assert_eq!(out.grid, (1, 1), "budget 1 → single-patch grid");
 
   // The single real patch is normalize_u8 of the u8-resized image, exactly.
-  let resized_u8 = resize_bilinear_antialias_u8(&rgb, 2, 2, CHANNELS, 16, 16).expect("resize");
+  let resized_u8 = resize_bilinear_antialias_u8(&rgb, 2, 2, 16, 16).expect("resize");
   assert_eq!(resized_u8.len(), 16 * 16 * CHANNELS);
   for (k, &v) in resized_u8.iter().enumerate() {
     assert_eq!(
@@ -636,8 +665,9 @@ fn preprocess_rejects_width_over_axis_bound() {
   assert!(matches!(err, Error::ImageDimensions { width, height } if width == w && height == 1));
 }
 
-/// Tall twin — the worse unbounded orientation (the horizontal pass would
-/// materialize a `src_h · dst_w · 3` intermediate, ~805 MB at 16.7M px).
+/// Tall twin — the same rejection on the other orientation. Without the cap an
+/// unbounded source height would drive the resize working set without limit; the
+/// guard fires before any resize allocation.
 #[test]
 fn preprocess_rejects_height_over_axis_bound() {
   let h = MAX_IMAGE_AXIS + 1;
@@ -680,8 +710,8 @@ fn preprocess_accepts_axis_bound_wide_panorama() {
   assert_eq!(real, gh * gw);
 }
 
-/// Tall boundary twin: `1 × MAX_IMAGE_AXIS` — exercises the bounded worst-case
-/// horizontal intermediate (`MAX_IMAGE_AXIS · 16 · 3 ≈ 50 MB`) end to end.
+/// Tall boundary twin: `1 × MAX_IMAGE_AXIS` — drives the bounded worst-case
+/// resize (a `MAX_IMAGE_AXIS`-tall source down to a 1-wide grid) end to end.
 #[test]
 fn preprocess_accepts_axis_bound_tall_strip() {
   let rgb = vec![127u8; MAX_IMAGE_AXIS * 3];

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
@@ -217,9 +217,12 @@ fn resize_preserves_vertical_constancy() {
 //
 // The u8 resize is delegated to colconv's byte-exact PIL-parity q8 resampler,
 // whose source frame is packed RGB8 (3-channel). The kernel is
-// channel-independent, so a single-channel Pillow oracle grid is driven by
-// replicating it across the three RGB channels and asserting the same grid on
-// each channel — the committed values are unchanged truth (assessment §5.3).
+// channel-independent, so most of these oracles drive a single-channel Pillow
+// grid by replicating it across the three RGB channels and asserting the same
+// grid on each channel — the committed values are unchanged truth.
+// `resize_u8_distinct_channels_match_independent_pil_grids` below instead
+// gives R, G, and B three independently-derived grids, so a channel-order
+// regression cannot hide behind the replication.
 
 /// Replicate a single-channel `u8` pattern across all three RGB channels, the
 /// harness form for driving the RGB8 [`resize_bilinear_antialias_u8`] with a
@@ -238,10 +241,18 @@ fn channel(rgb: &[u8], c: usize) -> Vec<u8> {
 }
 
 /// Identity dims (`src == dst`) pass the input bytes through byte-exactly on
-/// every channel — colconv plans a direct copy.
+/// every channel — colconv plans a direct copy. 27 distinct bytes (no value
+/// repeated, unlike a mono-replicated `R=G=B` pattern) so a channel-order
+/// permutation on the direct-copy plan would move a value to the wrong slot
+/// and fail this exact comparison.
 #[test]
 fn resize_u8_identity_is_exact() {
-  let src = mono_to_rgb(&[17u8, 200, 3, 250, 9, 128, 44, 71, 255]); // 3×3
+  #[rustfmt::skip]
+  let src: [u8; 27] = [
+     1,  2,  3,  4,  5,  6,  7,  8,  9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18,
+    19, 20, 21, 22, 23, 24, 25, 26, 27,
+  ]; // 3×3, RGB-interleaved, every byte distinct
   let out = resize_bilinear_antialias_u8(&src, 3, 3, 3, 3).expect("resize");
   assert_eq!(out, src);
 }
@@ -316,6 +327,88 @@ fn resize_u8_per_pass_rounding_discriminates_from_float() {
   }
 }
 
+/// Interleave three distinct single-channel `u8` patterns into one packed
+/// RGB8 buffer, one pattern per channel — the harness form for driving
+/// [`resize_bilinear_antialias_u8`] with per-channel-independent oracle grids.
+/// Unlike [`mono_to_rgb`] (which replicates one grid across R, G, and B, and
+/// so cannot see a channel-order permutation), this puts a different pattern
+/// in each channel.
+fn rgb_from_channels(r: &[u8], g: &[u8], b: &[u8]) -> Vec<u8> {
+  assert_eq!(r.len(), g.len());
+  assert_eq!(r.len(), b.len());
+  let mut rgb = Vec::with_capacity(r.len() * CHANNELS);
+  for i in 0..r.len() {
+    rgb.extend_from_slice(&[r[i], g[i], b[i]]);
+  }
+  rgb
+}
+
+/// Distinct-per-channel E3 oracle: R, G, and B carry three DIFFERENT patterns
+/// — the checker grid, its mirror, and the per-pass discriminant grid — each
+/// with its own independently hand-derived PIL fixed-point expectation. Every
+/// other E3 oracle replicates one pattern across all three channels
+/// (`mono_to_rgb`), so a channel-order permutation (RGB↔BGR) in a future
+/// colconv bump would pass them all unchanged; asserting each output channel
+/// against its OWN grid here makes that regression visible — swapping any two
+/// output channels below fails at least one of the three assertions.
+#[test]
+fn resize_u8_distinct_channels_match_independent_pil_grids() {
+  let r_src = [0u8, 255, 255, 0]; // the checker grid (2×2)
+  let g_src = [255u8, 0, 0, 255]; // its mirror
+  let b_src = [0u8, 1, 255, 255]; // the per-pass discriminant grid
+  let src = rgb_from_channels(&r_src, &g_src, &b_src);
+  let out = resize_bilinear_antialias_u8(&src, 2, 2, 4, 4).expect("resize");
+
+  // R: the checker grid's hand-derived surface (same values as
+  // `resize_u8_matches_hand_computed_pil_grid_checker`).
+  #[rustfmt::skip]
+  let r_expected: [u8; 16] = [
+      0,  64, 191, 255,
+     64,  96, 159, 191,
+    191, 159,  96,  64,
+    255, 191,  64,   0,
+  ];
+  // G: the mirror grid's own surface, derived by the same per-tap fixed-point
+  // method as R (not read back from colconv's output). The mirror source is
+  // the checker source's bytewise complement (`255 − v`), and every quantized
+  // weight pair in this 2→4 upscale sums to exactly 2²² with no output
+  // landing on a half-integer tie, so the complement carries through both
+  // passes exactly — this grid is `255 − r_expected` elementwise, confirmed by
+  // direct per-cell computation.
+  #[rustfmt::skip]
+  let g_expected: [u8; 16] = [
+    255, 191,  64,   0,
+    191, 159,  96,  64,
+     64,  96, 159, 191,
+      0,  64, 191, 255,
+  ];
+  // B: the per-pass discriminant grid's hand-derived surface (same values as
+  // `resize_u8_per_pass_rounding_discriminates_from_float`).
+  #[rustfmt::skip]
+  let b_expected: [u8; 16] = [
+      0,   0,   1,   1,
+     64,  64,  65,  65,
+    191, 191, 192, 192,
+    255, 255, 255, 255,
+  ];
+
+  assert_eq!(
+    channel(&out, 0),
+    r_expected,
+    "R channel diverged from its own PIL grid"
+  );
+  assert_eq!(
+    channel(&out, 1),
+    g_expected,
+    "G channel diverged from its own PIL grid"
+  );
+  assert_eq!(
+    channel(&out, 2),
+    b_expected,
+    "B channel diverged from its own PIL grid"
+  );
+}
+
 /// An over-tall source height that overflows colconv's `u32` frame geometry
 /// returns a typed [`Error::PreprocessAllocation`] `{ bytes: usize::MAX }` — no
 /// panic, no abort — before any resize work. (`preprocess_image` caps both axes
@@ -336,6 +429,19 @@ fn resize_u8_rejects_overflowing_geometry() {
 #[test]
 fn resize_u8_rejects_over_wide_source_extent() {
   match resize_bilinear_antialias_u8(&[0u8; 12], 2, usize::MAX / 2, 2, 16) {
+    Err(Error::PreprocessAllocation { bytes }) => assert_eq!(bytes, usize::MAX),
+    other => panic!("expected PreprocessAllocation, got {other:?}"),
+  }
+}
+
+/// The `dst_len` checked-mul twin: a destination geometry whose `dst_w · dst_h
+/// · 3` byte count overflows `usize` is rejected with the same typed
+/// [`Error::PreprocessAllocation`] `{ bytes: usize::MAX }`, from the output
+/// sizing arm rather than the source-geometry guards above — the tiny `src` is
+/// never resized.
+#[test]
+fn resize_u8_rejects_overflowing_destination_length() {
+  match resize_bilinear_antialias_u8(&[0u8; 12], 2, 2, 2, usize::MAX / 2) {
     Err(Error::PreprocessAllocation { bytes }) => assert_eq!(bytes, usize::MAX),
     other => panic!("expected PreprocessAllocation, got {other:?}"),
   }

--- a/crates/coremlit/tests/feature_map.rs
+++ b/crates/coremlit/tests/feature_map.rs
@@ -77,7 +77,7 @@ fn expected_features() -> Vec<(&'static str, Vec<&'static str>)> {
       "granite",
       vec!["dep:tokenizers", "dep:windit", "windit/text"],
     ),
-    ("siglip", vec!["dep:tokenizers"]),
+    ("siglip", vec!["dep:tokenizers", "dep:colconv"]),
   ]
 }
 


### PR DESCRIPTION
## Summary

Routes the siglip NaFlex uint8 antialiased-bilinear image resize through the `colconv` crate's public resampler (`Convert::from(&Rgb24Frame).resize_with(Triangle, …).rgb(…).run()`), retiring coremlit's hand-rolled fixed-point kernel. **Byte-identical output** — colconv's `Triangle` reproduces the retired kernel's PIL-BILINEAR Q22 fixed-point behavior exactly (0 mismatches / 46k comparisons in the original assessment, re-confirmed in-tree).

- **Retired:** `quantize_coeffs_8bpc`, `clip8`, `checked_len3`, `alloc_u8`, `PRECISION_BITS`, and the hand-rolled resize body.
- **Kept native (correctly):** the f64 position-embedding lift keeps its own interpolation — `precompute_coeffs`/`triangle` stay live only for it (colconv is the u8 image-resize path only).
- **Errors:** colconv failures map to the existing typed `Error::PreprocessAllocation` via `try_new`/`try_reserve_exact` — no panic/abort, no new `unsafe`.
- **Dep:** `colconv` optional git dep rev-pinned to `0e2cef9`, `default-features = false`, features `["std","rgb"]`, gated behind the `siglip` feature.
- **Tests:** every pre-existing E3 uint8 oracle keeps its committed values (the `(65,192)` per-pass discriminant, checker grid, per-pass intermediates); a new distinct-per-channel oracle guards channel order with independent PIL-derived expected grids (non-vacuity confirmed by an R↔B swap failing exactly the affected channels).

## Verification

`fmt=0 clippy=0 test_siglip=0 test_siglip_serde=0 featmap=0 doc=0` (169/169 lib tests). `cargo tree` confirms colconv at the pinned rev with `rgb,std` only — no `ort`, no `frame` umbrella.

## Reviews

- **Fable 5 (max-effort), two rounds: ACCEPT.** Re-derived the byte-exact mapping in colconv's own source (Triangle == the retired kernel, `FilterAxis::build` == PIL `precompute_coeffs`, H-then-V u8 stream ≡ the old kernel, exact-integer-in-f64 / SIMD-immune); re-derived the new oracle's hand-computed PIL grid twice (48/48 R/G/B cells) to confirm the oracle data itself is correct.
- **Codex adversarial review: APPROVE (R1, no material findings).** Confirmed the Triangle path preserves the retired q22 behavior across degenerate axes, extreme/mixed scaling, max extents, rounding boundaries, and RGB channel order; typed-error discipline holds; no UB/leaks/aliasing/races/feature-leakage.

## ⚠️ Merge gate (owner action)

`colconv` is currently **GPL-3.0-or-later**. It must be relicensed to **MIT OR Apache-2.0** (matching coremlit and the findit-studio convention) before this PR merges — flagged in the `siglip` feature + dep comments. The code integration is complete and byte-exact; only the relicense remains.

siglip model-gated parity (Waves B/C) remains deferred (ignored shells) pending the staged conversion.
