### PR TITLE
docs(coremlit/speaker): retire the CoreML PLDA test surface and correct the claims about it (#16 T3)

### DIFF
--- a/crates/coremlit/src/audio/speaker/extract/mod.rs
+++ b/crates/coremlit/src/audio/speaker/extract/mod.rs
@@ -709,9 +709,18 @@ impl Extraction {
   /// graphs (`PLDA.mlmodelc`, `PldaRho.mlmodelc`), and this crate deliberately
   /// loads neither. Both normalize with `clip(x, 1e-12) -> sqrt` and then divide
   /// by the result, at TWO sites each. 1e-12 is 1.7e-5x fp16's smallest
-  /// subnormal (`2^-24`), so under the default [`crate::ComputeUnits::All`] the
-  /// clip floor rounds to zero on the ANE, leaving `sqrt(0)` and a divide by
-  /// zero — silently, and only on the placement that actually ships.
+  /// subnormal (`2^-24`), so IF those ops are lowered to fp16 — which is what an
+  /// ANE placement under the default [`crate::ComputeUnits::All`] would mean —
+  /// the clip floor rounds to zero, leaving `sqrt(0)` and a silent divide by
+  /// zero.
+  ///
+  /// That antecedent is exactly where the evidence stops. `fp16_guards` reads
+  /// the MIL text STATICALLY, so the fp16 consequence is established, but its
+  /// PREMISE is UNTESTED: nothing loads these graphs, so no run has observed
+  /// where CoreML actually places their `clip`/`sqrt` ops, nor whether it
+  /// demotes them to fp16 under `ComputeUnits::All`. Read this as a decision to
+  /// decline an unnecessary risk, not as a reproduced divide-by-zero.
+  ///
   /// [`diaric::plda::PldaTransform`] instead `include_bytes!`s the fitted LDA +
   /// PLDA weights and projects in f64 on the host, so no compute-unit choice can
   /// demote the arithmetic and the projection is bit-reproducible across

--- a/crates/coremlit/src/audio/speaker/extract/mod.rs
+++ b/crates/coremlit/src/audio/speaker/extract/mod.rs
@@ -702,6 +702,25 @@ impl Extraction {
   ///
   /// Un-gated: `diaric` is a runtime dependency and `diaric::offline` is part of
   /// its ort-free clustering surface, so this bridge is always available.
+  ///
+  /// # Why the projection is Rust arithmetic and not the vendor's CoreML PLDA
+  ///
+  /// The speakerkit model repo ships the same community-1 projection as CoreML
+  /// graphs (`PLDA.mlmodelc`, `PldaRho.mlmodelc`), and this crate deliberately
+  /// loads neither. Both normalize with `clip(x, 1e-12) -> sqrt` and then divide
+  /// by the result, at TWO sites each. 1e-12 is 1.7e-5x fp16's smallest
+  /// subnormal (`2^-24`), so under the default [`crate::ComputeUnits::All`] the
+  /// clip floor rounds to zero on the ANE, leaving `sqrt(0)` and a divide by
+  /// zero — silently, and only on the placement that actually ships.
+  /// [`diaric::plda::PldaTransform`] instead `include_bytes!`s the fitted LDA +
+  /// PLDA weights and projects in f64 on the host, so no compute-unit choice can
+  /// demote the arithmetic and the projection is bit-reproducible across
+  /// placements.
+  ///
+  /// Both graphs stay pinned in `tests/fp16_guards.rs`'s `KNOWN_DEFECTS`. That
+  /// pin is what makes this decision revisitable rather than folkloric: the gate
+  /// fails if a re-converted graph ever repairs the epsilon, forcing the choice
+  /// to be re-made deliberately instead of a fixed model going unnoticed.
   pub fn into_offline_input<'a>(
     &'a self,
     plda: &'a diaric::plda::PldaTransform,

--- a/crates/coremlit/src/audio/speaker/source/argmax/mod.rs
+++ b/crates/coremlit/src/audio/speaker/source/argmax/mod.rs
@@ -210,12 +210,12 @@
 //! clustering it feeds already provides it. Per the design spec §4 the
 //! clustering is `diaric`'s — and `diaric`'s `diarize_offline` opens with a bit-exact
 //! port of the SAME pyannote community-1 `VBxClustering.filter_embeddings` that
-//! argmax's `VBxClustering.swift:50` ports (`offline/algo.rs:598-656`, with
-//! `MIN_ACTIVE_RATIO = 0.2` at `:622`), applied UNCONDITIONALLY to every
+//! argmax's `VBxClustering.swift:50` ports (`offline/algo.rs:620-680`, with
+//! `MIN_ACTIVE_RATIO = 0.2` at `:644`), applied UNCONDITIONALLY to every
 //! [`Extraction`], from either source. It withholds exactly the sparse
 //! `clean_count <= 117` slots from cluster FORMATION and then re-attaches each
 //! to its nearest centroid (`pipeline/algo.rs:636-712`, reached from the
-//! offline path's `assign_embeddings` call at `offline/algo.rs:747`) — argmax's
+//! offline path's `assign_embeddings` call at `offline/algo.rs:769`) — argmax's
 //! own withhold-then-`clusterReassignment` (`VBxClustering.swift:52,111`),
 //! reproduced downstream. So [`Extraction`] needs no "present, but do not
 //! cluster on me" channel: `diaric` is that channel. What the mask still has to
@@ -280,7 +280,7 @@
 //! | rule | applied by | fires when | on `02_pyannote_sample` |
 //! |---|---|---|---|
 //! | exclude-overlap fallback (`clean_count <= 2` ⇒ use the raw mask) | THIS port's `build_speaker_masks` | starved clean mask | 0 of 41 active slots |
-//! | `minActiveRatio` filter (`clean_count <= 117`, `ratio <= 0.2`) | `diaric`'s clustering (`offline/algo.rs:598-656`; reassignment `pipeline/algo.rs:636-712`) | sparse / overlap-heavy slot | 5 of 41 active slots |
+//! | `minActiveRatio` filter (`clean_count <= 117`, `ratio <= 0.2`) | `diaric`'s clustering (`offline/algo.rs:620-680`; reassignment `pipeline/algo.rs:636-712`) | sparse / overlap-heavy slot | 5 of 41 active slots |
 //!
 //! So a slot with, say, 40 clean frames of 589 keeps its SPARSE clean mask in
 //! the [`Extraction`] this port builds — but `diaric` does NOT then cluster on it.

--- a/crates/coremlit/tests/fp16_guards.rs
+++ b/crates/coremlit/tests/fp16_guards.rs
@@ -775,8 +775,13 @@ const KNOWN_DEFECTS: &[KnownDefect] = &[
     ],
     note: "Normalization clips to 1e-12 before `sqrt` at TWO sites, then divides by it. 1e-12 is \
            1.7e-5x fp16's smallest subnormal: on the ANE the clip floor is zero, giving sqrt(0) \
-           and a divide by zero. Not yet observed in a shipping path (found by this sweep, not by \
-           a failure).",
+           and a divide by zero. Never seen in a shipping path because nothing loads it: THIS \
+           finding is why the runtime projects with diaric's f64 `PldaTransform` (weights \
+           `include_bytes!`d, host arithmetic, no compute-unit demotion) instead of the CoreML \
+           PLDA the same model repo ships — see `Extraction::into_offline_input`. The graph \
+           arrives with the vendor tree whatever this crate decides, so the pin stays: it is what \
+           forces a re-conversion that repairs the epsilon to be SEEN, rather than leaving the \
+           rejection as folklore a future contributor would have to rediscover.",
   },
   KnownDefect {
     path: "speakerkit/PldaRho.mlmodelc",
@@ -784,7 +789,7 @@ const KNOWN_DEFECTS: &[KnownDefect] = &[
       "sqrt/fp32 guard=clip(alpha=9.999999960041972e-13) eff=9.999999960041972e-13",
       "sqrt/fp32 guard=clip(alpha=9.999999960041972e-13) eff=9.999999960041972e-13",
     ],
-    note: "Same two-site 1e-12 clip floor as PLDA.mlmodelc.",
+    note: "Same two-site 1e-12 clip floor as PLDA.mlmodelc, unloaded for the same reason.",
   },
   KnownDefect {
     path: "argmax-speakerkit/speaker_segmenter/pyannote-v3/W32A32/SpeakerSegmenter.mlmodelc",

--- a/crates/coremlit/tests/fp16_guards.rs
+++ b/crates/coremlit/tests/fp16_guards.rs
@@ -774,14 +774,16 @@ const KNOWN_DEFECTS: &[KnownDefect] = &[
       "sqrt/fp32 guard=clip(alpha=9.999999960041972e-13) eff=9.999999960041972e-13",
     ],
     note: "Normalization clips to 1e-12 before `sqrt` at TWO sites, then divides by it. 1e-12 is \
-           1.7e-5x fp16's smallest subnormal: on the ANE the clip floor is zero, giving sqrt(0) \
-           and a divide by zero. Never seen in a shipping path because nothing loads it: THIS \
-           finding is why the runtime projects with diaric's f64 `PldaTransform` (weights \
-           `include_bytes!`d, host arithmetic, no compute-unit demotion) instead of the CoreML \
-           PLDA the same model repo ships — see `Extraction::into_offline_input`. The graph \
-           arrives with the vendor tree whatever this crate decides, so the pin stays: it is what \
-           forces a re-conversion that repairs the epsilon to be SEEN, rather than leaving the \
-           rejection as folklore a future contributor would have to rediscover.",
+           1.7e-5x fp16's smallest subnormal, so IF these ops are lowered to fp16 the clip floor \
+           becomes zero, giving sqrt(0) and a divide by zero. That premise is UNTESTED: this sweep \
+           reads the MIL text STATICALLY, nothing loads these graphs, and no run has observed \
+           their actual placement or whether ComputeUnits::All demotes them. THIS finding is why \
+           the runtime projects with diaric's f64 `PldaTransform` (weights `include_bytes!`d, host \
+           arithmetic, no compute-unit demotion) instead of the CoreML PLDA the same model repo \
+           ships — see `Extraction::into_offline_input`. The graph arrives with the vendor tree \
+           whatever this crate decides, so the pin stays: it is what forces a re-conversion that \
+           repairs the epsilon to be SEEN, rather than leaving the rejection as folklore a future \
+           contributor would have to rediscover.",
   },
   KnownDefect {
     path: "speakerkit/PldaRho.mlmodelc",

--- a/crates/coremlit/tests/speaker/argmax_model_io.rs
+++ b/crates/coremlit/tests/speaker/argmax_model_io.rs
@@ -137,10 +137,25 @@
 //!    to zero; on such a kernel, with a zero variance, the 1e-6 floor and
 //!    the 1e-12 epsilon vanish together and the `rsqrt` takes a bare 0,
 //!    i.e. `1/sqrt(0)`.
-//!    **What would settle it:** a runtime placement test feeding
-//!    zero-variance input on the intended compute units and checking the
-//!    output. No such test exists, and none is warranted while nothing in
-//!    this crate loads this graph.
+//!    **What would settle it — and what a naive probe would NOT.** Not
+//!    "feed a zero-variance input and check the output". This graph has TWO
+//!    sequential normalization sites (`model.mil`'s `op_26` and `op_54`
+//!    `rsqrt`s), and a generic zero-variance MODEL input is not shown to
+//!    drive either into the zero/subnormal regime, let alone both. Site
+//!    one's `rsqrt` sees `mean_c((x - xvectors_mean)^2) + 1e-6` — the
+//!    external input is CENTERED first, so an all-zero `embeddings` yields
+//!    `mean_c(xvectors_mean^2)`, not `0`; only a slot of `x` equal to
+//!    `xvectors_mean` itself zeroes that reduction. Site two's sits AFTER
+//!    the LDA `conv` and its bias, so it is not directly addressable from
+//!    the model input at all — reaching it needs a solved pre-image. A test
+//!    that settles runtime safety therefore has to (i) use inputs PROVEN,
+//!    per site, to drive that site's `rsqrt` argument into the regime, and
+//!    (ii) compare EVERY supported `ComputeUnits` placement against a
+//!    CPU/f32 reference, since a finite number on one placement is neither
+//!    numerical correctness nor portability. Short of both, such a probe is
+//!    evidence about one input, one host and one placement — not about
+//!    runtime safety. No such test exists, and none is warranted while
+//!    nothing in this crate loads this graph.
 //! 5. None of the seven artifacts declare any shape flexibility
 //!    (`hasShapeFlexibility: "0"` on every input/output in every
 //!    `metadata.json`) — unlike some of `tests/model_io.rs`'s

--- a/crates/coremlit/tests/speaker/argmax_model_io.rs
+++ b/crates/coremlit/tests/speaker/argmax_model_io.rs
@@ -117,12 +117,30 @@
 //!    own, unrelated `PLDA.mlmodelc` — the two sources don't share a
 //!    contract here either, consistent with them being unrelated
 //!    conversions (pyannote-v4 vs. FluidAudio's own). This is argmax's own
-//!    PLDA, and unlike FluidAudio's it is fp16-SAFE, hence its absence from
-//!    `fp16_guards`' `KNOWN_DEFECTS`: both its normalizations do carry a
+//!    PLDA, and it PASSES THE STATIC MINIMUM-SUBNORMAL GUARD where the
+//!    FluidAudio pair does not — which is why it carries no `fp16_guards`
+//!    `KNOWN_DEFECTS` pin and they do. Both its normalizations do carry a
 //!    1e-12 `rsqrt` epsilon, but each sits behind an `add(variance, 1e-6)`
-//!    on its input, and 1e-6 clears fp16's smallest subnormal by ~17x. The
-//!    FluidAudio pair's only floor is the 1e-12 `clip` itself, which is why
-//!    they are pinned and this is not.
+//!    on that op's input, and 1e-6 is representable in fp16 at ~17x the
+//!    smallest subnormal (`2^-24`); the FluidAudio pair's only floor is
+//!    the bare 1e-12 `clip` itself. That contrast is solid, and it is the
+//!    whole reason for the differing pin status.
+//!
+//!    Do NOT restate that as "fp16-safe". An earlier revision of this doc
+//!    did, as did issue #16; both are corrected, and this is the wording
+//!    they agree on. **Established:** static representability — this
+//!    graph clears the check `fp16_guards` actually performs, which reads
+//!    the MIL text and compares floors against `2^-24`. **Not
+//!    established:** runtime safety. 1e-6 is itself SUBNORMAL in fp16 (it
+//!    is below `2^-14`, fp16's smallest NORMAL), and `fp16_guards` records
+//!    at its `FP16_MIN_NORMAL` constant that some kernels flush subnormals
+//!    to zero; on such a kernel, with a zero variance, the 1e-6 floor and
+//!    the 1e-12 epsilon vanish together and the `rsqrt` takes a bare 0,
+//!    i.e. `1/sqrt(0)`.
+//!    **What would settle it:** a runtime placement test feeding
+//!    zero-variance input on the intended compute units and checking the
+//!    output. No such test exists, and none is warranted while nothing in
+//!    this crate loads this graph.
 //! 5. None of the seven artifacts declare any shape flexibility
 //!    (`hasShapeFlexibility: "0"` on every input/output in every
 //!    `metadata.json`) — unlike some of `tests/model_io.rs`'s

--- a/crates/coremlit/tests/speaker/argmax_model_io.rs
+++ b/crates/coremlit/tests/speaker/argmax_model_io.rs
@@ -111,14 +111,18 @@
 //!    byte-identity alone.
 //! 4. `PldaProjector.mlmodelc` (`speaker_clusterer`, out of scope): input
 //!    `embeddings [1, 64, 256]`, output `plda_embeddings [1, 64, 128]` —
-//!    recorded for completeness (mirroring `tests/model_io.rs`'s
-//!    PLDA-recording precedent) with no expected contract to check it
-//!    against, so this is recorded, not a delta.
-//!    Note the name is `plda_embeddings`, not the FluidAudio-side PLDA
-//!    artifact's `plda_features` (`tests/model_io.rs`'s
-//!    `plda_io_recorded_out_of_scope`) — the two sources don't share a
+//!    recorded for completeness, with no expected contract to check it
+//!    against, so this is recorded, not a delta. Note the name is
+//!    `plda_embeddings`, not the `plda_features` emitted by FluidAudio's
+//!    own, unrelated `PLDA.mlmodelc` — the two sources don't share a
 //!    contract here either, consistent with them being unrelated
-//!    conversions (pyannote-v4 vs. FluidAudio's own).
+//!    conversions (pyannote-v4 vs. FluidAudio's own). This is argmax's own
+//!    PLDA, and unlike FluidAudio's it is fp16-SAFE, hence its absence from
+//!    `fp16_guards`' `KNOWN_DEFECTS`: both its normalizations do carry a
+//!    1e-12 `rsqrt` epsilon, but each sits behind an `add(variance, 1e-6)`
+//!    on its input, and 1e-6 clears fp16's smallest subnormal by ~17x. The
+//!    FluidAudio pair's only floor is the 1e-12 `clip` itself, which is why
+//!    they are pinned and this is not.
 //! 5. None of the seven artifacts declare any shape flexibility
 //!    (`hasShapeFlexibility: "0"` on every input/output in every
 //!    `metadata.json`) — unlike some of `tests/model_io.rs`'s

--- a/crates/coremlit/tests/speaker/model_io.rs
+++ b/crates/coremlit/tests/speaker/model_io.rs
@@ -1,8 +1,7 @@
 //! Ground-truth introspection of every candidate segmentation and embedding
 //! artifact named in the design spec
 //! (`docs/superpowers/specs/2026-07-11-dia-coreml-backends-design.md` §4, §9
-//! open item) plus the out-of-scope PLDA artifact the plan brief also names.
-//! Every value below comes from loading the real `.mlmodelc` via
+//! open item). Every value below comes from loading the real `.mlmodelc` via
 //! `coremlit::Model::load` + `.description()` — the spec's table is a
 //! HYPOTHESIS; reality wins, and every place it differs is marked `SPEC
 //! DELTA`. Feeds Task 2 (`SegmentModel`) and later tasks (`EmbedModel`,
@@ -19,7 +18,12 @@
 //! | `wespeaker.mlmodelc` | embedding, fp32, contract-equal | no |
 //! | `FBank.mlmodelc` | embedding frontend, split-pipeline alt | no |
 //! | `Embedding.mlmodelc` | embedding backend, split-pipeline alt | no |
-//! | `PLDA.mlmodelc` | clustering input transform | out of scope (spec §3 non-goal) |
+//!
+//! The repo also ships `PLDA.mlmodelc` / `PldaRho.mlmodelc`. Neither is a
+//! candidate and neither is introspected here: clustering — and with it the
+//! PLDA projection — stays in `diaric` (spec §3 non-goal), which projects in
+//! f64 on the host. `coremlit::audio::speaker::extract`'s `into_offline_input`
+//! records why the CoreML graphs are unusable even if that ever changed.
 //!
 //! # Licenses (`Models/speakerkit/README.md`)
 //!
@@ -432,25 +436,4 @@ fn embedding_split_io_recorded_not_targeted() {
     "dynamic output shape tracking the flexible `fbank_features`/`weights` inputs"
   );
   assert_eq!(embedding.data_type(), Some(DataType::F32));
-}
-
-#[test]
-#[ignore = "requires local speakerkit models (SPEAKERKIT_TEST_MODELS)"]
-fn plda_io_recorded_out_of_scope() {
-  // Out of scope per spec §3 non-goals ("Any clustering/VBx/PLDA port") —
-  // recorded because the plan brief names it as a candidate artifact to
-  // introspect. Fixed-shape throughout; no flexibility declared at all.
-  let path = common::models_dir().join("PLDA.mlmodelc");
-  let model = Model::load(path, ComputeUnits::CpuOnly).unwrap();
-  let description = model.description();
-
-  let embeddings = description.input("embeddings").expect("embeddings input");
-  assert_eq!(embeddings.shape(), &[1, 256]);
-  assert_eq!(embeddings.data_type(), Some(DataType::F32));
-
-  let plda_features = description
-    .output("plda_features")
-    .expect("plda_features output");
-  assert_eq!(plda_features.shape(), &[1, 128]);
-  assert_eq!(plda_features.data_type(), Some(DataType::F32));
 }

--- a/crates/coremlit/tests/speaker/model_io.rs
+++ b/crates/coremlit/tests/speaker/model_io.rs
@@ -25,6 +25,40 @@
 //! f64 on the host. `coremlit::audio::speaker::extract`'s `into_offline_input`
 //! records why the CoreML graphs are unusable even if that ever changed.
 //!
+//! ## Retired coverage: `plda_io_recorded_out_of_scope` (a deliberate loss)
+//!
+//! `PLDA.mlmodelc` once had a row in the table above and an `#[ignore]`d
+//! introspection test, `plda_io_recorded_out_of_scope`. Both were DELETED, not
+//! relocated, and deleting the test did cost coverage that nothing else
+//! provides. "No coverage was lost" would be false, so here is the ledger:
+//!
+//! - **What it uniquely asserted:** that `PLDA.mlmodelc` loads at all
+//!   (`Model::load`, `CpuOnly`), and that its description carries the input
+//!   `embeddings [1, 256]` F32 and the output `plda_features [1, 128]` F32.
+//! - **What still touches the artifact, and how far that reaches:** only
+//!   `tests/fp16_guards.rs`. Its sweep requires the bundle to be present with a
+//!   parseable `model.mil` and hard-fails if the pinned guard sites change or
+//!   vanish — so deletion of the artifact and drift in its numerical guards are
+//!   still caught. But it reads the MIL as TEXT: it never calls `Model::load`,
+//!   so it says nothing about CoreML loadability, and it never reads the model
+//!   description, so it says nothing about feature names, shapes or dtypes.
+//! - **So the loadability and schema assertions are simply gone**, and nothing
+//!   replaces them. A re-conversion that reshaped the I/O while leaving the
+//!   guard sites alone would now pass unnoticed.
+//! - **Why that is the intended trade rather than an oversight:** the artifact
+//!   is on no runtime path — nothing in this crate calls `Model::load` on it,
+//!   and nothing is planned to, because the projection is
+//!   `diaric::plda::PldaTransform` in f64 on the host. The test pinned the I/O
+//!   contract of a graph this crate will never consume, and being `#[ignore]`d
+//!   it ran only when someone staged the models and asked for it by name.
+//!   Retiring it with this record beats keeping a check whose presence implies
+//!   the graph is still a live candidate; the one scenario in which the lost
+//!   assertions would matter — the graph becoming a candidate again — is also
+//!   the one scenario in which it would be re-introspected from scratch anyway.
+//! - **If it ever does become one**, restore exactly the assertions listed
+//!   above; they are spelled out here so the restoration needs no `git log`
+//!   archaeology.
+//!
 //! # Licenses (`Models/speakerkit/README.md`)
 //!
 //! The repo's HuggingFace frontmatter declares `license: cc-by-4.0` for the

--- a/crates/coremlit/tests/speaker/parity_e2e.rs
+++ b/crates/coremlit/tests/speaker/parity_e2e.rs
@@ -587,18 +587,29 @@ const DER_PIN_TOL: f64 = 0.0005;
 /// sources produce those differently, which is the very thing under
 /// investigation. It can therefore retain a DIFFERENT set of embeddings for
 /// cluster FORMATION on the argmax side than on the FluidAudio side, and a
-/// different retained set means different centroids and so different final
+/// different retained set CAN move the centroids and so the final
 /// assignments. Shared filter, per-source input, possibly divergent effect:
 /// that is the shape of a mediator, and nothing measured here excludes it.
 ///
-/// **What would settle it.** Either (a) a 0.2-versus-disabled ablation, which
-/// has no OFF arm today because `diarize_offline` hardcodes `MIN_ACTIVE_RATIO`
-/// as a `const` and exposes no knob for it; or (b), cheaper and sufficient,
-/// dumping the RETAINED slot set per source per clip — `diaric`'s Stage-1
-/// `train_chunk_idx`/`train_speaker_idx` pair — and comparing them: identical
-/// retained sets on the failing clips would demote the filter to a genuine
-/// non-factor, differing sets would make it a live mediator whose contribution
-/// has to be quantified. Neither experiment exists today.
+/// **What would settle it — and what would NOT.** Settling it takes the
+/// ABLATION: run both sources with the 0.2 rule ON and OFF and measure how the
+/// CROSS-SOURCE divergence itself moves. That difference-in-differences is the
+/// filter's causal contribution to the gap; nothing weaker is. It has no OFF
+/// arm today because `diarize_offline` hardcodes `MIN_ACTIVE_RATIO` as a
+/// `const` and exposes no knob for it.
+///
+/// Dumping the RETAINED slot set per source per clip — `diaric`'s Stage-1
+/// `train_chunk_idx`/`train_speaker_idx` pair — is far cheaper and worth doing,
+/// but it is DIAGNOSTIC EVIDENCE ONLY, not a substitute. Those index arrays
+/// answer exactly one question: whether the rule selects different COORDINATES
+/// on the two sides. They settle causal impact in neither direction. Identical
+/// retained sets would NOT demote the filter to a non-factor — the EXCLUDED
+/// embeddings stay source-dependent, so disabling the rule hands each side a
+/// different set of restored vectors and can still move argmax and FluidAudio
+/// unequally. Differing retained sets would NOT establish a live mediator
+/// either — a different retained set need not shift the centroids, and shifted
+/// centroids need not flip any assignment. A difference is a REASON to spend
+/// the ablation; a match merely withholds one. Neither experiment exists today.
 /// So **§5.2/§5.6 is NARROWED, not closed** — one hypothesis eliminated, the
 /// mediator hypothesis still open. The front-end warp remains the leading
 /// explanation, and still not an isolated variable, because the segmenter and

--- a/crates/coremlit/tests/speaker/parity_e2e.rs
+++ b/crates/coremlit/tests/speaker/parity_e2e.rs
@@ -568,6 +568,19 @@ const DER_PIN_TOL: f64 = 0.0005;
 /// hears the same speech and assigns it to the wrong person, which is why no
 /// collar absorbs it.
 ///
+/// One rival explanation IS eliminated, and not by measurement. argmax's
+/// `minActiveRatio` sparse-slot exclusion was once a live suspect, on the
+/// premise that this port had not taken it. That premise is false: `diaric`'s
+/// `diarize_offline` applies the same `filter_embeddings` rule unconditionally
+/// to every [`Extraction`] from either source (`offline/algo.rs:620-680`,
+/// `MIN_ACTIVE_RATIO = 0.2` at `:644`), so every number in the table above was
+/// already measured WITH the exclusion in effect — for the failing argmax runs
+/// and the clean FluidAudio runs alike. Same filter, both sources, opposite
+/// outcomes: the filter cannot be what separates them, and the proposed
+/// ratio-ON-vs-OFF experiment has no OFF arm to run. The front-end warp remains
+/// the leading explanation, now with one fewer rival — still not an isolated
+/// variable, because the segmenter and in-graph decode swap with the embedder.
+///
 /// Note what the data does NOT say. It does not say "argmax fails at ≥3
 /// speakers": `06_long_recording` has 3 and is clean. It does not say the defect
 /// is only a spurious speaker: on `12_mrbeast_schools` argmax gets the speaker

--- a/crates/coremlit/tests/speaker/parity_e2e.rs
+++ b/crates/coremlit/tests/speaker/parity_e2e.rs
@@ -568,18 +568,41 @@ const DER_PIN_TOL: f64 = 0.0005;
 /// hears the same speech and assigns it to the wrong person, which is why no
 /// collar absorbs it.
 ///
-/// One rival explanation IS eliminated, and not by measurement. argmax's
-/// `minActiveRatio` sparse-slot exclusion was once a live suspect, on the
-/// premise that this port had not taken it. That premise is false: `diaric`'s
-/// `diarize_offline` applies the same `filter_embeddings` rule unconditionally
-/// to every [`Extraction`] from either source (`offline/algo.rs:620-680`,
-/// `MIN_ACTIVE_RATIO = 0.2` at `:644`), so every number in the table above was
-/// already measured WITH the exclusion in effect — for the failing argmax runs
-/// and the clean FluidAudio runs alike. Same filter, both sources, opposite
-/// outcomes: the filter cannot be what separates them, and the proposed
-/// ratio-ON-vs-OFF experiment has no OFF arm to run. The front-end warp remains
-/// the leading explanation, now with one fewer rival — still not an isolated
-/// variable, because the segmenter and in-graph decode swap with the embedder.
+/// One FORM of a rival explanation is eliminated, and not by measurement — but
+/// only one form, so read the split carefully.
+///
+/// **Established.** argmax's `minActiveRatio` sparse-slot exclusion was a live
+/// suspect on the premise that this port had never taken it. That premise is
+/// false: `diaric`'s `diarize_offline` applies the same `filter_embeddings`
+/// rule unconditionally to every [`Extraction`] from either source
+/// (`offline/algo.rs:620-680`, `MIN_ACTIVE_RATIO = 0.2` at `:644`), so every
+/// number in the table above was already measured WITH the exclusion in effect
+/// — on the failing argmax runs and the clean FluidAudio runs alike. The
+/// hypothesis "argmax degrades because the filter is MISSING from this port" is
+/// dead.
+///
+/// **NOT established: that the filter is not a MEDIATOR.** Same code and same
+/// threshold on both sources does not imply the same effect. The rule's
+/// decision is a function of each slot's active/overlap masks — and the two
+/// sources produce those differently, which is the very thing under
+/// investigation. It can therefore retain a DIFFERENT set of embeddings for
+/// cluster FORMATION on the argmax side than on the FluidAudio side, and a
+/// different retained set means different centroids and so different final
+/// assignments. Shared filter, per-source input, possibly divergent effect:
+/// that is the shape of a mediator, and nothing measured here excludes it.
+///
+/// **What would settle it.** Either (a) a 0.2-versus-disabled ablation, which
+/// has no OFF arm today because `diarize_offline` hardcodes `MIN_ACTIVE_RATIO`
+/// as a `const` and exposes no knob for it; or (b), cheaper and sufficient,
+/// dumping the RETAINED slot set per source per clip — `diaric`'s Stage-1
+/// `train_chunk_idx`/`train_speaker_idx` pair — and comparing them: identical
+/// retained sets on the failing clips would demote the filter to a genuine
+/// non-factor, differing sets would make it a live mediator whose contribution
+/// has to be quantified. Neither experiment exists today.
+/// So **§5.2/§5.6 is NARROWED, not closed** — one hypothesis eliminated, the
+/// mediator hypothesis still open. The front-end warp remains the leading
+/// explanation, and still not an isolated variable, because the segmenter and
+/// in-graph decode swap with the embedder.
 ///
 /// Note what the data does NOT say. It does not say "argmax fails at ≥3
 /// speakers": `06_long_recording` has 3 and is clean. It does not say the defect

--- a/crates/coremlit/tests/speaker/swift/Tests/ArgmaxTensorDump/DumpArgmaxTensors.swift
+++ b/crates/coremlit/tests/speaker/swift/Tests/ArgmaxTensorDump/DumpArgmaxTensors.swift
@@ -84,8 +84,11 @@ private struct GoldenSlot: Encodable {
   let activeFrames: String
   /// `SpeakerEmbedding.nonOverlappedFrameRatio` — recorded so the Rust side
   /// can REPORT how often argmax's `minActiveRatio` clustering filter would
-  /// have fired. Deliberately NOT ported (spec §5.2); it lives downstream of
-  /// the embeddings, so it is out of this gate's surface.
+  /// have fired. The filter is NOT missing from the Rust pipeline: `diaric`'s
+  /// clustering applies the same pyannote `filter_embeddings` rule, at the same
+  /// 0.2 ratio, to every `Extraction` from either source. It simply lives
+  /// downstream of the embeddings, so it is out of this gate's surface — which
+  /// is why this value is reported and never asserted on.
   let nonOverlappedFrameRatio: Float
   /// `SpeakerEmbedding.embedding` — the raw 256-d WeSpeaker vector.
   let embedding: [Float]


### PR DESCRIPTION
## Summary

Retires the CoreML PLDA test surface and corrects a set of documented claims about it — several of which were **factually wrong**, including two in this issue's own premise. The diff is **comment-only** apart from removing one `#[ignore]`d test; no runtime code changed.

Closes the remaining task (T3) of #16.

## What the investigation found

The task began as "retire argmax's fp16-fragile CoreML PLDA artifacts as dead weight." Three of those five words turned out to be wrong.

**They are not argmax's.** `PLDA.mlmodelc` and `PldaRho.mlmodelc` are **FluidAudio's** (`FluidInference/speaker-diarization-coreml`). argmax's PLDA is a different artifact entirely — `argmax-speakerkit/speaker_clusterer/pyannote-v4/W32A32/PldaProjector.mlmodelc`, introspected and SHA-pinned in `argmax_model_io.rs`.

**argmax's own PLDA is not fp16-fragile.** It carries the same two 1e-12 `rsqrt` epsilons, but each sits behind an `add(variance, 1e-6)` on that op's input, and 1e-6 clears fp16's smallest subnormal by ~17×. FluidAudio's only floor is the bare 1e-12 `clip`. That contrast is exactly why one is pinned in `fp16_guards` and the other is not.

**The pins cannot simply be deleted.** `KNOWN_DEFECTS` is a claim about the **staged vendor tree**, not about what the crate loads: `sweep_tree` walks every `.mlmodelc` under `Models/` and hard-fails on any unpinned graph carrying a vanishing guard — verified by experiment (removing both pins exits 101, both graphs flagged by name). It is also bidirectional, failing when a pinned model is absent while its vendor directory exists. Deleting the artifacts does not help either: `Models/speakerkit` is fetched as a whole repo with no `--include`, so the next download restores them. Retiring the pins is therefore coupled to narrowing the documented fetch — a separate, owner-level change.

So the artifacts stay staged and pinned, and what actually ships here is the **reasoning**, recorded where a contributor asking "why not the CoreML PLDA?" will land.

## What was removed, and what that cost

`plda_io_recorded_out_of_scope` — an `#[ignore]`d test that loaded FluidAudio's `PLDA.mlmodelc` purely to assert its IO shapes — is deleted, along with its doc-table row.

That **did** cost coverage, and the branch says so rather than glossing it. `fp16_guards` still requires the bundle present with a parseable `model.mil` and hard-fails on guard-site drift, but it reads the MIL as *text*: it never calls `Model::load` and never reads the model description, so loadability and schema assertions are simply gone and nothing replaces them. A re-conversion that reshaped the IO while leaving the guard sites intact would now pass unnoticed. The ledger in `model_io.rs` records exactly what was asserted, so a restoration needs no `git log` archaeology.

## Claims corrected

Every one of these was stronger than its evidence. Each is now written as **established / not established / what would settle it**:

- **The §5.2/§5.6 filter gate is NARROWED, not closed.** diaric's `diarize_offline` does apply argmax's `minActiveRatio = 0.2` to every source, so the hypothesis "argmax degrades because the filter is missing from this port" is dead. But the filter can still be a **mediator**: its decision depends on each source's active/overlap masks, so it can retain different embeddings per source. Only an enabled-versus-disabled ablation measuring the change in cross-source divergence settles that; a retained-set dump is diagnostic evidence in neither direction.
- **`PldaProjector` passes the static minimum-subnormal guard** — it is *not* demonstrated "fp16-safe". 1e-6 is itself subnormal in fp16, and `fp16_guards` records that some kernels flush subnormals to zero. Settling it needs inputs proven *per site* to drive each internal `rsqrt` into the regime — and the branch verifies from the MIL that a naive all-zero input does not: site one's reduction sees `mean_c((x − xvectors_mean)²) + 1e-6`, and site two sits after the LDA conv and bias, unreachable from the model input without solving a pre-image.
- **The PLDA divide-by-zero is conditional on fp16 lowering.** The sweep reads MIL statically; nothing loads these graphs, so no run has observed where CoreML places their ops or whether `ComputeUnits::All` demotes them. Recorded identically in `extract/mod.rs` and the `fp16_guards` defect note so the two cannot drift.
- Drifted diaric citations were corrected against the pinned revision (uniformly ~22 lines stale), and a surviving "deliberately NOT ported" claim in the Swift tensor-dump harness was fixed.

## Verification

`fmt · clippy --all-features --all-targets -D warnings · test --all-features · doc -D warnings · default-features test --no-run · fp16_guards · speaker_model_io · speaker_argmax_model_io` — all green. **42 model-gated tests ran with 0 ignored** (`fp16_guards` 24, `speaker_model_io` 8, `speaker_argmax_model_io` 10), the guard sweep covering 32 models / 1096 guard sites across all 9 vendors.

## Review

**Codex adversarial review, two rounds.** Round 1 raised three claims exceeding their evidence; round 2 found that **the corrections themselves overclaimed** — specifically inside the "what would settle it" clauses, proposing experiments that would not in fact settle the question. Both rounds are fixed. The remaining diff is comment-only and was deliberately not sent for a third round: the code is untouched and further findings would be wording precision, which is not a ship gate.

## Note if squashing

The first commit's message (`aec472f`) still reads *"close the 5.2/5.6 gate"* and *"the filter is eliminated as a rival"*. Later commits retract both in the documentation — HEAD says the gate is **narrowed, not closed**, and makes the ablation the only thing that can settle the mediator question. **This PR body carries the corrected wording; `aec472f`'s must not be used as the squashed message.**
