### PR TITLE
fix(coremlit/granite): #44 P1 correctness — fail-closed input/tokenizer bounds + unit-norm restore + SHA identity gate

### DIFF
--- a/crates/coremlit/Cargo.toml
+++ b/crates/coremlit/Cargo.toml
@@ -98,7 +98,7 @@ clap-oracle = ["clap", "dep:textclap"]
 # transformers-fp32 goldens (`tests/granite/fixtures/goldens/`), never a live
 # ONNX crate — so there is NO `granite-oracle` feature and NO `ort` in this path.
 # `default = []` pulls none of it.
-granite = ["dep:tokenizers", "dep:windit", "windit/text"]
+granite = ["dep:tokenizers", "dep:windit", "windit/text", "dep:sha2"]
 
 # --- embeddings::siglip (the SigLIP 2 image+text phase) ---
 # SigLIP 2 (`siglip2-base-patch16-naflex`) dual-tower image+text embeddings on
@@ -280,6 +280,15 @@ textclap = { git = "https://github.com/Findit-AI/textclap", rev = "584f21754337a
 #   windit = { path = "../windit" }
 #
 windit = { git = "https://github.com/findit-studio/windit", rev = "b49888002bcbf4927cf69e83323f15652655eed0", optional = true }
+
+# --- embeddings::granite runtime tokenizer-identity digest (the `granite` feature) ---
+# Pure-Rust SHA-256 for granite's supplied-tokenizer byte-identity backstop:
+# `from_memory`/`from_files` hash the RAW input bytes and compare against the
+# pinned `tokenizer.json` SHA-256, fail-closed. Rides `granite` ONLY (a
+# granite-less build never pulls it — proven by the no-default-features check),
+# and is a dev-dependency too (the model/tokenizer provenance SHA pins), which
+# cargo unifies with this optional entry.
+sha2 = { workspace = true, optional = true }
 
 # --- embeddings::siglip image resampler (the `siglip` feature) ---
 # `colconv` supplies the byte-exact PIL-parity q8 image resampler the NaFlex u8

--- a/crates/coremlit/src/embeddings/granite/embedding/mod.rs
+++ b/crates/coremlit/src/embeddings/granite/embedding/mod.rs
@@ -71,7 +71,11 @@ impl Embedding {
   }
 
   /// Reconstruct from a stored unit vector. Validates length, finiteness, AND
-  /// unit-norm (`(norm² − 1).abs() ≤ ``NORM_BUDGET`).
+  /// unit-norm (`(norm² − 1).abs() ≤ ``NORM_BUDGET`), then re-normalizes the
+  /// accepted vector through the f64 path, so the stored embedding is unit-norm
+  /// to fp32 ULP and [`Self::cosine`] stays in `[−1, 1]` (within fp rounding)
+  /// for every successfully constructed pair — a budget-edge vector stored raw
+  /// would let `cosine` escape `[−1, 1]`.
   ///
   /// # Errors
   /// [`Error::EmbeddingDimMismatch`] if `s.len() != `[`EMBEDDING_DIM`];
@@ -96,9 +100,12 @@ impl Embedding {
         norm_sq_deviation: dev,
       });
     }
-    let mut inner = [0.0f32; EMBEDDING_DIM];
-    inner.copy_from_slice(s);
-    Ok(Self { inner })
+    // Within budget: rebuild through the f64 normalization path so the STORED
+    // vector is unit-norm to fp32 ULP regardless of where in the budget the
+    // input fell — a budget-edge vector copied raw makes `cosine` escape
+    // [−1, 1]. `EmbeddingZero` is unreachable here (norm² ≥ 1 − NORM_BUDGET > 0)
+    // and the dim/finite re-checks inside are already-proven cheap passes.
+    Self::from_slice_normalizing(s)
   }
 
   /// Construct from any non-zero finite slice, re-normalizing to unit length.
@@ -137,17 +144,6 @@ impl Embedding {
       *out = ((v as f64) * inv_norm_f64) as f32;
     }
     Ok(Self { inner })
-  }
-
-  /// Module-internal constructor for producers whose upstream guard already
-  /// validated unit-norm within `NORM_BUDGET`. Bypasses re-normalization.
-  #[allow(dead_code)]
-  pub(crate) fn from_array_trusted_unit_norm(arr: [f32; EMBEDDING_DIM]) -> Self {
-    debug_assert!({
-      let n: f32 = arr.iter().map(|x| x * x).sum();
-      (n - 1.0).abs() <= NORM_BUDGET
-    });
-    Self { inner: arr }
   }
 
   /// Inner product. For two unit vectors this equals [`Self::cosine`] to fp32

--- a/crates/coremlit/src/embeddings/granite/embedding/mod.rs
+++ b/crates/coremlit/src/embeddings/granite/embedding/mod.rs
@@ -71,7 +71,7 @@ impl Embedding {
   }
 
   /// Reconstruct from a stored unit vector. Validates length, finiteness, AND
-  /// unit-norm (`(norm² − 1).abs() ≤ ``NORM_BUDGET`), then re-normalizes the
+  /// unit-norm (`(norm² − 1).abs() ≤ NORM_BUDGET`), then re-normalizes the
   /// accepted vector through the f64 path, so the stored embedding is unit-norm
   /// to fp32 ULP and [`Self::cosine`] stays in `[−1, 1]` (within fp rounding)
   /// for every successfully constructed pair — a budget-edge vector stored raw

--- a/crates/coremlit/src/embeddings/granite/embedding/tests.rs
+++ b/crates/coremlit/src/embeddings/granite/embedding/tests.rs
@@ -7,6 +7,18 @@ fn e0() -> [f32; EMBEDDING_DIM] {
   s
 }
 
+/// f64-accumulated norm² of a stored embedding. The renormalization tests
+/// measure norm in f64: the f32 accumulation error over 384 terms (up to
+/// ~2e-5) would drown the ~1e-7 deviation the post-renormalization invariant
+/// asserts, so an f32 measure could not tell a renormalized vector from a
+/// raw-copied budget-edge one.
+fn norm_sq_f64(e: &Embedding) -> f64 {
+  e.as_slice()
+    .iter()
+    .map(|&x| f64::from(x) * f64::from(x))
+    .sum()
+}
+
 #[test]
 fn from_slice_normalizing_produces_unit_norm() {
   let s: Vec<f32> = (0..EMBEDDING_DIM).map(|i| (i as f32) + 1.0).collect();
@@ -117,11 +129,135 @@ fn from_slice_normalizing_wrong_len() {
 
 #[test]
 fn try_from_unit_slice_accepts_at_budget_edge() {
-  // norm² = 1 + 0.5·NORM_BUDGET must pass (≤ inclusive).
+  // norm² = 1 + 0.5·NORM_BUDGET must pass (≤ inclusive). Acceptance is the
+  // pinned behavior; the accepted vector is additionally stored renormalized.
   let target_sq = 1.0 + 0.5 * NORM_BUDGET;
   let mut s = [0.0f32; EMBEDDING_DIM];
   s[0] = target_sq.sqrt();
-  Embedding::try_from_unit_slice(&s).expect("within budget");
+  let e = Embedding::try_from_unit_slice(&s).expect("within budget");
+  assert!(
+    (norm_sq_f64(&e) - 1.0).abs() <= 1e-6,
+    "accepted vector must be stored unit-norm (f64 norm² = {})",
+    norm_sq_f64(&e)
+  );
+}
+
+#[test]
+fn restored_budget_edge_vector_is_renormalized() {
+  // The audit replay: norm² ≈ 1.0000522 (dev 5.22e-5, inside NORM_BUDGET).
+  // Copied raw, cos(x, x) = 1.0000522 > 1 and cos(x, −x) < −1; renormalized,
+  // the stored vector is unit-norm and cosine stays in [−1, 1].
+  let mut s = [0.0f32; EMBEDDING_DIM];
+  s[0] = (1.0f32 + 0.522e-4).sqrt();
+  let e = Embedding::try_from_unit_slice(&s).expect("within budget");
+
+  assert!(
+    (norm_sq_f64(&e) - 1.0).abs() <= 1e-6,
+    "stored vector must be renormalized to unit norm (f64 norm² = {})",
+    norm_sq_f64(&e)
+  );
+  let self_cos = e.cosine(&e);
+  assert!(
+    (1.0 - 1e-5..=1.0 + 1e-5).contains(&self_cos),
+    "cos(x, x) must stay in [−1, 1] (got {self_cos})"
+  );
+  assert!(
+    1.0 - self_cos >= -1e-5,
+    "cosine distance must be non-negative (1 − cos = {})",
+    1.0 - self_cos
+  );
+
+  let mut neg_s = [0.0f32; EMBEDDING_DIM];
+  neg_s[0] = -s[0];
+  let neg = Embedding::try_from_unit_slice(&neg_s).expect("−s is also within budget");
+  let opp = e.cosine(&neg);
+  assert!(
+    (-1.0 - 1e-5..=-1.0 + 1e-5).contains(&opp),
+    "cos(x, −x) must stay in [−1, 1] (got {opp})"
+  );
+}
+
+#[test]
+fn near_budget_vectors_restore_unit_norm_property() {
+  // A deterministic grid straddling the budget edge, over three vector shapes.
+  // The ACTUAL f32-accumulated deviation (the production gate's own metric)
+  // decides expected accept/reject in-test, so f32 rounding at the boundary
+  // cannot make the test brittle.
+  let devs = [-1.0f32, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 0.95, 1.0];
+  let uniform = (1.0f32 / EMBEDDING_DIM as f32).sqrt();
+  for &d in &devs {
+    let scale = (1.0f32 + d * NORM_BUDGET).sqrt();
+    let shapes: [Vec<f32>; 3] = [
+      {
+        let mut v = vec![0.0f32; EMBEDDING_DIM];
+        v[0] = scale; // single axis: e0 · scale
+        v
+      },
+      (0..EMBEDDING_DIM).map(|_| uniform * scale).collect(), // uniform
+      (0..EMBEDDING_DIM) // alternating-sign uniform
+        .map(|i| {
+          if i % 2 == 0 {
+            uniform * scale
+          } else {
+            -uniform * scale
+          }
+        })
+        .collect(),
+    ];
+    for s in &shapes {
+      let norm_sq: f32 = s.iter().map(|x| x * x).sum();
+      let expect_accept = (norm_sq - 1.0).abs() <= NORM_BUDGET;
+      match Embedding::try_from_unit_slice(s) {
+        Ok(e) => {
+          assert!(
+            expect_accept,
+            "accepted a vector the gate should reject (norm² = {norm_sq})"
+          );
+          assert!(
+            (norm_sq_f64(&e) - 1.0).abs() <= 1e-6,
+            "accepted vector not stored unit-norm (f64 norm² = {})",
+            norm_sq_f64(&e)
+          );
+          let c = e.cosine(&e);
+          assert!(
+            (1.0 - 1e-5..=1.0 + 1e-5).contains(&c),
+            "cos(x, x) escaped [−1, 1]: {c}"
+          );
+          assert!(1.0 - c >= -1e-5, "negative cosine distance: {}", 1.0 - c);
+          let neg: Vec<f32> = e.to_vec().iter().map(|v| -v).collect();
+          let neg_e =
+            Embedding::try_from_unit_slice(&neg).expect("a negated unit vector is unit-norm");
+          let o = e.cosine(&neg_e);
+          assert!(
+            (-1.0 - 1e-5..=-1.0 + 1e-5).contains(&o),
+            "cos(x, −x) escaped [−1, 1]: {o}"
+          );
+        }
+        Err(Error::EmbeddingNotUnitNorm { .. }) => {
+          assert!(
+            !expect_accept,
+            "rejected a vector the gate should accept (norm² = {norm_sq})"
+          );
+        }
+        Err(other) => panic!("unexpected error: {other:?}"),
+      }
+    }
+  }
+}
+
+#[test]
+fn try_from_unit_slice_is_idempotent_on_its_output() {
+  // Renormalizing an already-renormalized vector is a no-op to ULP scale.
+  let uniform = (1.0f32 / EMBEDDING_DIM as f32).sqrt();
+  let scale = (1.0f32 + 0.5 * NORM_BUDGET).sqrt();
+  let s: Vec<f32> = (0..EMBEDDING_DIM).map(|_| uniform * scale).collect();
+  let first = Embedding::try_from_unit_slice(&s).expect("within budget");
+  let second =
+    Embedding::try_from_unit_slice(&first.to_vec()).expect("renormalized output re-accepts");
+  assert!(
+    second.is_close(&first, 1e-6),
+    "renormalizing an already-renormalized vector must be a no-op to ULP scale"
+  );
 }
 
 #[test]

--- a/crates/coremlit/src/embeddings/granite/error/mod.rs
+++ b/crates/coremlit/src/embeddings/granite/error/mod.rs
@@ -108,6 +108,24 @@ pub enum Error {
   #[error("failed to tokenize text: {0}")]
   Tokenize(#[source] tokenizers::Error),
 
+  /// A caller-supplied tokenizer parsed but does not match the Granite
+  /// tokenizer/model contract (vocabulary size, special-token ids, the model's
+  /// id range, or the pinned sentinel encoding), so it would produce finite but
+  /// semantically meaningless embeddings — or out-of-vocabulary ids the model
+  /// can only gather as zeros. Checked at construction, fail-closed, by every
+  /// constructor.
+  #[error("tokenizer contract mismatch on `{check}`: expected {expected}, got {actual}")]
+  TokenizerContractMismatch {
+    /// Name of the contract check that failed (e.g. `vocab size`,
+    /// `special token <|startoftext|>`, `max token id`, `sentinel encoding`).
+    check: &'static str,
+    /// The contract this module expects, rendered for display.
+    expected: String,
+    /// What the supplied tokenizer actually declares/produces, rendered for
+    /// display (`missing` for an absent token).
+    actual: String,
+  },
+
   /// The tokenized input exceeded the fixed
   /// [`MAX_TOKENS`](crate::embeddings::granite::MAX_TOKENS) window. Every
   /// constructor forces truncation at that length and disables the tokenizer's
@@ -156,6 +174,42 @@ pub enum Error {
     /// The requested per-chunk token budget (`opts.window()`).
     window: usize,
     /// The model's fixed input window ([`MAX_TOKENS`](crate::embeddings::granite::MAX_TOKENS)).
+    max: usize,
+  },
+
+  /// The text handed to [`TextEmbedder::embed_long_with`] exceeds the
+  /// caller-configured input byte limit
+  /// ([`LongTextOptions::max_input_bytes`]). Enforced BEFORE any tokenizer or
+  /// chunker work, so the reject path's cost is independent of the input size —
+  /// the limit to set when embedding untrusted text.
+  ///
+  /// [`TextEmbedder::embed_long_with`]: crate::embeddings::granite::TextEmbedder::embed_long_with
+  /// [`LongTextOptions::max_input_bytes`]: crate::embeddings::granite::LongTextOptions::max_input_bytes
+  #[error("text input is {got} bytes, exceeding the configured {max}-byte limit")]
+  InputTooLarge {
+    /// The input length, in UTF-8 bytes.
+    got: usize,
+    /// The configured limit, in UTF-8 bytes.
+    max: usize,
+  },
+
+  /// A contentless (separator-only) byte run that must be embedded as one whole
+  /// window — the ENTIRE input when it has no tokenizable content, or a
+  /// pure-separator gap between packed chunks that neither neighbor can absorb —
+  /// measures more tokens than the model's fixed window can hold, so embedding
+  /// it would silently drop its suffix tokens. Refused instead (measured with
+  /// the non-truncating tokenizer, special tokens included).
+  #[error(
+    "contentless text at bytes {start}..{end} measures {tokens} tokens, exceeding the model's fixed {max}-token window"
+  )]
+  ContentlessInputOverBudget {
+    /// Start of the offending run, as a UTF-8 byte offset into the input.
+    start: usize,
+    /// One past the end of the offending run, as a UTF-8 byte offset.
+    end: usize,
+    /// The run's untruncated token count (special tokens included).
+    tokens: usize,
+    /// The fixed window ([`MAX_TOKENS`](crate::embeddings::granite::MAX_TOKENS)).
     max: usize,
   },
 }

--- a/crates/coremlit/src/embeddings/granite/error/mod.rs
+++ b/crates/coremlit/src/embeddings/granite/error/mod.rs
@@ -112,12 +112,17 @@ pub enum Error {
   /// tokenizer/model contract (vocabulary size, special-token ids, the model's
   /// id range, or the pinned sentinel encoding), so it would produce finite but
   /// semantically meaningless embeddings — or out-of-vocabulary ids the model
-  /// can only gather as zeros. Checked at construction, fail-closed, by every
-  /// constructor.
+  /// can only gather as zeros; OR it is behaviorally valid but not byte-identical
+  /// (SHA-256) to the pinned granite `tokenizer.json`, catching corruption or
+  /// version skew outside the behavioral checks' coverage. Checked at
+  /// construction, fail-closed, by every constructor; the byte-identity stage
+  /// runs on the caller-supplied constructors (`from_memory` / `from_files`) —
+  /// the bundled tokenizer's identity is pinned at dev time.
   #[error("tokenizer contract mismatch on `{check}`: expected {expected}, got {actual}")]
   TokenizerContractMismatch {
     /// Name of the contract check that failed (e.g. `vocab size`,
-    /// `special token <|startoftext|>`, `max token id`, `sentinel encoding`).
+    /// `special token <|startoftext|>`, `max token id`, `sentinel encoding`,
+    /// `tokenizer identity (sha-256)`).
     check: &'static str,
     /// The contract this module expects, rendered for display.
     expected: String,

--- a/crates/coremlit/src/embeddings/granite/error/tests.rs
+++ b/crates/coremlit/src/embeddings/granite/error/tests.rs
@@ -47,3 +47,40 @@ fn non_finite_variants_carry_index() {
       .contains('3')
   );
 }
+
+#[test]
+fn tokenizer_contract_mismatch_display_names_check() {
+  let e = Error::TokenizerContractMismatch {
+    check: "vocab size",
+    expected: "180000".to_string(),
+    actual: "32".to_string(),
+  };
+  let msg = e.to_string();
+  assert!(msg.contains("vocab size"), "{msg}");
+  assert!(msg.contains("180000") && msg.contains("32"), "{msg}");
+}
+
+#[test]
+fn input_too_large_display_shows_sizes() {
+  let e = Error::InputTooLarge {
+    got: 8_388_608,
+    max: 1_048_576,
+  };
+  let msg = e.to_string();
+  assert!(msg.contains("8388608") && msg.contains("1048576"), "{msg}");
+}
+
+#[test]
+fn contentless_input_over_budget_display_shows_span_and_counts() {
+  let e = Error::ContentlessInputOverBudget {
+    start: 1,
+    end: 100_001,
+    tokens: 784,
+    max: 512,
+  };
+  let msg = e.to_string();
+  assert!(
+    msg.contains("100001") && msg.contains("784") && msg.contains("512"),
+    "{msg}"
+  );
+}

--- a/crates/coremlit/src/embeddings/granite/mod.rs
+++ b/crates/coremlit/src/embeddings/granite/mod.rs
@@ -67,8 +67,9 @@ pub use embedding::Embedding;
 pub use error::Error;
 
 /// windit's window geometry, re-exported as the one windit type in granite's
-/// public surface: the per-chunk token budget, overlap, and window cap
-/// [`TextEmbedder::embed_long_with`] accepts.
+/// public surface: the per-chunk token budget, overlap, and window cap. Carried
+/// by [`LongTextOptions`] (alongside granite's own `max_input_bytes` bound), the
+/// options [`TextEmbedder::embed_long_with`] accepts.
 pub use windit::plan::WindowOptions;
 
 use std::{path::Path, sync::OnceLock};
@@ -91,7 +92,10 @@ use crate::embeddings::granite::{
 /// byte-correct by `tests/granite/tokenizer_identity.rs`. Exposed for callers
 /// who construct [`TextEmbedder`] via [`TextEmbedder::from_memory`]; the
 /// [`TextEmbedder::load`] / [`TextEmbedder::from_file`] constructors use it
-/// directly.
+/// directly. It passes the construction-time tokenizer contract
+/// (`validate_tokenizer_contract`) trivially; a caller-supplied tokenizer (via
+/// [`TextEmbedder::from_memory`] / [`TextEmbedder::from_files`]) is checked
+/// against that same contract, fail-closed.
 pub const BUNDLED_TOKENIZER: &[u8] = include_bytes!("assets/tokenizer.json");
 
 /// Declared feature names on the granite `.mlmodelc` (pinned by
@@ -100,6 +104,33 @@ mod names {
   pub const INPUT_IDS: &str = "input_ids";
   pub const ATTENTION_MASK: &str = "attention_mask";
   pub const EMBEDDING: &str = "embedding";
+}
+
+/// The Granite tokenizer/model contract, verified against the bundled asset and
+/// the committed goldens: the total vocabulary INCLUDING added tokens, the
+/// highest id the model's embedding table can gather, the special tokens
+/// [`TextEmbedder::token_ids`] brackets every sequence with, and one pinned
+/// sentinel encoding. [`validate_tokenizer_contract`] checks every constructor's
+/// tokenizer against these, fail-closed.
+mod contract {
+  /// Total vocabulary size (base + added tokens) `get_vocab_size(true)` reports.
+  pub const VOCAB_SIZE: usize = 180_000;
+  /// Highest token id the model's embedding table can gather; an id past this
+  /// indexes outside the table and gathers zeros.
+  pub const MAX_TOKEN_ID: u32 = 179_999;
+  /// CLS / start-of-text special, pooled at position 0.
+  pub const CLS_TOKEN: &str = "<|startoftext|>";
+  pub const CLS_ID: u32 = 179_934;
+  /// Padding special (also the fixed-window pad id).
+  pub const PAD_TOKEN: &str = "<|endoftext|>";
+  pub const PAD_ID: u32 = 179_935;
+  /// End-of-sequence special.
+  pub const EOS_TOKEN: &str = "<|return|>";
+  pub const EOS_ID: u32 = 179_938;
+  /// Pinned sentinel: `SENTINEL_TEXT` encodes to `SENTINEL_IDS` (special tokens
+  /// included) — the same pin `token_ids_match_pinned_golden_subset` asserts.
+  pub const SENTINEL_TEXT: &str = "hello world";
+  pub const SENTINEL_IDS: [u32; 4] = [CLS_ID, 24_313, 2_318, EOS_ID];
 }
 
 /// Fixed token-sequence length the ModernBERT graph was converted at (the
@@ -170,6 +201,91 @@ impl TextEmbedderOptions {
   }
 }
 
+/// Options for [`TextEmbedder::embed_long_with`] (rust-options-pattern): windit's
+/// chunk geometry ([`WindowOptions`]) plus granite's pre-tokenization input
+/// bound.
+///
+/// Not serializable: coremlit deliberately does not enable `windit/serde`
+/// (granite serializes nothing of windit's), so the composed [`WindowOptions`]
+/// carries no serde impls in this build. If serialization is ever needed, add
+/// `windit?/serde` to coremlit's `serde` feature and derive here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LongTextOptions {
+  window_options: WindowOptions,
+  max_input_bytes: Option<usize>,
+}
+
+impl Default for LongTextOptions {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl From<WindowOptions> for LongTextOptions {
+  /// Geometry-only options: the given windit geometry, no input byte limit.
+  fn from(window_options: WindowOptions) -> Self {
+    Self {
+      window_options,
+      max_input_bytes: None,
+    }
+  }
+}
+
+impl LongTextOptions {
+  /// Options matching [`TextEmbedder::embed_long`]: a full-window geometry
+  /// (`WindowOptions::new(MAX_TOKENS)`) and no input byte limit.
+  pub const fn new() -> Self {
+    Self {
+      window_options: WindowOptions::new(MAX_TOKENS),
+      max_input_bytes: None,
+    }
+  }
+
+  /// The windit chunk geometry (per-chunk token budget, overlap, window cap).
+  #[inline]
+  pub const fn window_options(&self) -> WindowOptions {
+    self.window_options
+  }
+
+  /// Builder form of [`Self::set_window_options`].
+  #[must_use]
+  #[inline]
+  pub const fn with_window_options(mut self, window_options: WindowOptions) -> Self {
+    self.set_window_options(window_options);
+    self
+  }
+
+  /// Sets [`Self::window_options`] in place.
+  #[inline]
+  pub const fn set_window_options(&mut self, window_options: WindowOptions) -> &mut Self {
+    self.window_options = window_options;
+    self
+  }
+
+  /// The maximum accepted input length in UTF-8 bytes, if any. `None` (the
+  /// default) means unbounded. Enforced before any tokenizer or chunker work —
+  /// the limit callers embedding UNTRUSTED text should set.
+  #[inline]
+  pub const fn max_input_bytes(&self) -> Option<usize> {
+    self.max_input_bytes
+  }
+
+  /// Builder form of [`Self::set_max_input_bytes`].
+  #[must_use]
+  #[inline]
+  pub const fn with_max_input_bytes(mut self, max_input_bytes: usize) -> Self {
+    self.set_max_input_bytes(max_input_bytes);
+    self
+  }
+
+  /// Sets [`Self::max_input_bytes`] in place (to `Some(max_input_bytes)`).
+  #[inline]
+  pub const fn set_max_input_bytes(&mut self, max_input_bytes: usize) -> &mut Self {
+    self.max_input_bytes = Some(max_input_bytes);
+    self
+  }
+}
+
 /// granite text embedder: a `&str` in, a unit-norm 384-d [`Embedding`] out.
 ///
 /// Tokenizes with the bundled granite tokenizer (truncation `LongestFirst` at
@@ -223,7 +339,8 @@ impl TextEmbedder {
   /// [`Error::Load`] if CoreML rejects the model / [`Error::ContractMismatch`]
   /// if its I/O contract mismatches; [`Error::TokenizerLoad`] if the tokenizer
   /// JSON is unreadable/invalid; [`Error::TokenizerConfig`] if truncation cannot
-  /// be configured.
+  /// be configured; [`Error::TokenizerContractMismatch`] if the tokenizer does
+  /// not match the Granite tokenizer/model contract (`validate_tokenizer_contract`).
   pub fn from_files(
     model_path: impl AsRef<Path>,
     tokenizer_json_path: impl AsRef<Path>,
@@ -253,11 +370,18 @@ impl TextEmbedder {
     options: TextEmbedderOptions,
   ) -> Result<Self> {
     configure_tokenizer(&mut tokenizer)?;
+    // Reject a caller-supplied tokenizer that does not match the Granite
+    // tokenizer/model contract, fail-closed and BEFORE the expensive
+    // `Model::load` — every public constructor passes through here, so no
+    // `TextEmbedder` can exist with an unvalidated tokenizer (the bundled
+    // tokenizer passes trivially; this also guards a corrupted build asset).
+    validate_tokenizer_contract(&tokenizer)?;
     // The pad positions are attention-masked to 0 and CLS pooling reads position
     // 0 (never a pad), so the pad token value is immaterial to the output; a
-    // valid vocabulary index is all that is required. Resolve granite's pad
-    // token `<|endoftext|>` (checked into `i32` range), else fall back to `0`
-    // (the BOS/CLS index, always valid).
+    // valid vocabulary index is all that is required. `validate_tokenizer_contract`
+    // above proved `<|endoftext|>` resolves to `contract::PAD_ID` (in `i32`
+    // range), so the `unwrap_or(0)` fallback is now unreachable defensive code,
+    // kept for its guarantee of a valid index.
     let pad_id = tokenizer
       .token_to_id("<|endoftext|>")
       .and_then(|id| i32::try_from(id).ok())
@@ -428,26 +552,27 @@ impl TextEmbedder {
   /// fallback) are reattached to an adjacent chunk before embedding — so the
   /// aggregate represents the caller's whole text, as `embed` does within one
   /// window. Prompt-free, like [`Self::embed`], and equivalent to
-  /// `embed_long_with(text, &WindowOptions::new(MAX_TOKENS))`.
+  /// `embed_long_with(text, &LongTextOptions::new())`.
   ///
   /// Text that fits a single window returns exactly [`Self::embed`]'s embedding.
   ///
   /// # Errors
   /// As [`Self::embed_long_with`].
   pub fn embed_long(&self, text: &str) -> Result<Embedding> {
-    self.embed_long_with(text, &WindowOptions::new(MAX_TOKENS))
+    self.embed_long_with(text, &LongTextOptions::new())
   }
 
-  /// [`Self::embed_long`] with caller-controlled chunk geometry: `opts.window()`
-  /// is the per-chunk token budget (must be `1..=`[`MAX_TOKENS`]), the overlap
-  /// sets the repeated-token budget between consecutive chunks, and
-  /// `opts.max_windows()` caps the final chunk count — separator reattachment
-  /// and the whole-input fallback chunk for contentless text included — which
-  /// is exactly the number of CoreML predictions the call may dispatch. A cap
-  /// of `0` therefore rejects every nonempty text, while `""` still fails
-  /// [`Error::EmptyText`].
-  /// `opts.tail()` is ignored — content-aware chunking has no ragged-tail
-  /// concept, the final chunk is simply short.
+  /// [`Self::embed_long`] with caller-controlled chunk geometry and an optional
+  /// input-size bound ([`LongTextOptions`]). In the geometry
+  /// ([`LongTextOptions::window_options`]): `window()` is the per-chunk token
+  /// budget (must be `1..=`[`MAX_TOKENS`]), the overlap sets the repeated-token
+  /// budget between consecutive chunks, and `max_windows()` caps the final chunk
+  /// count — separator reattachment and the whole-input fallback chunk for
+  /// contentless text included — which is exactly the number of CoreML
+  /// predictions the call may dispatch. A cap of `0` therefore rejects every
+  /// nonempty text, while `""` still fails [`Error::EmptyText`]. `tail()` is
+  /// ignored — content-aware chunking has no ragged-tail concept, the final
+  /// chunk is simply short.
   ///
   /// The per-chunk token budget counts granite's special tokens (`[CLS]`/`[SEP]`,
   /// +2), because both the length measurement and each chunk's embedding run
@@ -458,27 +583,43 @@ impl TextEmbedder {
   /// each begins where the previous ends, the last ends at `text.len()`); a
   /// non-zero overlap additionally repeats trailing regions. Reattached
   /// separators are re-measured against the budget; a pure-separator run neither
-  /// neighbor can absorb becomes a chunk of its own and can exceed `window` only
-  /// when the run alone measures past it — the same recorded escape as windit's
-  /// lone oversized `char`, kept sound by the embed path's truncation guard.
-  /// Such insertions count against `opts.max_windows()`: the cap is enforced on
-  /// the repaired chunk list, never silently exceeded.
+  /// neighbor can absorb becomes a chunk of its own and may exceed `window` up to
+  /// [`MAX_TOKENS`] — the same tolerance as windit's lone oversized `char` — but a
+  /// run measuring past [`MAX_TOKENS`] is refused with
+  /// [`Error::ContentlessInputOverBudget`] rather than silently truncated. Such
+  /// insertions count against `max_windows()`: the cap is enforced on the
+  /// repaired chunk list, never silently exceeded.
+  ///
+  /// # Resource bounds
+  /// Three independent limits, in the order the reject path applies them:
+  /// * [`LongTextOptions::max_input_bytes`] — an input-size gate in UTF-8 bytes,
+  ///   enforced BEFORE any tokenizer or chunker work; the only bound whose reject
+  ///   cost is O(1) in the input size (`None` by default — the bound to set when
+  ///   embedding untrusted text).
+  /// * `window()` / `overlap()` — the per-chunk token geometry above.
+  /// * `max_windows()` — a prediction-count cap: it bounds the CoreML predictions
+  ///   dispatched and windit's chunk packing (which is cap-lazy), but NOT the
+  ///   measurement cost of chunking — even a `max_windows()` of `0` tokenizes the
+  ///   whole input unless `max_input_bytes` is set.
   ///
   /// # Errors
-  /// [`Error::WindowOverBudget`] if `opts.window()` exceeds [`MAX_TOKENS`] (every
-  /// chunk would be silently truncated); [`Error::EmptyText`] for `""` (as
-  /// [`Self::embed`]); [`Error::Tokenize`] on a tokenizer failure;
-  /// [`Error::Windowing`] carrying a [`WinditError`](crate::embeddings::granite::error::WinditError)
-  /// from chunking (e.g. `ZeroWindow`, `OverlapGeWindow`, `TooManyWindows` — the
-  /// `max_windows` cap binds the final chunk count — post-reattachment,
-  /// contentless nonempty text counting as one whole-input chunk — `got`
-  /// reporting that full count) or
+  /// [`Error::InputTooLarge`] if `text` exceeds `max_input_bytes`;
+  /// [`Error::WindowOverBudget`] if `window()` exceeds [`MAX_TOKENS`] (every chunk
+  /// would be silently truncated); [`Error::EmptyText`] for `""` (as
+  /// [`Self::embed`]); [`Error::ContentlessInputOverBudget`] if a contentless run
+  /// that must be embedded whole measures past [`MAX_TOKENS`]; [`Error::Tokenize`]
+  /// on a tokenizer failure; [`Error::Windowing`] carrying a
+  /// [`WinditError`](crate::embeddings::granite::error::WinditError) from chunking
+  /// (e.g. `ZeroWindow`, `OverlapGeWindow`, `TooManyWindows` — the `max_windows`
+  /// cap binds the final chunk count — post-reattachment, contentless nonempty
+  /// text counting as one whole-input chunk — `got` reporting that full count) or
   /// aggregation (e.g. `NonFinite` when the per-chunk embeddings cancel exactly);
   /// plus any per-chunk tensor / prediction / output error (the same set
   /// [`Self::embed`] can raise).
-  pub fn embed_long_with(&self, text: &str, opts: &WindowOptions) -> Result<Embedding> {
-    validate_long_options(opts)?;
-    let chunks = chunk_long(self.measuring_tokenizer()?, text, opts)?;
+  pub fn embed_long_with(&self, text: &str, opts: &LongTextOptions) -> Result<Embedding> {
+    validate_long_input(text, opts)?;
+    let wopts = opts.window_options();
+    let chunks = chunk_long(self.measuring_tokenizer()?, text, &wopts)?;
     match chunks.len() {
       // Only `""` chunks to nothing (`chunk_long` gives contentless nonempty
       // text a single whole-input chunk); `embed` defines the empty-input
@@ -549,6 +690,85 @@ fn configure_tokenizer(tokenizer: &mut Tokenizer) -> Result<()> {
   Ok(())
 }
 
+/// Validates a tokenizer against the Granite model contract, fail-closed: a
+/// parseable-but-foreign tokenizer would otherwise produce finite, unit-norm,
+/// semantically meaningless embeddings, or emit ids past the model's embedding
+/// table that gather to zeros and surface only as a misleading
+/// [`Error::EmbeddingZero`]. Run by every constructor on the CONFIGURED tokenizer
+/// (after [`configure_tokenizer`]), so the sentinel check proves the exact
+/// production [`TextEmbedder::token_ids`] behavior.
+///
+/// Checks, first failure wins: the three special-token ids, the total vocabulary
+/// size, the maximum token id (the out-of-vocabulary gate), then the pinned
+/// sentinel encoding.
+///
+/// # Errors
+/// [`Error::TokenizerContractMismatch`] naming the first failed check;
+/// [`Error::Tokenize`] if the sentinel encode itself fails.
+fn validate_tokenizer_contract(tokenizer: &Tokenizer) -> Result<()> {
+  for (check, token, expected_id) in [
+    (
+      "special token <|startoftext|>",
+      contract::CLS_TOKEN,
+      contract::CLS_ID,
+    ),
+    (
+      "special token <|endoftext|>",
+      contract::PAD_TOKEN,
+      contract::PAD_ID,
+    ),
+    (
+      "special token <|return|>",
+      contract::EOS_TOKEN,
+      contract::EOS_ID,
+    ),
+  ] {
+    let actual = tokenizer.token_to_id(token);
+    if actual != Some(expected_id) {
+      return Err(Error::TokenizerContractMismatch {
+        check,
+        expected: expected_id.to_string(),
+        actual: actual.map_or_else(|| "missing".to_string(), |id| id.to_string()),
+      });
+    }
+  }
+
+  let vocab_size = tokenizer.get_vocab_size(true);
+  if vocab_size != contract::VOCAB_SIZE {
+    return Err(Error::TokenizerContractMismatch {
+      check: "vocab size",
+      expected: contract::VOCAB_SIZE.to_string(),
+      actual: vocab_size.to_string(),
+    });
+  }
+
+  // The out-of-vocabulary gate: an id past the model's embedding table gathers
+  // zeros. The count check above does not imply this bound — added tokens carry
+  // explicit, possibly non-contiguous ids. `get_vocab(true)` allocates a ~180k
+  // entry map, one-time at construction and trivial next to the model load.
+  let max_id = tokenizer.get_vocab(true).values().copied().max();
+  if !matches!(max_id, Some(id) if id <= contract::MAX_TOKEN_ID) {
+    return Err(Error::TokenizerContractMismatch {
+      check: "max token id",
+      expected: format!("<= {}", contract::MAX_TOKEN_ID),
+      actual: max_id.map_or_else(|| "empty vocab".to_string(), |id| id.to_string()),
+    });
+  }
+
+  let sentinel = tokenizer
+    .encode(contract::SENTINEL_TEXT, true)
+    .map_err(Error::Tokenize)?;
+  if sentinel.get_ids() != contract::SENTINEL_IDS.as_slice() {
+    return Err(Error::TokenizerContractMismatch {
+      check: "sentinel encoding",
+      expected: format!("{:?}", contract::SENTINEL_IDS),
+      actual: format!("{:?}", sentinel.get_ids()),
+    });
+  }
+
+  Ok(())
+}
+
 /// Builds the fixed `[1, `[`MAX_TOKENS`]`]` `input_ids` / `attention_mask` window
 /// from the real token `ids`: the real tokens occupy the prefix (mask `1`) and
 /// the remainder is right-padded with `pad_id` (mask `0`). CLS therefore stays at
@@ -579,18 +799,33 @@ fn build_window(ids: &[u32], pad_id: i32) -> Result<([i32; MAX_TOKENS], [i32; MA
   Ok((input_ids, attention_mask))
 }
 
-/// Rejects an [`TextEmbedder::embed_long`] chunk budget above the model's fixed
-/// input window before any chunking or prediction: a larger budget would let
-/// [`TextEmbedder::token_ids`] silently truncate every chunk. Factored out so the
-/// check is hermetically testable. `window == 0` and `overlap >= window` are left
-/// to windit's own validation (surfacing as [`Error::Windowing`]).
+/// Rejects an oversized or mis-budgeted [`TextEmbedder::embed_long_with`] call
+/// before any tokenizer or chunker work. Checked in order: the input byte limit
+/// ([`Error::InputTooLarge`]), then the per-chunk budget
+/// ([`Error::WindowOverBudget`]) — an over-budget window would let
+/// [`TextEmbedder::token_ids`] silently truncate every chunk. Reads only
+/// `text.len()` and the options — O(1), no tokenizer access — so the reject
+/// path's cost is independent of the input size by construction. Factored out so
+/// the check is hermetically testable. `window == 0` and `overlap >= window` are
+/// left to windit's own validation (surfacing as [`Error::Windowing`]).
 ///
 /// # Errors
-/// [`Error::WindowOverBudget`] if `opts.window()` exceeds [`MAX_TOKENS`].
-fn validate_long_options(opts: &WindowOptions) -> Result<()> {
-  if opts.window() > MAX_TOKENS {
+/// [`Error::InputTooLarge`] if `text` exceeds
+/// [`LongTextOptions::max_input_bytes`]; [`Error::WindowOverBudget`] if the
+/// window exceeds [`MAX_TOKENS`].
+fn validate_long_input(text: &str, opts: &LongTextOptions) -> Result<()> {
+  if let Some(max) = opts.max_input_bytes()
+    && text.len() > max
+  {
+    return Err(Error::InputTooLarge {
+      got: text.len(),
+      max,
+    });
+  }
+  let window = opts.window_options().window();
+  if window > MAX_TOKENS {
     return Err(Error::WindowOverBudget {
-      window: opts.window(),
+      window,
       max: MAX_TOKENS,
     });
   }
@@ -618,15 +853,16 @@ fn validate_long_options(opts: &WindowOptions) -> Result<()> {
 /// Measurement and per-chunk embedding run the SAME tokenization
 /// (`encode(s, add_special_tokens = true)`) on the SAME substring, so a chunk
 /// measured at `<= window <= MAX_TOKENS` re-tokenizes to exactly the counted ids
-/// and [`build_window`] never truncates or rejects it. Three escapes can
-/// exceed the window: windit's lone oversized `char` whose own measure
-/// exceeds it, a pure-separator gap whose run alone measures past it (emitted
-/// as its own chunk when neither neighbor can absorb it), and the whole-input
-/// fallback chunk for contentless text, which is never measured (with the
-/// real tokenizer it holds only the specials, within any window ≥ 2). The
-/// first two are unreachable for a real tokenizer on natural text;
-/// `token_ids`' truncation plus [`build_window`]'s typed guard keep all three
-/// sound regardless.
+/// and [`build_window`] never truncates or rejects it. Every chunk returned has
+/// an untruncated measure `<= MAX_TOKENS`, with a single exception: windit's
+/// lone oversized `char` (one `char` encodes to at most a handful of ids, far
+/// below [`MAX_TOKENS`], so it can exceed a small `window` but never the model
+/// window). Both contentless escapes — a pure-separator gap [`attach_gaps`]
+/// would emit as its own chunk, and the whole-input fallback chunk for text with
+/// no tokenizable content — are now MEASURED and refused past [`MAX_TOKENS`]
+/// with [`Error::ContentlessInputOverBudget`] rather than silently truncated by
+/// the embed path. The production tokenizer's truncation therefore never engages
+/// on the `embed_long` path.
 ///
 /// # Errors
 /// [`Error::Windowing`] carrying whatever windit's `ContentAware::chunk` rejects
@@ -636,7 +872,11 @@ fn validate_long_options(opts: &WindowOptions) -> Result<()> {
 /// — the cap binds the FINAL chunk count, exactly the per-chunk predictions
 /// [`TextEmbedder::embed_long_with`] dispatches, `got` reporting that full
 /// count (windit's own raise aborts at `max + 1`; this one reports the whole
-/// overrun).
+/// overrun); [`Error::ContentlessInputOverBudget`] if a contentless run that
+/// must be embedded whole (the whole input, or a pure-separator gap
+/// [`attach_gaps`] emits) measures past [`MAX_TOKENS`] — measured at synthesis,
+/// BEFORE the `max_windows` re-check; [`Error::Tokenize`] if the measuring
+/// tokenizer fails to encode such a run.
 fn chunk_long(
   measure_tok: &Tokenizer,
   text: &str,
@@ -655,19 +895,43 @@ fn chunk_long(
       .map(|e| e.get_ids().len())
       .unwrap_or(usize::MAX)
   };
+  // Fallible companion for the granite-side own-chunk / whole-input decisions.
+  // The infallible `measure` above folds encode errors to `usize::MAX` ("does
+  // not fit"), which is right for windit's descent but would misreport an
+  // encode failure as `ContentlessInputOverBudget { tokens: usize::MAX }` here;
+  // this one surfaces the failure as `Error::Tokenize` — the same variant the
+  // per-chunk `token_ids` re-raise, one call earlier. The two are deliberately
+  // NOT unified.
+  let measure_checked = |s: &str| -> Result<usize> {
+    measure_tok
+      .encode(s, true)
+      .map(|e| e.get_ids().len())
+      .map_err(Error::Tokenize)
+  };
   let chunks = windit::split::ContentAware::new(&measure)
     .chunk(text, opts)
     .map_err(Error::from)?;
-  let mut repaired = attach_gaps(text, chunks, &measure, opts.window());
+  let mut repaired = attach_gaps(text, chunks, &measure_checked, opts.window())?;
   // Nonempty text with no tokenizable content (whitespace-only) chunks to
   // nothing, yet `embed_long_with` still embeds it — the whole input through
-  // `embed`, one CoreML prediction. Represent that cost as a single
-  // whole-input chunk so the cap below bounds every prediction the result can
-  // dispatch; only `""` stays chunkless (it fails `EmptyText` before any
-  // prediction). Like a pure-separator own-chunk, this chunk is not measured
-  // against `window` — there is no smaller unit to fall back to — and is kept
-  // sound the same way (`token_ids` truncation, `build_window`'s typed guard).
+  // `embed`, one CoreML prediction. Measure it first: a run measuring past
+  // MAX_TOKENS would be silently right-truncated by the embed path (dropping
+  // its suffix tokens), so refuse it with `ContentlessInputOverBudget`;
+  // otherwise represent the cost as a single whole-input chunk so the cap below
+  // bounds every prediction the result can dispatch. Only `""` stays chunkless
+  // (it fails `EmptyText` before any prediction). The measure runs BEFORE the
+  // `max_windows` re-check, so contentless over-budget input under
+  // `max_windows == 0` yields `ContentlessInputOverBudget`, not `TooManyWindows`.
   if repaired.is_empty() && !text.is_empty() {
+    let tokens = measure_checked(text)?;
+    if tokens > MAX_TOKENS {
+      return Err(Error::ContentlessInputOverBudget {
+        start: 0,
+        end: text.len(),
+        tokens,
+        max: MAX_TOKENS,
+      });
+    }
     repaired.push(windit::split::Chunk::new(0, text.len()));
   }
   // windit enforced `max_windows` on ITS output; each own-chunk the repair
@@ -718,43 +982,52 @@ fn chunk_long(
 /// per own-chunk emitted; [`chunk_long`] re-enforces `max_windows` on that
 /// final count.
 ///
-/// Every accepted attachment re-measures within `window`; the sole escape is a
-/// pure-separator own-chunk whose run alone measures past `window` — the same
-/// shape as windit's lone oversized-`char` escape, and kept sound the same way:
-/// [`TextEmbedder::token_ids`] truncates at [`MAX_TOKENS`] and [`build_window`]
-/// guards with a typed error rather than panicking. Every constructed boundary is
-/// a windit cut or `0`/`text.len()`, all on `char` boundaries, so `Chunk::new`
+/// Every accepted attachment re-measures within `window`. A pure-separator
+/// own-chunk (emitted when neither neighbor can absorb the gap) may still exceed
+/// `window` up to [`MAX_TOKENS`] — the same tolerance as windit's lone
+/// oversized-`char` escape — but its run is MEASURED, and a gap measuring past
+/// [`MAX_TOKENS`] is refused with [`Error::ContentlessInputOverBudget`] rather
+/// than left for the embed path to silently truncate. Every constructed boundary
+/// is a windit cut or `0`/`text.len()`, all on `char` boundaries, so `Chunk::new`
 /// never straddles a `char` and `as_str` never returns `None`.
+///
+/// # Errors
+/// [`Error::ContentlessInputOverBudget`] if a pure-separator gap emitted as its
+/// own chunk measures more than [`MAX_TOKENS`] tokens; [`Error::Tokenize`] if
+/// the measuring tokenizer fails to encode a candidate substring (surfaced here,
+/// one call earlier than the per-chunk `token_ids` would).
 fn attach_gaps(
   text: &str,
   chunks: Vec<windit::split::Chunk>,
-  measure: &dyn Fn(&str) -> usize,
+  measure: &dyn Fn(&str) -> Result<usize>,
   window: usize,
-) -> Vec<windit::split::Chunk> {
+) -> Result<Vec<windit::split::Chunk>> {
   use windit::split::Chunk;
   let Some(&first) = chunks.first() else {
-    return chunks;
+    return Ok(chunks);
   };
   let mut out = Vec::with_capacity(chunks.len());
   let mut cur = first;
-  // Leading gap: extend the first chunk left to byte 0, else emit the gap alone.
+  // Leading gap: extend the first chunk left to byte 0, else emit the gap alone
+  // (measured and refused past MAX_TOKENS, never left for the embed path to
+  // silently truncate).
   if cur.start() > 0 {
-    if measure(&text[..cur.end()]) <= window {
+    if measure(&text[..cur.end()])? <= window {
       cur = Chunk::new(0, cur.end());
     } else {
-      out.push(Chunk::new(0, cur.start()));
+      out.push(own_chunk(text, 0, cur.start(), measure)?);
     }
   }
   for mut next in chunks.into_iter().skip(1) {
     let (gap_start, gap_end) = (cur.end(), next.start());
     if gap_start < gap_end {
-      if measure(&text[cur.start()..gap_end]) <= window {
+      if measure(&text[cur.start()..gap_end])? <= window {
         cur = Chunk::new(cur.start(), gap_end);
-      } else if measure(&text[gap_start..next.end()]) <= window {
+      } else if measure(&text[gap_start..next.end()])? <= window {
         next = Chunk::new(gap_start, next.end());
       } else {
         out.push(cur);
-        out.push(Chunk::new(gap_start, gap_end));
+        out.push(own_chunk(text, gap_start, gap_end, measure)?);
         cur = next;
         continue;
       }
@@ -764,16 +1037,44 @@ fn attach_gaps(
   }
   // Trailing gap: extend the last chunk to `text.len()`, else emit the gap alone.
   if cur.end() < text.len() {
-    if measure(&text[cur.start()..]) <= window {
+    if measure(&text[cur.start()..])? <= window {
       cur = Chunk::new(cur.start(), text.len());
     } else {
-      let tail = Chunk::new(cur.end(), text.len());
+      let tail = own_chunk(text, cur.end(), text.len(), measure)?;
       out.push(cur);
       cur = tail;
     }
   }
   out.push(cur);
-  out
+  Ok(out)
+}
+
+/// Builds the pure-separator own-chunk spanning `text[start..end]`, measuring
+/// its run first: a gap measuring past [`MAX_TOKENS`] would be silently
+/// right-truncated by the embed path (dropping its suffix tokens), so it is
+/// refused with [`Error::ContentlessInputOverBudget`] instead. The `(window,
+/// MAX_TOKENS]` tolerance is kept — the same shape as windit's lone oversized
+/// `char`.
+///
+/// # Errors
+/// [`Error::ContentlessInputOverBudget`] if the run exceeds [`MAX_TOKENS`];
+/// [`Error::Tokenize`] if the measuring tokenizer fails to encode it.
+fn own_chunk(
+  text: &str,
+  start: usize,
+  end: usize,
+  measure: &dyn Fn(&str) -> Result<usize>,
+) -> Result<windit::split::Chunk> {
+  let tokens = measure(&text[start..end])?;
+  if tokens > MAX_TOKENS {
+    return Err(Error::ContentlessInputOverBudget {
+      start,
+      end,
+      tokens,
+      max: MAX_TOKENS,
+    });
+  }
+  Ok(windit::split::Chunk::new(start, end))
 }
 
 /// Test-only seam: the module's actual tokenizer configuration, without loading

--- a/crates/coremlit/src/embeddings/granite/mod.rs
+++ b/crates/coremlit/src/embeddings/granite/mod.rs
@@ -95,7 +95,8 @@ use crate::embeddings::granite::{
 /// directly. It passes the construction-time tokenizer contract
 /// (`validate_tokenizer_contract`) trivially; a caller-supplied tokenizer (via
 /// [`TextEmbedder::from_memory`] / [`TextEmbedder::from_files`]) is checked
-/// against that same contract, fail-closed.
+/// against that same contract AND against this artifact's SHA-256 (byte
+/// identity), fail-closed.
 pub const BUNDLED_TOKENIZER: &[u8] = include_bytes!("assets/tokenizer.json");
 
 /// Declared feature names on the granite `.mlmodelc` (pinned by
@@ -131,6 +132,13 @@ mod contract {
   /// included) — the same pin `token_ids_match_pinned_golden_subset` asserts.
   pub const SENTINEL_TEXT: &str = "hello world";
   pub const SENTINEL_IDS: [u32; 4] = [CLS_ID, 24_313, 2_318, EOS_ID];
+  /// SHA-256 (lowercase hex) of the pinned granite `tokenizer.json` artifact —
+  /// the exact bytes of `BUNDLED_TOKENIZER` — the byte identity a caller-supplied
+  /// tokenizer must match (the `validate_tokenizer_identity` backstop). Tied to
+  /// the artifact bytes and the golden-source SHA literal by
+  /// `bundled_tokenizer_sha_matches_golden_source_pin`.
+  pub const TOKENIZER_SHA256_HEX: &str =
+    "4f2842d568e2724370aec203652a42ac783c7937f8347a1a2cc7506d71f1582f";
 }
 
 /// Fixed token-sequence length the ModernBERT graph was converted at (the
@@ -321,7 +329,7 @@ impl TextEmbedder {
   /// As [`Self::from_files`] (with the bundled tokenizer bytes).
   pub fn load(model_path: impl AsRef<Path>, options: TextEmbedderOptions) -> Result<Self> {
     let tokenizer = Tokenizer::from_bytes(BUNDLED_TOKENIZER).map_err(Error::TokenizerLoad)?;
-    Self::from_parts(model_path, tokenizer, options)
+    Self::from_parts(model_path, tokenizer, options, TokenizerProvenance::Bundled)
   }
 
   /// Loads the granite `.mlmodelc` from `model_path` using the bundled tokenizer
@@ -340,15 +348,22 @@ impl TextEmbedder {
   /// if its I/O contract mismatches; [`Error::TokenizerLoad`] if the tokenizer
   /// JSON is unreadable/invalid; [`Error::TokenizerConfig`] if truncation cannot
   /// be configured; [`Error::TokenizerContractMismatch`] if the tokenizer does
-  /// not match the Granite tokenizer/model contract (`validate_tokenizer_contract`).
+  /// not match the Granite tokenizer/model contract (`validate_tokenizer_contract`)
+  /// or is not byte-identical (SHA-256) to the pinned granite `tokenizer.json` —
+  /// granite is a fixed model with exactly one correct tokenizer artifact; supply
+  /// the pinned bytes or [`BUNDLED_TOKENIZER`].
   pub fn from_files(
     model_path: impl AsRef<Path>,
     tokenizer_json_path: impl AsRef<Path>,
     options: TextEmbedderOptions,
   ) -> Result<Self> {
-    let tokenizer =
-      Tokenizer::from_file(tokenizer_json_path.as_ref()).map_err(Error::TokenizerLoad)?;
-    Self::from_parts(model_path, tokenizer, options)
+    // Read the file ONCE and delegate to `from_memory`, so the identity hash and
+    // the parse see the SAME bytes (no re-read, no TOCTOU). An unreadable file
+    // keeps today's `Error::TokenizerLoad` identity — `tokenizers::Error` is a
+    // boxed `dyn Error`, so `io::Error` converts with `.into()`.
+    let bytes =
+      std::fs::read(tokenizer_json_path.as_ref()).map_err(|e| Error::TokenizerLoad(e.into()))?;
+    Self::from_memory(model_path, &bytes, options)
   }
 
   /// Loads the model from a path and the tokenizer from caller-supplied bytes.
@@ -360,22 +375,36 @@ impl TextEmbedder {
     tokenizer_json_bytes: &[u8],
     options: TextEmbedderOptions,
   ) -> Result<Self> {
+    // Hash the RAW supplied bytes (never a re-serialization of the parsed
+    // `Tokenizer`, which would not reproduce the artifact's formatting/ordering)
+    // for the byte-identity backstop in `from_parts`.
+    let sha256_hex = sha256_hex(tokenizer_json_bytes);
     let tokenizer = Tokenizer::from_bytes(tokenizer_json_bytes).map_err(Error::TokenizerLoad)?;
-    Self::from_parts(model_path, tokenizer, options)
+    Self::from_parts(
+      model_path,
+      tokenizer,
+      options,
+      TokenizerProvenance::Supplied { sha256_hex },
+    )
   }
 
   fn from_parts(
     model_path: impl AsRef<Path>,
     mut tokenizer: Tokenizer,
     options: TextEmbedderOptions,
+    provenance: TokenizerProvenance,
   ) -> Result<Self> {
     configure_tokenizer(&mut tokenizer)?;
-    // Reject a caller-supplied tokenizer that does not match the Granite
-    // tokenizer/model contract, fail-closed and BEFORE the expensive
-    // `Model::load` — every public constructor passes through here, so no
-    // `TextEmbedder` can exist with an unvalidated tokenizer (the bundled
-    // tokenizer passes trivially; this also guards a corrupted build asset).
+    // Two-stage tokenizer gate, fail-closed and BEFORE the expensive `Model::load`
+    // — every public constructor passes through here, so no `TextEmbedder` can
+    // exist with an unvalidated tokenizer. FIRST the behavioral contract (named,
+    // actionable diagnostics for an accidentally foreign tokenizer; the bundled
+    // tokenizer passes trivially, and this also guards a corrupted build asset);
+    // THEN, for caller-supplied bytes, the byte-identity backstop that catches
+    // corruption or version skew outside the behavioral spot-checks' coverage
+    // (bundled bytes are identity-by-construction, so their provenance is a no-op).
     validate_tokenizer_contract(&tokenizer)?;
+    validate_tokenizer_identity(&provenance)?;
     // The pad positions are attention-masked to 0 and CLS pooling reads position
     // 0 (never a pad), so the pad token value is immaterial to the output; a
     // valid vocabulary index is all that is required. `validate_tokenizer_contract`
@@ -700,7 +729,9 @@ fn configure_tokenizer(tokenizer: &mut Tokenizer) -> Result<()> {
 ///
 /// Checks, first failure wins: the three special-token ids, the total vocabulary
 /// size, the maximum token id (the out-of-vocabulary gate), then the pinned
-/// sentinel encoding.
+/// sentinel encoding. These behavioral checks are a spot-check; on the
+/// caller-supplied path `validate_tokenizer_identity` runs next as the exact
+/// byte-identity backstop for corruption or version skew outside their coverage.
 ///
 /// # Errors
 /// [`Error::TokenizerContractMismatch`] naming the first failed check;
@@ -767,6 +798,62 @@ fn validate_tokenizer_contract(tokenizer: &Tokenizer) -> Result<()> {
   }
 
   Ok(())
+}
+
+/// Lowercase-hex SHA-256 of `bytes` — the tokenizer-identity digest. Mirrors the
+/// dev-time provenance folds (`granite/tests.rs`, `tests/granite/common`).
+fn sha256_hex(bytes: &[u8]) -> String {
+  use sha2::{Digest, Sha256};
+  Sha256::digest(bytes)
+    .iter()
+    .map(|b| format!("{b:02x}"))
+    .collect()
+}
+
+/// Where a constructor's tokenizer bytes came from — decides whether the
+/// byte-identity backstop ([`validate_tokenizer_identity`]) computes a hash.
+enum TokenizerProvenance {
+  /// The compiled-in [`BUNDLED_TOKENIZER`] bytes: byte identity holds by
+  /// construction (pinned dev-time by
+  /// `bundled_tokenizer_sha_matches_golden_source_pin` and
+  /// `tests/granite/tokenizer_identity.rs`), so no runtime hash is computed — the
+  /// bundled constructors stay zero-overhead.
+  Bundled,
+  /// Caller-supplied bytes (`from_files` / `from_memory`): the lowercase-hex
+  /// SHA-256 of the RAW input bytes, exactly as supplied (never a re-serialization
+  /// of the parsed tokenizer).
+  Supplied { sha256_hex: String },
+}
+
+/// Byte-identity backstop for caller-supplied tokenizers, fail-closed. granite is
+/// a FIXED model, so exactly one tokenizer artifact is correct — the pinned
+/// `tokenizer.json`, SHA-256 [`contract::TOKENIZER_SHA256_HEX`], the exact bytes
+/// of [`BUNDLED_TOKENIZER`]. The behavioral contract
+/// ([`validate_tokenizer_contract`]) runs FIRST (named, actionable diagnostics
+/// for accidentally foreign tokenizers); this then catches what no behavioral
+/// spot-check can — corruption or version skew outside the sentinel's coverage
+/// (swapped vocab entries, divergent merges, normalizer drift) that would
+/// silently produce wrong embeddings. A re-serialized but behaviorally identical
+/// tokenizer is rejected BY DESIGN: supply the pinned artifact bytes (or
+/// [`BUNDLED_TOKENIZER`]) instead.
+///
+/// # Errors
+/// [`Error::TokenizerContractMismatch`] with `check = "tokenizer identity
+/// (sha-256)"` if a supplied digest differs from the pin.
+fn validate_tokenizer_identity(provenance: &TokenizerProvenance) -> Result<()> {
+  match provenance {
+    TokenizerProvenance::Bundled => Ok(()),
+    TokenizerProvenance::Supplied { sha256_hex }
+      if sha256_hex == contract::TOKENIZER_SHA256_HEX =>
+    {
+      Ok(())
+    }
+    TokenizerProvenance::Supplied { sha256_hex } => Err(Error::TokenizerContractMismatch {
+      check: "tokenizer identity (sha-256)",
+      expected: contract::TOKENIZER_SHA256_HEX.to_string(),
+      actual: sha256_hex.clone(),
+    }),
+  }
 }
 
 /// Builds the fixed `[1, `[`MAX_TOKENS`]`]` `input_ids` / `attention_mask` window
@@ -888,7 +975,10 @@ fn chunk_long(
   // per-chunk `token_ids` in `embed_long_with`. The closure cannot stop early
   // (the tokenizers crate exposes no incremental token count on its stable
   // surface), so a giant untrusted input is scanned a few times even under a
-  // `max_windows` cap — a recorded limitation, not silently fine.
+  // `max_windows` cap — a recorded limitation, not silently fine. Mitigated by
+  // `LongTextOptions::max_input_bytes` (the pre-tokenization byte gate); windit's
+  // `measure_within` hook exists should the tokenizer ever grow incremental
+  // encoding.
   let measure = |s: &str| -> usize {
     measure_tok
       .encode(s, true)

--- a/crates/coremlit/src/embeddings/granite/tests.rs
+++ b/crates/coremlit/src/embeddings/granite/tests.rs
@@ -52,6 +52,13 @@ fn bundled_tokenizer_sha_matches_golden_source_pin() {
     sha, "4f2842d568e2724370aec203652a42ac783c7937f8347a1a2cc7506d71f1582f",
     "bundled tokenizer.json diverged from the granite tokenizer that cut the goldens"
   );
+  // Tie the runtime identity const to the same literal, so const ↔ literal ↔
+  // artifact-bytes cannot drift apart (the assert above ties bytes ↔ literal).
+  assert_eq!(
+    contract::TOKENIZER_SHA256_HEX,
+    "4f2842d568e2724370aec203652a42ac783c7937f8347a1a2cc7506d71f1582f",
+    "the tokenizer-identity contract const must equal the pinned golden-source SHA"
+  );
 }
 
 /// Encode `text` through granite's ACTUAL configured tokenizer seam (the same
@@ -1067,15 +1074,22 @@ fn input_too_large_takes_precedence_over_window_budget() {
 
 // ── #6: tokenizer contract validation (hermetic) ─────────────────────────────
 
-/// Parse the bundled tokenizer JSON, apply `mutate`, re-serialize, and build the
-/// module's CONFIGURED tokenizer from the result — so a contract check sees
-/// exactly the production tokenization. `serde_json` is a dev-dependency.
-fn mutated_bundled_tokenizer(mutate: impl FnOnce(&mut serde_json::Value)) -> Tokenizer {
+/// Parse the bundled tokenizer JSON, apply `mutate`, and re-serialize to bytes —
+/// the raw input a caller-supplied constructor receives. `serde_json` is a
+/// dev-dependency.
+fn mutated_bundled_tokenizer_bytes(mutate: impl FnOnce(&mut serde_json::Value)) -> Vec<u8> {
   let mut value: serde_json::Value =
     serde_json::from_slice(BUNDLED_TOKENIZER).expect("parse bundled tokenizer.json");
   mutate(&mut value);
-  let bytes = serde_json::to_vec(&value).expect("re-serialize mutated tokenizer.json");
-  configured_tokenizer_from_bytes(&bytes).expect("configure mutated tokenizer")
+  serde_json::to_vec(&value).expect("re-serialize mutated tokenizer.json")
+}
+
+/// Parse the bundled tokenizer JSON, apply `mutate`, re-serialize, and build the
+/// module's CONFIGURED tokenizer from the result — so a contract check sees
+/// exactly the production tokenization.
+fn mutated_bundled_tokenizer(mutate: impl FnOnce(&mut serde_json::Value)) -> Tokenizer {
+  configured_tokenizer_from_bytes(&mutated_bundled_tokenizer_bytes(mutate))
+    .expect("configure mutated tokenizer")
 }
 
 /// The bundled granite tokenizer passes every contract check — the invariant on
@@ -1200,4 +1214,129 @@ fn tokenizer_contract_rejects_divergent_encoding() {
     }
     other => panic!("expected TokenizerContractMismatch on sentinel encoding, got {other:?}"),
   }
+}
+
+// ── #6: tokenizer BYTE-IDENTITY backstop (hermetic) ──────────────────────────
+//
+// The behavioral contract above is a spot-check (specials, count, max id, one
+// sentinel), so a corrupted-but-behaviorally-valid supplied tokenizer slips
+// through it. `validate_tokenizer_identity` closes that gap on the
+// caller-supplied path by pinning the exact artifact SHA-256, fail-closed. These
+// tests drive the digest + provenance seam directly (no model).
+
+/// THE codex repro: two ordinary base-vocab entries with their ids swapped
+/// (5000 ↔ 6000, neither a special nor a sentinel content id) sail through every
+/// BEHAVIORAL check — specials, count, max id, and the `"hello world"` sentinel
+/// are all untouched — yet any text using those two tokens would embed with wrong
+/// ids. The byte-identity backstop REJECTS this behaviorally-valid but
+/// non-identical tokenizer (the gap this fix closes).
+#[test]
+fn tokenizer_identity_rejects_non_sentinel_vocab_corruption() {
+  const SWAP_A: u64 = 5_000;
+  const SWAP_B: u64 = 6_000;
+  // Guard: the swapped ids must avoid the specials and sentinel content ids, so
+  // the corruption stays invisible to every behavioral check.
+  const RESERVED: [u64; 5] = [24_313, 2_318, 179_934, 179_935, 179_938];
+  assert!(
+    !RESERVED.contains(&SWAP_A) && !RESERVED.contains(&SWAP_B),
+    "swap ids must avoid the specials and sentinel content ids"
+  );
+
+  let bytes = mutated_bundled_tokenizer_bytes(|value| {
+    let vocab = value["model"]["vocab"]
+      .as_object_mut()
+      .expect("model.vocab object");
+    let mut key_a = None;
+    let mut key_b = None;
+    for (key, id) in vocab.iter() {
+      match id.as_u64() {
+        Some(SWAP_A) => key_a = Some(key.clone()),
+        Some(SWAP_B) => key_b = Some(key.clone()),
+        _ => {}
+      }
+    }
+    let key_a = key_a.expect("id 5000 present in base vocab");
+    let key_b = key_b.expect("id 6000 present in base vocab");
+    vocab.insert(key_a, serde_json::json!(SWAP_B));
+    vocab.insert(key_b, serde_json::json!(SWAP_A));
+  });
+
+  // (a) finding pin: the BEHAVIORAL gate alone ACCEPTS this corruption (documents
+  // the gap; a future behavioral check that starts catching it flags the fixture
+  // for rework).
+  let configured = configured_tokenizer_from_bytes(&bytes).expect("configure mutated");
+  validate_tokenizer_contract(&configured)
+    .expect("behavioral contract accepts non-sentinel vocab corruption");
+
+  // (b) premise guard: the mutated bytes are not the pinned artifact.
+  assert_ne!(
+    bytes.as_slice(),
+    BUNDLED_TOKENIZER,
+    "the swap must actually change the bytes"
+  );
+
+  // (c) the identity backstop REJECTS it, naming the identity check with the
+  // pinned expected / computed actual digests.
+  let actual = sha256_hex(&bytes);
+  match validate_tokenizer_identity(&TokenizerProvenance::Supplied {
+    sha256_hex: actual.clone(),
+  }) {
+    Err(Error::TokenizerContractMismatch {
+      check,
+      expected,
+      actual: reported,
+    }) => {
+      assert_eq!(check, "tokenizer identity (sha-256)");
+      assert_eq!(expected, contract::TOKENIZER_SHA256_HEX);
+      assert_eq!(reported, actual);
+    }
+    other => panic!("expected identity TokenizerContractMismatch, got {other:?}"),
+  }
+}
+
+/// Policy pin: byte identity, NOT behavioral identity, on the supplied path. A
+/// parse→re-serialize round-trip of the bundled JSON (no semantic change) stays
+/// behaviorally valid yet is byte-different (serde_json reorders keys / drops the
+/// artifact's formatting), so the backstop REJECTS it — callers must supply the
+/// pinned artifact bytes, not a re-emitted equivalent.
+#[test]
+fn tokenizer_identity_rejects_reserialized_bundled_json() {
+  let bytes = mutated_bundled_tokenizer_bytes(|_| {});
+
+  let configured = configured_tokenizer_from_bytes(&bytes).expect("configure round-trip");
+  validate_tokenizer_contract(&configured).expect("a re-serialized bundle is behaviorally valid");
+
+  assert_ne!(
+    bytes.as_slice(),
+    BUNDLED_TOKENIZER,
+    "a serde_json round-trip must actually differ from the pinned bytes"
+  );
+
+  let actual = sha256_hex(&bytes);
+  match validate_tokenizer_identity(&TokenizerProvenance::Supplied {
+    sha256_hex: actual.clone(),
+  }) {
+    Err(Error::TokenizerContractMismatch {
+      check,
+      actual: reported,
+      ..
+    }) => {
+      assert_eq!(check, "tokenizer identity (sha-256)");
+      assert_eq!(reported, actual);
+    }
+    other => panic!("expected identity TokenizerContractMismatch, got {other:?}"),
+  }
+}
+
+/// The backstop ACCEPTS the two legitimate supplied-byte sources: the pinned
+/// artifact bytes (`BUNDLED_TOKENIZER`) via `Supplied`, and the zero-overhead
+/// `Bundled` provenance the internal constructors pass (no hash computed).
+#[test]
+fn tokenizer_identity_accepts_bundled_bytes_and_bundled_provenance() {
+  validate_tokenizer_identity(&TokenizerProvenance::Supplied {
+    sha256_hex: sha256_hex(BUNDLED_TOKENIZER),
+  })
+  .expect("the pinned bundled bytes are the identity");
+  validate_tokenizer_identity(&TokenizerProvenance::Bundled)
+    .expect("bundled provenance is identity by construction");
 }

--- a/crates/coremlit/src/embeddings/granite/tests.rs
+++ b/crates/coremlit/src/embeddings/granite/tests.rs
@@ -165,8 +165,9 @@ fn long_input_truncation_keeps_the_right_directional_prefix() {
 
 /// "hello world" through the granite tokenizer: `<|startoftext|>`=179934 (CLS,
 /// pooled), then `hello`/`world`, then `<|return|>`=179938 (EOS). The exact
-/// sequence is pinned by `token_ids_match_pinned_golden_subset` above.
-const HELLO_WORLD_IDS: [u32; 4] = [179934, 24313, 2318, 179938];
+/// sequence is pinned by `token_ids_match_pinned_golden_subset` above; sourced
+/// from the module contract (single source of truth).
+const HELLO_WORLD_IDS: [u32; 4] = contract::SENTINEL_IDS;
 
 /// A fresh bundled tokenizer carrying an adversarial fixed-window padding policy
 /// (the kind a caller-supplied tokenizer might inherit), BEFORE this module's
@@ -590,13 +591,17 @@ fn gap_attachment_falls_back_right_then_own_chunk() {
   use windit::split::ContentAware;
 
   let measure = |s: &str| -> usize { s.chars().count() };
+  // `attach_gaps` now takes a fallible measure; a `char`-count never fails, so
+  // the own-chunks (all far below MAX_TOKENS) attach exactly as before.
+  let measure_checked = |s: &str| -> Result<usize> { Ok(s.chars().count()) };
   // windit's raw chunks for `text` at `window`, repaired by `attach_gaps`, as
   // (start, end) byte ranges.
   let repair = |text: &str, window: usize| -> Vec<(usize, usize)> {
     let chunks = ContentAware::new(&measure)
       .chunk(text, &WindowOptions::new(window))
       .expect("chunk");
-    attach_gaps(text, chunks, &measure, window)
+    attach_gaps(text, chunks, &measure_checked, window)
+      .expect("own-chunks measure within MAX_TOKENS")
       .iter()
       .map(|c| (c.start(), c.end()))
       .collect()
@@ -735,6 +740,165 @@ fn whitespace_only_text_counts_one_window_against_the_cap() {
   );
 }
 
+/// Contentless over-budget input is REFUSED, not silently truncated. windit
+/// drops the whitespace-only text; the whole-input fallback would then embed it
+/// through the truncating production tokenizer, dropping every token past the
+/// 512-window. The measured fallback refuses it instead. Fixtures span spaces,
+/// tabs, CRLF, NBSP, and a mixed run (em/thin spaces); `tokens` is compared to
+/// the test's own untruncated encode so the pin is self-consistent under any
+/// tokenizer.
+#[test]
+fn contentless_over_budget_input_is_refused_not_truncated() {
+  let mt = measuring_tokenizer_from_bytes(BUNDLED_TOKENIZER).expect("measuring");
+  let fixtures = [
+    " ".repeat(100_000),
+    "\t".repeat(100_000),
+    "\r\n".repeat(50_000),
+    "\u{00A0}".repeat(100_000),
+    " \t\r\n\u{00A0}\u{2003}\u{2009}".repeat(15_000),
+  ];
+  for s in &fixtures {
+    let expected_tokens = mt.encode(s.as_str(), true).expect("encode").get_ids().len();
+    assert!(
+      expected_tokens > MAX_TOKENS,
+      "fixture must actually exceed the window (got {expected_tokens})"
+    );
+    match chunk_long(&mt, s, &WindowOptions::new(MAX_TOKENS)) {
+      Err(Error::ContentlessInputOverBudget {
+        start,
+        end,
+        tokens,
+        max,
+      }) => {
+        assert_eq!(start, 0, "the whole input is the offending run");
+        assert_eq!(end, s.len());
+        assert_eq!(
+          tokens, expected_tokens,
+          "reported count is the untruncated measure"
+        );
+        assert_eq!(max, MAX_TOKENS);
+      }
+      other => panic!("expected ContentlessInputOverBudget, got {other:?}"),
+    }
+  }
+}
+
+/// The at-budget boundary is embedded whole; the first over-budget count is
+/// refused. Binary-searches the largest space run that fits the window, so the
+/// boundary is exact regardless of the pinned tokenizer.
+#[test]
+fn contentless_input_at_or_under_budget_still_embeds_whole() {
+  let mt = measuring_tokenizer_from_bytes(BUNDLED_TOKENIZER).expect("measuring");
+  let measure = |n: usize| {
+    mt.encode(" ".repeat(n).as_str(), true)
+      .expect("encode")
+      .get_ids()
+      .len()
+  };
+  let mut lo = 1usize;
+  let mut hi = 100_000usize;
+  assert!(measure(lo) <= MAX_TOKENS, "one space fits");
+  assert!(measure(hi) > MAX_TOKENS, "100k spaces overflow");
+  while lo + 1 < hi {
+    let mid = (lo + hi) / 2;
+    if measure(mid) <= MAX_TOKENS {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  // `lo` is the largest in-budget count; `hi == lo + 1` the first over-budget.
+  let at_budget = " ".repeat(lo);
+  let chunks = chunk_long(&mt, &at_budget, &WindowOptions::new(MAX_TOKENS))
+    .expect("in-budget contentless input embeds whole");
+  assert_eq!(
+    chunks
+      .iter()
+      .map(|c| (c.start(), c.end()))
+      .collect::<Vec<_>>(),
+    vec![(0, at_budget.len())],
+    "in-budget contentless input is one whole-input chunk"
+  );
+  let over = " ".repeat(hi);
+  match chunk_long(&mt, &over, &WindowOptions::new(MAX_TOKENS)) {
+    Err(Error::ContentlessInputOverBudget { .. }) => {}
+    other => panic!("expected ContentlessInputOverBudget just past the budget, got {other:?}"),
+  }
+}
+
+/// A pure-separator gap between two content chunks that neither neighbor can
+/// absorb (the `attach_gaps` own-chunk escape, interior case) is refused when
+/// its run measures past the window. `a<100k spaces>b` at window 3 forces the
+/// escape; the in-budget own-chunk escape (`a\n\nb`) still chunks Ok.
+#[test]
+fn separator_gap_over_budget_is_refused() {
+  let mt = measuring_tokenizer_from_bytes(BUNDLED_TOKENIZER).expect("measuring");
+  let text = format!("a{}b", " ".repeat(100_000));
+  match chunk_long(&mt, &text, &WindowOptions::new(3)) {
+    Err(Error::ContentlessInputOverBudget {
+      start,
+      end,
+      tokens,
+      max,
+    }) => {
+      assert_eq!(start, 1, "the gap starts right after `a`");
+      assert_eq!(end, 100_001, "the gap ends right before `b`");
+      assert!(tokens > MAX_TOKENS, "the gap run measures over the window");
+      assert_eq!(max, MAX_TOKENS);
+    }
+    other => panic!("expected ContentlessInputOverBudget, got {other:?}"),
+  }
+  // Control: an in-budget own-chunk gap still chunks Ok — the escape stays.
+  let ok = chunk_long(&mt, "a\n\nb", &WindowOptions::new(3)).expect("in-budget own-chunk escape");
+  assert_eq!(
+    ok.iter().map(|c| (c.start(), c.end())).collect::<Vec<_>>(),
+    vec![(0, 1), (1, 3), (3, 4)]
+  );
+}
+
+/// Leading and trailing pure-separator gaps that measure past the window are
+/// refused with the correct byte span (the `attach_gaps` leading and trailing
+/// branches, measuring the GAP itself, not the extended candidate).
+#[test]
+fn leading_and_trailing_over_budget_gaps_are_refused() {
+  let mt = measuring_tokenizer_from_bytes(BUNDLED_TOKENIZER).expect("measuring");
+
+  let leading = format!("{}a", " ".repeat(100_000));
+  match chunk_long(&mt, &leading, &WindowOptions::new(MAX_TOKENS)) {
+    Err(Error::ContentlessInputOverBudget { start, end, .. }) => {
+      assert_eq!(start, 0, "leading gap starts at byte 0");
+      assert_eq!(end, 100_000, "leading gap ends right before `a`");
+    }
+    other => panic!("expected leading ContentlessInputOverBudget, got {other:?}"),
+  }
+
+  let trailing = format!("a{}", " ".repeat(100_000));
+  match chunk_long(&mt, &trailing, &WindowOptions::new(MAX_TOKENS)) {
+    Err(Error::ContentlessInputOverBudget { start, end, .. }) => {
+      assert_eq!(start, 1, "trailing gap starts right after `a`");
+      assert_eq!(end, 100_001, "trailing gap ends at text length");
+    }
+    other => panic!("expected trailing ContentlessInputOverBudget, got {other:?}"),
+  }
+}
+
+/// An encode failure during the fallback measure surfaces as `Error::Tokenize`,
+/// NOT a bogus `ContentlessInputOverBudget { tokens: usize::MAX }`: the fallible
+/// measure closure must preserve the tokenizer error's identity. A tiny
+/// WordLevel tokenizer whose unk token is absent from its vocab fails to encode
+/// the whitespace-only fallback input.
+#[test]
+fn tokenizer_failure_on_fallback_measure_keeps_tokenize_identity() {
+  // WordLevel, no pre-tokenizer, unk token `<unk>` not in vocab: encoding the
+  // whole-string `"   "` (not in vocab) errors instead of truncating.
+  const TINY_NO_UNK: &[u8] = br#"{"version":"1.0","truncation":null,"padding":null,"added_tokens":[],"normalizer":null,"pre_tokenizer":null,"post_processor":null,"decoder":null,"model":{"type":"WordLevel","vocab":{"hello":0,"world":1},"unk_token":"<unk>"}}"#;
+  let mt = tokenizers::Tokenizer::from_bytes(TINY_NO_UNK).expect("load tiny WordLevel");
+  match chunk_long(&mt, "   ", &WindowOptions::new(MAX_TOKENS)) {
+    Err(Error::Tokenize(_)) => {}
+    other => panic!("expected Err(Tokenize), got {other:?}"),
+  }
+}
+
 /// `""` costs zero predictions (`embed_long_with` delegates it to `embed`,
 /// which fails `EmptyText` before the model), so no fallback chunk is
 /// synthesized and even a cap of 0 passes chunking.
@@ -812,12 +976,15 @@ fn overlap_repeats_trailing_tokens_within_budget() {
   }
 }
 
-/// `validate_long_options` (and thus `embed_long_with`) rejects a per-chunk
-/// budget above the model's fixed window before any tokenization — hermetically,
-/// no model.
+/// `validate_long_input` (and thus `embed_long_with`) rejects a per-chunk budget
+/// above the model's fixed window before any tokenization — hermetically, no
+/// model.
 #[test]
 fn window_over_budget_is_rejected() {
-  match validate_long_options(&WindowOptions::new(MAX_TOKENS + 1)) {
+  match validate_long_input(
+    "any text",
+    &LongTextOptions::from(WindowOptions::new(MAX_TOKENS + 1)),
+  ) {
     Err(Error::WindowOverBudget { window, max }) => {
       assert_eq!(window, MAX_TOKENS + 1);
       assert_eq!(max, MAX_TOKENS);
@@ -825,5 +992,212 @@ fn window_over_budget_is_rejected() {
     other => panic!("expected Err(WindowOverBudget), got {other:?}"),
   }
   // The exact budget is accepted.
-  assert!(validate_long_options(&WindowOptions::new(MAX_TOKENS)).is_ok());
+  assert!(
+    validate_long_input(
+      "any text",
+      &LongTextOptions::from(WindowOptions::new(MAX_TOKENS)),
+    )
+    .is_ok()
+  );
+}
+
+// ── #2: LongTextOptions + input-size gate (hermetic) ─────────────────────────
+
+/// `Default` == `new`, the documented defaults (full window, no byte limit), the
+/// builder/setter round-trips, and the `From<WindowOptions>` geometry-only form.
+#[test]
+fn long_text_options_default_equals_new() {
+  assert_eq!(LongTextOptions::default(), LongTextOptions::new());
+  assert_eq!(
+    LongTextOptions::new().window_options(),
+    WindowOptions::new(MAX_TOKENS)
+  );
+  assert_eq!(LongTextOptions::new().max_input_bytes(), None);
+
+  let built = LongTextOptions::new()
+    .with_window_options(WindowOptions::new(64))
+    .with_max_input_bytes(4096);
+  assert_eq!(built.window_options(), WindowOptions::new(64));
+  assert_eq!(built.max_input_bytes(), Some(4096));
+
+  let mut set = LongTextOptions::new();
+  set.set_window_options(WindowOptions::new(32));
+  set.set_max_input_bytes(2048);
+  assert_eq!(set.window_options(), WindowOptions::new(32));
+  assert_eq!(set.max_input_bytes(), Some(2048));
+
+  let from = LongTextOptions::from(WindowOptions::new(64));
+  assert_eq!(from.window_options().window(), 64);
+  assert_eq!(from.max_input_bytes(), None);
+}
+
+/// The input-size gate refuses an oversized input reading only `text.len()` (no
+/// tokenizer); at-limit passes (`>` rejects, `==` accepts), and a `None` limit
+/// accepts the same oversized input.
+#[test]
+fn input_too_large_is_rejected_before_any_tokenizer_work() {
+  let big = "x".repeat(8 * 1024 * 1024);
+  let opts = LongTextOptions::new().with_max_input_bytes(1024 * 1024);
+  match validate_long_input(&big, &opts) {
+    Err(Error::InputTooLarge { got, max }) => {
+      assert_eq!(got, big.len());
+      assert_eq!(max, 1024 * 1024);
+    }
+    other => panic!("expected InputTooLarge, got {other:?}"),
+  }
+  // At-limit is accepted.
+  let at_limit = "x".repeat(1024 * 1024);
+  assert!(validate_long_input(&at_limit, &opts).is_ok());
+  // No limit accepts the same 8 MiB input.
+  assert!(validate_long_input(&big, &LongTextOptions::new()).is_ok());
+}
+
+/// The untrusted-input gate is the outermost shield: an oversized input AND an
+/// over-budget window yields `InputTooLarge`, not `WindowOverBudget`.
+#[test]
+fn input_too_large_takes_precedence_over_window_budget() {
+  let big = "x".repeat(2 * 1024 * 1024);
+  let opts =
+    LongTextOptions::from(WindowOptions::new(MAX_TOKENS + 1)).with_max_input_bytes(1024 * 1024);
+  match validate_long_input(&big, &opts) {
+    Err(Error::InputTooLarge { .. }) => {}
+    other => panic!("expected InputTooLarge to win over WindowOverBudget, got {other:?}"),
+  }
+}
+
+// ── #6: tokenizer contract validation (hermetic) ─────────────────────────────
+
+/// Parse the bundled tokenizer JSON, apply `mutate`, re-serialize, and build the
+/// module's CONFIGURED tokenizer from the result — so a contract check sees
+/// exactly the production tokenization. `serde_json` is a dev-dependency.
+fn mutated_bundled_tokenizer(mutate: impl FnOnce(&mut serde_json::Value)) -> Tokenizer {
+  let mut value: serde_json::Value =
+    serde_json::from_slice(BUNDLED_TOKENIZER).expect("parse bundled tokenizer.json");
+  mutate(&mut value);
+  let bytes = serde_json::to_vec(&value).expect("re-serialize mutated tokenizer.json");
+  configured_tokenizer_from_bytes(&bytes).expect("configure mutated tokenizer")
+}
+
+/// The bundled granite tokenizer passes every contract check — the invariant on
+/// which all keep-green constructor/golden behavior rests. If this fails the
+/// contract constants are wrong; strengthen the constants, never the checks.
+#[test]
+fn tokenizer_contract_accepts_the_bundled_tokenizer() {
+  let tok = configured_tokenizer_from_bytes(BUNDLED_TOKENIZER).expect("configure bundled");
+  validate_tokenizer_contract(&tok).expect("bundled tokenizer must satisfy the contract");
+}
+
+/// A tiny foreign tokenizer with none of granite's specials fails the first
+/// check (`<|startoftext|>`), reported as `missing`.
+#[test]
+fn tokenizer_contract_rejects_missing_specials() {
+  const TINY: &[u8] = br#"{"version":"1.0","truncation":null,"padding":null,"added_tokens":[],"normalizer":null,"pre_tokenizer":null,"post_processor":null,"decoder":null,"model":{"type":"WordLevel","vocab":{"hello":0,"world":1},"unk_token":"<unk>"}}"#;
+  let tok = configured_tokenizer_from_bytes(TINY).expect("configure tiny");
+  match validate_tokenizer_contract(&tok) {
+    Err(Error::TokenizerContractMismatch { check, actual, .. }) => {
+      assert!(
+        check.contains("<|startoftext|>"),
+        "check names the missing special: {check}"
+      );
+      assert_eq!(actual, "missing");
+    }
+    other => panic!("expected TokenizerContractMismatch, got {other:?}"),
+  }
+}
+
+/// The bundled tokenizer with one trailing (non-special) added token removed
+/// keeps granite's three specials but drops the vocabulary to 179999, so the
+/// vocab-size check fires. The pinned `tokenizers` reassigns added-token ids
+/// densely as `base + array_index` (ignoring the JSON `id` field), and the three
+/// specials are the array's first entries, so removing the LAST entry leaves
+/// their ids intact — the fixture edits structure, not a declared id.
+#[test]
+fn tokenizer_contract_rejects_wrong_vocab_size() {
+  let tok = mutated_bundled_tokenizer(|value| {
+    let added = value["added_tokens"]
+      .as_array_mut()
+      .expect("added_tokens array");
+    added.pop().expect("added_tokens is non-empty");
+  });
+  match validate_tokenizer_contract(&tok) {
+    Err(Error::TokenizerContractMismatch {
+      check,
+      expected,
+      actual,
+    }) => {
+      assert_eq!(check, "vocab size");
+      assert!(
+        expected.contains("180000"),
+        "expected names the contract size: {expected}"
+      );
+      assert!(
+        actual.contains("179999"),
+        "actual names the reduced size: {actual}"
+      );
+    }
+    other => panic!("expected TokenizerContractMismatch on vocab size, got {other:?}"),
+  }
+}
+
+/// The bundled tokenizer with its highest BASE-vocab id pushed past the model's
+/// table (to 180000) keeps the count at 180000 and the specials intact, so the
+/// specials and vocab-size checks pass but the max-token-id gate fires — the
+/// out-of-vocabulary case a larger foreign tokenizer would hit. (Added-token ids
+/// are reassigned densely by this `tokenizers`, so an OOV id can only come from
+/// the base vocab; the fixture moves a base id, leaving a hole the count check
+/// tolerates.)
+#[test]
+fn tokenizer_contract_rejects_out_of_model_vocab_id() {
+  let tok = mutated_bundled_tokenizer(|value| {
+    let vocab = value["model"]["vocab"]
+      .as_object_mut()
+      .expect("model.vocab object");
+    let key = vocab
+      .iter()
+      .max_by_key(|(_, id)| id.as_u64().unwrap_or(0))
+      .map(|(k, _)| k.clone())
+      .expect("non-empty base vocab");
+    vocab.insert(key, serde_json::json!(180_000));
+  });
+  match validate_tokenizer_contract(&tok) {
+    Err(Error::TokenizerContractMismatch { check, actual, .. }) => {
+      assert_eq!(check, "max token id");
+      assert!(
+        actual.contains("180000"),
+        "actual carries the offending id: {actual}"
+      );
+    }
+    other => panic!("expected TokenizerContractMismatch on max token id, got {other:?}"),
+  }
+}
+
+/// Two base-vocab entries with their ids swapped (`hello`↔`Ġworld`, 24313↔2318)
+/// leave the specials, vocab size, and max id intact but change the sentinel
+/// encoding, so only the final check fires.
+#[test]
+fn tokenizer_contract_rejects_divergent_encoding() {
+  let tok = mutated_bundled_tokenizer(|value| {
+    let vocab = value["model"]["vocab"]
+      .as_object_mut()
+      .expect("model.vocab object");
+    let mut key_a = None;
+    let mut key_b = None;
+    for (key, id) in vocab.iter() {
+      match id.as_u64() {
+        Some(24_313) => key_a = Some(key.clone()),
+        Some(2_318) => key_b = Some(key.clone()),
+        _ => {}
+      }
+    }
+    let key_a = key_a.expect("id 24313 present in base vocab");
+    let key_b = key_b.expect("id 2318 present in base vocab");
+    vocab.insert(key_a, serde_json::json!(2_318));
+    vocab.insert(key_b, serde_json::json!(24_313));
+  });
+  match validate_tokenizer_contract(&tok) {
+    Err(Error::TokenizerContractMismatch { check, .. }) => {
+      assert_eq!(check, "sentinel encoding");
+    }
+    other => panic!("expected TokenizerContractMismatch on sentinel encoding, got {other:?}"),
+  }
 }

--- a/crates/coremlit/tests/feature_map.rs
+++ b/crates/coremlit/tests/feature_map.rs
@@ -75,7 +75,7 @@ fn expected_features() -> Vec<(&'static str, Vec<&'static str>)> {
     ("clap-oracle", vec!["clap", "dep:textclap"]),
     (
       "granite",
-      vec!["dep:tokenizers", "dep:windit", "windit/text"],
+      vec!["dep:tokenizers", "dep:windit", "windit/text", "dep:sha2"],
     ),
     (
       "ced",

--- a/crates/coremlit/tests/granite/embed_long.rs
+++ b/crates/coremlit/tests/granite/embed_long.rs
@@ -10,7 +10,9 @@
 
 mod common;
 
-use coremlit::embeddings::granite::{Error, MAX_TOKENS, TextEmbedder, WindowOptions};
+use coremlit::embeddings::granite::{
+  Error, LongTextOptions, MAX_TOKENS, TextEmbedder, WindowOptions,
+};
 
 fn embedder() -> TextEmbedder {
   TextEmbedder::from_file(common::model_path()).unwrap_or_else(|e| panic!("load granite: {e}"))
@@ -85,7 +87,10 @@ fn empty_text_errors_like_embed() {
 fn over_budget_window_rejected_before_any_prediction() {
   let emb = embedder();
   let err = emb
-    .embed_long_with("any text", &WindowOptions::new(MAX_TOKENS + 1))
+    .embed_long_with(
+      "any text",
+      &LongTextOptions::from(WindowOptions::new(MAX_TOKENS + 1)),
+    )
     .unwrap_err();
   assert!(
     matches!(err, Error::WindowOverBudget { window, max } if window == MAX_TOKENS + 1 && max == MAX_TOKENS),
@@ -104,7 +109,10 @@ fn whitespace_at_cap_zero_rejected_before_any_prediction() {
 
   let emb = embedder();
   let err = emb
-    .embed_long_with("   ", &WindowOptions::new(MAX_TOKENS).with_max_windows(0))
+    .embed_long_with(
+      "   ",
+      &LongTextOptions::from(WindowOptions::new(MAX_TOKENS).with_max_windows(0)),
+    )
     .unwrap_err();
   assert!(
     matches!(
@@ -123,11 +131,47 @@ fn whitespace_at_cap_zero_rejected_before_any_prediction() {
 fn whitespace_at_cap_one_matches_embed() {
   let emb = embedder();
   let via_long = emb
-    .embed_long_with("   ", &WindowOptions::new(MAX_TOKENS).with_max_windows(1))
+    .embed_long_with(
+      "   ",
+      &LongTextOptions::from(WindowOptions::new(MAX_TOKENS).with_max_windows(1)),
+    )
     .expect("cap 1 admits the one whole-input prediction");
   let via_embed = emb.embed("   ").expect("embed whitespace");
   assert!(
     via_long.is_close(&via_embed, 1e-5),
     "whole-input fallback must match embed"
+  );
+}
+
+/// A whitespace-only input too long to embed as one window is refused with
+/// `Error::ContentlessInputOverBudget` — the public end-to-end proof of the
+/// measured-fallback fix (the chunk geometry is proven model-free in the in-lib
+/// granite suite; this is the CoreML-path contract).
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn contentless_over_budget_input_is_refused() {
+  let emb = embedder();
+  let err = emb.embed_long(&" ".repeat(100_000)).unwrap_err();
+  assert!(
+    matches!(err, Error::ContentlessInputOverBudget { .. }),
+    "expected ContentlessInputOverBudget, got {err:?}"
+  );
+}
+
+/// An oversized input is refused by the byte gate before any tokenizer or
+/// chunker work (`Error::InputTooLarge`). Error-identity only — no timing
+/// assertions (flaky in CI); the reject-cost characterization belongs in the PR
+/// notes, per the issue's gate.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn oversized_input_rejected_with_input_too_large() {
+  let emb = embedder();
+  let big = "x".repeat(8 * 1024 * 1024);
+  let err = emb
+    .embed_long_with(&big, &LongTextOptions::new().with_max_input_bytes(1 << 20))
+    .unwrap_err();
+  assert!(
+    matches!(err, Error::InputTooLarge { got, max } if got == big.len() && max == (1 << 20)),
+    "expected InputTooLarge, got {err:?}"
   );
 }

--- a/crates/coremlit/tests/granite/model_io.rs
+++ b/crates/coremlit/tests/granite/model_io.rs
@@ -162,6 +162,53 @@ fn from_memory_rejects_foreign_tokenizer() {
   );
 }
 
+/// A caller-supplied tokenizer that is behaviorally VALID but not byte-identical
+/// to the pinned artifact is refused at construction by the SHA-256 identity
+/// backstop — the codex repro (two base-vocab ids, 5000 ↔ 6000, swapped;
+/// invisible to every behavioral check). Asserting the `check` FIELD proves the
+/// behavioral stage passed first and the identity stage fired, end to end, before
+/// `Model::load`.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn from_memory_rejects_corrupted_tokenizer_with_identity_check() {
+  // Parse → swap two non-sentinel base-vocab ids → re-serialize. `serde_json` is
+  // a dev-dependency; a small local copy of the in-lib fixture is fine here.
+  let mut value: serde_json::Value =
+    serde_json::from_slice(coremlit::embeddings::granite::BUNDLED_TOKENIZER)
+      .expect("parse bundled tokenizer.json");
+  {
+    let vocab = value["model"]["vocab"]
+      .as_object_mut()
+      .expect("model.vocab object");
+    let mut key_a = None;
+    let mut key_b = None;
+    for (key, id) in vocab.iter() {
+      match id.as_u64() {
+        Some(5_000) => key_a = Some(key.clone()),
+        Some(6_000) => key_b = Some(key.clone()),
+        _ => {}
+      }
+    }
+    let key_a = key_a.expect("id 5000 present in base vocab");
+    let key_b = key_b.expect("id 6000 present in base vocab");
+    vocab.insert(key_a, serde_json::json!(6_000));
+    vocab.insert(key_b, serde_json::json!(5_000));
+  }
+  let bytes = serde_json::to_vec(&value).expect("re-serialize mutated tokenizer.json");
+
+  let err = TextEmbedder::from_memory(common::model_path(), &bytes, TextEmbedderOptions::new())
+    .expect_err("a non-identical tokenizer must be refused at construction");
+  match err {
+    Error::TokenizerContractMismatch { check, .. } => {
+      assert_eq!(
+        check, "tokenizer identity (sha-256)",
+        "the behavioral stage must pass first, then the identity backstop fires"
+      );
+    }
+    other => panic!("expected identity TokenizerContractMismatch, got {other:?}"),
+  }
+}
+
 /// Hermetic non-vacuity proof for [`common::collect_files_rel`]'s sidecar
 /// filter (no staged model needed). On exFAT/FAT/SMB volumes macOS
 /// materializes AppleDouble `._*` and `.DS_Store` sidecars inside `.mlmodelc`

--- a/crates/coremlit/tests/granite/model_io.rs
+++ b/crates/coremlit/tests/granite/model_io.rs
@@ -29,7 +29,9 @@ use std::collections::BTreeSet;
 
 use coremlit::{
   ComputeUnits, DataType, Model,
-  embeddings::granite::{MAX_TOKENS, embedding::EMBEDDING_DIM},
+  embeddings::granite::{
+    Error, MAX_TOKENS, TextEmbedder, TextEmbedderOptions, embedding::EMBEDDING_DIM,
+  },
 };
 
 /// The `.mlmodelc` bundle's per-file SHA-256, EXACTLY enumerated (the #30
@@ -138,6 +140,26 @@ fn granite_artifact_bytes_match_pinned_sha256() {
       common::EMBEDKIT_REVISION
     );
   }
+}
+
+/// A caller-supplied tokenizer that parses but does not match the Granite
+/// contract is refused at construction, fail-closed — the audit's live repro (a
+/// tiny WordLevel tokenizer via `from_memory`). The contract gate runs before
+/// `Model::load`, so this proves the constructor's fail-closed order end-to-end.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn from_memory_rejects_foreign_tokenizer() {
+  const TINY_WORDLEVEL: &[u8] = br#"{"version":"1.0","truncation":null,"padding":null,"added_tokens":[],"normalizer":null,"pre_tokenizer":null,"post_processor":null,"decoder":null,"model":{"type":"WordLevel","vocab":{"hello":0,"world":1},"unk_token":"<unk>"}}"#;
+  let err = TextEmbedder::from_memory(
+    common::model_path(),
+    TINY_WORDLEVEL,
+    TextEmbedderOptions::new(),
+  )
+  .expect_err("a foreign tokenizer must be refused at construction");
+  assert!(
+    matches!(err, Error::TokenizerContractMismatch { .. }),
+    "expected TokenizerContractMismatch, got {err:?}"
+  );
 }
 
 /// Hermetic non-vacuity proof for [`common::collect_files_rel`]'s sidecar


### PR DESCRIPTION
## Summary

Fixes the confirmed **P1 correctness defects** from the granite audit (#44) in `embeddings::granite` — each independently verified against the real code and adversarially reviewed:

- **#1 — silent truncation:** contentless / over-budget input (and the three `attach_gaps` own-chunk sites) silently dropped suffix tokens (`" ".repeat(100_000)` → 784 tokenized, 512 kept, **272 lost**). Now **measured-refusal at `MAX_TOKENS`** with a fallible measure closure (`Error::Tokenize` on encode failure, never a bogus over-budget) → typed `ContentlessInputOverBudget`; the falsified "whitespace is only specials" comment corrected.
- **#2 — unbounded pre-prediction resource use:** `max_windows` bounded only the prediction count; a ~4 MiB input still ran O(input) chunking + repeated BPE (~1.6 GiB RSS) before rejection. New `LongTextOptions.max_input_bytes`, enforced **O(1), tokenizer-free, first** in `embed_long_with` → typed `InputTooLarge` (precedes `WindowOverBudget`).
- **#5 — `Embedding` cosine invariant:** a vector whose norm² is within the `1e-4` tolerance (e.g. `1.0000522`) was copied unchanged → `cos(x,x) > 1`, `cos(x,−x) < −1`. Now delegates to the existing f64 normalizing path (the f32 acceptance gate stays **bit-identical**); dead `from_array_trusted_unit_norm` removed.
- **#6 — tokenizer contract validation:** `from_files`/`from_memory` accepted any parseable tokenizer → finite but semantically-meaningless embeddings. Now validates the Granite contract at construction (3 special ids + vocab size 180000 + max-id ≤179999 OOV gate + sentinel) for named diagnostics, backed by an **exact SHA-256 tokenizer-identity gate** on the caller-supplied path — granite is a fixed model, so the **raw input bytes** must hash to the pinned granite tokenizer (`4f2842d…582f`). Reuses `TokenizerContractMismatch{check:"tokenizer identity (sha-256)"}`; the bundled path stays zero-overhead.

## Verification

`fmt / clippy (granite + granite,serde, `-D warnings`) / test (granite + granite,serde) / check --no-default-features / feature_map --all-features / doc` all green (124 lib under `granite`, 125 under `granite,serde`, 0 failed). `sha2` (workspace 0.11) promoted to an **optional dep riding only `granite`** — verified absent from `--no-default-features` and other feature graphs; `Cargo.lock` unchanged.

## Reviews

- **Fable 5 (max-effort): ACCEPT** — all four fixes verified correct (the audit's `cos>1` replay closed; the byte-limit is first/O(1); the tokenizer gate rejects foreign/OOV tokenizers). The `tokenizers 0.23.1` dense-id-reassignment deviation in two #6 fixtures was independently confirmed **sound against the crate source**.
- **Codex R1** flagged a **[P2]**: the behavioral #6 gate could still accept a tokenizer corrupted *off* the single sentinel. → **SHA-256 identity backstop added** (Fable adjudicated its own SHA-rejection as over-generalized — it was scoped to the bundled path). → **Codex R2: clean.**

## Scope / deferred (tracked)

Addresses the **P1 correctness items** of #44. Deferred by design (not this PR): **#3** single-pass token-offset chunking (perf), **#4** `embed_windows` retrieval API, **#7/#8/#9** real-model CI gate / replayable conversion provenance / evidence-label wording. The **identical `Embedding` cosine defect exists in `clap` + `siglip`** (`try_from_unit_slice` twin) — tracked for its own branch.
