### PR TITLE
build(deps): bump crates.io majors to latest — cpal 0.18, rand 0.10, rubato 4.0, png 0.18, mach2 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 serde_json = "1"
 libc = "0.2"
-mach2 = "0.4"
+mach2 = "0.6"
 tempfile = "3"
-rand = "0.9"
+rand = "0.10"
 hound = "3.5"
 sha2 = "0.11"
 rustfft = "6"
@@ -48,13 +48,13 @@ rustfft = "6"
 # `serde` stay off.
 soundevents-dataset = { version = "0.2", default-features = false, features = ["std", "rated"] }
 npyz = "0.9"
-cpal = "0.16"
-rubato = "0.16"
+cpal = "0.18"
+rubato = "4.0"
 criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 # Pure-Rust PNG decoder — a DEV-dep only, for decoding the committed siglip
 # corpus PNG fixtures in tests (the crate itself is sans-I/O: `Rgb8Image` takes
 # already-decoded RGB, so no image-decoder enters the library's own graph).
-png = "0.17"
+png = "0.18"
 
 [workspace.lints.rust]
 missing_docs = "deny"

--- a/crates/coremlit/examples/whisper/mic_stream.rs
+++ b/crates/coremlit/examples/whisper/mic_stream.rs
@@ -25,7 +25,7 @@ use coremlit::audio::whisper::{
   transcribe::WhisperKit,
 };
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use rubato::{FftFixedIn, Resampler};
+use rubato::{Fft, FixedSync, Indexing, Resampler, audioadapter_buffers::direct::InterleavedSlice};
 
 /// Resampler input chunk: 64 ms at 48 kHz — small enough for sub-100 ms
 /// push latency, large enough to keep the FFT resampler efficient.
@@ -185,11 +185,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     return Err(format!("unsupported input format {:?}", supported.sample_format()).into());
   }
   let channels = usize::from(supported.channels());
-  let device_rate = supported.sample_rate().0 as usize;
+  // cpal 0.18: `SampleRate` is a `u32` alias (no `.0` newtype field), and the
+  // device label now comes from the `Display` impl (the fallible `name()` is
+  // gone).
+  let device_rate = supported.sample_rate() as usize;
   eprintln!(
-    "capturing from {} at {device_rate} Hz, {channels} ch, {QUEUE_CAPACITY_SECONDS}s buffer \
+    "capturing from {device} at {device_rate} Hz, {channels} ch, {QUEUE_CAPACITY_SECONDS}s buffer \
      (Ctrl-C to stop)",
-    device.name().unwrap_or_else(|_| "<unnamed>".into()),
   );
 
   // The cpal callback runs on a realtime thread: downmix and copy straight
@@ -200,7 +202,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
   let callback_queue = Arc::clone(&queue);
   let config: cpal::StreamConfig = supported.into();
   let stream = device.build_input_stream(
-    &config,
+    config,
     move |data: &[f32], _: &cpal::InputCallbackInfo| {
       let mono = data
         .chunks_exact(channels)
@@ -212,7 +214,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
   )?;
   stream.play()?;
 
-  let mut resampler = FftFixedIn::<f32>::new(device_rate, 16_000, RESAMPLE_CHUNK, 2, 1)?;
+  // rubato 4.0: the unified `Fft` resampler (`FixedSync::Input` consumes a fixed
+  // RESAMPLE_CHUNK input frames per call — the former `FftFixedIn` role) that
+  // writes into a preallocated audioadapter buffer instead of returning a fresh
+  // Vec. `Fft::new` picks its sub-chunk count as `chunk / 256` (12 here for the
+  // 3072-frame RESAMPLE_CHUNK), replacing the old `FftFixedIn` explicit argument
+  // `2` — the larger count slightly reduces leading latency. `Fft::new_custom`
+  // is the knob if that ever matters, but a live-mic reference stream pins no
+  // resampled output.
+  let mut resampler = Fft::<f32>::new(device_rate, 16_000, RESAMPLE_CHUNK, 1, FixedSync::Input)?;
+  let mut resample_out = vec![0.0f32; resampler.output_frames_max()];
+  let indexing = Indexing::new();
   let mut captured: Vec<f32> = Vec::new();
   let mut pending: Vec<f32> = Vec::new();
   let mut resampled: Vec<f32> = Vec::new();
@@ -228,8 +240,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     while pending.len() >= RESAMPLE_CHUNK {
       let chunk: Vec<f32> = pending.drain(..RESAMPLE_CHUNK).collect();
-      let output = resampler.process(&[chunk], None)?;
-      resampled.extend_from_slice(&output[0]);
+      // Mono (1 channel) so interleaved == sequential: wrap the fixed input
+      // chunk and the reusable output buffer as audioadapter views, resample
+      // into the buffer, then copy out only the frames actually written.
+      let input = InterleavedSlice::new(&chunk, 1, RESAMPLE_CHUNK)?;
+      let out_capacity = resample_out.len();
+      let frames_written = {
+        let mut output = InterleavedSlice::new_mut(&mut resample_out, 1, out_capacity)?;
+        let (_, written) = resampler.process_into_buffer(&input, &mut output, Some(&indexing))?;
+        written
+      };
+      resampled.extend_from_slice(&resample_out[..frames_written]);
     }
     if resampled.is_empty() {
       continue;

--- a/crates/coremlit/src/audio/whisper/decode/sampler/mod.rs
+++ b/crates/coremlit/src/audio/whisper/decode/sampler/mod.rs
@@ -34,7 +34,7 @@
 
 use std::num::NonZeroUsize;
 
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 use crate::audio::whisper::options::DecodingOptions;
 
@@ -113,8 +113,10 @@ impl GreedyTokenSampler {
   /// Builds a sampler for `temperature`/`eot_token`, capturing `options`'
   /// [`DecodingOptions::top_k`] (`top_k` is a plain `usize` knob with no
   /// non-zero invariant of its own, so `0` clamps up to
-  /// `NonZeroUsize::MIN`). Seeds its RNG from the OS
-  /// (`StdRng::from_os_rng`) — `temperature == 0.0` never consults the
+  /// `NonZeroUsize::MIN`). Seeds its RNG from the OS (`StdRng::from_rng`
+  /// fed the OS-seeded `rand::rng()` thread RNG, so the sampler's full
+  /// internal state is OS-derived, not just a 64-bit seed) —
+  /// `temperature == 0.0` never consults the
   /// RNG, so this only matters for reproducibility at `temperature !=
   /// 0.0`; see [`Self::with_seed`] for the deterministic alternative,
   /// which [`crate::audio::whisper::transcribe::TranscribeTask`]'s fallback ladder now
@@ -126,7 +128,7 @@ impl GreedyTokenSampler {
       temperature,
       eot_token,
       top_k: NonZeroUsize::new(options.top_k()).unwrap_or(NonZeroUsize::MIN),
-      rng: StdRng::from_os_rng(),
+      rng: StdRng::from_rng(&mut rand::rng()),
       drew_from_rng: false,
       probs: Vec::new(),
       indices: Vec::new(),

--- a/crates/coremlit/src/audio/whisper/mod.rs
+++ b/crates/coremlit/src/audio/whisper/mod.rs
@@ -228,7 +228,9 @@
 //!   [`DecodingOptions::seed`](options::DecodingOptions::seed) left `None` (the default) this port's
 //!   sampler matches that non-determinism
 //!   ([`GreedyTokenSampler::new`](decode::sampler::GreedyTokenSampler::new)
-//!   seeds from the OS via `StdRng::from_os_rng`) — two identical unseeded
+//!   seeds from the OS (`StdRng::from_rng` fed the OS-seeded
+//!   `rand::rng()` thread RNG, so its full internal state is OS-derived,
+//!   not just a 64-bit value) — two identical unseeded
 //!   runs that fall back can legitimately differ, by design, exactly like
 //!   Swift, and this is the byte-unchanged default path. Setting
 //!   [`DecodingOptions::seed`](options::DecodingOptions::seed) to `Some(_)` makes the full

--- a/crates/coremlit/tests/siglip/common/mod.rs
+++ b/crates/coremlit/tests/siglip/common/mod.rs
@@ -251,10 +251,16 @@ pub fn assert_exact_sha_manifest(dir: &Path, cases: &[(&str, &str)]) {
 #[allow(dead_code)]
 pub fn decode_png_rgb8(path: &Path) -> (Vec<u8>, usize, usize) {
   let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {path:?}: {e}"));
-  let mut reader = png::Decoder::new(file)
+  // png 0.18's `Decoder::new` requires `BufRead + Seek`; `File` is `Read + Seek`
+  // only, so wrap it in a `BufReader`.
+  let mut reader = png::Decoder::new(std::io::BufReader::new(file))
     .read_info()
     .unwrap_or_else(|e| panic!("read png header {path:?}: {e}"));
-  let mut buf = vec![0u8; reader.output_buffer_size()];
+  // `output_buffer_size` returns `Option<usize>` in png 0.18 (`None` on overflow).
+  let out_size = reader
+    .output_buffer_size()
+    .unwrap_or_else(|| panic!("png output buffer size unavailable {path:?}"));
+  let mut buf = vec![0u8; out_size];
   let info = reader
     .next_frame(&mut buf)
     .unwrap_or_else(|e| panic!("decode png {path:?}: {e}"));


### PR DESCRIPTION
## Summary

Consolidates every outstanding crates.io dependency update into one reviewed change: all in-constraint patch/minor updates (`cargo update`) plus the **five majors** that needed coupled code adaptation. `Cargo.lock` is gitignored, so a fresh resolve already lands the latest in-constraint versions; the seven internal git deps are all exact-rev pinned, so `cargo update` cannot advance them — none needed re-pinning, keeping this a crates.io-only change.

Supersedes the five individual Dependabot PRs (they auto-close on merge): #53 (png), #26 (rand), #24 (rubato), #23 (mach2), #22 (cpal).

## Majors bumped + adaptations

| dep | from → to | kind | adaptation |
|---|---|---|---|
| **cpal** | 0.16.0 → 0.18.1 | dev (mic example) | `build_input_stream` takes `StreamConfig` by value; `SampleRate` is a `u32` alias (dropped `.0`); `Device::name()` → `Display` impl |
| **mach2** | 0.4.3 → 0.6.0 | optional (whisper) + dev | none — `mach2::traps::mach_task_self` unchanged (verified against vendored 0.6.0) |
| **png** | 0.17.16 → 0.18.1 | dev (siglip tests) | `Decoder::new` now needs `BufRead + Seek` (wrap in `BufReader`); `output_buffer_size()` → `Option` |
| **rand** | 0.9.5 → 0.10.2 | optional (whisper sampler) | `Rng` trait renamed `RngExt` (rand_core's `RngCore` took `Rng`); `from_os_rng()` removed → `StdRng::from_rng(&mut rand::rng())` (full-width OS seeding, not a 64-bit seed) |
| **rubato** | 0.16.2 → 4.0.0 | dev (mic example) | `FftFixedIn` → unified `Fft` + `FixedSync::Input`; `process(&[Vec], None)` → `process_into_buffer` over audioadapter `InterleavedSlice` views |

No other direct dependency has an available stable major (only a `libc` pre-release exists, correctly not taken). Seeded sampler goldens and whisper temperature-0 parity paths reproduce identically — `StdRng`'s ChaCha output is unchanged across the bump and no test pins an absolute drawn value.

