### PR TITLE
fix(coremlit/whisper): long-form parity — Swift's alignment-gather stride bug, plus the tokenizer and test fixes it surfaced

### DIFF
--- a/crates/coremlit/src/audio/whisper/error/mod.rs
+++ b/crates/coremlit/src/audio/whisper/error/mod.rs
@@ -155,8 +155,10 @@ pub enum SegmentError {
   /// [`AlignmentGather::Complete`](crate::audio::whisper::options::AlignmentGather::Complete)
   /// names, and substituting it under a `SwiftParity` request would be the
   /// same silent, host-dependent swap of transcript-changing behavior that
-  /// whisper #41 exists to remove. A caller who prefers timings over parity
-  /// asks for `Complete` explicitly.
+  /// whisper #41 exists to remove. `SwiftParity` is opt-in, so refusing an
+  /// environment where it cannot be honored costs a caller nothing they did
+  /// not explicitly ask for — a caller who prefers timings over parity simply
+  /// does not opt in, and gets `Complete` by default.
   #[error(
     "cannot measure this host's CoreVideo Float16 row pitch for the {rows} x {cols} alignment \
      gather, so the Swift-parity gather cannot be reproduced (select \
@@ -192,42 +194,6 @@ pub enum SegmentError {
     cols: usize,
     /// The element strides the probe allocation actually reported.
     strides: Vec<usize>,
-  },
-  /// This host's CoreVideo handed back a Float16 surface whose storage past
-  /// the logical element count was **not** zero, so the tail Swift's gather
-  /// reads but never writes cannot be reproduced.
-  ///
-  /// Swift's destination array
-  /// (`SegmentSeeker.swift:450`,
-  /// `MLMultiArray(shape:dataType:initialValue: FloatType(0))`) fills only
-  /// its logical `count` elements — the row pitch's padding, and every
-  /// element the gather's `columnCount`-pitched `memcpy` overruns into, keep
-  /// whatever `CVPixelBufferCreate` left. `dynamicTimeWarping` then reads
-  /// those cells as alignment weights. This port reproduces them by
-  /// allocating the same surface and looking at that region before touching
-  /// it; when the region comes back zero — as it does on every host measured
-  /// so far — Swift's DTW input is fully determined and reproducible.
-  ///
-  /// Nonzero means it is not: the values Swift would feed DTW came from
-  /// *its* allocation, which this port cannot observe and could not
-  /// reproduce even if it could. Fail-closed for the same reason as
-  /// [`Self::AlignmentPitchUnavailable`] — an unreproducible input is not an
-  /// absent one, and silently substituting zeros (or
-  /// [`AlignmentGather::Complete`](crate::audio::whisper::options::AlignmentGather::Complete))
-  /// would report parity for a different DTW input.
-  #[error(
-    "this host's CoreVideo left {nonzero_bytes} nonzero byte(s) in the untouched storage past the \
-     {rows} x {cols} alignment gather's logical elements, which Swift's gather reads but never \
-     writes, so its DTW input is not reproducible here (select `AlignmentGather::Complete` to \
-     gather every row in full instead)"
-  )]
-  AlignmentGatherTailNotZero {
-    /// Rows the gather allocated (gathered tokens).
-    rows: usize,
-    /// Columns the gather allocated (audio tokens).
-    cols: usize,
-    /// Nonzero bytes found past the surface's logical element count.
-    nonzero_bytes: usize,
   },
   /// Decoding a slice's tokens back to text failed.
   #[error("tokenizer decode failed: {0}")]

--- a/crates/coremlit/src/audio/whisper/error/mod.rs
+++ b/crates/coremlit/src/audio/whisper/error/mod.rs
@@ -144,6 +144,55 @@ pub enum SegmentError {
     /// Actual flattened element count.
     len: usize,
   },
+  /// This host's CoreVideo row pitch for the Float16 surface Swift's
+  /// alignment gather allocates could not be measured, so
+  /// [`AlignmentGather::SwiftParity`](crate::audio::whisper::options::AlignmentGather::SwiftParity)
+  /// — whose whole content is replicating what that pitch truncates —
+  /// cannot be honored.
+  ///
+  /// Fail-closed by design: the alternative, quietly gathering every row in
+  /// full, is the behavior
+  /// [`AlignmentGather::Complete`](crate::audio::whisper::options::AlignmentGather::Complete)
+  /// names, and substituting it under a `SwiftParity` request would be the
+  /// same silent, host-dependent swap of transcript-changing behavior that
+  /// whisper #41 exists to remove. A caller who prefers timings over parity
+  /// asks for `Complete` explicitly.
+  #[error(
+    "cannot measure this host's CoreVideo Float16 row pitch for the {rows} x {cols} alignment \
+     gather, so the Swift-parity gather cannot be reproduced (select \
+     `AlignmentGather::Complete` to gather every row in full instead): {source}"
+  )]
+  AlignmentPitchUnavailable {
+    /// Rows the gather would have allocated (gathered tokens).
+    rows: usize,
+    /// Columns the gather would have allocated (audio tokens).
+    cols: usize,
+    /// Why the probe allocation could not supply a pitch.
+    #[source]
+    source: crate::TensorError,
+  },
+  /// The probe allocation behind
+  /// [`AlignmentGather::SwiftParity`](crate::audio::whisper::options::AlignmentGather::SwiftParity)
+  /// succeeded but reported a layout the gather's model cannot describe —
+  /// anything other than `[pitch, 1]` element strides with `pitch >= cols`,
+  /// i.e. rows padded only *between* each other.
+  ///
+  /// Fail-closed for the same reason as [`Self::AlignmentPitchUnavailable`]:
+  /// an unmodellable layout means the truncation Swift's gather performs is
+  /// unknown, not absent.
+  #[error(
+    "this host's CoreVideo Float16 surface for the {rows} x {cols} alignment gather reports \
+     element strides {strides:?}, which is not the row-padded row-major layout the Swift-parity \
+     gather models (select `AlignmentGather::Complete` to gather every row in full instead)"
+  )]
+  AlignmentPitchUnexpectedLayout {
+    /// Rows the gather allocated (gathered tokens).
+    rows: usize,
+    /// Columns the gather allocated (audio tokens).
+    cols: usize,
+    /// The element strides the probe allocation actually reported.
+    strides: Vec<usize>,
+  },
   /// Decoding a slice's tokens back to text failed.
   #[error("tokenizer decode failed: {0}")]
   Tokenizer(#[from] TokenizerError),

--- a/crates/coremlit/src/audio/whisper/error/mod.rs
+++ b/crates/coremlit/src/audio/whisper/error/mod.rs
@@ -193,6 +193,42 @@ pub enum SegmentError {
     /// The element strides the probe allocation actually reported.
     strides: Vec<usize>,
   },
+  /// This host's CoreVideo handed back a Float16 surface whose storage past
+  /// the logical element count was **not** zero, so the tail Swift's gather
+  /// reads but never writes cannot be reproduced.
+  ///
+  /// Swift's destination array
+  /// (`SegmentSeeker.swift:450`,
+  /// `MLMultiArray(shape:dataType:initialValue: FloatType(0))`) fills only
+  /// its logical `count` elements — the row pitch's padding, and every
+  /// element the gather's `columnCount`-pitched `memcpy` overruns into, keep
+  /// whatever `CVPixelBufferCreate` left. `dynamicTimeWarping` then reads
+  /// those cells as alignment weights. This port reproduces them by
+  /// allocating the same surface and looking at that region before touching
+  /// it; when the region comes back zero — as it does on every host measured
+  /// so far — Swift's DTW input is fully determined and reproducible.
+  ///
+  /// Nonzero means it is not: the values Swift would feed DTW came from
+  /// *its* allocation, which this port cannot observe and could not
+  /// reproduce even if it could. Fail-closed for the same reason as
+  /// [`Self::AlignmentPitchUnavailable`] — an unreproducible input is not an
+  /// absent one, and silently substituting zeros (or
+  /// [`AlignmentGather::Complete`](crate::audio::whisper::options::AlignmentGather::Complete))
+  /// would report parity for a different DTW input.
+  #[error(
+    "this host's CoreVideo left {nonzero_bytes} nonzero byte(s) in the untouched storage past the \
+     {rows} x {cols} alignment gather's logical elements, which Swift's gather reads but never \
+     writes, so its DTW input is not reproducible here (select `AlignmentGather::Complete` to \
+     gather every row in full instead)"
+  )]
+  AlignmentGatherTailNotZero {
+    /// Rows the gather allocated (gathered tokens).
+    rows: usize,
+    /// Columns the gather allocated (audio tokens).
+    cols: usize,
+    /// Nonzero bytes found past the surface's logical element count.
+    nonzero_bytes: usize,
+  },
   /// Decoding a slice's tokens back to text failed.
   #[error("tokenizer decode failed: {0}")]
   Tokenizer(#[from] TokenizerError),

--- a/crates/coremlit/src/audio/whisper/error/tests.rs
+++ b/crates/coremlit/src/audio/whisper/error/tests.rs
@@ -63,6 +63,40 @@ fn segment_error_composes_tokenizer_arm() {
 }
 
 #[test]
+fn alignment_pitch_errors_name_the_shape_and_the_explicit_way_out() {
+  // Both arms are FAIL-CLOSED refusals of `AlignmentGather::SwiftParity`, so
+  // their whole job is telling a caller what could not be measured and which
+  // option gathers every row instead. Neither is reachable on a supported
+  // host (the probe allocation is the same one the decoder's f16 tensors
+  // use), which is exactly why the messages are pinned here rather than by a
+  // path that can produce them.
+  let unavailable = SegmentError::AlignmentPitchUnavailable {
+    rows: 30,
+    cols: 1500,
+    source: crate::TensorError::SurfaceUnsupported,
+  };
+  let text = unavailable.to_string();
+  assert!(text.contains("30 x 1500"), "{text}");
+  assert!(text.contains("AlignmentGather::Complete"), "{text}");
+  assert!(
+    std::error::Error::source(&unavailable).is_some(),
+    "the tensor failure must survive as the source"
+  );
+
+  let unexpected = SegmentError::AlignmentPitchUnexpectedLayout {
+    rows: 30,
+    cols: 1500,
+    strides: vec![1504, 2],
+  };
+  let text = unexpected.to_string();
+  assert!(text.contains("[1504, 2]"), "{text}");
+  assert!(text.contains("AlignmentGather::Complete"), "{text}");
+
+  let composed: TranscribeError = unexpected.into();
+  assert!(matches!(composed, TranscribeError::Segment(_)));
+}
+
+#[test]
 fn transcribe_error_composes_segment_arm() {
   let e: TranscribeError = SegmentError::InvalidAlignmentShape {
     rows: 4,

--- a/crates/coremlit/src/audio/whisper/error/tests.rs
+++ b/crates/coremlit/src/audio/whisper/error/tests.rs
@@ -64,15 +64,13 @@ fn segment_error_composes_tokenizer_arm() {
 
 #[test]
 fn alignment_pitch_errors_name_the_shape_and_the_explicit_way_out() {
-  // All three arms are FAIL-CLOSED refusals of
+  // Both arms are FAIL-CLOSED refusals of the OPT-IN
   // `AlignmentGather::SwiftParity`, so their whole job is telling a caller
-  // what could not be measured or reproduced and which option gathers every
-  // row instead. None is reachable on a supported host (the probe allocation
-  // is the same one the decoder's f16 tensors use, and its untouched tail
-  // comes back zero — see
-  // `segment::tests::coreml_f16_gather_destination_probe_reports_a_clean_tail_on_this_host`),
-  // which is exactly why the messages are pinned here rather than by a path
-  // that can produce them.
+  // what could not be measured and which option gathers every row instead.
+  // Neither is reachable on a supported host (the probe allocation is the same
+  // one the decoder's f16 tensors use), which is exactly why the messages are
+  // pinned here rather than by a path that can produce them. The default
+  // gather returns neither: it allocates no surface and measures nothing.
   let unavailable = SegmentError::AlignmentPitchUnavailable {
     rows: 30,
     cols: 1500,
@@ -95,19 +93,9 @@ fn alignment_pitch_errors_name_the_shape_and_the_explicit_way_out() {
   assert!(text.contains("[1504, 2]"), "{text}");
   assert!(text.contains("AlignmentGather::Complete"), "{text}");
 
-  let dirty_tail = SegmentError::AlignmentGatherTailNotZero {
-    rows: 30,
-    cols: 1500,
-    nonzero_bytes: 7,
-  };
-  let text = dirty_tail.to_string();
-  assert!(text.contains("7 nonzero byte(s)"), "{text}");
-  assert!(text.contains("30 x 1500"), "{text}");
-  assert!(text.contains("AlignmentGather::Complete"), "{text}");
-
   let composed: TranscribeError = unexpected.into();
   assert!(matches!(composed, TranscribeError::Segment(_)));
-  let composed: TranscribeError = dirty_tail.into();
+  let composed: TranscribeError = unavailable.into();
   assert!(matches!(composed, TranscribeError::Segment(_)));
 }
 

--- a/crates/coremlit/src/audio/whisper/error/tests.rs
+++ b/crates/coremlit/src/audio/whisper/error/tests.rs
@@ -64,12 +64,15 @@ fn segment_error_composes_tokenizer_arm() {
 
 #[test]
 fn alignment_pitch_errors_name_the_shape_and_the_explicit_way_out() {
-  // Both arms are FAIL-CLOSED refusals of `AlignmentGather::SwiftParity`, so
-  // their whole job is telling a caller what could not be measured and which
-  // option gathers every row instead. Neither is reachable on a supported
-  // host (the probe allocation is the same one the decoder's f16 tensors
-  // use), which is exactly why the messages are pinned here rather than by a
-  // path that can produce them.
+  // All three arms are FAIL-CLOSED refusals of
+  // `AlignmentGather::SwiftParity`, so their whole job is telling a caller
+  // what could not be measured or reproduced and which option gathers every
+  // row instead. None is reachable on a supported host (the probe allocation
+  // is the same one the decoder's f16 tensors use, and its untouched tail
+  // comes back zero — see
+  // `segment::tests::coreml_f16_gather_destination_probe_reports_a_clean_tail_on_this_host`),
+  // which is exactly why the messages are pinned here rather than by a path
+  // that can produce them.
   let unavailable = SegmentError::AlignmentPitchUnavailable {
     rows: 30,
     cols: 1500,
@@ -92,7 +95,19 @@ fn alignment_pitch_errors_name_the_shape_and_the_explicit_way_out() {
   assert!(text.contains("[1504, 2]"), "{text}");
   assert!(text.contains("AlignmentGather::Complete"), "{text}");
 
+  let dirty_tail = SegmentError::AlignmentGatherTailNotZero {
+    rows: 30,
+    cols: 1500,
+    nonzero_bytes: 7,
+  };
+  let text = dirty_tail.to_string();
+  assert!(text.contains("7 nonzero byte(s)"), "{text}");
+  assert!(text.contains("30 x 1500"), "{text}");
+  assert!(text.contains("AlignmentGather::Complete"), "{text}");
+
   let composed: TranscribeError = unexpected.into();
+  assert!(matches!(composed, TranscribeError::Segment(_)));
+  let composed: TranscribeError = dirty_tail.into();
   assert!(matches!(composed, TranscribeError::Segment(_)));
 }
 

--- a/crates/coremlit/src/audio/whisper/mod.rs
+++ b/crates/coremlit/src/audio/whisper/mod.rs
@@ -168,6 +168,8 @@
 //! the provenance code, and `provenance`'s mutation table — whose coverage
 //! is derived from [`DecodingOptions`](options::DecodingOptions)' own field
 //! set, not hand-written — fails the suite if one ever is not.
+//! `alignment_gather` (whisper #41) is a third such transcript-changing knob,
+//! captured with no change to the provenance code.
 //!
 //! The remaining three are **consumer-supplied**: settable `Option` fields,
 //! left `None` and never guessed, because this crate genuinely cannot

--- a/crates/coremlit/src/audio/whisper/options/mod.rs
+++ b/crates/coremlit/src/audio/whisper/options/mod.rs
@@ -313,6 +313,14 @@ impl core::str::FromStr for WordGrouping {
 /// switch — it has exactly one gather, and that gather silently drops the
 /// tail of its final row.
 ///
+/// **[`Self::Complete`] is the default; [`Self::SwiftParity`] is an opt-in
+/// that fails closed.** `Complete` is the numerically correct gather and has
+/// no platform dependency at all. `SwiftParity` reproduces a Swift defect
+/// whose behavior rests on unspecified CoreVideo layout, so it carries three
+/// stated assumptions (A1–A3, enumerated on that variant) and refuses
+/// outright on any layout it cannot describe. Correct everywhere by default;
+/// bit-parity for callers who explicitly ask and accept the constraint.
+///
 /// # What Swift actually does, and why the two variants differ at all
 ///
 /// `SegmentSeeker.addWordTimestamps` (`SegmentSeeker.swift:444-461`) copies
@@ -386,27 +394,12 @@ impl core::str::FromStr for WordGrouping {
 /// heights differently gets Swift's actual DTW input instead of a silently
 /// wrong "parity".
 ///
-/// The storage nothing ever wrote is the one part of Swift's DTW input that
-/// no amount of arithmetic settles: no part of CoreVideo promises a freshly
-/// created IOSurface is zeroed, and no part of WhisperKit writes it. So it
-/// is **verified, not assumed** — the destination probe reports what its own
-/// fresh allocation held there before anything touched it, and a dirty tail
-/// fails the gather closed
-/// ([`SegmentError::AlignmentGatherTailNotZero`](crate::audio::whisper::error::SegmentError::AlignmentGatherTailNotZero))
-/// rather than substituting zeros. The source's padding needs no such check:
-/// its array is allocated through the same `initialValue: FloatType(0)`
-/// initializer, whose fill runs over the LOGICAL element count and so zeroes
-/// storage `[0, src_rows * cols)` — padding cells included — and its only
-/// writer (`TextDecoder.updateAlignmentWeights`, `:272-295`) is stride-aware,
-/// so every padding cell the gather can reach still holds that zero on any
-/// host.
-///
 /// Every measured number above is probed — see
 /// `probe_alignment_stride.swift`/`.out` under
 /// `crates/coremlit/tests/whisper_swift_probes/`. A host whose CoreVideo does
 /// not pad `cols` at all measures `pitch == cols` for both surfaces, which
-/// makes this variant identical to [`Self::Complete`] there — correctly,
-/// because Swift's gather then has nothing to disturb either.
+/// makes [`Self::SwiftParity`] identical to [`Self::Complete`] there —
+/// correctly, because Swift's gather then has nothing to disturb either.
 #[derive(
   Debug, Default, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, derive_more::IsVariant,
 )]
@@ -420,18 +413,77 @@ pub enum AlignmentGather {
   /// 120-token window at the reference host's measured pitch, the rest
   /// zero).
   ///
-  /// **The default**, and the fix for coremlit issue #41. That one row's
-  /// tail picks the DTW path, which picks the pre-merge word-duration
-  /// multiset behind `constrainedMedianDuration`/`maxDuration`, which picks
-  /// the last word's end, which picks the segment's end and therefore —
-  /// through `seek = max(seek, Int(lastSpeechTimestamp * sampleRate))`
+  /// **Opt-in, and it fails closed.** That one row's tail picks the DTW path,
+  /// which picks the pre-merge word-duration multiset behind
+  /// `constrainedMedianDuration`/`maxDuration`, which picks the last word's
+  /// end, which picks the segment's end and therefore — through `seek =
+  /// max(seek, Int(lastSpeechTimestamp * sampleRate))`
   /// (`TranscribeTask.swift:221-223`) — the **next window's seek**. So a
   /// gather that keeps the row in full is "more correct" and yet lands the
   /// pipeline on different windows from Swift's within a minute of audio:
   /// measured against official Swift on the pinned model, the 1417 s fixture
   /// cost 984 words of edit distance and an entire extra window (52 against
-  /// Swift's 51) before this variant existed, and matched token-for-token
-  /// after.
+  /// Swift's 51) under [`Self::Complete`], and matched token-for-token under
+  /// this variant. That is what this variant is for, and the only thing it is
+  /// for.
+  ///
+  /// # The three assumptions this mode carries
+  ///
+  /// Reproducing a defect whose behavior rests on unspecified CoreVideo
+  /// layout means reproducing its unspecified parts too. Three of them are
+  /// **assumed, not established**, and none of them is contractual. They are
+  /// listed here rather than buried because opting in means accepting them.
+  ///
+  /// **A1 — layout determinism.** The pitches are measured by allocating the
+  /// same Float16 IOSurface Swift's gather allocates and reading CoreVideo's
+  /// strides back (`segment::coreml_f16_row_pitch`). That establishes the
+  /// pitch of *this port's* allocation. Nothing in CoreVideo promises two
+  /// allocations of one shape share a layout, and Swift's allocation lives in
+  /// another process this port cannot observe. *Would settle it:* a published
+  /// guarantee that row alignment is a pure function of pixel format and
+  /// dimensions. Apple's QA1829 requires the value to be queried per buffer,
+  /// which is the opposite posture.
+  ///
+  /// **A2 — fresh-allocation zero fill.** `dynamicTimeWarping` reads
+  /// destination storage past the gather's copied prefix; Swift's
+  /// `initialValue: FloatType(0)` fill covers only the logical `count` and
+  /// the `memcpy` covers only that same prefix, so those cells are whatever
+  /// `CVPixelBufferCreate` returned. This mode substitutes **zero**. No part
+  /// of CoreVideo promises a fresh IOSurface-backed buffer is zeroed —
+  /// `IOSurfaceSetPurgeable(kIOSurfacePurgeableEmpty)` explicitly makes
+  /// contents undefined, which is hard to reconcile with an implicit
+  /// always-zero guarantee. A previous revision claimed to *verify* this by
+  /// sampling a freshly allocated surface's tail; that was wrong twice over —
+  /// reading those bytes was undefined behavior, and one clean allocation
+  /// says nothing about a different, possibly reused one. Both the reading
+  /// and the claim are gone. *Would settle it:* a documented IOSurface/
+  /// CoreVideo initialization guarantee, or an in-process handle on the
+  /// exact allocation Swift gathered into — neither exists.
+  ///
+  /// **A3 — layout stability across mutable access.** The reproduction reads
+  /// the source array's inter-row padding as zero. Construction does zero it
+  /// (the `initialValue:` fill runs over the LOGICAL count, flat, so storage
+  /// `[0, src_rows * cols)` starts zero, padding included) and its only
+  /// writer, `TextDecoder.updateAlignmentWeights` (`:272-295`), is
+  /// stride-aware. But writer and gather both reach the array through
+  /// `withUnsafeMutableBytes`, whose contract states the strides handed to
+  /// the closure may differ from the value before invocation — so no cited
+  /// contract rules out a relayout or a replacement of the backing storage
+  /// introducing padding that construction never zeroed. *Would settle it:* a
+  /// lifecycle-equivalent native probe at the exact 224-row source height —
+  /// repeated stride-aware writes, then a gather-style access, recording the
+  /// closure strides and the gather-reachable padding each time — and even
+  /// that would be one host's observation, not a contract.
+  ///
+  /// **Consequence.** This variant claims parity **only where A1–A3 hold**.
+  /// It does not detect their violation; where the layout is one this port
+  /// cannot describe at all it refuses outright
+  /// ([`SegmentError::AlignmentPitchUnavailable`](crate::audio::whisper::error::SegmentError::AlignmentPitchUnavailable),
+  /// [`AlignmentPitchUnexpectedLayout`](crate::audio::whisper::error::SegmentError::AlignmentPitchUnexpectedLayout))
+  /// rather than guessing. On a host whose CoreVideo does not pad at all,
+  /// A2 and A3 are vacuous and this variant equals [`Self::Complete`].
+  ///
+  /// # Short-form
   ///
   /// Short-form is bit-exact either way — the divergence needs the seek
   /// cascade to accumulate — but that is a *measured* result, not a
@@ -442,18 +494,33 @@ pub enum AlignmentGather {
   /// final row keeping 1384 of them. The integration test
   /// `jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather`
   /// (`crates/coremlit/tests/whisper/parity_jfk.rs`) is what keeps the claim
-  /// honest: it pins every short-form word against the Swift oracle exactly
-  /// AND asserts [`Self::Complete`] produces the identical list.
-  #[default]
+  /// honest: it pins every short-form word of the DEFAULT gather against the
+  /// Swift oracle exactly AND asserts this variant produces the identical
+  /// list.
   SwiftParity,
-  /// Gather every row in full — no truncation. This port's behavior before
-  /// coremlit issue #41.
+  /// Gather every row in full — no truncation.
   ///
-  /// The honest reading of the alignment weights: it feeds DTW everything
-  /// the model actually produced, which is what the code appears to promise
-  /// and what a caller who wants this port's best word timings should ask
-  /// for. It does **not** track Swift, and on long-form audio it will not —
-  /// see [`Self::SwiftParity`] for the cascade.
+  /// **The default.** It is the numerically correct gather: it feeds DTW
+  /// everything the model actually produced, which is what the code appears
+  /// to promise and what a caller who wants this port's best word timings
+  /// should get without asking.
+  ///
+  /// Just as decisively, it is the gather with **nothing to assume**. It
+  /// allocates no IOSurface, measures no row pitch, inspects no storage past
+  /// what it wrote, and executes no `unsafe`; none of A1–A3 on
+  /// [`Self::SwiftParity`] applies to it, and no property of the host can
+  /// move its output. A default whose behavior depends on unspecified
+  /// CoreVideo layout is a defect surface for every caller, including every
+  /// caller who never heard of this knob — and three review rounds each
+  /// uncovered a further unspecified layer under the previous one. So the
+  /// correct-everywhere gather is what a caller gets by default, and
+  /// bit-parity with a Swift defect is what a caller opts into, having
+  /// accepted the constraint.
+  ///
+  /// It does **not** track Swift, and on long-form audio it will not — see
+  /// [`Self::SwiftParity`] for the seek cascade and the measured 1417 s
+  /// numbers.
+  #[default]
   Complete,
 }
 
@@ -683,27 +750,35 @@ pub(crate) mod finite_f32_vec {
 /// [`Self::alignment_gather`] (how the per-token alignment rows are gathered
 /// before DTW). `new()`/`Default` apply Swift's defaults verbatim for every
 /// ported knob; `seed` defaults unset (`None`), matching today's OS-seeded
-/// behavior exactly, and `word_grouping`/`alignment_gather` both default to
-/// Swift's own behavior (coremlit issue #41).
+/// behavior exactly, and `word_grouping` defaults to Swift's own behavior
+/// (coremlit issue #41).
 ///
-/// **One knob's default deliberately diverges from Swift, with an exact parity
-/// escape hatch** — it is the only such deviation; every other default here is
-/// Swift's. [`Self::drop_blank_audio`] defaults `true`, dropping the
-/// `[BLANK_AUDIO]` segments Swift emits (a product decision, with `false` the
-/// exact parity escape hatch). [`Self::word_grouping`] defaults to
+/// **Exactly TWO knobs' defaults deliberately diverge from Swift, each with an
+/// exact-parity escape hatch** — they are the only such deviations; every other
+/// default here is Swift's.
+///
+/// 1. [`Self::drop_blank_audio`] defaults `true`, dropping the `[BLANK_AUDIO]`
+///    segments Swift emits (a product decision, with `false` the exact-parity
+///    escape hatch).
+/// 2. [`Self::alignment_gather`] defaults to [`AlignmentGather::Complete`],
+///    which gathers every alignment row in full where Swift's stride-ignoring
+///    gather truncates the last one. `Complete` is the numerically correct
+///    gather and depends on no property of the host;
+///    [`AlignmentGather::SwiftParity`] replicates the truncation — the
+///    mechanism behind the long-form divergence of coremlit issue #41 — and is
+///    the exact-parity escape hatch, opt-in because its behavior rests on
+///    unspecified CoreVideo layout (see that variant's stated assumptions
+///    A1–A3).
+///
+/// [`Self::word_grouping`] is NOT one of them: it defaults to
 /// [`WordGrouping::SwiftParity`] — Swift's own Chinese/Cantonese
 /// space-fallthrough grouping (coremlit issue #41, reversing the #11 pin,
 /// user-approved) — while [`WordGrouping::FineGrained`] is the product-quality
 /// opt-in that Unicode-splits CJK into fine-grained words. Default options on a
 /// Mandarin clip therefore space-split as Swift does; the behavioral contrast
 /// between the two variants is pinned by the named invariant
-/// `word_grouping_splits_chinese_and_only_chinese` (`tokenizer/tests.rs`).
-/// [`Self::alignment_gather`] is the same shape: it defaults to
-/// [`AlignmentGather::SwiftParity`], replicating the truncated final alignment
-/// row Swift's stride-ignoring gather produces — the mechanism behind the
-/// long-form divergence of coremlit issue #41 — while
-/// [`AlignmentGather::Complete`] is the un-truncated opt-in. See each field's
-/// own doc.
+/// `word_grouping_splits_chinese_and_only_chinese` (`tokenizer/tests.rs`). See
+/// each field's own doc.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DecodingOptions {
@@ -901,9 +976,10 @@ pub struct DecodingOptions {
   #[cfg_attr(feature = "serde", serde(default))]
   word_grouping: WordGrouping,
   /// How the per-token alignment rows are gathered before DTW. Defaults to
-  /// [`AlignmentGather::SwiftParity`] (coremlit issue #41; serde follows via
-  /// the enum's `Default`). [`AlignmentGather::Complete`] is the un-truncated
-  /// opt-in.
+  /// [`AlignmentGather::Complete`], the un-truncated, platform-independent
+  /// gather (coremlit issue #41; serde follows via the enum's `Default`).
+  /// [`AlignmentGather::SwiftParity`] is the fail-closed opt-in that
+  /// reproduces Swift's truncating gather.
   #[cfg_attr(feature = "serde", serde(default))]
   alignment_gather: AlignmentGather,
 }
@@ -1016,7 +1092,7 @@ impl DecodingOptions {
       verbose: false,
       drop_blank_audio: DEFAULT_DROP_BLANK_AUDIO,
       word_grouping: WordGrouping::SwiftParity,
-      alignment_gather: AlignmentGather::SwiftParity,
+      alignment_gather: AlignmentGather::Complete,
     }
   }
 
@@ -2157,20 +2233,25 @@ impl DecodingOptions {
 
   // -- alignment_gather -----------------------------------------------------
   /// How the per-token cross-attention rows are gathered into the DTW input
-  /// when [`Self::word_timestamps`] is on (coremlit issue #41). Defaults to
-  /// [`AlignmentGather::SwiftParity`]: Swift's gather ignores its own
-  /// `MLMultiArray` row strides and indexes both sides by the column count,
-  /// which — against the padded rows CoreVideo gives its Float16
-  /// pixel-buffer backing — silently truncates the final gathered row to its
-  /// first `N * cols - (N - 1) * pitch` columns and zero-fills the rest. That
-  /// `pitch` is measured on the running host, never assumed; the mode fails
-  /// closed rather than guess one (see
-  /// [`SegmentError::AlignmentPitchUnavailable`](crate::audio::whisper::error::SegmentError::AlignmentPitchUnavailable)).
+  /// when [`Self::word_timestamps`] is on (coremlit issue #41).
   ///
-  /// [`AlignmentGather::Complete`] gathers every row in full instead, this
-  /// port's behavior before #41. See [`AlignmentGather`]'s own doc for the
-  /// mechanism, the cited Swift lines, and why the truncated row — not the
-  /// complete one — is what keeps long-form transcripts on Swift's windows.
+  /// Defaults to [`AlignmentGather::Complete`]: every row in full, no
+  /// truncation, no IOSurface allocation, no row-pitch measurement and no
+  /// dependence on any property of the host.
+  ///
+  /// [`AlignmentGather::SwiftParity`] is the opt-in. Swift's gather ignores
+  /// its own `MLMultiArray` row strides and indexes both sides by the column
+  /// count, which — against the padded rows CoreVideo gives its Float16
+  /// pixel-buffer backing — silently truncates the final gathered row to its
+  /// first `N * cols - (N - 1) * pitch` columns and leaves the rest reading
+  /// storage nothing wrote. That `pitch` is measured on the running host,
+  /// never assumed; the mode fails closed rather than guess one (see
+  /// [`SegmentError::AlignmentPitchUnavailable`](crate::audio::whisper::error::SegmentError::AlignmentPitchUnavailable)),
+  /// and what it substitutes for the unwritten storage is a stated assumption
+  /// rather than an observation. See [`AlignmentGather`]'s own doc for the
+  /// mechanism, the cited Swift lines, the three assumptions the opt-in
+  /// carries, and why the truncated row — not the complete one — is what
+  /// keeps long-form transcripts on Swift's windows.
   ///
   /// Inert unless [`Self::word_timestamps`] is set: the gather only runs
   /// inside the DTW alignment pass. Unlike [`Self::word_grouping`] it is not

--- a/crates/coremlit/src/audio/whisper/options/mod.rs
+++ b/crates/coremlit/src/audio/whisper/options/mod.rs
@@ -325,11 +325,21 @@ impl core::str::FromStr for WordGrouping {
 /// `MLMultiArray(shape:dataType:initialValue:)`
 /// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`), which for `.float16`
 /// backs the array with an IOSurface `CVPixelBuffer` (`:121-136`,
-/// `kCVPixelFormatType_OneComponent16Half`), and CoreVideo pads every row up
-/// to a 64-byte boundary — 32 Float16 elements — so `cols = 1500` is stored
-/// at a pitch of **1504**. (The plain `MLMultiArray(shape:dataType:)`
+/// `kCVPixelFormatType_OneComponent16Half`), and CoreVideo pads every row out
+/// to a **platform-chosen** boundary. (The plain `MLMultiArray(shape:dataType:)`
 /// initializer is contiguous; the padding belongs to the pixel-buffer path,
 /// and the pixel-buffer path is the one WhisperKit takes.)
+///
+/// How much padding is a property of the host, not of this code: Apple's
+/// QA1829 states `CVPixelBuffer` row alignment varies by hardware and must be
+/// queried, and [`MultiArray::f16_surface`](crate::MultiArray::f16_surface)
+/// documents the same. So this port **measures** the pitch at run time, by
+/// allocating the identical `[N, cols]` Float16 surface Swift's gather
+/// allocates and reading back CoreVideo's own strides
+/// (`segment::coreml_f16_row_pitch`); nothing below is compiled in. On the
+/// reference host for whisper #41 (M1 Max, macOS 26.5) rows align to 64 bytes
+/// — 32 Float16 elements — so `cols = 1500` is stored at a pitch of 1504, and
+/// that is the layout every worked example here uses.
 ///
 /// Two errors follow, and they cancel almost everywhere:
 ///
@@ -352,17 +362,22 @@ impl core::str::FromStr for WordGrouping {
 /// ```
 ///
 /// Only the LAST row can be affected while `cols >= (N - 2) * (pitch - cols)`.
-/// That is a property of the shipping shape, not a general one: it holds for
-/// every real Whisper model (`cols = n_audio_ctx = 1500`, `pitch = 1504`,
-/// `N <= 224`, so reaching the second-to-last row would take `N > 377`), and
-/// fails at the small `n_audio_ctx` a test backend can configure, where a run
-/// of whole rows goes. At `N = 120`, `cols = 1500` the final row keeps 1024
+/// That is a property of the shipping shape and the reference host's pitch,
+/// not a general one: it holds for every real Whisper model (`cols =
+/// n_audio_ctx = 1500`, measured `pitch = 1504`, `N <= 224`, so reaching the
+/// second-to-last row would take `N > 377`), and fails at the small
+/// `n_audio_ctx` a test backend can configure, where a run of whole rows goes
+/// — hence the general per-row form above rather than a last-row special
+/// case. At `N = 120`, `cols = 1500`, `pitch = 1504` the final row keeps 1024
 /// columns and reads the remaining 476 out of storage nothing ever wrote.
 /// Those bytes read back as zero in practice — an **observation, not a
 /// contract**: no part of CoreVideo promises a freshly created IOSurface is
 /// zeroed, and no part of WhisperKit writes them. Every number above is
 /// probed — see `probe_alignment_stride.swift`/`.out` under
-/// `crates/coremlit/tests/whisper_swift_probes/`.
+/// `crates/coremlit/tests/whisper_swift_probes/`. A host whose CoreVideo does
+/// not pad `cols` at all measures `pitch == cols`, which makes this variant
+/// identical to [`Self::Complete`] there — correctly, because Swift's gather
+/// then has nothing to truncate either.
 #[derive(
   Debug, Default, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, derive_more::IsVariant,
 )]
@@ -373,7 +388,8 @@ impl core::str::FromStr for WordGrouping {
 pub enum AlignmentGather {
   /// Swift's gather reproduced deliberately, truncated final row and all
   /// (`kept` columns per the type's own doc — 1024 of 1500 on a full
-  /// 120-token window, the rest zero).
+  /// 120-token window at the reference host's measured pitch, the rest
+  /// zero).
   ///
   /// **The default**, and the fix for coremlit issue #41. That one row's
   /// tail picks the DTW path, which picks the pre-merge word-duration
@@ -2104,9 +2120,12 @@ impl DecodingOptions {
   /// when [`Self::word_timestamps`] is on (coremlit issue #41). Defaults to
   /// [`AlignmentGather::SwiftParity`]: Swift's gather ignores its own
   /// `MLMultiArray` row strides and indexes both sides by the column count,
-  /// which — against the 64-byte-padded rows CoreVideo gives its Float16
+  /// which — against the padded rows CoreVideo gives its Float16
   /// pixel-buffer backing — silently truncates the final gathered row to its
-  /// first `N * cols - (N - 1) * pitch` columns and zero-fills the rest.
+  /// first `N * cols - (N - 1) * pitch` columns and zero-fills the rest. That
+  /// `pitch` is measured on the running host, never assumed; the mode fails
+  /// closed rather than guess one (see
+  /// [`SegmentError::AlignmentPitchUnavailable`](crate::audio::whisper::error::SegmentError::AlignmentPitchUnavailable)).
   ///
   /// [`AlignmentGather::Complete`] gathers every row in full instead, this
   /// port's behavior before #41. See [`AlignmentGather`]'s own doc for the

--- a/crates/coremlit/src/audio/whisper/options/mod.rs
+++ b/crates/coremlit/src/audio/whisper/options/mod.rs
@@ -413,19 +413,24 @@ pub enum AlignmentGather {
   /// 120-token window at the reference host's measured pitch, the rest
   /// zero).
   ///
-  /// **Opt-in, and it fails closed.** That one row's tail picks the DTW path,
-  /// which picks the pre-merge word-duration multiset behind
-  /// `constrainedMedianDuration`/`maxDuration`, which picks the last word's
-  /// end, which picks the segment's end and therefore — through `seek =
-  /// max(seek, Int(lastSpeechTimestamp * sampleRate))`
-  /// (`TranscribeTask.swift:221-223`) — the **next window's seek**. So a
-  /// gather that keeps the row in full is "more correct" and yet lands the
-  /// pipeline on different windows from Swift's within a minute of audio:
-  /// measured against official Swift on the pinned model, the 1417 s fixture
-  /// cost 984 words of edit distance and an entire extra window (52 against
-  /// Swift's 51) under [`Self::Complete`], and matched token-for-token under
-  /// this variant. That is what this variant is for, and the only thing it is
-  /// for.
+  /// **Opt-in, and it fails closed.** That one row's tail is an input to the
+  /// DTW path, the path is what the pre-merge word-duration multiset behind
+  /// `constrainedMedianDuration`/`maxDuration` is read off, that multiset is
+  /// what fixes the last word's end, the segment's end takes that word's end
+  /// unless `SegmentSeeker.swift:642-649` clamps the word instead, and —
+  /// through `seek = max(seek, Int(lastSpeechTimestamp * sampleRate))`
+  /// (`TranscribeTask.swift:221-223`) — the segment's end is what the **next
+  /// window's seek** is taken from. Being an input is not the same as moving
+  /// the output: each link moves only if the one before it moved something
+  /// far enough, and the `max` leaves the seek untouched by a segment end
+  /// that does not land later than it. Where the links do all move, though,
+  /// they compound, so a gather that keeps the row in full can be "more
+  /// correct" and still put the pipeline on windows Swift never used. That is
+  /// what the long-form measurement found: against official Swift on the
+  /// pinned model, the 1417 s fixture cost 984 words of edit distance and an
+  /// entire extra window (52 against Swift's 51) under [`Self::Complete`],
+  /// and matched token-for-token under this variant. That is what this
+  /// variant is for, and the only thing it is for.
   ///
   /// # The three assumptions this mode carries
   ///
@@ -550,11 +555,25 @@ pub enum AlignmentGather {
   /// bit-parity with a Swift defect is what a caller opts into, having
   /// accepted the constraint.
   ///
-  /// It does **not** track Swift. On long-form audio the divergence is
-  /// measured — see [`Self::SwiftParity`] for the seek cascade and the
-  /// 1417 s numbers. Short form is not exempt from the mechanism either;
-  /// that variant's "Short-form" section states what is and is not
-  /// established there.
+  /// It does **not reproduce Swift's gather**: it measures no row pitch and
+  /// truncates nothing. That much is unconditional — and it is a claim about
+  /// the algorithm, not about the output. What follows for the output is
+  /// weaker. Where the host pads and a window gathers more than one row, the
+  /// matrix DTW runs over differs from the one Swift's gather builds;
+  /// whether the *path* through it differs, and whether any boundary then
+  /// moves, is a property of the numbers in that matrix. So this variant is
+  /// **not guaranteed** to track Swift's output — and where it has been
+  /// measured against official Swift it has gone both ways. On the 1417 s
+  /// long-form fixture it diverged: 984 words of edit distance and an extra
+  /// window (see [`Self::SwiftParity`] for those numbers and the seek path
+  /// behind them). On `jfk.wav` / `openai_whisper-tiny`, under the pinned
+  /// oracle options, it matched official Swift word for word, exactly as
+  /// [`Self::SwiftParity`] did. Each result is that fixture's and that
+  /// model's, not a rule for long or short audio generally. Short form
+  /// carries no exemption from the mechanism either; that variant's
+  /// "Short-form" section states what is and is not established there. And
+  /// on a host whose CoreVideo does not pad, the two variants are one gather
+  /// and the question does not arise.
   #[default]
   Complete,
 }
@@ -2288,15 +2307,29 @@ impl DecodingOptions {
   /// and what it substitutes for the unwritten storage is a stated assumption
   /// rather than an observation. See [`AlignmentGather`]'s own doc for the
   /// mechanism, the cited Swift lines, the three assumptions the opt-in
-  /// carries, and why the truncated row — not the complete one — is what
-  /// keeps long-form transcripts on Swift's windows.
+  /// carries, and why it was the truncated row — not the complete one — that
+  /// held the 1417 s fixture on Swift's own windows.
   ///
   /// Inert unless [`Self::word_timestamps`] is set: the gather only runs
-  /// inside the DTW alignment pass. Unlike [`Self::word_grouping`] it is not
-  /// confined to a segment's words, though — a changed final row moves the
-  /// last word's end, which moves the segment's end, which moves the next
-  /// window's seek, so with word timestamps on it reaches the transcript
-  /// itself.
+  /// inside the DTW alignment pass. Unlike [`Self::word_grouping`], though,
+  /// its reach is not confined to a segment's words — and every step of that
+  /// reach is conditional on magnitude rather than automatic. A changed final
+  /// row **can** change the DTW path. If the path moves the boundary the last
+  /// word's end is read off, that end moves — and the segment's end **can**
+  /// move with it, though `SegmentSeeker.swift:642-649` instead clamps the
+  /// WORD and leaves the segment's end alone — which it does only where the
+  /// word would end more than 0.5 s past that segment end. And because the
+  /// next window's seek is taken as `seek =
+  /// max(seek, Int(lastSpeechTimestamp * sampleRate))`
+  /// (`TranscribeTask.swift:221-223`), a segment end that moves LATER **can**
+  /// carry that seek — and the rest of the transcript — with it, while one
+  /// that moves earlier, or not past the seek already set, leaves it exactly
+  /// where it was. The first link is the one visibly shown not to fire on its
+  /// own: on `jfk.wav` / `openai_whisper-tiny` the two gathers hand DTW
+  /// different matrices and it picks the same path, so the words come out
+  /// identical. So with word timestamps on, this knob **can** reach the
+  /// transcript itself; whether it does on a given clip is that clip's
+  /// measured result, not something the mechanism settles in advance.
   ///
   /// It applies to **every** word-timestamp window, including a single-window
   /// short-form clip with no seek cascade to accumulate — matching Swift,

--- a/crates/coremlit/src/audio/whisper/options/mod.rs
+++ b/crates/coremlit/src/audio/whisper/options/mod.rs
@@ -333,29 +333,36 @@ impl core::str::FromStr for WordGrouping {
 /// How much padding is a property of the host, not of this code: Apple's
 /// QA1829 states `CVPixelBuffer` row alignment varies by hardware and must be
 /// queried, and [`MultiArray::f16_surface`](crate::MultiArray::f16_surface)
-/// documents the same. So this port **measures** the pitch at run time, by
-/// allocating the identical `[N, cols]` Float16 surface Swift's gather
-/// allocates and reading back CoreVideo's own strides
-/// (`segment::coreml_f16_row_pitch`); nothing below is compiled in. On the
-/// reference host for whisper #41 (M1 Max, macOS 26.5) rows align to 64 bytes
-/// — 32 Float16 elements — so `cols = 1500` is stored at a pitch of 1504, and
-/// that is the layout every worked example here uses.
+/// documents the same. So this port **measures** it at run time, allocating
+/// the identical Float16 surfaces Swift's gather allocates and reading back
+/// CoreVideo's own strides (`segment::coreml_f16_row_pitch`); nothing below
+/// is compiled in. There are TWO such surfaces and they are probed
+/// separately — the once-allocated `[max_token_context + 1, cols]` source
+/// (`TextDecoder.swift:141`) and the per-call `[N, cols]` destination
+/// (`SegmentSeeker.swift:450`) — because "the pitch does not depend on the
+/// row count" is something this host was measured to do, not something
+/// CoreVideo promises. On the reference host for whisper #41 (M1 Max, macOS
+/// 26.5) rows align to 64 bytes — 32 Float16 elements — so `cols = 1500` is
+/// stored at a pitch of 1504 at every height, and that is the layout every
+/// worked example here uses.
 ///
-/// Two errors follow, and they cancel almost everywhere:
+/// Two errors follow:
 ///
-/// 1. Swift's `filteredIndices` are `0..<N` by construction, so source pitch
-///    equals destination pitch and the loop degenerates into one verbatim
-///    contiguous copy of the destination's first `N * cols` elements.
+/// 1. Swift's `filteredIndices` are `0..<N` by construction, so both sides'
+///    offsets are `index * columnCount` and the copies tile contiguously:
+///    destination STORAGE offset `o` ends up holding source STORAGE offset
+///    `o`, for every `o < N * cols`. (Contiguous *storage* offsets — the
+///    logical rows they land on depend on each surface's own pitch.)
 /// 2. `dynamicTimeWarping` then reads `matrix[(row - 1) * numberOfColumns +
 ///    (column - 1)]` (`SegmentSeeker.swift:217`) through `MLMultiArray`'s
 ///    flat subscript, which *is* stride-aware — so logical row `r` reads
-///    storage `[r * pitch, r * pitch + cols)`.
+///    destination storage `[r * dst_pitch, r * dst_pitch + cols)`.
 ///
-/// Wherever that read window still lies inside the copied prefix the two
-/// errors annihilate and the row is exactly right; row `r` is truncated
-/// exactly when `r * pitch + cols > N * cols`, overrunning into destination
-/// storage the `initialValue:` fill never covered either — that fill covers
-/// only the logical `count`. Per row:
+/// **When the two pitches agree** the errors annihilate wherever that read
+/// window still lies inside the copied prefix, and the gather reduces to a
+/// truncation: row `r` is cut exactly when `r * pitch + cols > N * cols`,
+/// overrunning into destination storage the `initialValue:` fill never
+/// covered either — that fill covers only the logical `count`. Per row:
 ///
 /// ```text
 /// kept = min(cols, N * cols - r * pitch)   // saturating at 0
@@ -370,14 +377,36 @@ impl core::str::FromStr for WordGrouping {
 /// — hence the general per-row form above rather than a last-row special
 /// case. At `N = 120`, `cols = 1500`, `pitch = 1504` the final row keeps 1024
 /// columns and reads the remaining 476 out of storage nothing ever wrote.
-/// Those bytes read back as zero in practice — an **observation, not a
-/// contract**: no part of CoreVideo promises a freshly created IOSurface is
-/// zeroed, and no part of WhisperKit writes them. Every number above is
-/// probed — see `probe_alignment_stride.swift`/`.out` under
+///
+/// **When they disagree** it is not a truncation at all: row `r` reads a
+/// SHIFTED window of the source, splicing the tail of one logical row onto
+/// the head of the next across the source's own (zero) padding. `segment::
+/// gather_swift_rows` reproduces that general mapping rather than the
+/// equal-pitch special case, so a host whose CoreVideo pitches the two
+/// heights differently gets Swift's actual DTW input instead of a silently
+/// wrong "parity".
+///
+/// The storage nothing ever wrote is the one part of Swift's DTW input that
+/// no amount of arithmetic settles: no part of CoreVideo promises a freshly
+/// created IOSurface is zeroed, and no part of WhisperKit writes it. So it
+/// is **verified, not assumed** — the destination probe reports what its own
+/// fresh allocation held there before anything touched it, and a dirty tail
+/// fails the gather closed
+/// ([`SegmentError::AlignmentGatherTailNotZero`](crate::audio::whisper::error::SegmentError::AlignmentGatherTailNotZero))
+/// rather than substituting zeros. The source's padding needs no such check:
+/// its array is allocated through the same `initialValue: FloatType(0)`
+/// initializer, whose fill runs over the LOGICAL element count and so zeroes
+/// storage `[0, src_rows * cols)` — padding cells included — and its only
+/// writer (`TextDecoder.updateAlignmentWeights`, `:272-295`) is stride-aware,
+/// so every padding cell the gather can reach still holds that zero on any
+/// host.
+///
+/// Every measured number above is probed — see
+/// `probe_alignment_stride.swift`/`.out` under
 /// `crates/coremlit/tests/whisper_swift_probes/`. A host whose CoreVideo does
-/// not pad `cols` at all measures `pitch == cols`, which makes this variant
-/// identical to [`Self::Complete`] there — correctly, because Swift's gather
-/// then has nothing to truncate either.
+/// not pad `cols` at all measures `pitch == cols` for both surfaces, which
+/// makes this variant identical to [`Self::Complete`] there — correctly,
+/// because Swift's gather then has nothing to disturb either.
 #[derive(
   Debug, Default, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, derive_more::IsVariant,
 )]

--- a/crates/coremlit/src/audio/whisper/options/mod.rs
+++ b/crates/coremlit/src/audio/whisper/options/mod.rs
@@ -414,23 +414,16 @@ pub enum AlignmentGather {
   /// zero).
   ///
   /// **Opt-in, and it fails closed.** That one row's tail is an input to the
-  /// DTW path, the path is what the pre-merge word-duration multiset behind
-  /// `constrainedMedianDuration`/`maxDuration` is read off, that multiset is
-  /// what fixes the last word's end, the segment's end takes that word's end
-  /// unless `SegmentSeeker.swift:642-649` clamps the word instead, and —
-  /// through `seek = max(seek, Int(lastSpeechTimestamp * sampleRate))`
-  /// (`TranscribeTask.swift:221-223`) — the segment's end is what the **next
-  /// window's seek** is taken from. Being an input is not the same as moving
-  /// the output: each link moves only if the one before it moved something
-  /// far enough, and the `max` leaves the seek untouched by a segment end
-  /// that does not land later than it. Where the links do all move, though,
-  /// they compound, so a gather that keeps the row in full can be "more
-  /// correct" and still put the pipeline on windows Swift never used. That is
-  /// what the long-form measurement found: against official Swift on the
-  /// pinned model, the 1417 s fixture cost 984 words of edit distance and an
-  /// entire extra window (52 against Swift's 51) under [`Self::Complete`],
-  /// and matched token-for-token under this variant. That is what this
-  /// variant is for, and the only thing it is for.
+  /// DTW path, and the path is what the last word's end — and through it the
+  /// segment's end, and the **next window's seek** — is read off. Being an
+  /// input is not the same as moving the output; where it does move, it
+  /// **can** compound across windows, so a gather that keeps the row in full
+  /// can be "more correct" and still put the pipeline on windows Swift never
+  /// used. That is what the long-form measurement found: against official
+  /// Swift on the pinned model, the 1417 s fixture cost 984 words of edit
+  /// distance and an entire extra window (52 against Swift's 51) under
+  /// [`Self::Complete`], and matched token-for-token under this variant. That
+  /// is what this variant is for, and the only thing it is for.
   ///
   /// # The three assumptions this mode carries
   ///
@@ -494,11 +487,7 @@ pub enum AlignmentGather {
   /// guard and no subsequent-window guard (Swift has none either, so a guard
   /// would itself be a deviation), and the truncation is real on a single
   /// window: on jfk/tiny, 30 gathered rows over 1500 columns at the measured
-  /// pitch of 1504 leave the final row keeping 1384 of them. The matrix DTW
-  /// runs over therefore differs between the two variants on a short clip
-  /// too. Whether the *path* DTW picks through it also differs is a property
-  /// of the numbers in that matrix — not of the clip's length, and not of
-  /// whether a seek cascade follows.
+  /// pitch of 1504 leave the final row keeping 1384 of them.
   ///
   /// **Established.** On `jfk.wav` / `openai_whisper-tiny`, under the pinned
   /// oracle options, this variant and [`Self::Complete`] produce the same 22
@@ -556,24 +545,19 @@ pub enum AlignmentGather {
   /// accepted the constraint.
   ///
   /// It does **not reproduce Swift's gather**: it measures no row pitch and
-  /// truncates nothing. That much is unconditional — and it is a claim about
-  /// the algorithm, not about the output. What follows for the output is
-  /// weaker. Where the host pads and a window gathers more than one row, the
-  /// matrix DTW runs over differs from the one Swift's gather builds;
-  /// whether the *path* through it differs, and whether any boundary then
-  /// moves, is a property of the numbers in that matrix. So this variant is
-  /// **not guaranteed** to track Swift's output — and where it has been
-  /// measured against official Swift it has gone both ways. On the 1417 s
-  /// long-form fixture it diverged: 984 words of edit distance and an extra
-  /// window (see [`Self::SwiftParity`] for those numbers and the seek path
-  /// behind them). On `jfk.wav` / `openai_whisper-tiny`, under the pinned
-  /// oracle options, it matched official Swift word for word, exactly as
-  /// [`Self::SwiftParity`] did. Each result is that fixture's and that
-  /// model's, not a rule for long or short audio generally. Short form
-  /// carries no exemption from the mechanism either; that variant's
-  /// "Short-form" section states what is and is not established there. And
-  /// on a host whose CoreVideo does not pad, the two variants are one gather
-  /// and the question does not arise.
+  /// truncates nothing. That is unconditional, and it is a claim about the
+  /// algorithm rather than about the output — so this variant is **not
+  /// guaranteed** to track Swift's output, and where it has been measured
+  /// against official Swift it has gone both ways. On the 1417 s long-form
+  /// fixture it diverged: 984 words of edit distance and an extra window (see
+  /// [`Self::SwiftParity`] for those numbers). On `jfk.wav` /
+  /// `openai_whisper-tiny`, under the pinned oracle options, it matched
+  /// official Swift word for word, exactly as [`Self::SwiftParity`] did. Each
+  /// result is that fixture's and that model's, not a rule for long or short
+  /// audio generally; short form carries no exemption either, and that
+  /// variant's "Short-form" section states what is and is not established
+  /// there. On a host whose CoreVideo does not pad, the two variants are one
+  /// gather and the question does not arise.
   #[default]
   Complete,
 }
@@ -2312,34 +2296,25 @@ impl DecodingOptions {
   ///
   /// Inert unless [`Self::word_timestamps`] is set: the gather only runs
   /// inside the DTW alignment pass. Unlike [`Self::word_grouping`], though,
-  /// its reach is not confined to a segment's words — and every step of that
-  /// reach is conditional on magnitude rather than automatic. A changed final
-  /// row **can** change the DTW path. If the path moves the boundary the last
-  /// word's end is read off, that end moves — and the segment's end **can**
-  /// move with it, though `SegmentSeeker.swift:642-649` instead clamps the
-  /// WORD and leaves the segment's end alone — which it does only where the
-  /// word would end more than 0.5 s past that segment end. And because the
-  /// next window's seek is taken as `seek =
-  /// max(seek, Int(lastSpeechTimestamp * sampleRate))`
-  /// (`TranscribeTask.swift:221-223`), a segment end that moves LATER **can**
-  /// carry that seek — and the rest of the transcript — with it, while one
-  /// that moves earlier, or not past the seek already set, leaves it exactly
-  /// where it was. The first link is the one visibly shown not to fire on its
-  /// own: on `jfk.wav` / `openai_whisper-tiny` the two gathers hand DTW
-  /// different matrices and it picks the same path, so the words come out
-  /// identical. So with word timestamps on, this knob **can** reach the
-  /// transcript itself; whether it does on a given clip is that clip's
-  /// measured result, not something the mechanism settles in advance.
+  /// its reach is not confined to a segment's words — changing it **can**
+  /// move a word's end, and with it the segment's end, the next window's seek
+  /// and the rest of the transcript. It applies to **every** word-timestamp
+  /// window, including a single-window short-form clip with no seek cascade
+  /// to accumulate — matching Swift, which has no such guard either — so
+  /// short form is not exempt.
   ///
-  /// It applies to **every** word-timestamp window, including a single-window
-  /// short-form clip with no seek cascade to accumulate — matching Swift,
-  /// which has no such guard either. Short form is therefore **not** exempt:
-  /// changing this knob can move a word's end, and with it the segment's
-  /// end, within one window, which the branch's own single-call fixture
-  /// measures at 0.88 s against 1.58 s. What is *established* is narrower —
-  /// on `jfk.wav` / `openai_whisper-tiny` the two variants agree word for
-  /// word and both match official Swift. That is one clip's measured result,
-  /// not a guarantee for short clips generally; see
+  /// Whether it *does* move anything on a given clip is that clip's measured
+  /// result, not something the mechanism settles in advance. Measured: over
+  /// one `add_word_timestamps` call the two variants put the last word's end,
+  /// and the segment's, at 0.88 s against 1.58 s (`segment::tests`'
+  /// `swift_parity_gather_truncates_final_alignment_row`); end to end they
+  /// move a first window's end and the seek taken from it (`transcribe::
+  /// tests`' `swift_parity_gather_moves_the_first_windows_end_and_the_next_seek`);
+  /// and on `jfk.wav` / `openai_whisper-tiny` they instead agree word for
+  /// word and both match official Swift
+  /// (`jfk_tiny_word_timestamps_match_swift_and_this_clip_is_gather_invariant`,
+  /// `crates/coremlit/tests/whisper/parity_jfk.rs`). Those tests are where
+  /// the mechanism is written out and kept true; see also
   /// [`AlignmentGather::SwiftParity`]'s "Short-form" section for the
   /// established / not-established split and what would settle it.
   #[inline(always)]

--- a/crates/coremlit/src/audio/whisper/options/mod.rs
+++ b/crates/coremlit/src/audio/whisper/options/mod.rs
@@ -485,18 +485,51 @@ pub enum AlignmentGather {
   ///
   /// # Short-form
   ///
-  /// Short-form is bit-exact either way — the divergence needs the seek
-  /// cascade to accumulate — but that is a *measured* result, not a
-  /// structural one: the gather runs on every word-timestamp window, with no
-  /// long-form or subsequent-window guard (Swift has none either, so a guard
-  /// would itself be a deviation), and the truncation is real even on a
-  /// single window. On jfk/tiny, 30 gathered rows over 1500 columns leave the
-  /// final row keeping 1384 of them. The integration test
-  /// `jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather`
-  /// (`crates/coremlit/tests/whisper/parity_jfk.rs`) is what keeps the claim
-  /// honest: it pins every short-form word of the DEFAULT gather against the
-  /// Swift oracle exactly AND asserts this variant produces the identical
-  /// list.
+  /// The gather runs on **every** word-timestamp window, with no long-form
+  /// guard and no subsequent-window guard (Swift has none either, so a guard
+  /// would itself be a deviation), and the truncation is real on a single
+  /// window: on jfk/tiny, 30 gathered rows over 1500 columns at the measured
+  /// pitch of 1504 leave the final row keeping 1384 of them. The matrix DTW
+  /// runs over therefore differs between the two variants on a short clip
+  /// too. Whether the *path* DTW picks through it also differs is a property
+  /// of the numbers in that matrix — not of the clip's length, and not of
+  /// whether a seek cascade follows.
+  ///
+  /// **Established.** On `jfk.wav` / `openai_whisper-tiny`, under the pinned
+  /// oracle options, this variant and [`Self::Complete`] produce the same 22
+  /// words, and that list matches official Swift exactly — text, start, end,
+  /// probability and token ids, no epsilon — as do the segment seeks and
+  /// bounds. The integration test
+  /// `jfk_tiny_word_timestamps_match_swift_and_this_clip_is_gather_invariant`
+  /// (`crates/coremlit/tests/whisper/parity_jfk.rs`) pins both halves.
+  ///
+  /// **Not established: that short-form output is invariant in general.** It
+  /// is not, and a previous revision of this doc said it was. Gather
+  /// selection can move a word's end — and with it the segment's end —
+  /// **inside a single window**, which this branch's own fixtures measure.
+  /// Over ONE `add_word_timestamps` call, with no seek, no second window and
+  /// no cascade of any kind, the last word's end and the segment's end come
+  /// out **0.88 s under [`Self::Complete`] against 1.58 s under this
+  /// variant**
+  /// (`segment::tests::swift_parity_gather_truncates_final_alignment_row`).
+  /// End to end, a run diverges in its **first** window — same audio, same
+  /// decoded script, `seek` 0 under both — at **0.88 s against 1.18 s**,
+  /// which is what then places window 2 at a different sample offset
+  /// (`transcribe::tests`'
+  /// `swift_parity_gather_moves_the_first_windows_end_and_the_next_seek`).
+  /// Both fixtures drive constructed alignment matrices rather than a real
+  /// decode's, so neither says that some particular clip diverges; what they
+  /// establish is that nothing about a short clip exempts it. **A caller who
+  /// changes this knob for a short clip can receive different word and
+  /// segment timestamps.**
+  ///
+  /// *Would settle it:* Swift-oracle word goldens over a corpus — several
+  /// clips, models and window occupancies — characterizing when a real
+  /// decode's DTW path is sensitive to the truncated tail. One clip's
+  /// insensitivity is one clip's, and the mechanism predicts no other.
+  /// Until that exists, the supportable reading is that the two variants may
+  /// differ on any word-timestamp window, and jfk/tiny is the one where they
+  /// are measured not to.
   SwiftParity,
   /// Gather every row in full — no truncation.
   ///
@@ -517,9 +550,11 @@ pub enum AlignmentGather {
   /// bit-parity with a Swift defect is what a caller opts into, having
   /// accepted the constraint.
   ///
-  /// It does **not** track Swift, and on long-form audio it will not — see
-  /// [`Self::SwiftParity`] for the seek cascade and the measured 1417 s
-  /// numbers.
+  /// It does **not** track Swift. On long-form audio the divergence is
+  /// measured — see [`Self::SwiftParity`] for the seek cascade and the
+  /// 1417 s numbers. Short form is not exempt from the mechanism either;
+  /// that variant's "Short-form" section states what is and is not
+  /// established there.
   #[default]
   Complete,
 }
@@ -768,7 +803,10 @@ pub(crate) mod finite_f32_vec {
 ///    mechanism behind the long-form divergence of coremlit issue #41 — and is
 ///    the exact-parity escape hatch, opt-in because its behavior rests on
 ///    unspecified CoreVideo layout (see that variant's stated assumptions
-///    A1–A3).
+///    A1–A3). Long-form is where the divergence was *measured*, not where the
+///    mechanism is confined: it runs on every word-timestamp window, and can
+///    move timestamps within a single short-form one — see that variant's
+///    "Short-form" section.
 ///
 /// [`Self::word_grouping`] is NOT one of them: it defaults to
 /// [`WordGrouping::SwiftParity`] — Swift's own Chinese/Cantonese
@@ -2262,9 +2300,15 @@ impl DecodingOptions {
   ///
   /// It applies to **every** word-timestamp window, including a single-window
   /// short-form clip with no seek cascade to accumulate — matching Swift,
-  /// which has no such guard either. Short-form output is nevertheless
-  /// unchanged between the two variants, and that is asserted rather than
-  /// assumed: see [`AlignmentGather::SwiftParity`].
+  /// which has no such guard either. Short form is therefore **not** exempt:
+  /// changing this knob can move a word's end, and with it the segment's
+  /// end, within one window, which the branch's own single-call fixture
+  /// measures at 0.88 s against 1.58 s. What is *established* is narrower —
+  /// on `jfk.wav` / `openai_whisper-tiny` the two variants agree word for
+  /// word and both match official Swift. That is one clip's measured result,
+  /// not a guarantee for short clips generally; see
+  /// [`AlignmentGather::SwiftParity`]'s "Short-form" section for the
+  /// established / not-established split and what would settle it.
   #[inline(always)]
   pub const fn alignment_gather(&self) -> AlignmentGather {
     self.alignment_gather

--- a/crates/coremlit/src/audio/whisper/options/mod.rs
+++ b/crates/coremlit/src/audio/whisper/options/mod.rs
@@ -402,8 +402,19 @@ pub enum AlignmentGather {
   /// measured against official Swift on the pinned model, the 1417 s fixture
   /// cost 984 words of edit distance and an entire extra window (52 against
   /// Swift's 51) before this variant existed, and matched token-for-token
-  /// after. Short-form (JFK) is bit-exact either way — the divergence needs
-  /// the seek cascade to accumulate.
+  /// after.
+  ///
+  /// Short-form is bit-exact either way — the divergence needs the seek
+  /// cascade to accumulate — but that is a *measured* result, not a
+  /// structural one: the gather runs on every word-timestamp window, with no
+  /// long-form or subsequent-window guard (Swift has none either, so a guard
+  /// would itself be a deviation), and the truncation is real even on a
+  /// single window. On jfk/tiny, 30 gathered rows over 1500 columns leave the
+  /// final row keeping 1384 of them. The integration test
+  /// `jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather`
+  /// (`crates/coremlit/tests/whisper/parity_jfk.rs`) is what keeps the claim
+  /// honest: it pins every short-form word against the Swift oracle exactly
+  /// AND asserts [`Self::Complete`] produces the identical list.
   #[default]
   SwiftParity,
   /// Gather every row in full — no truncation. This port's behavior before
@@ -2138,6 +2149,12 @@ impl DecodingOptions {
   /// last word's end, which moves the segment's end, which moves the next
   /// window's seek, so with word timestamps on it reaches the transcript
   /// itself.
+  ///
+  /// It applies to **every** word-timestamp window, including a single-window
+  /// short-form clip with no seek cascade to accumulate — matching Swift,
+  /// which has no such guard either. Short-form output is nevertheless
+  /// unchanged between the two variants, and that is asserted rather than
+  /// assumed: see [`AlignmentGather::SwiftParity`].
   #[inline(always)]
   pub const fn alignment_gather(&self) -> AlignmentGather {
     self.alignment_gather

--- a/crates/coremlit/src/audio/whisper/options/mod.rs
+++ b/crates/coremlit/src/audio/whisper/options/mod.rs
@@ -305,6 +305,131 @@ impl core::str::FromStr for WordGrouping {
 }
 
 // ---------------------------------------------------------------------
+// AlignmentGather
+// ---------------------------------------------------------------------
+
+/// How a window's per-token cross-attention rows are gathered into the
+/// matrix DTW runs over (coremlit issue #41). Rust-only: Swift has no such
+/// switch — it has exactly one gather, and that gather silently drops the
+/// tail of its final row.
+///
+/// # What Swift actually does, and why the two variants differ at all
+///
+/// `SegmentSeeker.addWordTimestamps` (`SegmentSeeker.swift:444-461`) copies
+/// the gathered rows by hand. It binds both arrays' stride vectors
+/// (`weightsStride`/`filteredWeightsStride`) and then ignores them, using
+/// `columnCount` — the *logical* column count, 1500 for a 30 s window — as
+/// the row pitch on the source and on the destination alike. That is correct
+/// only while storage pitch equals column count, and for WhisperKit's
+/// Float16 arrays it does not: every one of them is allocated through
+/// `MLMultiArray(shape:dataType:initialValue:)`
+/// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`), which for `.float16`
+/// backs the array with an IOSurface `CVPixelBuffer` (`:121-136`,
+/// `kCVPixelFormatType_OneComponent16Half`), and CoreVideo pads every row up
+/// to a 64-byte boundary — 32 Float16 elements — so `cols = 1500` is stored
+/// at a pitch of **1504**. (The plain `MLMultiArray(shape:dataType:)`
+/// initializer is contiguous; the padding belongs to the pixel-buffer path,
+/// and the pixel-buffer path is the one WhisperKit takes.)
+///
+/// Two errors follow, and they cancel almost everywhere:
+///
+/// 1. Swift's `filteredIndices` are `0..<N` by construction, so source pitch
+///    equals destination pitch and the loop degenerates into one verbatim
+///    contiguous copy of the destination's first `N * cols` elements.
+/// 2. `dynamicTimeWarping` then reads `matrix[(row - 1) * numberOfColumns +
+///    (column - 1)]` (`SegmentSeeker.swift:217`) through `MLMultiArray`'s
+///    flat subscript, which *is* stride-aware — so logical row `r` reads
+///    storage `[r * pitch, r * pitch + cols)`.
+///
+/// Wherever that read window still lies inside the copied prefix the two
+/// errors annihilate and the row is exactly right; row `r` is truncated
+/// exactly when `r * pitch + cols > N * cols`, overrunning into destination
+/// storage the `initialValue:` fill never covered either — that fill covers
+/// only the logical `count`. Per row:
+///
+/// ```text
+/// kept = min(cols, N * cols - r * pitch)   // saturating at 0
+/// ```
+///
+/// Only the LAST row can be affected while `cols >= (N - 2) * (pitch - cols)`.
+/// That is a property of the shipping shape, not a general one: it holds for
+/// every real Whisper model (`cols = n_audio_ctx = 1500`, `pitch = 1504`,
+/// `N <= 224`, so reaching the second-to-last row would take `N > 377`), and
+/// fails at the small `n_audio_ctx` a test backend can configure, where a run
+/// of whole rows goes. At `N = 120`, `cols = 1500` the final row keeps 1024
+/// columns and reads the remaining 476 out of storage nothing ever wrote.
+/// Those bytes read back as zero in practice — an **observation, not a
+/// contract**: no part of CoreVideo promises a freshly created IOSurface is
+/// zeroed, and no part of WhisperKit writes them. Every number above is
+/// probed — see `probe_alignment_stride.swift`/`.out` under
+/// `crates/coremlit/tests/whisper_swift_probes/`.
+#[derive(
+  Debug, Default, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, derive_more::IsVariant,
+)]
+#[display("{}", self.as_str())]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum AlignmentGather {
+  /// Swift's gather reproduced deliberately, truncated final row and all
+  /// (`kept` columns per the type's own doc — 1024 of 1500 on a full
+  /// 120-token window, the rest zero).
+  ///
+  /// **The default**, and the fix for coremlit issue #41. That one row's
+  /// tail picks the DTW path, which picks the pre-merge word-duration
+  /// multiset behind `constrainedMedianDuration`/`maxDuration`, which picks
+  /// the last word's end, which picks the segment's end and therefore —
+  /// through `seek = max(seek, Int(lastSpeechTimestamp * sampleRate))`
+  /// (`TranscribeTask.swift:221-223`) — the **next window's seek**. So a
+  /// gather that keeps the row in full is "more correct" and yet lands the
+  /// pipeline on different windows from Swift's within a minute of audio:
+  /// measured against official Swift on the pinned model, the 1417 s fixture
+  /// cost 984 words of edit distance and an entire extra window (52 against
+  /// Swift's 51) before this variant existed, and matched token-for-token
+  /// after. Short-form (JFK) is bit-exact either way — the divergence needs
+  /// the seek cascade to accumulate.
+  #[default]
+  SwiftParity,
+  /// Gather every row in full — no truncation. This port's behavior before
+  /// coremlit issue #41.
+  ///
+  /// The honest reading of the alignment weights: it feeds DTW everything
+  /// the model actually produced, which is what the code appears to promise
+  /// and what a caller who wants this port's best word timings should ask
+  /// for. It does **not** track Swift, and on long-form audio it will not —
+  /// see [`Self::SwiftParity`] for the cascade.
+  Complete,
+}
+
+impl AlignmentGather {
+  /// Stable snake_case name of the variant.
+  #[inline(always)]
+  pub const fn as_str(&self) -> &'static str {
+    match self {
+      Self::SwiftParity => "swift_parity",
+      Self::Complete => "complete",
+    }
+  }
+}
+
+/// Error parsing an [`AlignmentGather`] name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("unknown alignment gather name")]
+pub struct ParseAlignmentGatherError(());
+
+impl core::str::FromStr for AlignmentGather {
+  type Err = ParseAlignmentGatherError;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    Ok(match s {
+      "swift_parity" => Self::SwiftParity,
+      "complete" => Self::Complete,
+      _ => return Err(ParseAlignmentGatherError(())),
+    })
+  }
+}
+
+// ---------------------------------------------------------------------
 // DecodingOptions
 // ---------------------------------------------------------------------
 
@@ -493,15 +618,17 @@ pub(crate) mod finite_f32_vec {
 }
 
 /// Decode-time configuration: Swift's 27-knob `DecodingOptions` surface
-/// (spec §6.2), plus three Rust-only additions — [`Self::seed`], for
+/// (spec §6.2), plus four Rust-only additions — [`Self::seed`], for
 /// reproducible temperature-fallback sampling (coremlit issue #9; see the
-/// crate root's "Reproducibility and provenance" docs), and, from coremlit
-/// issue #14, [`Self::drop_blank_audio`] (the post-decode blank-audio
+/// crate root's "Reproducibility and provenance" docs), from coremlit
+/// issue #14 [`Self::drop_blank_audio`] (the post-decode blank-audio
 /// segment filter) and [`Self::word_grouping`] (the explicit CJK
-/// word-grouping mode). `new()`/`Default` apply Swift's defaults verbatim
-/// for every ported knob; `seed` defaults unset (`None`), matching today's
-/// OS-seeded behavior exactly, and `word_grouping` defaults to Swift's own
-/// grouping (coremlit issue #41).
+/// word-grouping mode), and from coremlit issue #41
+/// [`Self::alignment_gather`] (how the per-token alignment rows are gathered
+/// before DTW). `new()`/`Default` apply Swift's defaults verbatim for every
+/// ported knob; `seed` defaults unset (`None`), matching today's OS-seeded
+/// behavior exactly, and `word_grouping`/`alignment_gather` both default to
+/// Swift's own behavior (coremlit issue #41).
 ///
 /// **One knob's default deliberately diverges from Swift, with an exact parity
 /// escape hatch** — it is the only such deviation; every other default here is
@@ -514,8 +641,13 @@ pub(crate) mod finite_f32_vec {
 /// opt-in that Unicode-splits CJK into fine-grained words. Default options on a
 /// Mandarin clip therefore space-split as Swift does; the behavioral contrast
 /// between the two variants is pinned by the named invariant
-/// `word_grouping_splits_chinese_and_only_chinese` (`tokenizer/tests.rs`). See
-/// each field's own doc.
+/// `word_grouping_splits_chinese_and_only_chinese` (`tokenizer/tests.rs`).
+/// [`Self::alignment_gather`] is the same shape: it defaults to
+/// [`AlignmentGather::SwiftParity`], replicating the truncated final alignment
+/// row Swift's stride-ignoring gather produces — the mechanism behind the
+/// long-form divergence of coremlit issue #41 — while
+/// [`AlignmentGather::Complete`] is the un-truncated opt-in. See each field's
+/// own doc.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DecodingOptions {
@@ -712,6 +844,12 @@ pub struct DecodingOptions {
   /// product-quality opt-in.
   #[cfg_attr(feature = "serde", serde(default))]
   word_grouping: WordGrouping,
+  /// How the per-token alignment rows are gathered before DTW. Defaults to
+  /// [`AlignmentGather::SwiftParity`] (coremlit issue #41; serde follows via
+  /// the enum's `Default`). [`AlignmentGather::Complete`] is the un-truncated
+  /// opt-in.
+  #[cfg_attr(feature = "serde", serde(default))]
+  alignment_gather: AlignmentGather,
 }
 
 /// Names every field of [`DecodingOptions`] exactly once, generating (for
@@ -779,6 +917,7 @@ decoding_option_field_names!(
   verbose,
   drop_blank_audio,
   word_grouping,
+  alignment_gather,
 );
 
 impl Default for DecodingOptions {
@@ -821,6 +960,7 @@ impl DecodingOptions {
       verbose: false,
       drop_blank_audio: DEFAULT_DROP_BLANK_AUDIO,
       word_grouping: WordGrouping::SwiftParity,
+      alignment_gather: AlignmentGather::SwiftParity,
     }
   }
 
@@ -1956,6 +2096,44 @@ impl DecodingOptions {
   #[inline(always)]
   pub const fn set_word_grouping(&mut self, word_grouping: WordGrouping) -> &mut Self {
     self.word_grouping = word_grouping;
+    self
+  }
+
+  // -- alignment_gather -----------------------------------------------------
+  /// How the per-token cross-attention rows are gathered into the DTW input
+  /// when [`Self::word_timestamps`] is on (coremlit issue #41). Defaults to
+  /// [`AlignmentGather::SwiftParity`]: Swift's gather ignores its own
+  /// `MLMultiArray` row strides and indexes both sides by the column count,
+  /// which — against the 64-byte-padded rows CoreVideo gives its Float16
+  /// pixel-buffer backing — silently truncates the final gathered row to its
+  /// first `N * cols - (N - 1) * pitch` columns and zero-fills the rest.
+  ///
+  /// [`AlignmentGather::Complete`] gathers every row in full instead, this
+  /// port's behavior before #41. See [`AlignmentGather`]'s own doc for the
+  /// mechanism, the cited Swift lines, and why the truncated row — not the
+  /// complete one — is what keeps long-form transcripts on Swift's windows.
+  ///
+  /// Inert unless [`Self::word_timestamps`] is set: the gather only runs
+  /// inside the DTW alignment pass. Unlike [`Self::word_grouping`] it is not
+  /// confined to a segment's words, though — a changed final row moves the
+  /// last word's end, which moves the segment's end, which moves the next
+  /// window's seek, so with word timestamps on it reaches the transcript
+  /// itself.
+  #[inline(always)]
+  pub const fn alignment_gather(&self) -> AlignmentGather {
+    self.alignment_gather
+  }
+  /// Builder form of [`Self::set_alignment_gather`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn with_alignment_gather(mut self, alignment_gather: AlignmentGather) -> Self {
+    self.set_alignment_gather(alignment_gather);
+    self
+  }
+  /// Sets [`Self::alignment_gather`] in place.
+  #[inline(always)]
+  pub const fn set_alignment_gather(&mut self, alignment_gather: AlignmentGather) -> &mut Self {
+    self.alignment_gather = alignment_gather;
     self
   }
 }

--- a/crates/coremlit/src/audio/whisper/options/mod.rs
+++ b/crates/coremlit/src/audio/whisper/options/mod.rs
@@ -2313,8 +2313,8 @@ impl DecodingOptions {
   /// and on `jfk.wav` / `openai_whisper-tiny` they instead agree word for
   /// word and both match official Swift
   /// (`jfk_tiny_word_timestamps_match_swift_and_this_clip_is_gather_invariant`,
-  /// `crates/coremlit/tests/whisper/parity_jfk.rs`). Those tests are where
-  /// the mechanism is written out and kept true; see also
+  /// `crates/coremlit/tests/whisper/parity_jfk.rs`). Each of those tests pins
+  /// the measured output of its own fixture and nothing wider; see also
   /// [`AlignmentGather::SwiftParity`]'s "Short-form" section for the
   /// established / not-established split and what would settle it.
   #[inline(always)]

--- a/crates/coremlit/src/audio/whisper/options/tests.rs
+++ b/crates/coremlit/src/audio/whisper/options/tests.rs
@@ -47,8 +47,10 @@ fn decoding_defaults_match_swift() {
   assert_eq!(o.word_grouping(), WordGrouping::SwiftParity);
   // Rust-only addition (coremlit issue #41). Swift has no gather knob either
   // — it has one gather, whose stride-ignoring memcpy truncates the final
-  // alignment row; the default replicates that, `Complete` opts out.
-  assert_eq!(o.alignment_gather(), AlignmentGather::SwiftParity);
+  // alignment row. The default is the un-truncated, platform-independent
+  // `Complete`; `SwiftParity` is the fail-closed opt-in that replicates the
+  // truncation (owner decision, round 3).
+  assert_eq!(o.alignment_gather(), AlignmentGather::Complete);
   assert_eq!(DecodingOptions::default(), DecodingOptions::new());
 }
 
@@ -82,19 +84,19 @@ fn drop_blank_audio_defaults_on_and_opts_out_to_swift_parity() {
 }
 
 #[test]
-fn swift_parity_option_deviations_are_exactly_one() {
+fn swift_parity_option_deviations_are_exactly_two() {
   // Executable form of the DecodingOptions doc contract (`options/mod.rs`):
   // `new()` diverges from Swift's `Configurations.swift` defaults in EXACTLY
-  // one knob, with an exact-parity escape hatch; every other ported default
-  // equals Swift's. (whisper #41 §3 P2 — the token-leak refutation's
+  // two knobs, each with an exact-parity escape hatch; every other ported
+  // default equals Swift's. (whisper #41 §3 P2 — the token-leak refutation's
   // parity-recipe lock. The behavioral consequences are already pinned by
   // `word_timestamps_drop_cleared_reproduces_swifts_duplicate_ids` and
   // `word_grouping_splits_chinese_and_only_chinese`; this locks the recipe.)
   let o = DecodingOptions::new();
 
-  // Deviation 1 (the only one) — `drop_blank_audio` defaults `true` (Swift
-  // emits `[BLANK_AUDIO]`); `maybe_drop_blank_audio(false)` is the
-  // exact-parity escape hatch.
+  // Deviation 1 — `drop_blank_audio` defaults `true` (Swift emits
+  // `[BLANK_AUDIO]`); `maybe_drop_blank_audio(false)` is the exact-parity
+  // escape hatch.
   assert!(o.drop_blank_audio());
   assert!(
     !DecodingOptions::new()
@@ -111,15 +113,18 @@ fn swift_parity_option_deviations_are_exactly_one() {
       .word_grouping()
       .is_fine_grained()
   );
-  // NOT a deviation either — `alignment_gather` defaults to Swift's own
-  // truncating gather (coremlit issue #41), and `Complete` is the
-  // un-truncated opt-in away from it.
-  assert_eq!(o.alignment_gather(), AlignmentGather::SwiftParity);
+  // Deviation 2 — `alignment_gather` defaults to the un-truncated `Complete`
+  // where Swift's stride-ignoring gather truncates the final alignment row
+  // (owner decision, round 3 of the #41 review: `Complete` is numerically
+  // correct and carries no platform dependency, so it is what a caller gets
+  // without asking). `with_alignment_gather(SwiftParity)` is the exact-parity
+  // escape hatch, opt-in and fail-closed.
+  assert_eq!(o.alignment_gather(), AlignmentGather::Complete);
   assert!(
     DecodingOptions::new()
-      .with_alignment_gather(AlignmentGather::Complete)
+      .with_alignment_gather(AlignmentGather::SwiftParity)
       .alignment_gather()
-      .is_complete()
+      .is_swift_parity()
   );
 
   // The parity-relevant Swift-equal defaults the refutation rests on: the
@@ -267,40 +272,41 @@ fn word_grouping_serde_omitted_stays_swift_parity() {
 }
 
 #[test]
-fn alignment_gather_defaults_to_swift_parity() {
-  // #41 default: a caller who never mentions the gather replicates Swift's
-  // truncated final alignment row — the mechanism behind the long-form
-  // divergence — and reaches the un-truncated gather only by naming it.
-  assert_eq!(AlignmentGather::default(), AlignmentGather::SwiftParity);
+fn alignment_gather_defaults_to_complete() {
+  // The round-3 owner decision, pinned: a caller who never mentions the gather
+  // gets the numerically correct, platform-independent `Complete` — no
+  // IOSurface allocation, no row-pitch measurement, no assumption about this
+  // host — and reaches Swift's truncating gather only by naming it.
+  assert_eq!(AlignmentGather::default(), AlignmentGather::Complete);
   assert_eq!(
     DecodingOptions::new().alignment_gather(),
-    AlignmentGather::SwiftParity
+    AlignmentGather::Complete
   );
-  assert!(DecodingOptions::new().alignment_gather().is_swift_parity());
+  assert!(DecodingOptions::new().alignment_gather().is_complete());
 
-  let built = DecodingOptions::new().with_alignment_gather(AlignmentGather::Complete);
-  assert_eq!(built.alignment_gather(), AlignmentGather::Complete);
-  assert!(built.alignment_gather().is_complete());
+  let built = DecodingOptions::new().with_alignment_gather(AlignmentGather::SwiftParity);
+  assert_eq!(built.alignment_gather(), AlignmentGather::SwiftParity);
+  assert!(built.alignment_gather().is_swift_parity());
 
   let mut m = DecodingOptions::new();
-  m.set_alignment_gather(AlignmentGather::Complete);
-  assert_eq!(m.alignment_gather(), AlignmentGather::Complete);
   m.set_alignment_gather(AlignmentGather::SwiftParity);
   assert_eq!(m.alignment_gather(), AlignmentGather::SwiftParity);
+  m.set_alignment_gather(AlignmentGather::Complete);
+  assert_eq!(m.alignment_gather(), AlignmentGather::Complete);
 }
 
 #[cfg(feature = "serde")]
 #[test]
-fn alignment_gather_serde_omitted_stays_swift_parity() {
-  // An omitted field follows the enum `Default` — SwiftParity, so a config
-  // that never heard of #41 still gets the parity-bearing gather; an explicit
-  // value still wins.
+fn alignment_gather_serde_omitted_stays_complete() {
+  // An omitted field follows the enum `Default` — Complete, so a config that
+  // never heard of #41 gets the gather with nothing to assume; an explicit
+  // value still wins, including the opt-in one.
   let omitted: DecodingOptions = serde_json::from_str("{}").unwrap();
-  assert_eq!(omitted.alignment_gather(), AlignmentGather::SwiftParity);
+  assert_eq!(omitted.alignment_gather(), AlignmentGather::Complete);
 
-  let complete: DecodingOptions =
-    serde_json::from_str(r#"{"alignment_gather":"complete"}"#).unwrap();
-  assert_eq!(complete.alignment_gather(), AlignmentGather::Complete);
+  let parity: DecodingOptions =
+    serde_json::from_str(r#"{"alignment_gather":"swift_parity"}"#).unwrap();
+  assert_eq!(parity.alignment_gather(), AlignmentGather::SwiftParity);
 
   for wanted in [AlignmentGather::SwiftParity, AlignmentGather::Complete] {
     let options = DecodingOptions::new().with_alignment_gather(wanted);

--- a/crates/coremlit/src/audio/whisper/options/tests.rs
+++ b/crates/coremlit/src/audio/whisper/options/tests.rs
@@ -45,6 +45,10 @@ fn decoding_defaults_match_swift() {
   // Swift's own grouping (space-fallthrough for zh/yue); FineGrained is the
   // #11-pinned fine-grained CJK opt-in.
   assert_eq!(o.word_grouping(), WordGrouping::SwiftParity);
+  // Rust-only addition (coremlit issue #41). Swift has no gather knob either
+  // — it has one gather, whose stride-ignoring memcpy truncates the final
+  // alignment row; the default replicates that, `Complete` opts out.
+  assert_eq!(o.alignment_gather(), AlignmentGather::SwiftParity);
   assert_eq!(DecodingOptions::default(), DecodingOptions::new());
 }
 
@@ -106,6 +110,16 @@ fn swift_parity_option_deviations_are_exactly_one() {
       .with_word_grouping(WordGrouping::FineGrained)
       .word_grouping()
       .is_fine_grained()
+  );
+  // NOT a deviation either — `alignment_gather` defaults to Swift's own
+  // truncating gather (coremlit issue #41), and `Complete` is the
+  // un-truncated opt-in away from it.
+  assert_eq!(o.alignment_gather(), AlignmentGather::SwiftParity);
+  assert!(
+    DecodingOptions::new()
+      .with_alignment_gather(AlignmentGather::Complete)
+      .alignment_gather()
+      .is_complete()
   );
 
   // The parity-relevant Swift-equal defaults the refutation rests on: the
@@ -198,6 +212,13 @@ fn enums_round_trip_and_display() {
   assert_eq!(WordGrouping::FineGrained.to_string(), "fine_grained");
   assert_eq!(WordGrouping::SwiftParity.as_str(), "swift_parity");
   assert!("bogus".parse::<WordGrouping>().is_err());
+
+  for g in [AlignmentGather::SwiftParity, AlignmentGather::Complete] {
+    assert_eq!(g.as_str().parse::<AlignmentGather>().unwrap(), g);
+  }
+  assert_eq!(AlignmentGather::Complete.to_string(), "complete");
+  assert_eq!(AlignmentGather::SwiftParity.as_str(), "swift_parity");
+  assert!("bogus".parse::<AlignmentGather>().is_err());
 }
 
 #[test]
@@ -237,6 +258,52 @@ fn word_grouping_serde_omitted_stays_swift_parity() {
 
   for wanted in [WordGrouping::FineGrained, WordGrouping::SwiftParity] {
     let options = DecodingOptions::new().with_word_grouping(wanted);
+    let json = serde_json::to_string(&options).unwrap();
+    assert_eq!(
+      serde_json::from_str::<DecodingOptions>(&json).unwrap(),
+      options
+    );
+  }
+}
+
+#[test]
+fn alignment_gather_defaults_to_swift_parity() {
+  // #41 default: a caller who never mentions the gather replicates Swift's
+  // truncated final alignment row — the mechanism behind the long-form
+  // divergence — and reaches the un-truncated gather only by naming it.
+  assert_eq!(AlignmentGather::default(), AlignmentGather::SwiftParity);
+  assert_eq!(
+    DecodingOptions::new().alignment_gather(),
+    AlignmentGather::SwiftParity
+  );
+  assert!(DecodingOptions::new().alignment_gather().is_swift_parity());
+
+  let built = DecodingOptions::new().with_alignment_gather(AlignmentGather::Complete);
+  assert_eq!(built.alignment_gather(), AlignmentGather::Complete);
+  assert!(built.alignment_gather().is_complete());
+
+  let mut m = DecodingOptions::new();
+  m.set_alignment_gather(AlignmentGather::Complete);
+  assert_eq!(m.alignment_gather(), AlignmentGather::Complete);
+  m.set_alignment_gather(AlignmentGather::SwiftParity);
+  assert_eq!(m.alignment_gather(), AlignmentGather::SwiftParity);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn alignment_gather_serde_omitted_stays_swift_parity() {
+  // An omitted field follows the enum `Default` — SwiftParity, so a config
+  // that never heard of #41 still gets the parity-bearing gather; an explicit
+  // value still wins.
+  let omitted: DecodingOptions = serde_json::from_str("{}").unwrap();
+  assert_eq!(omitted.alignment_gather(), AlignmentGather::SwiftParity);
+
+  let complete: DecodingOptions =
+    serde_json::from_str(r#"{"alignment_gather":"complete"}"#).unwrap();
+  assert_eq!(complete.alignment_gather(), AlignmentGather::Complete);
+
+  for wanted in [AlignmentGather::SwiftParity, AlignmentGather::Complete] {
+    let options = DecodingOptions::new().with_alignment_gather(wanted);
     let json = serde_json::to_string(&options).unwrap();
     assert_eq!(
       serde_json::from_str::<DecodingOptions>(&json).unwrap(),

--- a/crates/coremlit/src/audio/whisper/provenance/tests.rs
+++ b/crates/coremlit/src/audio/whisper/provenance/tests.rs
@@ -102,9 +102,9 @@ fn mutations() -> Vec<OptionMutation> {
       o.with_word_grouping(WordGrouping::FineGrained)
     }),
     ("alignment_gather", |o| {
-      // Same story as `word_grouping`: SwiftParity is the #41 default, so the
-      // value change has to be the un-truncated `Complete`.
-      o.with_alignment_gather(AlignmentGather::Complete)
+      // `Complete` is the default after the round-3 owner decision, so the
+      // value change has to be the opt-in `SwiftParity`.
+      o.with_alignment_gather(AlignmentGather::SwiftParity)
     }),
   ]
 }

--- a/crates/coremlit/src/audio/whisper/provenance/tests.rs
+++ b/crates/coremlit/src/audio/whisper/provenance/tests.rs
@@ -6,7 +6,7 @@ use crate::audio::whisper::{
     chunker::{AudioChunk, VadChunker, prepare_seek_clips},
     vad::{EnergyVad, VoiceActivityDetector},
   },
-  options::{ChunkingStrategy, Task, WordGrouping},
+  options::{AlignmentGather, ChunkingStrategy, Task, WordGrouping},
   result::TranscriptionTimings,
   task_facts::{SpanKnowledge, TaskFacts},
 };
@@ -100,6 +100,11 @@ fn mutations() -> Vec<OptionMutation> {
       // keep this row an actual value change (else the completeness gate below
       // sees a byte-identical record and rightly fails).
       o.with_word_grouping(WordGrouping::FineGrained)
+    }),
+    ("alignment_gather", |o| {
+      // Same story as `word_grouping`: SwiftParity is the #41 default, so the
+      // value change has to be the un-truncated `Complete`.
+      o.with_alignment_gather(AlignmentGather::Complete)
     }),
   ]
 }

--- a/crates/coremlit/src/audio/whisper/segment/mod.rs
+++ b/crates/coremlit/src/audio/whisper/segment/mod.rs
@@ -1003,7 +1003,7 @@ pub(crate) fn rounded_to_places(value: f32, decimal_places: i32) -> f32 {
 /// fail-closed: see [`SegmentError::AlignmentPitchUnavailable`] for why a
 /// silent fall back to [`AlignmentGather::Complete`] is not offered.
 // `pub(crate)`, not private: `transcribe::tests`' own gather fixture
-// (`swift_parity_gather_moves_the_next_window_seek`) is built around where
+// (`swift_parity_gather_moves_the_first_windows_end_and_the_next_seek`) is built around where
 // this host's pitch cuts the gather, and has to ask the same helper the
 // pipeline asks rather than restate a number.
 pub(crate) fn coreml_f16_row_pitch(rows: usize, cols: usize) -> Result<usize, SegmentError> {

--- a/crates/coremlit/src/audio/whisper/segment/mod.rs
+++ b/crates/coremlit/src/audio/whisper/segment/mod.rs
@@ -32,13 +32,16 @@
 
 use unicode_categories::UnicodeCategories;
 
-use crate::audio::whisper::{
-  backend::{AlignmentMatrix, AlignmentView},
-  constants::{SAMPLE_RATE, SECONDS_PER_TIME_TOKEN},
-  error::SegmentError,
-  options::{AlignmentGather, DecodingOptions, WordGrouping},
-  result::{DecodingResult, TranscriptionSegment, WordTiming},
-  tokenizer::WhisperTokenizer,
+use crate::{
+  MultiArray,
+  audio::whisper::{
+    backend::{AlignmentMatrix, AlignmentView},
+    constants::{SAMPLE_RATE, SECONDS_PER_TIME_TOKEN},
+    error::SegmentError,
+    options::{AlignmentGather, DecodingOptions, WordGrouping},
+    result::{DecodingResult, TranscriptionSegment, WordTiming},
+    tokenizer::WhisperTokenizer,
+  },
 };
 
 /// Turns `decoding` — the just-decoded window starting at `current_seek`
@@ -935,18 +938,94 @@ pub(crate) fn rounded_to_places(value: f32, decimal_places: i32) -> f32 {
 // add_word_timestamps: the orchestration wrapper
 // ---------------------------------------------------------------------
 
-/// CoreVideo's row pitch, in Float16 elements, for the IOSurface-backed
-/// `MLMultiArray`s WhisperKit allocates
-/// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`, `:121-136`): row bytes
-/// are padded up to a 64-byte boundary, i.e. 32 Float16 elements. Probed
-/// (`tests/whisper_swift_probes/probe_alignment_stride.out`): cols 8 -> 32,
-/// 9 -> 32, 100 -> 128, 1496/1500/1504 -> 1504.
+/// Measures **this host's** CoreVideo row pitch, in Float16 elements, for
+/// the IOSurface-backed `MLMultiArray` Swift's alignment gather allocates —
+/// `MLMultiArray(shape: [rows, cols], dataType: .float16, initialValue: 0)`
+/// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`), which for `.float16`
+/// is a `kCVPixelFormatType_OneComponent16Half` `CVPixelBuffer`
+/// (`:121-136`) — by allocating the equivalent array through
+/// [`MultiArray::f16_surface`] and reading the strides CoreVideo actually
+/// chose.
 ///
-/// The 32-element quantum is load-bearing: `div_ceil(8) * 8` coincidentally
-/// agrees at the shipping `cols = 1500`, and is wrong at `cols = 100` (104,
-/// against the probed 128).
-const fn coreml_f16_row_pitch(cols: usize) -> usize {
-  cols.div_ceil(32) * 32
+/// **Not a constant, deliberately.** Apple documents `CVPixelBuffer` row
+/// alignment as hardware-dependent and requires it to be queried (QA1829,
+/// "Understanding CVPixelBuffer memory alignment"), and
+/// [`MultiArray::f16_surface`]'s own contract calls the padding
+/// platform-chosen. The reference host for whisper #41 (M1 Max, macOS 26.5)
+/// aligns rows to 64 bytes — 32 Float16 elements — which is what
+/// `tests/whisper_swift_probes/probe_alignment_stride.out` recorded (cols
+/// 8 -> 32, 9 -> 32, 100 -> 128, 1496/1500/1504 -> 1504); that table is
+/// evidence of the layout, not a rule about it. A host that pads
+/// differently would have Swift's gather truncate *different* cells, so a
+/// compiled-in quantum would zero the wrong ones and make
+/// [`AlignmentGather::SwiftParity`] silently non-parity there. Querying the
+/// same allocator Swift's array comes from is what makes the mode correct
+/// on every host rather than on one.
+///
+/// The probe uses the gather's exact `[rows, cols]` shape rather than a
+/// cheaper 1-row stand-in, so nothing here assumes the pitch is independent
+/// of the row count either. One `CVPixelBufferCreate` plus its zero-fill
+/// per word-timestamped window is immaterial next to that window's encoder
+/// and decoder runs.
+///
+/// # Errors
+/// [`SegmentError::AlignmentPitchUnavailable`] if the probe allocation
+/// fails (e.g. [`TensorError::SurfaceUnsupported`](crate::TensorError) below
+/// macOS 12, where `MLMultiArray` has no pixel-buffer initializer);
+/// [`SegmentError::AlignmentPitchUnexpectedLayout`] if it succeeds but
+/// reports strides other than `[pitch, 1]` with `pitch >= cols`. Both are
+/// fail-closed: see [`SegmentError::AlignmentPitchUnavailable`] for why a
+/// silent fall back to [`AlignmentGather::Complete`] is not offered.
+// `pub(crate)`, not private: `transcribe::tests`' own gather fixture
+// (`swift_parity_gather_moves_the_next_window_seek`) is built around where
+// this host's pitch cuts the gather, and has to ask the same helper the
+// pipeline asks rather than restate a number.
+pub(crate) fn coreml_f16_row_pitch(rows: usize, cols: usize) -> Result<usize, SegmentError> {
+  let probe = MultiArray::f16_surface(&[rows, cols])
+    .map_err(|source| SegmentError::AlignmentPitchUnavailable { rows, cols, source })?;
+  let strides = probe.strides();
+  // CoreML pads only BETWEEN rows (the invariant `MultiArray::copy_into`'s
+  // padded-gather already relies on), so the only layout the truncation
+  // models is a unit last-dimension stride under a row pitch that is at
+  // least the logical width. Anything else is a layout this port has never
+  // seen and cannot claim to replicate.
+  match *strides {
+    [pitch, 1] if pitch >= cols => Ok(pitch),
+    _ => Err(SegmentError::AlignmentPitchUnexpectedLayout {
+      rows,
+      cols,
+      strides: strides.to_vec(),
+    }),
+  }
+}
+
+/// Applies Swift's gather truncation in place to `data`, a `rows * cols`
+/// row-major gather whose destination storage CoreVideo pitches at `pitch`
+/// Float16 elements per row.
+///
+/// Swift's memcpy loop (`SegmentSeeker.swift:454-459`) writes only storage
+/// `[0, rows * cols)` because it pitches by `columnCount`, while
+/// `dynamicTimeWarping`'s flat subscript (`:217`) reads logical row `r` at
+/// the array's TRUE pitch, `[r * pitch, r * pitch + cols)`. Wherever those
+/// two windows overlap the errors cancel exactly; past the copied prefix the
+/// read lands on storage neither the memcpy nor the `initialValue:` fill
+/// ever wrote — zero in practice. So row `r` keeps
+/// `min(cols, rows * cols - r * pitch)` columns (saturating at zero) and
+/// reads zeros after them.
+///
+/// Split out from [`add_word_timestamps`] so the parity-bearing arithmetic
+/// is testable against explicit pitches, independent of whatever pitch the
+/// running host happens to choose. `pitch == cols` (a host that does not pad
+/// at this width) makes it a no-op, which is correct: Swift's gather has
+/// nothing to truncate when storage pitch equals the column count.
+fn truncate_gathered_rows(data: &mut [f32], rows: usize, cols: usize, pitch: usize) {
+  let copied = rows * cols;
+  for row in 0..rows {
+    let kept = copied.saturating_sub(row * pitch).min(cols);
+    if kept < cols {
+      data[row * cols + kept..(row + 1) * cols].fill(0.0);
+    }
+  }
 }
 
 /// Assembles one window's word-level timestamps end to end. Ports
@@ -975,7 +1054,9 @@ const fn coreml_f16_row_pitch(cols: usize) -> usize {
 /// subscript (`:217`) *is* stride-aware and CoreVideo pads the Float16
 /// backing's rows (`ArgmaxCore/MLMultiArrayExtensions.swift:121-136`), so
 /// row `r` keeps only its first `min(cols, needed * cols - r * pitch)`
-/// columns and reads zeros past that. [`AlignmentGather::Complete`] gathers
+/// columns and reads zeros past that — where `pitch` is measured on the
+/// running host by this module's `coreml_f16_row_pitch`, not assumed.
+/// [`AlignmentGather::Complete`] gathers
 /// every row whole — see [`AlignmentGather`] for why the truncated form is
 /// the parity-bearing one (whisper #41). Swift's
 /// `segmentSize` and `options` parameters are unused in the function body
@@ -991,7 +1072,13 @@ const fn coreml_f16_row_pitch(cols: usize) -> usize {
 /// all-empty-tokens) `segments` input, which Swift's own unguarded
 /// `1...0` range would instead crash on (see [`dynamic_time_warping`]'s
 /// doc); [`SegmentError::Tokenizer`] if `split_to_word_tokens` or a
-/// partial-special retokenize fails.
+/// partial-special retokenize fails;
+/// [`SegmentError::AlignmentPitchUnavailable`] /
+/// [`SegmentError::AlignmentPitchUnexpectedLayout`] under
+/// [`AlignmentGather::SwiftParity`] only, if this host's CoreVideo row pitch
+/// cannot be measured or is not a row-padded row-major layout — parity
+/// cannot be claimed against a layout this port cannot see, so it is refused
+/// rather than approximated (see this module's `coreml_f16_row_pitch`).
 #[allow(clippy::too_many_arguments)] // Mirrors Swift's addWordTimestamps argument
 // surface (mirroring decode_text's own precedent for this exact lint, per its
 // doc comment); no natural subset of these forms a cohesive struct without
@@ -1074,17 +1161,21 @@ pub fn add_word_timestamps(
   // + cols > needed * cols`; only the LAST row can be while `cols >= (needed -
   // 2) * (pitch - cols)`, which holds for every real Whisper model (1500/1504,
   // `needed <= 224`) but not at the small `n_audio_ctx` a test backend can set
-  // -- hence the general per-row loop, not a last-row special case. See
-  // [`AlignmentGather`] for the derivation.
-  if gather == AlignmentGather::SwiftParity {
-    let pitch = coreml_f16_row_pitch(cols);
-    let copied = needed * cols;
-    for row in 0..needed {
-      let kept = copied.saturating_sub(row * pitch).min(cols);
-      if kept < cols {
-        data[row * cols + kept..(row + 1) * cols].fill(0.0);
-      }
-    }
+  // -- hence the general per-row loop in [`truncate_gathered_rows`], not a
+  // last-row special case. See [`AlignmentGather`] for the derivation.
+  //
+  // The pitch is MEASURED on this host, never assumed: see
+  // [`coreml_f16_row_pitch`] for why a compiled-in alignment quantum would
+  // make this mode silently non-parity on a host CoreVideo pads differently,
+  // and why the failure to measure one is an error rather than a quiet
+  // downgrade to [`AlignmentGather::Complete`]. `needed == 0` skips the probe
+  // (and the no-op loop): there is no gather to truncate, and the empty
+  // `segments` input it comes from is already
+  // `SegmentError::InvalidAlignmentShape`'s -- reported below by
+  // `dynamic_time_warping`, as this function's `# Errors` doc promises.
+  if gather == AlignmentGather::SwiftParity && needed > 0 {
+    let pitch = coreml_f16_row_pitch(needed, cols)?;
+    truncate_gathered_rows(&mut data, needed, cols, pitch);
   }
 
   let filtered = AlignmentMatrix::new(data, needed, cols);

--- a/crates/coremlit/src/audio/whisper/segment/mod.rs
+++ b/crates/coremlit/src/audio/whisper/segment/mod.rs
@@ -36,7 +36,7 @@ use crate::audio::whisper::{
   backend::{AlignmentMatrix, AlignmentView},
   constants::{SAMPLE_RATE, SECONDS_PER_TIME_TOKEN},
   error::SegmentError,
-  options::{DecodingOptions, WordGrouping},
+  options::{AlignmentGather, DecodingOptions, WordGrouping},
   result::{DecodingResult, TranscriptionSegment, WordTiming},
   tokenizer::WhisperTokenizer,
 };
@@ -935,6 +935,20 @@ pub(crate) fn rounded_to_places(value: f32, decimal_places: i32) -> f32 {
 // add_word_timestamps: the orchestration wrapper
 // ---------------------------------------------------------------------
 
+/// CoreVideo's row pitch, in Float16 elements, for the IOSurface-backed
+/// `MLMultiArray`s WhisperKit allocates
+/// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`, `:121-136`): row bytes
+/// are padded up to a 64-byte boundary, i.e. 32 Float16 elements. Probed
+/// (`tests/whisper_swift_probes/probe_alignment_stride.out`): cols 8 -> 32,
+/// 9 -> 32, 100 -> 128, 1496/1500/1504 -> 1504.
+///
+/// The 32-element quantum is load-bearing: `div_ceil(8) * 8` coincidentally
+/// agrees at the shipping `cols = 1500`, and is wrong at `cols = 100` (104,
+/// against the probed 128).
+const fn coreml_f16_row_pitch(cols: usize) -> usize {
+  cols.div_ceil(32) * 32
+}
+
 /// Assembles one window's word-level timestamps end to end. Ports
 /// `SegmentSeeker.addWordTimestamps` (`SegmentSeeker.swift:410-496`):
 /// flattens `segments`' tokens/log-probs into the flat list
@@ -951,7 +965,19 @@ pub(crate) fn rounded_to_places(value: f32, decimal_places: i32) -> f32 {
 /// [`WhisperTokenizer::split_to_word_tokens`] (spec §5.3), plus the
 /// explicit word-grouping mode from coremlit issue #14
 /// ([`WordGrouping::SwiftParity`] is the default after #41;
-/// [`WordGrouping::FineGrained`] is this port's long-standing opt-in). Swift's
+/// [`WordGrouping::FineGrained`] is this port's long-standing opt-in).
+///
+/// `gather` selects what the prefix take hands to DTW.
+/// [`AlignmentGather::SwiftParity`] (the pipeline default) additionally
+/// replicates the truncation Swift's own gather performs: its `memcpy` loop
+/// (`SegmentSeeker.swift:454-459`) binds both `MLMultiArray`s' strides and
+/// then indexes with `columnCount`, while `dynamicTimeWarping`'s flat
+/// subscript (`:217`) *is* stride-aware and CoreVideo pads the Float16
+/// backing's rows (`ArgmaxCore/MLMultiArrayExtensions.swift:121-136`), so
+/// row `r` keeps only its first `min(cols, needed * cols - r * pitch)`
+/// columns and reads zeros past that. [`AlignmentGather::Complete`] gathers
+/// every row whole — see [`AlignmentGather`] for why the truncated form is
+/// the parity-bearing one (whisper #41). Swift's
 /// `segmentSize` and `options` parameters are unused in the function body
 /// (verified against `SegmentSeeker.swift:410-496`), and `timings` is
 /// only passed through to `findAlignment` (`:471`), which ignores it —
@@ -976,6 +1002,7 @@ pub fn add_word_timestamps(
   tokenizer: &WhisperTokenizer,
   language_code: &str,
   grouping: WordGrouping,
+  gather: AlignmentGather,
   seek: usize,
   prepended: &str,
   appended: &str,
@@ -1038,6 +1065,28 @@ pub fn add_word_timestamps(
   {
     row.copy_from_slice(alignment.row(row_index));
   }
+
+  // Swift's gather truncates: its memcpy writes only storage `[0, needed *
+  // cols)` (`:454-459`, pitched by `columnCount`), while `dynamicTimeWarping`
+  // reads logical row `r` at the TRUE pitch (`:217`), so `r` keeps only what
+  // still falls inside that copied prefix and reads never-written storage --
+  // zero in practice -- past it. Row `r` is truncated exactly when `r * pitch
+  // + cols > needed * cols`; only the LAST row can be while `cols >= (needed -
+  // 2) * (pitch - cols)`, which holds for every real Whisper model (1500/1504,
+  // `needed <= 224`) but not at the small `n_audio_ctx` a test backend can set
+  // -- hence the general per-row loop, not a last-row special case. See
+  // [`AlignmentGather`] for the derivation.
+  if gather == AlignmentGather::SwiftParity {
+    let pitch = coreml_f16_row_pitch(cols);
+    let copied = needed * cols;
+    for row in 0..needed {
+      let kept = copied.saturating_sub(row * pitch).min(cols);
+      if kept < cols {
+        data[row * cols + kept..(row + 1) * cols].fill(0.0);
+      }
+    }
+  }
+
   let filtered = AlignmentMatrix::new(data, needed, cols);
 
   // :465-472. The construction above guarantees `filtered.rows() ==

--- a/crates/coremlit/src/audio/whisper/segment/mod.rs
+++ b/crates/coremlit/src/audio/whisper/segment/mod.rs
@@ -689,8 +689,12 @@ const SENTENCE_END_MARKS: [&str; 6] = [".", "。", "!", "！", "?", "？"];
 /// needed the way Swift's `1..<0` `ClosedRange` would require). For each
 /// later word whose `duration()` exceeds `max_duration`:
 /// - if the word's own text EXACTLY matches a mark in the internal
-///   `SENTENCE_END_MARKS` table (whole-word — `" ."` with a leading space
-///   does not qualify), its `end` is pulled back to `start + max_duration`;
+///   `SENTENCE_END_MARKS` table (whole-word — a caller passing `" ."` with
+///   a leading space does not qualify; note that words reaching here from
+///   [`find_alignment`] never carry that space, because
+///   [`WhisperTokenizer::decode`]'s tokenization-space cleanup strips it,
+///   just as Swift's does), its `end` is pulled back to
+///   `start + max_duration`;
 /// - otherwise, if the PRECEDING word's text exactly matches a mark, this
 ///   word's `start` is pushed forward to `end - max_duration`.
 ///

--- a/crates/coremlit/src/audio/whisper/segment/mod.rs
+++ b/crates/coremlit/src/audio/whisper/segment/mod.rs
@@ -947,6 +947,10 @@ pub(crate) fn rounded_to_places(value: f32, decimal_places: i32) -> f32 {
 /// [`MultiArray::f16_surface`] and reading the strides CoreVideo actually
 /// chose.
 ///
+/// **Only [`AlignmentGather::SwiftParity`] — the opt-in mode — calls this.**
+/// The default gather ([`AlignmentGather::Complete`]) allocates no surface,
+/// measures nothing and depends on no property of this host.
+///
 /// **Not a constant, deliberately.** Apple documents `CVPixelBuffer` row
 /// alignment as hardware-dependent and requires it to be queried (QA1829,
 /// "Understanding CVPixelBuffer memory alignment"), and
@@ -964,11 +968,27 @@ pub(crate) fn rounded_to_places(value: f32, decimal_places: i32) -> f32 {
 ///
 /// The probe uses the caller's exact `[rows, cols]` shape rather than a
 /// cheaper 1-row stand-in, so nothing here assumes the pitch is independent
-/// of the row count — which is why [`gather_swift_rows`] asks for the SOURCE
-/// and DESTINATION shapes separately instead of reusing one answer for both.
-/// One `CVPixelBufferCreate` plus its zero-fill per shape per
+/// of the row count — which is why [`gather_swift_parity_into`] asks for the
+/// SOURCE and DESTINATION shapes separately instead of reusing one answer for
+/// both. One `CVPixelBufferCreate` plus its zero-fill per shape per
 /// word-timestamped window is immaterial next to that window's encoder and
 /// decoder runs.
+///
+/// # What this establishes, and what it does not
+///
+/// **Established:** the row pitch of the surface THIS call allocated, read
+/// back from CoreVideo's own strides.
+///
+/// **Not established:** the row pitch of the surface Swift's process
+/// allocated. Nothing in CoreVideo promises two allocations of one shape
+/// share a layout, and this port cannot observe Swift's. `SwiftParity`
+/// assumes they agree — assumption **A1** on
+/// [`AlignmentGather::SwiftParity`], stated there rather than left implicit.
+///
+/// **What would settle it:** a documented CoreVideo/IOSurface guarantee that
+/// row alignment is a pure function of pixel format and dimensions. No such
+/// guarantee is published; QA1829 says the opposite in spirit by requiring
+/// the value to be queried per buffer.
 ///
 /// # Errors
 /// [`SegmentError::AlignmentPitchUnavailable`] if the probe allocation
@@ -983,7 +1003,7 @@ pub(crate) fn rounded_to_places(value: f32, decimal_places: i32) -> f32 {
 // this host's pitch cuts the gather, and has to ask the same helper the
 // pipeline asks rather than restate a number.
 pub(crate) fn coreml_f16_row_pitch(rows: usize, cols: usize) -> Result<usize, SegmentError> {
-  let (probe, _) = MultiArray::f16_surface_probing_fresh_tail(&[rows, cols])
+  let probe = MultiArray::f16_surface(&[rows, cols])
     .map_err(|source| SegmentError::AlignmentPitchUnavailable { rows, cols, source })?;
   row_pitch_of(&probe, rows, cols)
 }
@@ -1008,40 +1028,82 @@ fn row_pitch_of(probe: &MultiArray, rows: usize, cols: usize) -> Result<usize, S
   }
 }
 
-/// Measures the DESTINATION surface Swift's gather allocates per call
-/// (`SegmentSeeker.swift:450`) — its row pitch, plus the one property of
-/// that surface the pitch does not capture: whether the storage past its
-/// logical `rows * cols` elements comes back zero.
+/// The row-pitch measurement [`gather_swift_parity_into`] runs, as a
+/// parameter rather than a hard-wired call.
 ///
-/// That tail is read by `dynamicTimeWarping` and written by nobody. Swift's
-/// `initialValue: FloatType(0)` fill covers only the logical `count`
-/// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`, over a buffer the row
-/// pitch made larger), and the gather's `memcpy` covers the same `rows *
-/// cols` prefix, so every cell past it is whatever `CVPixelBufferCreate`
-/// returned. [`MultiArray::f16_surface_probing_fresh_tail`] reports exactly
-/// that region, sampled on a real allocation of the same shape before
-/// anything writes to it — an observation of this host's allocator, not an
-/// assumption about it.
+/// Production passes [`coreml_f16_row_pitch`], which measures the running
+/// host. `segment::tests` passes layouts this host will never produce — above
+/// all a host that pitches Swift's 224-row source array differently from this
+/// port's 225-row accumulator, which is the ONLY way to check that the probe
+/// asks CoreVideo about Swift's height rather than the port's (whisper #41,
+/// codex round 3, F2).
+type RowPitchProbe<'a> = &'a dyn Fn(usize, usize) -> Result<usize, SegmentError>;
+
+/// Reproduces Swift's alignment gather into `out` (supplied zero-filled),
+/// measuring both surfaces' row pitches through `row_pitch`.
+///
+/// # The two heights are NOT the same number
+///
+/// `alignment.rows()` is this port's accumulator height,
+/// `max_token_context + 1` — 225 — because
+/// [`commit_alignment_row`](crate::audio::whisper::backend::InferenceBackend::commit_alignment_row)
+/// commits step `position`'s row at `position + 1`, so the last trait-legal
+/// position needs one slot of headroom past the KV dimension. Swift has no
+/// such headroom: `alignmentWeights` is allocated at
+/// `[kvCacheMaxSequenceLength, n_audio_ctx]` (`TextDecoder.swift:141`) — the
+/// **224**-slot KV dimension itself.
+///
+/// The pitch is a function of the shape CoreVideo is handed, and this branch
+/// exists precisely because pitch may vary with height. Probing `[225, cols]`
+/// would therefore decode Swift's storage offsets with a pitch Swift's array
+/// never had wherever `pitch(224, cols) != pitch(225, cols)`, splicing the
+/// wrong weights (or the wrong padding) into DTW's input while still
+/// reporting parity. `swift_source_rows` is Swift's physical height, passed
+/// down from the model's own `max_token_context` — never derived from the
+/// view — and it is the shape this probes.
+///
+/// The reproduction's read bound is the smaller of the two: an offset past
+/// `swift_source_rows` is past Swift's array (Swift would read off its end),
+/// and an offset past `alignment.rows()` is past this port's data. Neither is
+/// reachable for a real window (`needed <= 224 <= min(224, 225)`); the bound
+/// is the same defensive branch the prefix take has always carried.
 ///
 /// # Errors
 /// [`SegmentError::AlignmentPitchUnavailable`] /
-/// [`SegmentError::AlignmentPitchUnexpectedLayout`] as
-/// [`coreml_f16_row_pitch`], and
-/// [`SegmentError::AlignmentGatherTailNotZero`] when the probe found the
-/// tail dirty — see that variant for why an unreproducible DTW input is
-/// refused rather than approximated.
-fn coreml_f16_gather_destination_pitch(rows: usize, cols: usize) -> Result<usize, SegmentError> {
-  let (probe, nonzero_bytes) = MultiArray::f16_surface_probing_fresh_tail(&[rows, cols])
-    .map_err(|source| SegmentError::AlignmentPitchUnavailable { rows, cols, source })?;
-  let pitch = row_pitch_of(&probe, rows, cols)?;
-  if nonzero_bytes > 0 {
-    return Err(SegmentError::AlignmentGatherTailNotZero {
-      rows,
-      cols,
-      nonzero_bytes,
-    });
-  }
-  Ok(pitch)
+/// [`SegmentError::AlignmentPitchUnexpectedLayout`] from `row_pitch`, for
+/// either surface — see [`coreml_f16_row_pitch`].
+fn gather_swift_parity_into(
+  out: &mut [f32],
+  alignment: &AlignmentView<'_>,
+  needed: usize,
+  cols: usize,
+  swift_source_rows: usize,
+  row_pitch: RowPitchProbe<'_>,
+) -> Result<(), SegmentError> {
+  let src_rows = alignment.rows().min(swift_source_rows);
+  // A row-less source has no surface for Swift to have allocated, and the
+  // gather reads nothing from it whatever CoreVideo would have pitched it at
+  // (every offset lands past row `src_rows`), so the reproduction is all
+  // zeros. Skipping the probe keeps a caller-built empty view out of
+  // `AlignmentPitchUnavailable`, which reports an unmeasurable HOST rather
+  // than an empty input. No backend produces one: both build the FIXED
+  // `max_token_context + 1` accumulator against a nonzero `max_token_context`.
+  let src_pitch = if src_rows == 0 {
+    cols
+  } else {
+    row_pitch(swift_source_rows, cols)?
+  };
+  let dst_pitch = row_pitch(needed, cols)?;
+  gather_swift_rows(
+    out,
+    alignment.data(),
+    src_rows,
+    needed,
+    cols,
+    src_pitch,
+    dst_pitch,
+  );
+  Ok(())
 }
 
 /// Reproduces Swift's alignment gather: what `dynamicTimeWarping` actually
@@ -1065,25 +1127,40 @@ fn coreml_f16_gather_destination_pitch(rows: usize, cols: usize) -> Result<usize
 ///
 /// - `o >= needed * cols` — past the copy. Neither the `memcpy` nor the
 ///   `initialValue:` fill (logical `count` elements, `:450`) ever wrote
-///   there, so it is the destination allocation's untouched tail:
-///   [`coreml_f16_gather_destination_pitch`] verified it comes back zero on
-///   this host, and refused the gather otherwise.
+///   there, so it is the destination allocation's untouched tail, and what
+///   DTW reads from it is whatever `CVPixelBufferCreate` returned. This
+///   function substitutes ZERO, which is assumption **A2** of the opt-in
+///   mode — see [`AlignmentGather::SwiftParity`], where it is stated in full
+///   rather than presented as established. It is not verified here and
+///   cannot be: an earlier revision sampled a *different*, disposable
+///   allocation's tail, which proves nothing about the one Swift's process
+///   gathered into (codex round 3, F3), and the sampling itself read
+///   uninitialized memory (F1).
 /// - `o < needed * cols` — source storage `o`, which is source logical row
 ///   `o / src_pitch`, column `o % src_pitch`. A column below `cols` is a
-///   real weight; at or above it, the source's own inter-row padding.
+///   real weight; at or above it, the source's own inter-row padding, for
+///   which this function likewise substitutes ZERO.
 ///
-/// **The source's padding is zero, and that is Swift's guarantee rather than
-/// this host's.** `alignmentWeights` is allocated once
-/// (`TextDecoder.swift:141`) through the same `initialValue: FloatType(0)`
-/// initializer, whose `initialize(repeating:count:)` runs over the LOGICAL
-/// element count — flat, ignoring the pitch — and so zeroes storage `[0,
-/// src_rows * cols)`, padding cells included. It is never a model input or
-/// output backing (`TextDecoder.swift:394-401`, `:414`) and `DecodingInputs.
-/// reset` never clears it (`Models.swift:312-322`); its only writer is
-/// `updateAlignmentWeights` (`:272-295`), which is stride-aware and
-/// therefore never touches a padding cell. The gather reads storage below
-/// `needed * cols <= src_rows * cols`, so every padding cell it can reach is
-/// still carrying that initial zero — on any host, at any pitch.
+/// **What the source-padding zero rests on.** `alignmentWeights` is allocated
+/// once (`TextDecoder.swift:141`) through the same `initialValue:
+/// FloatType(0)` initializer, whose `initialize(repeating:count:)` runs over
+/// the LOGICAL element count — flat, ignoring the pitch — and so zeroes
+/// storage `[0, src_rows * cols)` at construction, padding cells included. It
+/// is never a model input or output backing (`TextDecoder.swift:394-401`,
+/// `:414`) and `DecodingInputs.reset` never clears it
+/// (`Models.swift:312-322`); its only writer is `updateAlignmentWeights`
+/// (`:272-295`), which is stride-aware and so writes no padding cell. The
+/// gather reads storage below `needed * cols <= src_rows * cols`, so every
+/// padding cell it can reach was zero *at construction*.
+///
+/// That its construction-time value SURVIVES is a separate step, and an
+/// unverified one: both the writer and the gather reach the array through
+/// `withUnsafeMutableBytes`, whose contract states the strides handed to the
+/// closure may differ from the value before invocation — so no cited contract
+/// rules out a relayout or a replacement of the backing storage introducing
+/// padding that construction never zeroed. That is assumption **A3** of the
+/// opt-in mode, stated on [`AlignmentGather::SwiftParity`] (codex round 3,
+/// F4).
 ///
 /// # Why the two pitches are measured separately
 ///
@@ -1137,15 +1214,15 @@ fn gather_swift_rows(
         out_row[column..column + run].copy_from_slice(&source[start..start + run]);
         run
       } else {
-        // Source-side inter-row padding: zero, per this function's doc, and
-        // `out` already holds zero.
+        // Source-side inter-row padding: zero under assumption A3, per this
+        // function's doc, and `out` already holds zero.
         (src_pitch - source_column).min(end - offset)
       };
       offset += run;
       column += run;
     }
-    // `[column, cols)` is the destination tail (verified zero) — already
-    // zero in `out`.
+    // `[column, cols)` is the destination tail: zero under assumption A2,
+    // per this function's doc, and already zero in `out`.
   }
 }
 
@@ -1168,19 +1245,25 @@ fn gather_swift_rows(
 /// [`WordGrouping::FineGrained`] is this port's long-standing opt-in).
 ///
 /// `gather` selects what the prefix take hands to DTW.
-/// [`AlignmentGather::SwiftParity`] (the pipeline default) instead
-/// reproduces Swift's own gather: its `memcpy` loop
-/// (`SegmentSeeker.swift:452-460`) binds both `MLMultiArray`s' strides and
-/// then indexes with `columnCount`, while `dynamicTimeWarping`'s flat
-/// subscript (`:217`) *is* stride-aware and CoreVideo pads the Float16
-/// backing's rows (`ArgmaxCore/MLMultiArrayExtensions.swift:121-136`), so
-/// what DTW reads back is a function of BOTH surfaces' row pitches — each
-/// measured on the running host by this module's `coreml_f16_row_pitch`,
-/// neither assumed, and the destination's untouched tail verified rather
-/// than presumed zero. This module's `gather_swift_rows` derives the mapping;
-/// [`AlignmentGather::Complete`] gathers
-/// every row whole — see [`AlignmentGather`] for why the reproduced form is
-/// the parity-bearing one (whisper #41). Swift's
+/// [`AlignmentGather::Complete`] — **the default** — gathers every row whole:
+/// a plain prefix take, allocating no surface, measuring nothing about the
+/// host and assuming nothing about it.
+/// [`AlignmentGather::SwiftParity`] is the opt-in that instead reproduces
+/// Swift's own gather: its `memcpy` loop (`SegmentSeeker.swift:452-460`) binds
+/// both `MLMultiArray`s' strides and then indexes with `columnCount`, while
+/// `dynamicTimeWarping`'s flat subscript (`:217`) *is* stride-aware and
+/// CoreVideo pads the Float16 backing's rows
+/// (`ArgmaxCore/MLMultiArrayExtensions.swift:121-136`), so what DTW reads back
+/// is a function of BOTH surfaces' row pitches — each measured on the running
+/// host by this module's `coreml_f16_row_pitch`, at each surface's own height.
+/// This module's `gather_swift_parity_into`/`gather_swift_rows` derive the
+/// mapping; see [`AlignmentGather::SwiftParity`] for the three assumptions
+/// that mode carries and why they are acceptable only because it is opt-in
+/// (whisper #41). `swift_source_rows` is Swift's PHYSICAL source height —
+/// `kvCacheMaxSequenceLength`, i.e. the model's `max_token_context` — which
+/// is one row SHORTER than `alignment.rows()`; it is ignored under `Complete`
+/// and load-bearing under `SwiftParity` (see `gather_swift_parity_into`).
+/// Swift's
 /// `segmentSize` and `options` parameters are unused in the function body
 /// (verified against `SegmentSeeker.swift:410-496`), and `timings` is
 /// only passed through to `findAlignment` (`:471`), which ignores it —
@@ -1196,14 +1279,12 @@ fn gather_swift_rows(
 /// doc); [`SegmentError::Tokenizer`] if `split_to_word_tokens` or a
 /// partial-special retokenize fails;
 /// [`SegmentError::AlignmentPitchUnavailable`] /
-/// [`SegmentError::AlignmentPitchUnexpectedLayout`] /
-/// [`SegmentError::AlignmentGatherTailNotZero`] under
+/// [`SegmentError::AlignmentPitchUnexpectedLayout`] under
 /// [`AlignmentGather::SwiftParity`] only, if either surface's CoreVideo row
-/// pitch cannot be measured or is not a row-padded row-major layout, or the
-/// destination's untouched tail does not come back zero — parity cannot be
-/// claimed against storage this port cannot see, so it is refused rather
-/// than approximated (see this module's `coreml_f16_row_pitch` and
-/// `coreml_f16_gather_destination_pitch`).
+/// pitch cannot be measured or is not a row-padded row-major layout — parity
+/// cannot be claimed against a layout this port cannot describe, so it is
+/// refused rather than approximated (see this module's
+/// `coreml_f16_row_pitch`). The default gather returns none of the three.
 #[allow(clippy::too_many_arguments)] // Mirrors Swift's addWordTimestamps argument
 // surface (mirroring decode_text's own precedent for this exact lint, per its
 // doc comment); no natural subset of these forms a cohesive struct without
@@ -1215,6 +1296,7 @@ pub fn add_word_timestamps(
   language_code: &str,
   grouping: WordGrouping,
   gather: AlignmentGather,
+  swift_source_rows: usize,
   seek: usize,
   prepended: &str,
   appended: &str,
@@ -1271,48 +1353,34 @@ pub fn add_word_timestamps(
   }
   let mut data = vec![0.0f32; needed * cols];
 
-  // Under `SwiftParity` the gather is REPRODUCED rather than copied: what
-  // `dynamicTimeWarping` reads back out of Swift's destination array is a
-  // function of BOTH surfaces' CoreVideo row pitches, and neither is a
-  // constant -- see [`gather_swift_rows`] for the derivation and
-  // [`coreml_f16_row_pitch`] for why a compiled-in alignment quantum would
-  // make this mode silently non-parity on a host CoreVideo pads differently.
-  // The source shape is the accumulator Swift allocates once
-  // (`TextDecoder.swift:141`), the destination the per-call `[needed, cols]`
-  // one (`SegmentSeeker.swift:450`); measuring only the destination would
-  // assume the pitch does not vary with height, which is exactly the class of
-  // assumption this mode exists to stop making.
+  // Under the opt-in `SwiftParity` the gather is REPRODUCED rather than
+  // copied: what `dynamicTimeWarping` reads back out of Swift's destination
+  // array is a function of BOTH surfaces' CoreVideo row pitches, and neither
+  // is a constant -- see `gather_swift_parity_into` for the two heights and
+  // `coreml_f16_row_pitch` for why a compiled-in alignment quantum would make
+  // this mode silently non-parity on a host CoreVideo pads differently. The
+  // source shape is the accumulator Swift allocates once
+  // (`TextDecoder.swift:141`, `swift_source_rows` rows -- NOT this port's
+  // `alignment.rows()`, which carries one extra commit slot), the destination
+  // the per-call `[needed, cols]` one (`SegmentSeeker.swift:450`).
   //
   // `needed == 0` skips the probes (and the no-op gather): there is nothing to
   // reproduce, and the empty `segments` input it comes from is already
   // `SegmentError::InvalidAlignmentShape`'s -- reported below by
   // `dynamic_time_warping`, as this function's `# Errors` doc promises.
   if gather == AlignmentGather::SwiftParity && needed > 0 {
-    let src_rows = alignment.rows();
-    // A row-less view has no source surface for Swift to have allocated, and
-    // the gather reads nothing from it whatever CoreVideo would have pitched
-    // it at (every offset lands past row `src_rows`), so the reproduction is
-    // all zeros. Skipping the probe keeps a caller-built empty view out of
-    // `AlignmentPitchUnavailable`, which reports an unmeasurable HOST rather
-    // than an empty input. No backend produces one: both build the FIXED
-    // `max_token_context + 1` accumulator.
-    let src_pitch = if src_rows == 0 {
-      cols
-    } else {
-      coreml_f16_row_pitch(src_rows, cols)?
-    };
-    let dst_pitch = coreml_f16_gather_destination_pitch(needed, cols)?;
-    gather_swift_rows(
+    gather_swift_parity_into(
       &mut data,
-      alignment.data(),
-      src_rows,
+      alignment,
       needed,
       cols,
-      src_pitch,
-      dst_pitch,
-    );
+      swift_source_rows,
+      &coreml_f16_row_pitch,
+    )?;
   } else {
-    // `Complete`: the prefix take with no gather artifacts at all.
+    // `Complete`, the DEFAULT: the prefix take with no gather artifacts at
+    // all -- and, just as importantly, no surface allocation, no pitch
+    // measurement and no host-dependent assumption anywhere on this path.
     for (row_index, row) in data
       .chunks_mut(cols)
       .enumerate()

--- a/crates/coremlit/src/audio/whisper/segment/mod.rs
+++ b/crates/coremlit/src/audio/whisper/segment/mod.rs
@@ -962,11 +962,13 @@ pub(crate) fn rounded_to_places(value: f32, decimal_places: i32) -> f32 {
 /// same allocator Swift's array comes from is what makes the mode correct
 /// on every host rather than on one.
 ///
-/// The probe uses the gather's exact `[rows, cols]` shape rather than a
+/// The probe uses the caller's exact `[rows, cols]` shape rather than a
 /// cheaper 1-row stand-in, so nothing here assumes the pitch is independent
-/// of the row count either. One `CVPixelBufferCreate` plus its zero-fill
-/// per word-timestamped window is immaterial next to that window's encoder
-/// and decoder runs.
+/// of the row count — which is why [`gather_swift_rows`] asks for the SOURCE
+/// and DESTINATION shapes separately instead of reusing one answer for both.
+/// One `CVPixelBufferCreate` plus its zero-fill per shape per
+/// word-timestamped window is immaterial next to that window's encoder and
+/// decoder runs.
 ///
 /// # Errors
 /// [`SegmentError::AlignmentPitchUnavailable`] if the probe allocation
@@ -981,14 +983,21 @@ pub(crate) fn rounded_to_places(value: f32, decimal_places: i32) -> f32 {
 // this host's pitch cuts the gather, and has to ask the same helper the
 // pipeline asks rather than restate a number.
 pub(crate) fn coreml_f16_row_pitch(rows: usize, cols: usize) -> Result<usize, SegmentError> {
-  let probe = MultiArray::f16_surface(&[rows, cols])
+  let (probe, _) = MultiArray::f16_surface_probing_fresh_tail(&[rows, cols])
     .map_err(|source| SegmentError::AlignmentPitchUnavailable { rows, cols, source })?;
+  row_pitch_of(&probe, rows, cols)
+}
+
+/// The row pitch a probe surface reports, rejecting any layout the gather
+/// cannot describe.
+///
+/// CoreML pads only BETWEEN rows (the invariant `MultiArray::copy_into`'s
+/// padded-gather already relies on), so the only layout [`gather_swift_rows`]
+/// reproduces is a unit last-dimension stride under a row pitch that is at
+/// least the logical width. Anything else is a layout this port has never
+/// seen and cannot claim to replicate.
+fn row_pitch_of(probe: &MultiArray, rows: usize, cols: usize) -> Result<usize, SegmentError> {
   let strides = probe.strides();
-  // CoreML pads only BETWEEN rows (the invariant `MultiArray::copy_into`'s
-  // padded-gather already relies on), so the only layout the truncation
-  // models is a unit last-dimension stride under a row pitch that is at
-  // least the logical width. Anything else is a layout this port has never
-  // seen and cannot claim to replicate.
   match *strides {
     [pitch, 1] if pitch >= cols => Ok(pitch),
     _ => Err(SegmentError::AlignmentPitchUnexpectedLayout {
@@ -999,32 +1008,144 @@ pub(crate) fn coreml_f16_row_pitch(rows: usize, cols: usize) -> Result<usize, Se
   }
 }
 
-/// Applies Swift's gather truncation in place to `data`, a `rows * cols`
-/// row-major gather whose destination storage CoreVideo pitches at `pitch`
-/// Float16 elements per row.
+/// Measures the DESTINATION surface Swift's gather allocates per call
+/// (`SegmentSeeker.swift:450`) — its row pitch, plus the one property of
+/// that surface the pitch does not capture: whether the storage past its
+/// logical `rows * cols` elements comes back zero.
 ///
-/// Swift's memcpy loop (`SegmentSeeker.swift:454-459`) writes only storage
-/// `[0, rows * cols)` because it pitches by `columnCount`, while
-/// `dynamicTimeWarping`'s flat subscript (`:217`) reads logical row `r` at
-/// the array's TRUE pitch, `[r * pitch, r * pitch + cols)`. Wherever those
-/// two windows overlap the errors cancel exactly; past the copied prefix the
-/// read lands on storage neither the memcpy nor the `initialValue:` fill
-/// ever wrote — zero in practice. So row `r` keeps
-/// `min(cols, rows * cols - r * pitch)` columns (saturating at zero) and
-/// reads zeros after them.
+/// That tail is read by `dynamicTimeWarping` and written by nobody. Swift's
+/// `initialValue: FloatType(0)` fill covers only the logical `count`
+/// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`, over a buffer the row
+/// pitch made larger), and the gather's `memcpy` covers the same `rows *
+/// cols` prefix, so every cell past it is whatever `CVPixelBufferCreate`
+/// returned. [`MultiArray::f16_surface_probing_fresh_tail`] reports exactly
+/// that region, sampled on a real allocation of the same shape before
+/// anything writes to it — an observation of this host's allocator, not an
+/// assumption about it.
 ///
-/// Split out from [`add_word_timestamps`] so the parity-bearing arithmetic
-/// is testable against explicit pitches, independent of whatever pitch the
-/// running host happens to choose. `pitch == cols` (a host that does not pad
-/// at this width) makes it a no-op, which is correct: Swift's gather has
-/// nothing to truncate when storage pitch equals the column count.
-fn truncate_gathered_rows(data: &mut [f32], rows: usize, cols: usize, pitch: usize) {
-  let copied = rows * cols;
-  for row in 0..rows {
-    let kept = copied.saturating_sub(row * pitch).min(cols);
-    if kept < cols {
-      data[row * cols + kept..(row + 1) * cols].fill(0.0);
+/// # Errors
+/// [`SegmentError::AlignmentPitchUnavailable`] /
+/// [`SegmentError::AlignmentPitchUnexpectedLayout`] as
+/// [`coreml_f16_row_pitch`], and
+/// [`SegmentError::AlignmentGatherTailNotZero`] when the probe found the
+/// tail dirty — see that variant for why an unreproducible DTW input is
+/// refused rather than approximated.
+fn coreml_f16_gather_destination_pitch(rows: usize, cols: usize) -> Result<usize, SegmentError> {
+  let (probe, nonzero_bytes) = MultiArray::f16_surface_probing_fresh_tail(&[rows, cols])
+    .map_err(|source| SegmentError::AlignmentPitchUnavailable { rows, cols, source })?;
+  let pitch = row_pitch_of(&probe, rows, cols)?;
+  if nonzero_bytes > 0 {
+    return Err(SegmentError::AlignmentGatherTailNotZero {
+      rows,
+      cols,
+      nonzero_bytes,
+    });
+  }
+  Ok(pitch)
+}
+
+/// Reproduces Swift's alignment gather: what `dynamicTimeWarping` actually
+/// reads out of the destination array `addWordTimestamps` builds, given the
+/// source's logical rows and the two surfaces' measured row pitches.
+///
+/// Writes `needed * cols` row-major f32 into `out`, which the caller supplies
+/// zero-filled.
+///
+/// # The reproduction, cell by cell
+///
+/// Swift's loop (`SegmentSeeker.swift:452-460`) binds both arrays' strides
+/// and then ignores them, offsetting BOTH sides by `index * columnCount`.
+/// Its `filteredIndices` are `0..needed` by construction (`:429-432`,
+/// `:441`), so the copies tile `[0, needed * cols)` contiguously on each
+/// side and the whole loop is one verbatim copy: destination STORAGE offset
+/// `o` holds source STORAGE offset `o`, for every `o < needed * cols`.
+/// `dynamicTimeWarping` reads logical row `r`, column `c` through
+/// `MLMultiArray`'s stride-aware flat subscript (`:217`), i.e. destination
+/// storage `o = r * dst_pitch + c`. So:
+///
+/// - `o >= needed * cols` — past the copy. Neither the `memcpy` nor the
+///   `initialValue:` fill (logical `count` elements, `:450`) ever wrote
+///   there, so it is the destination allocation's untouched tail:
+///   [`coreml_f16_gather_destination_pitch`] verified it comes back zero on
+///   this host, and refused the gather otherwise.
+/// - `o < needed * cols` — source storage `o`, which is source logical row
+///   `o / src_pitch`, column `o % src_pitch`. A column below `cols` is a
+///   real weight; at or above it, the source's own inter-row padding.
+///
+/// **The source's padding is zero, and that is Swift's guarantee rather than
+/// this host's.** `alignmentWeights` is allocated once
+/// (`TextDecoder.swift:141`) through the same `initialValue: FloatType(0)`
+/// initializer, whose `initialize(repeating:count:)` runs over the LOGICAL
+/// element count — flat, ignoring the pitch — and so zeroes storage `[0,
+/// src_rows * cols)`, padding cells included. It is never a model input or
+/// output backing (`TextDecoder.swift:394-401`, `:414`) and `DecodingInputs.
+/// reset` never clears it (`Models.swift:312-322`); its only writer is
+/// `updateAlignmentWeights` (`:272-295`), which is stride-aware and
+/// therefore never touches a padding cell. The gather reads storage below
+/// `needed * cols <= src_rows * cols`, so every padding cell it can reach is
+/// still carrying that initial zero — on any host, at any pitch.
+///
+/// # Why the two pitches are measured separately
+///
+/// `src_pitch == dst_pitch` collapses this to "row `r` keeps its first
+/// `min(cols, needed * cols - r * dst_pitch)` columns and reads zeros after
+/// them", the form the shipping host takes. But row-count invariance is a
+/// property this host was measured to have, not one CoreVideo promises, and
+/// where the pitches differ the reproduction is not a truncation at all: row
+/// `r` reads a SHIFTED window of the source, mixing the tail of one logical
+/// row with the head of the next and with zeroed padding. Modelling only the
+/// equal-pitch case would have made [`AlignmentGather::SwiftParity`]
+/// silently wrong there while still reporting parity, so both shapes are
+/// probed and the general mapping is what runs.
+///
+/// Rows at or past `src_rows` read zeros: Swift's gather would run off the
+/// end of its source array there. `needed <= src_rows` for every real window
+/// (the accumulator is `max_token_context + 1` rows and `needed <= 224`), so
+/// this is the same defensive branch [`add_word_timestamps`]'s prefix take
+/// has always had, not a modelled behavior.
+///
+/// Taking both pitches as parameters (rather than measuring inside) is what
+/// lets the reproduction be tested at pitches this host will never choose —
+/// see `segment::tests`.
+fn gather_swift_rows(
+  out: &mut [f32],
+  source: &[f32],
+  src_rows: usize,
+  needed: usize,
+  cols: usize,
+  src_pitch: usize,
+  dst_pitch: usize,
+) {
+  debug_assert!(src_pitch >= cols && dst_pitch >= cols && cols > 0);
+  let copied = needed * cols;
+  for (row, out_row) in out.chunks_mut(cols).enumerate().take(needed) {
+    // Destination storage this logical row reads, clipped to the copy.
+    let mut offset = row * dst_pitch;
+    let end = (offset + cols).min(copied);
+    let mut column = 0usize;
+    while offset < end {
+      let source_row = offset / src_pitch;
+      if source_row >= src_rows {
+        // Past the source array; every later offset is too, so the rest of
+        // this row and every row after it keeps `out`'s zero.
+        break;
+      }
+      let source_column = offset % src_pitch;
+      let run = if source_column < cols {
+        let run = (cols - source_column).min(end - offset);
+        let start = source_row * cols + source_column;
+        out_row[column..column + run].copy_from_slice(&source[start..start + run]);
+        run
+      } else {
+        // Source-side inter-row padding: zero, per this function's doc, and
+        // `out` already holds zero.
+        (src_pitch - source_column).min(end - offset)
+      };
+      offset += run;
+      column += run;
     }
+    // `[column, cols)` is the destination tail (verified zero) — already
+    // zero in `out`.
   }
 }
 
@@ -1047,17 +1168,18 @@ fn truncate_gathered_rows(data: &mut [f32], rows: usize, cols: usize, pitch: usi
 /// [`WordGrouping::FineGrained`] is this port's long-standing opt-in).
 ///
 /// `gather` selects what the prefix take hands to DTW.
-/// [`AlignmentGather::SwiftParity`] (the pipeline default) additionally
-/// replicates the truncation Swift's own gather performs: its `memcpy` loop
-/// (`SegmentSeeker.swift:454-459`) binds both `MLMultiArray`s' strides and
+/// [`AlignmentGather::SwiftParity`] (the pipeline default) instead
+/// reproduces Swift's own gather: its `memcpy` loop
+/// (`SegmentSeeker.swift:452-460`) binds both `MLMultiArray`s' strides and
 /// then indexes with `columnCount`, while `dynamicTimeWarping`'s flat
 /// subscript (`:217`) *is* stride-aware and CoreVideo pads the Float16
 /// backing's rows (`ArgmaxCore/MLMultiArrayExtensions.swift:121-136`), so
-/// row `r` keeps only its first `min(cols, needed * cols - r * pitch)`
-/// columns and reads zeros past that — where `pitch` is measured on the
-/// running host by this module's `coreml_f16_row_pitch`, not assumed.
+/// what DTW reads back is a function of BOTH surfaces' row pitches — each
+/// measured on the running host by this module's `coreml_f16_row_pitch`,
+/// neither assumed, and the destination's untouched tail verified rather
+/// than presumed zero. This module's `gather_swift_rows` derives the mapping;
 /// [`AlignmentGather::Complete`] gathers
-/// every row whole — see [`AlignmentGather`] for why the truncated form is
+/// every row whole — see [`AlignmentGather`] for why the reproduced form is
 /// the parity-bearing one (whisper #41). Swift's
 /// `segmentSize` and `options` parameters are unused in the function body
 /// (verified against `SegmentSeeker.swift:410-496`), and `timings` is
@@ -1074,11 +1196,14 @@ fn truncate_gathered_rows(data: &mut [f32], rows: usize, cols: usize, pitch: usi
 /// doc); [`SegmentError::Tokenizer`] if `split_to_word_tokens` or a
 /// partial-special retokenize fails;
 /// [`SegmentError::AlignmentPitchUnavailable`] /
-/// [`SegmentError::AlignmentPitchUnexpectedLayout`] under
-/// [`AlignmentGather::SwiftParity`] only, if this host's CoreVideo row pitch
-/// cannot be measured or is not a row-padded row-major layout — parity
-/// cannot be claimed against a layout this port cannot see, so it is refused
-/// rather than approximated (see this module's `coreml_f16_row_pitch`).
+/// [`SegmentError::AlignmentPitchUnexpectedLayout`] /
+/// [`SegmentError::AlignmentGatherTailNotZero`] under
+/// [`AlignmentGather::SwiftParity`] only, if either surface's CoreVideo row
+/// pitch cannot be measured or is not a row-padded row-major layout, or the
+/// destination's untouched tail does not come back zero — parity cannot be
+/// claimed against storage this port cannot see, so it is refused rather
+/// than approximated (see this module's `coreml_f16_row_pitch` and
+/// `coreml_f16_gather_destination_pitch`).
 #[allow(clippy::too_many_arguments)] // Mirrors Swift's addWordTimestamps argument
 // surface (mirroring decode_text's own precedent for this exact lint, per its
 // doc comment); no natural subset of these forms a cohesive struct without
@@ -1145,37 +1270,56 @@ pub fn add_word_timestamps(
     });
   }
   let mut data = vec![0.0f32; needed * cols];
-  for (row_index, row) in data
-    .chunks_mut(cols)
-    .enumerate()
-    .take(alignment.rows().min(needed))
-  {
-    row.copy_from_slice(alignment.row(row_index));
-  }
 
-  // Swift's gather truncates: its memcpy writes only storage `[0, needed *
-  // cols)` (`:454-459`, pitched by `columnCount`), while `dynamicTimeWarping`
-  // reads logical row `r` at the TRUE pitch (`:217`), so `r` keeps only what
-  // still falls inside that copied prefix and reads never-written storage --
-  // zero in practice -- past it. Row `r` is truncated exactly when `r * pitch
-  // + cols > needed * cols`; only the LAST row can be while `cols >= (needed -
-  // 2) * (pitch - cols)`, which holds for every real Whisper model (1500/1504,
-  // `needed <= 224`) but not at the small `n_audio_ctx` a test backend can set
-  // -- hence the general per-row loop in [`truncate_gathered_rows`], not a
-  // last-row special case. See [`AlignmentGather`] for the derivation.
-  //
-  // The pitch is MEASURED on this host, never assumed: see
+  // Under `SwiftParity` the gather is REPRODUCED rather than copied: what
+  // `dynamicTimeWarping` reads back out of Swift's destination array is a
+  // function of BOTH surfaces' CoreVideo row pitches, and neither is a
+  // constant -- see [`gather_swift_rows`] for the derivation and
   // [`coreml_f16_row_pitch`] for why a compiled-in alignment quantum would
-  // make this mode silently non-parity on a host CoreVideo pads differently,
-  // and why the failure to measure one is an error rather than a quiet
-  // downgrade to [`AlignmentGather::Complete`]. `needed == 0` skips the probe
-  // (and the no-op loop): there is no gather to truncate, and the empty
-  // `segments` input it comes from is already
+  // make this mode silently non-parity on a host CoreVideo pads differently.
+  // The source shape is the accumulator Swift allocates once
+  // (`TextDecoder.swift:141`), the destination the per-call `[needed, cols]`
+  // one (`SegmentSeeker.swift:450`); measuring only the destination would
+  // assume the pitch does not vary with height, which is exactly the class of
+  // assumption this mode exists to stop making.
+  //
+  // `needed == 0` skips the probes (and the no-op gather): there is nothing to
+  // reproduce, and the empty `segments` input it comes from is already
   // `SegmentError::InvalidAlignmentShape`'s -- reported below by
   // `dynamic_time_warping`, as this function's `# Errors` doc promises.
   if gather == AlignmentGather::SwiftParity && needed > 0 {
-    let pitch = coreml_f16_row_pitch(needed, cols)?;
-    truncate_gathered_rows(&mut data, needed, cols, pitch);
+    let src_rows = alignment.rows();
+    // A row-less view has no source surface for Swift to have allocated, and
+    // the gather reads nothing from it whatever CoreVideo would have pitched
+    // it at (every offset lands past row `src_rows`), so the reproduction is
+    // all zeros. Skipping the probe keeps a caller-built empty view out of
+    // `AlignmentPitchUnavailable`, which reports an unmeasurable HOST rather
+    // than an empty input. No backend produces one: both build the FIXED
+    // `max_token_context + 1` accumulator.
+    let src_pitch = if src_rows == 0 {
+      cols
+    } else {
+      coreml_f16_row_pitch(src_rows, cols)?
+    };
+    let dst_pitch = coreml_f16_gather_destination_pitch(needed, cols)?;
+    gather_swift_rows(
+      &mut data,
+      alignment.data(),
+      src_rows,
+      needed,
+      cols,
+      src_pitch,
+      dst_pitch,
+    );
+  } else {
+    // `Complete`: the prefix take with no gather artifacts at all.
+    for (row_index, row) in data
+      .chunks_mut(cols)
+      .enumerate()
+      .take(alignment.rows().min(needed))
+    {
+      row.copy_from_slice(alignment.row(row_index));
+    }
   }
 
   let filtered = AlignmentMatrix::new(data, needed, cols);

--- a/crates/coremlit/src/audio/whisper/segment/tests.rs
+++ b/crates/coremlit/src/audio/whisper/segment/tests.rs
@@ -865,6 +865,13 @@ fn coreml_f16_row_pitch_is_measured_from_a_live_pixel_buffer_allocation() {
   // back off the same allocation Swift's gather makes -- never a compiled-in
   // rule. Apple's QA1829 says the alignment is hardware-dependent and must be
   // queried; `MultiArray::f16_surface`'s own doc says the same.
+  //
+  // Every assertion here compares the helper against a LIVE allocation, so it
+  // holds on any host. It deliberately does NOT assert that the pitch is
+  // independent of the row count: `add_word_timestamps` probes the source and
+  // destination shapes separately and reproduces the unequal case, so
+  // row-count invariance is a fact about this host (see
+  // `reference_host_pitch_table`) rather than something the gather needs.
   for cols in PROBE_WIDTHS {
     for rows in [1usize, 3, 120, 224] {
       let pitch = coreml_f16_row_pitch(rows, cols).unwrap();
@@ -879,42 +886,115 @@ fn coreml_f16_row_pitch_is_measured_from_a_live_pixel_buffer_allocation() {
       assert!(
         pitch >= cols,
         "rows={rows} cols={cols}: a row pitch below the logical width ({pitch}) would make \
-         the gather truncation nonsense"
+         the gather reproduction nonsense"
       );
-      // The helper probes with the gather's exact `[rows, cols]` shape, so it
-      // does not need this -- but the doc claims the pitch is a function of
-      // the width alone, and an unchecked claim in a doc is how #41 started.
+      // Repeat allocations of one shape must agree, or no single measurement
+      // could describe the surface Swift's gather allocates.
       assert_eq!(
         pitch,
-        coreml_f16_row_pitch(1, cols).unwrap(),
-        "rows={rows} cols={cols}: pitch must not depend on the row count"
+        coreml_f16_row_pitch(rows, cols).unwrap(),
+        "rows={rows} cols={cols}: the pitch moved between two allocations of the same shape"
       );
     }
   }
 }
 
 #[test]
+fn coreml_f16_gather_destination_probe_reports_a_clean_tail_on_this_host() {
+  // Finding #2 of the round-2 review: `SwiftParity` feeds DTW zeros for the
+  // storage past the gather's copied prefix, which Swift reads and nobody
+  // writes. That is now VERIFIED per call rather than assumed --
+  // `MultiArray::f16_surface_probing_fresh_tail` looks at a real allocation
+  // before anything touches it -- and this pins that the verification passes
+  // here, i.e. that `AlignmentGather::SwiftParity` is actually usable on this
+  // host.
+  //
+  // Unlike the recorded pitch table, a failure here is NOT cosmetic: the
+  // shipping gather takes the identical probe and returns
+  // `AlignmentGatherTailNotZero`, so a host that fails this test is a host
+  // where the default gather refuses to run. That is exactly what the test
+  // should report.
+  for cols in PROBE_WIDTHS {
+    for rows in [1usize, 3, 120, 224] {
+      assert_eq!(
+        coreml_f16_gather_destination_pitch(rows, cols).unwrap(),
+        coreml_f16_row_pitch(rows, cols).unwrap(),
+        "rows={rows} cols={cols}: the destination probe must report the same pitch as the plain \
+         one, and must not have found a dirty tail"
+      );
+    }
+  }
+}
+
+/// Replays Swift's gather on ITS OWN terms rather than restating the
+/// production formula: build the two padded STORAGE buffers Swift's arrays
+/// are, run the `columnCount`-pitched `memcpy` between them
+/// (`SegmentSeeker.swift:452-460`), then read logical row `r` back at the
+/// destination's true pitch the way `dynamicTimeWarping`'s stride-aware flat
+/// subscript does (`:217`).
+///
+/// The two storages are filled the way Swift's own allocator fills them:
+/// `MLMultiArray(shape:dataType:initialValue: FloatType(0))` zeroes the
+/// LOGICAL element count flat (`ArgmaxCore/MLMultiArrayExtensions.swift:
+/// 11-53`), so the source's `[0, src_rows * cols)` storage -- padding cells
+/// included -- is zero before its stride-aware writer fills the real rows,
+/// and the destination's storage past `needed * cols` is the one region
+/// nothing writes. `NAN` marks that region here, so the assertions can prove
+/// the production path only ever reads it where the destination probe
+/// verified it comes back zero.
+///
+/// Both pitches are parameters, never lookups: the reproduction must be right
+/// for any padding a host might choose, including hosts that pitch the two
+/// heights differently.
+fn replay_swift_gather(
+  source_rows: &[f32],
+  src_rows: usize,
+  needed: usize,
+  cols: usize,
+  src_pitch: usize,
+  dst_pitch: usize,
+) -> Vec<f32> {
+  let mut source_storage = vec![0.0f32; src_rows * src_pitch];
+  for row in 0..src_rows {
+    source_storage[row * src_pitch..row * src_pitch + cols]
+      .copy_from_slice(&source_rows[row * cols..(row + 1) * cols]);
+  }
+  let mut destination_storage = vec![f32::NAN; needed * dst_pitch];
+  for (offset, cell) in destination_storage
+    .iter_mut()
+    .enumerate()
+    .take(needed * cols)
+  {
+    // Swift would read off the end of its source array when `needed >
+    // src_rows`; the port zero-fills those rows instead (the same defensive
+    // branch the prefix take has always had), so the replay does too.
+    *cell = source_storage.get(offset).copied().unwrap_or(0.0);
+  }
+  (0..needed)
+    .flat_map(|row| {
+      destination_storage[row * dst_pitch..row * dst_pitch + cols]
+        .iter()
+        .copied()
+        // The verified-zero destination tail.
+        .map(|value| if value.is_nan() { 0.0 } else { value })
+        .collect::<Vec<_>>()
+    })
+    .collect()
+}
+
+#[test]
 fn swift_gather_keeps_only_the_final_rows_prefix() {
-  /// Replays Swift's gather on ITS OWN terms rather than restating the
-  /// production formula: allocate the padded destination storage, memcpy the
-  /// contiguous `rows * cols` prefix as `SegmentSeeker.swift:454-459` does,
-  /// then read logical row `r` back at the true pitch as
-  /// `dynamicTimeWarping`'s flat subscript does (`:217`), and count what
-  /// survived. `NAN` stands for the storage neither the memcpy nor the
-  /// `initialValue: FloatType(0)` fill ever writes -- the bytes that read
-  /// back as zero in practice.
-  ///
-  /// `pitch` is a parameter, not a lookup: the arithmetic must be right for
-  /// ANY row padding a host might choose, so the worked examples below drive
-  /// it explicitly instead of asking the machine the test happens to run on.
+  // The equal-pitch case, where the reproduction reduces to a truncation.
+  // Count what survives in the replay, so the expected numbers come from
+  // storage arithmetic rather than from restating the production formula.
   fn kept_per_row(rows: usize, cols: usize, pitch: usize) -> Vec<usize> {
-    let mut storage = vec![f32::NAN; rows * pitch];
-    storage[..rows * cols].fill(1.0);
+    let ones = vec![1.0f32; rows * cols];
+    let gathered = replay_swift_gather(&ones, rows, rows, cols, pitch, pitch);
     (0..rows)
       .map(|row| {
-        storage[row * pitch..row * pitch + cols]
+        gathered[row * cols..(row + 1) * cols]
           .iter()
-          .take_while(|value| !value.is_nan())
+          .take_while(|&&value| value == 1.0)
           .count()
       })
       .collect()
@@ -944,7 +1024,7 @@ fn swift_gather_keeps_only_the_final_rows_prefix() {
   // nothing, so `SwiftParity` and `Complete` coincide there.
   assert_eq!(kept_per_row(120, 1500, 1500), vec![1500; 120]);
 
-  // The production truncation reproduces the replay for every shape AND every
+  // The production reproduction matches the replay for every shape AND every
   // pitch -- including shapes where more than one row is truncated, which is
   // why `add_word_timestamps` runs the general per-row form rather than
   // special-casing the last row.
@@ -967,10 +1047,123 @@ fn swift_gather_keeps_only_the_final_rows_prefix() {
     for (row, &kept) in kept_per_row(rows, cols, pitch).iter().enumerate() {
       expected_data[row * cols..row * cols + kept].fill(1.0);
     }
-    let mut data = vec![1.0f32; rows * cols];
-    truncate_gathered_rows(&mut data, rows, cols, pitch);
+    let source = vec![1.0f32; rows * cols];
+    let mut data = vec![0.0f32; rows * cols];
+    gather_swift_rows(&mut data, &source, rows, rows, cols, pitch, pitch);
     assert_eq!(data, expected_data, "rows={rows} cols={cols} pitch={pitch}");
   }
+}
+
+#[test]
+fn swift_gather_reproduces_the_copy_when_the_two_surfaces_pitch_differently() {
+  // Finding #1 of the round-2 review: the cancellation that makes the gather
+  // a mere truncation needs the SOURCE and DESTINATION pitches to agree, and
+  // only the destination was ever measured. Row-count invariance is a
+  // property this host happens to have, not a CoreVideo guarantee, so the
+  // reproduction has to be right when the two disagree -- where it is not a
+  // truncation at all but a SHIFTED read that splices logical rows together
+  // across the source's own zeroed padding.
+  //
+  // Distinct per-cell values (row * cols + column + 1, never 0) so any
+  // shift, any padding cell and any tail cell is individually visible: a
+  // wrong offset cannot coincide with a right one.
+  fn ramp(rows: usize, cols: usize) -> Vec<f32> {
+    (0..rows * cols).map(|index| index as f32 + 1.0).collect()
+  }
+
+  for (src_rows, needed, cols, src_pitch, dst_pitch) in [
+    // The shipping shape, both directions of inequality and equality.
+    (225usize, 120usize, 1500usize, 1504usize, 1504usize),
+    (225, 120, 1500, 1504, 1536),
+    (225, 120, 1500, 1536, 1504),
+    (225, 120, 1500, 1500, 1504),
+    (225, 120, 1500, 1504, 1500),
+    // The unpadded identity on both sides: no shift, no truncation.
+    (225, 120, 1500, 1500, 1500),
+    // Small shapes a test backend can configure, where whole rows go.
+    (8, 5, 4, 8, 4),
+    (8, 5, 4, 4, 8),
+    (8, 5, 4, 8, 8),
+    (8, 8, 4, 6, 5),
+    // Edges: a single gathered row, a single-column matrix, and the
+    // one-row-source corner.
+    (225, 1, 1500, 1504, 1504),
+    (225, 1, 1500, 1500, 1504),
+    (4, 4, 1, 1, 1),
+    (4, 4, 1, 3, 2),
+    (1, 1, 1, 1, 1),
+    (1, 1, 4, 7, 5),
+    // `needed > src_rows`: Swift would run off its source array; the port
+    // zero-fills, and the replay agrees.
+    (3, 6, 4, 5, 5),
+    (3, 6, 4, 4, 7),
+    // A row-less source: everything the gather reads is past its rows.
+    (0, 3, 4, 4, 6),
+  ] {
+    let source = ramp(src_rows, cols);
+    let expected = replay_swift_gather(&source, src_rows, needed, cols, src_pitch, dst_pitch);
+    let mut data = vec![0.0f32; needed * cols];
+    gather_swift_rows(
+      &mut data, &source, src_rows, needed, cols, src_pitch, dst_pitch,
+    );
+    assert_eq!(
+      data, expected,
+      "src_rows={src_rows} needed={needed} cols={cols} src_pitch={src_pitch} \
+       dst_pitch={dst_pitch}"
+    );
+  }
+}
+
+#[test]
+fn swift_gather_at_equal_unpadded_pitches_is_the_plain_prefix_take() {
+  // The identity the `AlignmentGather` doc claims for a host that does not
+  // pad: `SwiftParity` and `Complete` coincide there, so a host without
+  // padding is not a special case anyone has to guard.
+  for (src_rows, needed, cols) in [
+    (225usize, 120usize, 1500usize),
+    (8, 5, 4),
+    (1, 1, 1),
+    (3, 6, 4),
+  ] {
+    let source: Vec<f32> = (0..src_rows * cols).map(|i| i as f32 + 1.0).collect();
+    let mut prefix = vec![0.0f32; needed * cols];
+    let copied = src_rows.min(needed) * cols;
+    prefix[..copied].copy_from_slice(&source[..copied]);
+
+    let mut data = vec![0.0f32; needed * cols];
+    gather_swift_rows(&mut data, &source, src_rows, needed, cols, cols, cols);
+    assert_eq!(
+      data, prefix,
+      "src_rows={src_rows} needed={needed} cols={cols}: an unpadded host must gather every row \
+       whole"
+    );
+  }
+}
+
+#[test]
+fn swift_gather_reads_the_sources_padding_as_zero() {
+  // The one source-side fact the reproduction relies on, isolated: where the
+  // shifted read lands on the source's inter-row padding it must produce
+  // zero -- Swift's `initialValue:` fill covers the LOGICAL count flat, so
+  // those cells still hold that zero, and its only writer
+  // (`TextDecoder.updateAlignmentWeights`) is stride-aware and never touches
+  // them.
+  //
+  // src_pitch 6 > cols 4 with dst_pitch 4: destination logical row 1 reads
+  // source storage [4, 8) = source row 0's two padding cells then source row
+  // 1's first two real cells.
+  let source: Vec<f32> = (0..3 * 4).map(|i| i as f32 + 1.0).collect();
+  let mut data = vec![0.0f32; 3 * 4];
+  gather_swift_rows(&mut data, &source, 3, 3, 4, 6, 4);
+  assert_eq!(
+    data,
+    vec![
+      1.0, 2.0, 3.0, 4.0, // row 0: storage [0, 4) -- source row 0 entire
+      0.0, 0.0, 5.0, 6.0, // row 1: storage [4, 8) -- 2 padding cells, then row 1
+      7.0, 8.0, 0.0, 0.0, // row 2: storage [8, 12) -- row 1's tail, then padding
+    ],
+    "the source's padding must read as zero, not as a neighbouring row's weights"
+  );
 }
 
 /// The layout `crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.out`
@@ -978,13 +1171,11 @@ fn swift_gather_keeps_only_the_final_rows_prefix() {
 /// 26.5): `MLMultiArray.strides[0]` for pixel-buffer-backed Float16 arrays,
 /// i.e. rows aligned to 64 bytes = 32 Float16 elements.
 ///
-/// **Evidence about a host, not a rule about CoreVideo.** No production path
-/// consults it: `coreml_f16_row_pitch` measures the running host. It lives
-/// here so the two fixtures that hand-compute DTW paths around a specific
-/// truncation point -- `swift_parity_gather_truncates_final_alignment_row`
-/// here and `swift_parity_gather_moves_the_next_window_seek` in
-/// `transcribe::tests` -- have ONE diagnosable place to fail if this host
-/// pads differently, instead of failing later as unexplained word timings.
+/// **Evidence about one host, not a rule about CoreVideo**, and nothing in
+/// the port consults it: `coreml_f16_row_pitch` measures the running host and
+/// `gather_swift_rows` reproduces whatever it measures. It is kept as
+/// provenance for the recorded long-form parity numbers and for the
+/// hand-computed columns in the model-gated gather fixtures.
 const RECORDED_REFERENCE_HOST_PITCH: [(usize, usize); 6] = [
   (8, 32),
   (9, 32),
@@ -995,7 +1186,20 @@ const RECORDED_REFERENCE_HOST_PITCH: [(usize, usize); 6] = [
 ];
 
 #[test]
-fn the_recorded_swift_probe_still_describes_this_host() {
+#[ignore = "reference-host layout probe: asserts the #41 capture host's CoreVideo pitches, which \
+            no production path depends on (run explicitly when re-capturing the Swift probe)"]
+fn reference_host_pitch_table() {
+  // Deliberately NOT an ordinary test. It compares this machine against ONE
+  // recorded machine, so a different-but-perfectly-supported host fails it
+  // while the shipping gather -- which measures rather than assumes, and now
+  // reproduces unequal source/destination pitches too -- keeps working. An
+  // unignored version of this was a red CI on valid hardware whose own
+  // diagnostic said the gather was unaffected; the portable replacements are
+  // `coreml_f16_row_pitch_is_measured_from_a_live_pixel_buffer_allocation`
+  // (live allocations only) and the injected-pitch reproduction tests.
+  //
+  // Run it when re-capturing `probe_alignment_stride.out`, or to explain why
+  // a model-gated gather fixture's hand-computed columns no longer line up.
   for (cols, recorded) in RECORDED_REFERENCE_HOST_PITCH {
     assert_eq!(
       coreml_f16_row_pitch(224, cols).unwrap(),
@@ -1006,6 +1210,19 @@ fn the_recorded_swift_probe_still_describes_this_host() {
        the hand-computed columns in the gather fixtures, and the recorded 1417 s/1042 s \
        parity results, describe the reference layout only"
     );
+  }
+  // Row-count invariance, likewise a fact about this host rather than one the
+  // gather needs: `add_word_timestamps` probes the source and destination
+  // shapes separately precisely so it does not.
+  for (cols, recorded) in RECORDED_REFERENCE_HOST_PITCH {
+    for rows in [1usize, 3, 120, 225] {
+      assert_eq!(
+        coreml_f16_row_pitch(rows, cols).unwrap(),
+        recorded,
+        "rows={rows} cols={cols}: this host's pitch varies with the row count, unlike the \
+         reference host's"
+      );
+    }
   }
 }
 
@@ -1047,7 +1264,10 @@ fn swift_parity_gather_truncates_final_alignment_row() {
   let cols = 100usize;
   let rows = 3usize;
   // Where this host's gather actually stops copying, from the same helper
-  // `add_word_timestamps` uses.
+  // `add_word_timestamps` uses. The view below is `rows` tall, so source and
+  // destination are the SAME shape here and one pitch describes both — the
+  // fixture is deliberately built on the equal-pitch case, where the
+  // reproduction reduces to a truncation with a hand-computable cut.
   let pitch = coreml_f16_row_pitch(rows, cols).unwrap();
   let truncated_at = (rows * cols).saturating_sub((rows - 1) * pitch).min(cols);
   assert_eq!(
@@ -1055,7 +1275,7 @@ fn swift_parity_gather_truncates_final_alignment_row() {
     "at the reference host's pitch of 128 the final row keeps 44 of {cols} columns; this host \
      measured a pitch of {pitch}, so the plateau/cutoff columns below no longer straddle the \
      truncation and this fixture would not discriminate (see \
-     `the_recorded_swift_probe_still_describes_this_host`)"
+     `reference_host_pitch_table`)"
   );
   let row_one_cutoff = truncated_at + 36;
 

--- a/crates/coremlit/src/audio/whisper/segment/tests.rs
+++ b/crates/coremlit/src/audio/whisper/segment/tests.rs
@@ -668,6 +668,12 @@ fn empty_segments_returns_empty_without_consuming_alignment() {
 // wrapper composing gather -> prefix-take/zero-pad -> find_alignment ->
 // duration constraints/truncation -> merge_punctuations -> word-timing
 // re-anchoring.
+//
+// The four tests below predate the #41 gather split and their expectations
+// were written against the un-truncated gather, so they pass
+// `AlignmentGather::Complete` to keep their original intent; the pipeline
+// default (`SwiftParity`) is exercised by
+// `swift_parity_gather_truncates_final_alignment_row` below.
 
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
@@ -713,6 +719,7 @@ fn add_word_timestamps_attaches_merged_monotonic_words() {
     &t,
     "en",
     WordGrouping::FineGrained,
+    AlignmentGather::Complete,
     0,
     crate::audio::whisper::constants::PREPEND_PUNCTUATION,
     crate::audio::whisper::constants::APPEND_PUNCTUATION,
@@ -762,6 +769,7 @@ fn add_word_timestamps_zero_pads_missing_rows() {
     &t,
     "en",
     WordGrouping::FineGrained,
+    AlignmentGather::Complete,
     0,
     crate::audio::whisper::constants::PREPEND_PUNCTUATION,
     crate::audio::whisper::constants::APPEND_PUNCTUATION,
@@ -793,6 +801,7 @@ fn add_word_timestamps_errors_on_empty_segments() {
     &t,
     "en",
     WordGrouping::FineGrained,
+    AlignmentGather::Complete,
     0,
     crate::audio::whisper::constants::PREPEND_PUNCTUATION,
     crate::audio::whisper::constants::APPEND_PUNCTUATION,
@@ -821,6 +830,7 @@ fn add_word_timestamps_errors_on_zero_columns() {
     &t,
     "en",
     WordGrouping::FineGrained,
+    AlignmentGather::Complete,
     0,
     "",
     "",
@@ -831,4 +841,208 @@ fn add_word_timestamps_errors_on_zero_columns() {
     err,
     SegmentError::InvalidAlignmentShape { cols: 0, .. }
   ));
+}
+
+// whisper #41 -- the Swift-parity alignment gather. CoreVideo pads the rows of
+// the Float16 pixel-buffer backing every WhisperKit `MLMultiArray` uses
+// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`, `:121-136`);
+// `addWordTimestamps`' gather memcpy indexes by `columnCount` instead
+// (`SegmentSeeker.swift:444-461`) while `dynamicTimeWarping` reads through the
+// stride-aware flat subscript (`:217`), so the final gathered row loses its
+// tail.
+
+#[test]
+fn coreml_f16_row_pitch_matches_the_probed_core_video_padding() {
+  // Pinned against the Swift capture in
+  // `crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.out`
+  // (`MLMultiArray.strides[0]` of the pixel-buffer-backed Float16 arrays):
+  // rows align to 64 bytes, i.e. 32 Float16 elements.
+  for (cols, pitch) in [
+    (8, 32),
+    (9, 32),
+    (100, 128),
+    (1496, 1504),
+    (1500, 1504),
+    (1504, 1504),
+  ] {
+    assert_eq!(
+      coreml_f16_row_pitch(cols),
+      pitch,
+      "probed pitch for cols={cols}"
+    );
+  }
+  // The quantum has to come from the probe, not from the shipping shape: an
+  // 8-element quantum agrees at cols=1500 and disagrees at cols=100.
+  assert_eq!(1500_usize.div_ceil(8) * 8, coreml_f16_row_pitch(1500));
+  assert_ne!(100_usize.div_ceil(8) * 8, coreml_f16_row_pitch(100));
+}
+
+#[test]
+fn swift_gather_keeps_only_the_final_rows_prefix() {
+  /// Replays Swift's gather on ITS OWN terms rather than restating the
+  /// production formula: allocate the padded destination storage, memcpy the
+  /// contiguous `rows * cols` prefix as `SegmentSeeker.swift:454-459` does,
+  /// then read logical row `r` back at the true pitch as
+  /// `dynamicTimeWarping`'s flat subscript does (`:217`), and count what
+  /// survived. `NAN` stands for the storage neither the memcpy nor the
+  /// `initialValue: FloatType(0)` fill ever writes -- the bytes that read
+  /// back as zero in practice.
+  fn kept_per_row(rows: usize, cols: usize) -> Vec<usize> {
+    let pitch = coreml_f16_row_pitch(cols);
+    let mut storage = vec![f32::NAN; rows * pitch];
+    storage[..rows * cols].fill(1.0);
+    (0..rows)
+      .map(|row| {
+        storage[row * pitch..row * pitch + cols]
+          .iter()
+          .take_while(|value| !value.is_nan())
+          .count()
+      })
+      .collect()
+  }
+
+  // The shipping shape, and the probe's own worked example ("logical row 119
+  // reads 476 element(s) past the copied prefix (kept columns = 1024)").
+  let kept = kept_per_row(120, 1500);
+  assert_eq!(kept[119], 1024, "the final row keeps 1024 of 1500 columns");
+  assert_eq!(1500 - kept[119], 476, "and reads 476 zeros after them");
+  assert!(
+    kept[..119].iter().all(|&columns| columns == 1500),
+    "no row but the last is touched"
+  );
+
+  assert_eq!(*kept_per_row(31, 1500).last().unwrap(), 1380);
+  assert_eq!(*kept_per_row(2, 1500).last().unwrap(), 1496);
+  assert_eq!(
+    kept_per_row(1, 1500),
+    vec![1500],
+    "a lone row is never truncated: it starts at storage 0"
+  );
+
+  // The production arithmetic reproduces the replay shape for shape --
+  // including shapes where more than one row is truncated, which is why
+  // `add_word_timestamps` runs the general per-row form rather than special-
+  // casing the last row.
+  for (rows, cols) in [
+    (120, 1500),
+    (31, 1500),
+    (2, 1500),
+    (1, 1500),
+    (3, 100),
+    (7, 40),
+  ] {
+    let pitch = coreml_f16_row_pitch(cols);
+    let copied = rows * cols;
+    let production: Vec<usize> = (0..rows)
+      .map(|row| copied.saturating_sub(row * pitch).min(cols))
+      .collect();
+    assert_eq!(
+      production,
+      kept_per_row(rows, cols),
+      "rows={rows} cols={cols}"
+    );
+  }
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn swift_parity_gather_truncates_final_alignment_row() {
+  // The behavioral consequence, end to end through `add_word_timestamps`:
+  // three gathered rows over 100 columns (pitch 128), so the copied prefix
+  // runs out 44 columns into row 2 and Swift reads zeros for columns 44..100
+  // of it.
+  //
+  // The weights are built so that row 2's ZEROED TAIL is what decides where
+  // the DTW path leaves row 1 -- and the row-1 -> row-2 boundary is the last
+  // text word's end, because the trailing timestamp token forms its own word
+  // group (`split_tokens_on_spaces` starts a new group at every special id)
+  // and `update_segments_with_word_timings` then drops it. Row 1 pays for
+  // every column past 79, so with row 2 blank the path stays in row 1 to
+  // column 79; with row 2's tail intact the +1.0 plateau from column 44 pulls
+  // the boundary back there instead.
+  let t = tiny_tokenizer();
+  let s = SpecialTokens::whisper_defaults();
+  let hello = t.encode(" Hello").unwrap()[0];
+  let world = t.encode(" world").unwrap()[0];
+  let tokens = vec![hello, world, s.time_token_begin() + 100];
+  let log_probs: Vec<(u32, f32)> = tokens.iter().map(|&token| (token, -0.2)).collect();
+  let mut segment = TranscriptionSegment::new();
+  segment
+    .set_tokens(tokens)
+    .set_token_log_probs(log_probs)
+    .set_start(0.0)
+    // Generously past every column time (99 * 0.02 = 1.98 s) so the segment
+    // keeps the last word's own end (`:642-649`'s else branch) instead of
+    // clamping it, which would hide the very difference under test.
+    .set_end(3.0);
+
+  let cols = 100usize;
+  let mut weights = vec![0.0f32; 3 * cols];
+  weights[0] = 3.0; // row 0: one spike, so the path enters row 1 immediately
+  for column in 0..cols {
+    weights[cols + column] = if column < 80 { 0.5 } else { -0.1 };
+    weights[2 * cols + column] = if column < 44 { 0.0 } else { 1.0 };
+  }
+  // The same matrix with Swift's truncation already applied by hand: row 2's
+  // columns 44..100 zeroed, nothing else.
+  let mut pre_truncated = weights.clone();
+  pre_truncated[2 * cols + 44..3 * cols].fill(0.0);
+
+  let last_word_end = |weights: &[f32], gather| {
+    let view = AlignmentView::new(weights, 3, cols);
+    let updated = add_word_timestamps(
+      std::slice::from_ref(&segment),
+      &view,
+      &t,
+      "en",
+      WordGrouping::FineGrained,
+      gather,
+      0,
+      PREPEND_PUNCTUATION,
+      APPEND_PUNCTUATION,
+      0.0,
+    )
+    .unwrap();
+    let words = updated[0].words_slice();
+    assert_eq!(
+      words.iter().map(WordTiming::word).collect::<Vec<_>>(),
+      vec![" Hello", " world"],
+      "the trailing timestamp token is dropped, so ` world` is the last word"
+    );
+    (words.last().unwrap().end(), updated[0].end())
+  };
+
+  let (complete_end, complete_segment_end) = last_word_end(&weights, AlignmentGather::Complete);
+  let (parity_end, parity_segment_end) = last_word_end(&weights, AlignmentGather::SwiftParity);
+  let (reference_end, _) = last_word_end(&pre_truncated, AlignmentGather::Complete);
+
+  assert_ne!(
+    complete_end, parity_end,
+    "the gather modes must disagree, or this fixture proves nothing"
+  );
+  // The boundary columns the fixture is built around, at 0.02 s per encoder
+  // frame: column 44, where row 2's surviving plateau starts, against column
+  // 79, row 1's last profitable column (the diagonal step into row 2 spends
+  // the 80th).
+  assert_eq!(
+    complete_end, 0.88,
+    "row 2's tail pulls the boundary to col 44"
+  );
+  assert_eq!(
+    parity_end, 1.58,
+    "with that tail zeroed, row 1 keeps the path to col 79"
+  );
+  assert_eq!(
+    parity_end, reference_end,
+    "SwiftParity over the full matrix == Complete over the hand-truncated one"
+  );
+  assert_ne!(
+    complete_end, reference_end,
+    "the hand truncation must actually move the boundary"
+  );
+  // The segment's end follows the last word's (`:642-649`), which is what
+  // reaches `seek = max(seek, lastSpeechTimestamp * sampleRate)`
+  // (`TranscribeTask.swift:221-223`) and cascades into the next window.
+  assert_eq!(complete_segment_end, complete_end);
+  assert_eq!(parity_segment_end, parity_end);
 }

--- a/crates/coremlit/src/audio/whisper/segment/tests.rs
+++ b/crates/coremlit/src/audio/whisper/segment/tests.rs
@@ -1328,6 +1328,13 @@ fn swift_parity_gather_truncates_final_alignment_row() {
   // exercises the real production path, so it has to be built on the same
   // number that path found.
   //
+  // This is ONE `add_word_timestamps` call: no pipeline, no seek, no second
+  // window, no cascade of any kind. It is therefore the tightest evidence
+  // that gather selection reaches word and segment timestamps WITHIN a single
+  // window, which is why `AlignmentGather::SwiftParity`'s "Short-form" section
+  // cites the 0.88/1.58 pair below as the bound on what the jfk/tiny golden
+  // establishes.
+  //
   // The weights are built so that row 2's ZEROED TAIL is what decides where
   // the DTW path leaves row 1 -- and the row-1 -> row-2 boundary is the last
   // text word's end, because the trailing timestamp token forms its own word

--- a/crates/coremlit/src/audio/whisper/segment/tests.rs
+++ b/crates/coremlit/src/audio/whisper/segment/tests.rs
@@ -1446,9 +1446,13 @@ fn swift_parity_gather_truncates_final_alignment_row() {
     complete_end, reference_end,
     "the hand truncation must actually move the boundary"
   );
-  // The segment's end follows the last word's (`:642-649`), which is what
-  // reaches `seek = max(seek, lastSpeechTimestamp * sampleRate)`
-  // (`TranscribeTask.swift:221-223`) and cascades into the next window.
+  // Here the segment's end follows the last word's -- `:642-649`'s else
+  // branch, which the generous 3.0 s segment end above selects. That end is
+  // what `seek = max(seek, lastSpeechTimestamp * sampleRate)`
+  // (`TranscribeTask.swift:221-223`) is taken from -- so a segment end that
+  // lands later than the standing seek can carry the next window with it, and
+  // one that does not is discarded by the `max`. Only the within-call equality
+  // is asserted here; nothing past this one call is.
   assert_eq!(complete_segment_end, complete_end);
   assert_eq!(parity_segment_end, parity_end);
 }

--- a/crates/coremlit/src/audio/whisper/segment/tests.rs
+++ b/crates/coremlit/src/audio/whisper/segment/tests.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use super::*;
 use crate::audio::whisper::{
   backend::AlignmentView,
-  constants::{APPEND_PUNCTUATION, PREPEND_PUNCTUATION},
+  constants::{APPEND_PUNCTUATION, MAX_TOKEN_CONTEXT, PREPEND_PUNCTUATION},
   options::DecodingOptions,
   result::{DecodingResult, WordTiming},
   tokenizer::{SpecialTokens, WhisperTokenizer},
@@ -670,10 +670,14 @@ fn empty_segments_returns_empty_without_consuming_alignment() {
 // re-anchoring.
 //
 // The four tests below predate the #41 gather split and their expectations
-// were written against the un-truncated gather, so they pass
-// `AlignmentGather::Complete` to keep their original intent; the pipeline
-// default (`SwiftParity`) is exercised by
-// `swift_parity_gather_truncates_final_alignment_row` below.
+// were written against the un-truncated gather, which is also the pipeline
+// DEFAULT, so they name `AlignmentGather::Complete` explicitly to say which
+// gather they mean rather than to opt out of one. The opt-in `SwiftParity` is
+// exercised by `swift_parity_gather_truncates_final_alignment_row` below.
+//
+// Every call also passes `MAX_TOKEN_CONTEXT` as Swift's physical source
+// height: inert under `Complete` (which probes nothing), load-bearing under
+// `SwiftParity` (see `gather_swift_parity_into`).
 
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
@@ -720,6 +724,7 @@ fn add_word_timestamps_attaches_merged_monotonic_words() {
     "en",
     WordGrouping::FineGrained,
     AlignmentGather::Complete,
+    MAX_TOKEN_CONTEXT,
     0,
     crate::audio::whisper::constants::PREPEND_PUNCTUATION,
     crate::audio::whisper::constants::APPEND_PUNCTUATION,
@@ -770,6 +775,7 @@ fn add_word_timestamps_zero_pads_missing_rows() {
     "en",
     WordGrouping::FineGrained,
     AlignmentGather::Complete,
+    MAX_TOKEN_CONTEXT,
     0,
     crate::audio::whisper::constants::PREPEND_PUNCTUATION,
     crate::audio::whisper::constants::APPEND_PUNCTUATION,
@@ -802,6 +808,7 @@ fn add_word_timestamps_errors_on_empty_segments() {
     "en",
     WordGrouping::FineGrained,
     AlignmentGather::Complete,
+    MAX_TOKEN_CONTEXT,
     0,
     crate::audio::whisper::constants::PREPEND_PUNCTUATION,
     crate::audio::whisper::constants::APPEND_PUNCTUATION,
@@ -831,6 +838,7 @@ fn add_word_timestamps_errors_on_zero_columns() {
     "en",
     WordGrouping::FineGrained,
     AlignmentGather::Complete,
+    MAX_TOKEN_CONTEXT,
     0,
     "",
     "",
@@ -858,69 +866,84 @@ fn add_word_timestamps_errors_on_zero_columns() {
 const PROBE_WIDTHS: [usize; 13] = [1, 3, 8, 9, 37, 63, 64, 100, 511, 1496, 1500, 1504, 4096];
 
 #[test]
-fn coreml_f16_row_pitch_is_measured_from_a_live_pixel_buffer_allocation() {
-  // THE property the whole Swift-parity gather rests on, and the one #41's
-  // first cut got wrong by promoting one host's 32-element alignment quantum
-  // into a `const fn`: the pitch is whatever THIS host's CoreVideo chose, read
-  // back off the same allocation Swift's gather makes -- never a compiled-in
-  // rule. Apple's QA1829 says the alignment is hardware-dependent and must be
-  // queried; `MultiArray::f16_surface`'s own doc says the same.
+fn coreml_f16_row_pitch_answers_with_a_usable_pitch_or_a_typed_refusal() {
+  // THE portable contract of the probe, and all of it: whatever this host's
+  // CoreVideo does, `coreml_f16_row_pitch` either returns a pitch the gather
+  // can actually reproduce (`>= cols`, matching the surface's own strides) or
+  // it REFUSES with one of the two typed errors. Both outcomes are legitimate
+  // -- a host with an allocation-dependent or otherwise undescribable layout
+  // is a supported host on which `AlignmentGather::SwiftParity` correctly
+  // declines, and `AlignmentGather::Complete` (the default) is unaffected
+  // either way.
   //
-  // Every assertion here compares the helper against a LIVE allocation, so it
-  // holds on any host. It deliberately does NOT assert that the pitch is
-  // independent of the row count: `add_word_timestamps` probes the source and
-  // destination shapes separately and reproduces the unequal case, so
-  // row-count invariance is a fact about this host (see
-  // `reference_host_pitch_table`) rather than something the gather needs.
+  // Round-3 finding #5: the previous version of this test hard-asserted host
+  // allocator behavior -- that two independent allocations of one shape pitch
+  // identically -- which turns a perfectly valid host into a red `cargo test`
+  // while production is behaving exactly as designed. That assertion now lives
+  // in the `#[ignore]`d allocator diagnostic below.
   for cols in PROBE_WIDTHS {
-    for rows in [1usize, 3, 120, 224] {
+    for rows in [1usize, 3, 120, 224, 225] {
+      match coreml_f16_row_pitch(rows, cols) {
+        Ok(pitch) => assert!(
+          pitch >= cols,
+          "rows={rows} cols={cols}: a row pitch below the logical width ({pitch}) would make \
+           the gather reproduction nonsense, and must have been refused instead"
+        ),
+        Err(
+          SegmentError::AlignmentPitchUnavailable {
+            rows: r, cols: c, ..
+          }
+          | SegmentError::AlignmentPitchUnexpectedLayout {
+            rows: r, cols: c, ..
+          },
+        ) => {
+          assert_eq!(
+            (r, c),
+            (rows, cols),
+            "the refusal must name the shape it refused"
+          );
+        }
+        Err(other) => panic!("rows={rows} cols={cols}: unexpected error {other}"),
+      }
+    }
+  }
+}
+
+#[test]
+#[ignore = "host allocator diagnostic: asserts this machine's CoreVideo answers one shape with \
+            one layout, which nothing in production requires (SwiftParity fails closed on a host \
+            that does otherwise, and Complete never asks)"]
+fn coreml_f16_row_pitch_reports_this_hosts_live_allocation_layout() {
+  // The stronger claims, kept as a DIAGNOSTIC rather than a gate (round-3
+  // finding #5). Each is a fact about this machine's allocator:
+  //
+  //   * the helper reports the surface's own strides rather than deriving a
+  //     number -- the property #41's first cut got wrong by promoting one
+  //     host's 32-element quantum into a `const fn`;
+  //   * two independently allocated surfaces of one shape agree, which is
+  //     assumption A1 of `AlignmentGather::SwiftParity` holding here.
+  //
+  // Neither is a CoreVideo guarantee (QA1829 requires the alignment to be
+  // queried per buffer), so neither belongs in a portable test. It deliberately
+  // does NOT assert that the pitch is independent of the ROW COUNT:
+  // `gather_swift_parity_into` probes the source and destination heights
+  // separately and reproduces the unequal case, so row-count invariance is a
+  // fact about this host (see `reference_host_pitch_table`) rather than
+  // something the gather needs.
+  for cols in PROBE_WIDTHS {
+    for rows in [1usize, 3, 120, 224, 225] {
       let pitch = coreml_f16_row_pitch(rows, cols).unwrap();
-      // Same shape, allocated independently of the production helper: the
-      // helper must be reporting CoreVideo's answer, not deriving one.
       let independent = MultiArray::f16_surface(&[rows, cols]).unwrap();
       assert_eq!(
         independent.strides(),
         [pitch, 1],
         "rows={rows} cols={cols}: the helper must return the surface's own strides"
       );
-      assert!(
-        pitch >= cols,
-        "rows={rows} cols={cols}: a row pitch below the logical width ({pitch}) would make \
-         the gather reproduction nonsense"
-      );
-      // Repeat allocations of one shape must agree, or no single measurement
-      // could describe the surface Swift's gather allocates.
       assert_eq!(
         pitch,
         coreml_f16_row_pitch(rows, cols).unwrap(),
-        "rows={rows} cols={cols}: the pitch moved between two allocations of the same shape"
-      );
-    }
-  }
-}
-
-#[test]
-fn coreml_f16_gather_destination_probe_reports_a_clean_tail_on_this_host() {
-  // Finding #2 of the round-2 review: `SwiftParity` feeds DTW zeros for the
-  // storage past the gather's copied prefix, which Swift reads and nobody
-  // writes. That is now VERIFIED per call rather than assumed --
-  // `MultiArray::f16_surface_probing_fresh_tail` looks at a real allocation
-  // before anything touches it -- and this pins that the verification passes
-  // here, i.e. that `AlignmentGather::SwiftParity` is actually usable on this
-  // host.
-  //
-  // Unlike the recorded pitch table, a failure here is NOT cosmetic: the
-  // shipping gather takes the identical probe and returns
-  // `AlignmentGatherTailNotZero`, so a host that fails this test is a host
-  // where the default gather refuses to run. That is exactly what the test
-  // should report.
-  for cols in PROBE_WIDTHS {
-    for rows in [1usize, 3, 120, 224] {
-      assert_eq!(
-        coreml_f16_gather_destination_pitch(rows, cols).unwrap(),
-        coreml_f16_row_pitch(rows, cols).unwrap(),
-        "rows={rows} cols={cols}: the destination probe must report the same pitch as the plain \
-         one, and must not have found a dirty tail"
+        "rows={rows} cols={cols}: the pitch moved between two allocations of the same shape, so \
+         assumption A1 of `AlignmentGather::SwiftParity` does not hold here"
       );
     }
   }
@@ -1166,6 +1189,72 @@ fn swift_gather_reads_the_sources_padding_as_zero() {
   );
 }
 
+#[test]
+fn swift_parity_probes_swifts_source_height_not_this_ports_commit_headroom() {
+  // Round-3 finding #2. `alignment.rows()` is `max_token_context + 1` = 225:
+  // this port commits step `position`'s row at `position + 1`, so it carries
+  // one slot of headroom Swift does not. Swift allocates `alignmentWeights` at
+  // the KV dimension ITSELF (`TextDecoder.swift:141`) -- 224 rows. The pitch is
+  // a function of the shape CoreVideo is handed, and this whole branch exists
+  // because it may vary with height, so probing `[225, cols]` would decode
+  // Swift's storage offsets with a pitch Swift's array never had and splice the
+  // wrong cells into DTW while still reporting parity.
+  //
+  // No host this port has measured pitches the two heights differently, so the
+  // layout is INJECTED -- which is exactly why `gather_swift_parity_into` takes
+  // its probe as a parameter. The point is not the numbers; it is WHICH HEIGHT
+  // the code asks CoreVideo about.
+  const COLS: usize = 8;
+  const SWIFT_ROWS: usize = MAX_TOKEN_CONTEXT; // 224 -- Swift's physical array
+  const VIEW_ROWS: usize = SWIFT_ROWS + 1; // 225 -- this port's accumulator
+  const NEEDED: usize = 5;
+
+  // A host that pads the 225-row surface and leaves every other height
+  // unpadded, so the two heights cannot produce the same gather.
+  let asked = std::cell::RefCell::new(Vec::new());
+  let injected = |rows: usize, cols: usize| -> Result<usize, SegmentError> {
+    asked.borrow_mut().push((rows, cols));
+    Ok(if rows == VIEW_ROWS { cols * 2 } else { cols })
+  };
+
+  let source: Vec<f32> = (0..VIEW_ROWS * COLS).map(|i| i as f32 + 1.0).collect();
+  let view = AlignmentView::new(&source, VIEW_ROWS, COLS);
+  let mut data = vec![0.0f32; NEEDED * COLS];
+  gather_swift_parity_into(&mut data, &view, NEEDED, COLS, SWIFT_ROWS, &injected).unwrap();
+
+  // (1) THE assertion: the source probe named Swift's height, never the port's.
+  let asked_shapes: Vec<(usize, usize)> = asked.borrow().clone();
+  assert!(
+    asked_shapes.contains(&(SWIFT_ROWS, COLS)),
+    "the source probe must ask CoreVideo about Swift's own {SWIFT_ROWS}-row array; asked \
+     {asked_shapes:?}"
+  );
+  assert!(
+    !asked_shapes.contains(&(VIEW_ROWS, COLS)),
+    "the source probe must NOT ask about this port's {VIEW_ROWS}-row commit accumulator; asked \
+     {asked_shapes:?}"
+  );
+  assert!(
+    asked_shapes.contains(&(NEEDED, COLS)),
+    "and the destination probe must ask about the per-call `[needed, cols]` surface; asked \
+     {asked_shapes:?}"
+  );
+
+  // (2) the gathered matrix is the one Swift's 224-row layout produces ...
+  let at_swift_height = replay_swift_gather(&source, SWIFT_ROWS, NEEDED, COLS, COLS, COLS);
+  assert_eq!(
+    data, at_swift_height,
+    "the reproduction must decode Swift's storage at Swift's own source pitch"
+  );
+  // (3) ... and the injected layout genuinely discriminates, so (2) is not
+  // passing vacuously: at the port's height the same gather is another matrix.
+  let at_port_height = replay_swift_gather(&source, SWIFT_ROWS, NEEDED, COLS, COLS * 2, COLS);
+  assert_ne!(
+    at_swift_height, at_port_height,
+    "the fixture proves nothing unless the two heights disagree"
+  );
+}
+
 /// The layout `crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.out`
 /// captured from Swift on the whisper #41 reference host (M1 Max / macOS
 /// 26.5): `MLMultiArray.strides[0]` for pixel-buffer-backed Float16 arrays,
@@ -1191,12 +1280,14 @@ const RECORDED_REFERENCE_HOST_PITCH: [(usize, usize); 6] = [
 fn reference_host_pitch_table() {
   // Deliberately NOT an ordinary test. It compares this machine against ONE
   // recorded machine, so a different-but-perfectly-supported host fails it
-  // while the shipping gather -- which measures rather than assumes, and now
-  // reproduces unequal source/destination pitches too -- keeps working. An
+  // while the OPT-IN gather -- which measures rather than assumes, and
+  // reproduces unequal source/destination pitches too -- keeps working, and
+  // the DEFAULT gather never consults any of it. An
   // unignored version of this was a red CI on valid hardware whose own
   // diagnostic said the gather was unaffected; the portable replacements are
-  // `coreml_f16_row_pitch_is_measured_from_a_live_pixel_buffer_allocation`
-  // (live allocations only) and the injected-pitch reproduction tests.
+  // `coreml_f16_row_pitch_answers_with_a_usable_pitch_or_a_typed_refusal`
+  // (which accepts the typed refusals as legitimate host outcomes) and the
+  // injected-layout reproduction tests.
   //
   // Run it when re-capturing `probe_alignment_stride.out`, or to explain why
   // a model-gated gather fixture's hand-computed columns no longer line up.
@@ -1299,6 +1390,7 @@ fn swift_parity_gather_truncates_final_alignment_row() {
       "en",
       WordGrouping::FineGrained,
       gather,
+      MAX_TOKEN_CONTEXT,
       0,
       PREPEND_PUNCTUATION,
       APPEND_PUNCTUATION,

--- a/crates/coremlit/src/audio/whisper/segment/tests.rs
+++ b/crates/coremlit/src/audio/whisper/segment/tests.rs
@@ -851,30 +851,46 @@ fn add_word_timestamps_errors_on_zero_columns() {
 // stride-aware flat subscript (`:217`), so the final gathered row loses its
 // tail.
 
+/// Widths worth probing: the shipping `n_audio_ctx` and its neighbours, the
+/// small `n_audio_ctx` the mock backend uses, and widths the recorded Swift
+/// probe never covered (3, 37, 63, 64, 511, 4096) -- the point of a runtime
+/// query is that it answers for widths nobody wrote down.
+const PROBE_WIDTHS: [usize; 13] = [1, 3, 8, 9, 37, 63, 64, 100, 511, 1496, 1500, 1504, 4096];
+
 #[test]
-fn coreml_f16_row_pitch_matches_the_probed_core_video_padding() {
-  // Pinned against the Swift capture in
-  // `crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.out`
-  // (`MLMultiArray.strides[0]` of the pixel-buffer-backed Float16 arrays):
-  // rows align to 64 bytes, i.e. 32 Float16 elements.
-  for (cols, pitch) in [
-    (8, 32),
-    (9, 32),
-    (100, 128),
-    (1496, 1504),
-    (1500, 1504),
-    (1504, 1504),
-  ] {
-    assert_eq!(
-      coreml_f16_row_pitch(cols),
-      pitch,
-      "probed pitch for cols={cols}"
-    );
+fn coreml_f16_row_pitch_is_measured_from_a_live_pixel_buffer_allocation() {
+  // THE property the whole Swift-parity gather rests on, and the one #41's
+  // first cut got wrong by promoting one host's 32-element alignment quantum
+  // into a `const fn`: the pitch is whatever THIS host's CoreVideo chose, read
+  // back off the same allocation Swift's gather makes -- never a compiled-in
+  // rule. Apple's QA1829 says the alignment is hardware-dependent and must be
+  // queried; `MultiArray::f16_surface`'s own doc says the same.
+  for cols in PROBE_WIDTHS {
+    for rows in [1usize, 3, 120, 224] {
+      let pitch = coreml_f16_row_pitch(rows, cols).unwrap();
+      // Same shape, allocated independently of the production helper: the
+      // helper must be reporting CoreVideo's answer, not deriving one.
+      let independent = MultiArray::f16_surface(&[rows, cols]).unwrap();
+      assert_eq!(
+        independent.strides(),
+        [pitch, 1],
+        "rows={rows} cols={cols}: the helper must return the surface's own strides"
+      );
+      assert!(
+        pitch >= cols,
+        "rows={rows} cols={cols}: a row pitch below the logical width ({pitch}) would make \
+         the gather truncation nonsense"
+      );
+      // The helper probes with the gather's exact `[rows, cols]` shape, so it
+      // does not need this -- but the doc claims the pitch is a function of
+      // the width alone, and an unchecked claim in a doc is how #41 started.
+      assert_eq!(
+        pitch,
+        coreml_f16_row_pitch(1, cols).unwrap(),
+        "rows={rows} cols={cols}: pitch must not depend on the row count"
+      );
+    }
   }
-  // The quantum has to come from the probe, not from the shipping shape: an
-  // 8-element quantum agrees at cols=1500 and disagrees at cols=100.
-  assert_eq!(1500_usize.div_ceil(8) * 8, coreml_f16_row_pitch(1500));
-  assert_ne!(100_usize.div_ceil(8) * 8, coreml_f16_row_pitch(100));
 }
 
 #[test]
@@ -887,8 +903,11 @@ fn swift_gather_keeps_only_the_final_rows_prefix() {
   /// survived. `NAN` stands for the storage neither the memcpy nor the
   /// `initialValue: FloatType(0)` fill ever writes -- the bytes that read
   /// back as zero in practice.
-  fn kept_per_row(rows: usize, cols: usize) -> Vec<usize> {
-    let pitch = coreml_f16_row_pitch(cols);
+  ///
+  /// `pitch` is a parameter, not a lookup: the arithmetic must be right for
+  /// ANY row padding a host might choose, so the worked examples below drive
+  /// it explicitly instead of asking the machine the test happens to run on.
+  fn kept_per_row(rows: usize, cols: usize, pitch: usize) -> Vec<usize> {
     let mut storage = vec![f32::NAN; rows * pitch];
     storage[..rows * cols].fill(1.0);
     (0..rows)
@@ -901,9 +920,11 @@ fn swift_gather_keeps_only_the_final_rows_prefix() {
       .collect()
   }
 
-  // The shipping shape, and the probe's own worked example ("logical row 119
-  // reads 476 element(s) past the copied prefix (kept columns = 1024)").
-  let kept = kept_per_row(120, 1500);
+  // The shipping shape at the pitch the Swift probe recorded on the reference
+  // host (`crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.out`:
+  // 1500 -> 1504), and that probe's own worked example -- "logical row 119
+  // reads 476 element(s) past the copied prefix (kept columns = 1024)".
+  let kept = kept_per_row(120, 1500, 1504);
   assert_eq!(kept[119], 1024, "the final row keeps 1024 of 1500 columns");
   assert_eq!(1500 - kept[119], 476, "and reads 476 zeros after them");
   assert!(
@@ -911,35 +932,79 @@ fn swift_gather_keeps_only_the_final_rows_prefix() {
     "no row but the last is touched"
   );
 
-  assert_eq!(*kept_per_row(31, 1500).last().unwrap(), 1380);
-  assert_eq!(*kept_per_row(2, 1500).last().unwrap(), 1496);
+  assert_eq!(*kept_per_row(31, 1500, 1504).last().unwrap(), 1380);
+  assert_eq!(*kept_per_row(2, 1500, 1504).last().unwrap(), 1496);
   assert_eq!(
-    kept_per_row(1, 1500),
+    kept_per_row(1, 1500, 1504),
     vec![1500],
     "a lone row is never truncated: it starts at storage 0"
   );
+  // An unpadded host is not a special case to guard, it is the identity: with
+  // pitch == cols the two errors cancel everywhere and Swift's gather loses
+  // nothing, so `SwiftParity` and `Complete` coincide there.
+  assert_eq!(kept_per_row(120, 1500, 1500), vec![1500; 120]);
 
-  // The production arithmetic reproduces the replay shape for shape --
-  // including shapes where more than one row is truncated, which is why
-  // `add_word_timestamps` runs the general per-row form rather than special-
-  // casing the last row.
-  for (rows, cols) in [
-    (120, 1500),
-    (31, 1500),
-    (2, 1500),
-    (1, 1500),
-    (3, 100),
-    (7, 40),
+  // The production truncation reproduces the replay for every shape AND every
+  // pitch -- including shapes where more than one row is truncated, which is
+  // why `add_word_timestamps` runs the general per-row form rather than
+  // special-casing the last row.
+  for (rows, cols, pitch) in [
+    (120, 1500, 1504),
+    (31, 1500, 1504),
+    (2, 1500, 1504),
+    (1, 1500, 1504),
+    (3, 100, 128),
+    (7, 40, 64),
+    // Hypothetical hosts: a bigger quantum truncates a run of rows, and no
+    // padding at all truncates none.
+    (120, 1500, 1536),
+    (120, 1500, 2048),
+    (7, 40, 40),
   ] {
-    let pitch = coreml_f16_row_pitch(cols);
-    let copied = rows * cols;
-    let production: Vec<usize> = (0..rows)
-      .map(|row| copied.saturating_sub(row * pitch).min(cols))
-      .collect();
+    // Whole-buffer equality, not a per-row kept count: it pins that the tails
+    // are zeroed AND that nothing before them was touched.
+    let mut expected_data = vec![0.0f32; rows * cols];
+    for (row, &kept) in kept_per_row(rows, cols, pitch).iter().enumerate() {
+      expected_data[row * cols..row * cols + kept].fill(1.0);
+    }
+    let mut data = vec![1.0f32; rows * cols];
+    truncate_gathered_rows(&mut data, rows, cols, pitch);
+    assert_eq!(data, expected_data, "rows={rows} cols={cols} pitch={pitch}");
+  }
+}
+
+/// The layout `crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.out`
+/// captured from Swift on the whisper #41 reference host (M1 Max / macOS
+/// 26.5): `MLMultiArray.strides[0]` for pixel-buffer-backed Float16 arrays,
+/// i.e. rows aligned to 64 bytes = 32 Float16 elements.
+///
+/// **Evidence about a host, not a rule about CoreVideo.** No production path
+/// consults it: `coreml_f16_row_pitch` measures the running host. It lives
+/// here so the two fixtures that hand-compute DTW paths around a specific
+/// truncation point -- `swift_parity_gather_truncates_final_alignment_row`
+/// here and `swift_parity_gather_moves_the_next_window_seek` in
+/// `transcribe::tests` -- have ONE diagnosable place to fail if this host
+/// pads differently, instead of failing later as unexplained word timings.
+const RECORDED_REFERENCE_HOST_PITCH: [(usize, usize); 6] = [
+  (8, 32),
+  (9, 32),
+  (100, 128),
+  (1496, 1504),
+  (1500, 1504),
+  (1504, 1504),
+];
+
+#[test]
+fn the_recorded_swift_probe_still_describes_this_host() {
+  for (cols, recorded) in RECORDED_REFERENCE_HOST_PITCH {
     assert_eq!(
-      production,
-      kept_per_row(rows, cols),
-      "rows={rows} cols={cols}"
+      coreml_f16_row_pitch(224, cols).unwrap(),
+      recorded,
+      "cols={cols}: this host's CoreVideo Float16 row pitch differs from the reference host \
+       the whisper #41 probe and long-form parity numbers were captured on. The shipping \
+       gather is UNAFFECTED -- it measures this host rather than assuming a quantum -- but \
+       the hand-computed columns in the gather fixtures, and the recorded 1417 s/1042 s \
+       parity results, describe the reference layout only"
     );
   }
 }
@@ -948,18 +1013,21 @@ fn swift_gather_keeps_only_the_final_rows_prefix() {
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn swift_parity_gather_truncates_final_alignment_row() {
   // The behavioral consequence, end to end through `add_word_timestamps`:
-  // three gathered rows over 100 columns (pitch 128), so the copied prefix
-  // runs out 44 columns into row 2 and Swift reads zeros for columns 44..100
-  // of it.
+  // three gathered rows over 100 columns, so the copied prefix runs out
+  // `truncated_at` columns into row 2 and Swift reads zeros for the rest of
+  // it. `truncated_at` is DERIVED from the pitch the gather measures on this
+  // host (44 at the reference host's 128), not written in -- the fixture
+  // exercises the real production path, so it has to be built on the same
+  // number that path found.
   //
   // The weights are built so that row 2's ZEROED TAIL is what decides where
   // the DTW path leaves row 1 -- and the row-1 -> row-2 boundary is the last
   // text word's end, because the trailing timestamp token forms its own word
   // group (`split_tokens_on_spaces` starts a new group at every special id)
   // and `update_segments_with_word_timings` then drops it. Row 1 pays for
-  // every column past 79, so with row 2 blank the path stays in row 1 to
-  // column 79; with row 2's tail intact the +1.0 plateau from column 44 pulls
-  // the boundary back there instead.
+  // every column past `truncated_at + 35`, so with row 2 blank the path stays
+  // in row 1 to that column; with row 2's tail intact the +1.0 plateau from
+  // `truncated_at` pulls the boundary back there instead.
   let t = tiny_tokenizer();
   let s = SpecialTokens::whisper_defaults();
   let hello = t.encode(" Hello").unwrap()[0];
@@ -977,16 +1045,30 @@ fn swift_parity_gather_truncates_final_alignment_row() {
     .set_end(3.0);
 
   let cols = 100usize;
-  let mut weights = vec![0.0f32; 3 * cols];
+  let rows = 3usize;
+  // Where this host's gather actually stops copying, from the same helper
+  // `add_word_timestamps` uses.
+  let pitch = coreml_f16_row_pitch(rows, cols).unwrap();
+  let truncated_at = (rows * cols).saturating_sub((rows - 1) * pitch).min(cols);
+  assert_eq!(
+    truncated_at, 44,
+    "at the reference host's pitch of 128 the final row keeps 44 of {cols} columns; this host \
+     measured a pitch of {pitch}, so the plateau/cutoff columns below no longer straddle the \
+     truncation and this fixture would not discriminate (see \
+     `the_recorded_swift_probe_still_describes_this_host`)"
+  );
+  let row_one_cutoff = truncated_at + 36;
+
+  let mut weights = vec![0.0f32; rows * cols];
   weights[0] = 3.0; // row 0: one spike, so the path enters row 1 immediately
   for column in 0..cols {
-    weights[cols + column] = if column < 80 { 0.5 } else { -0.1 };
-    weights[2 * cols + column] = if column < 44 { 0.0 } else { 1.0 };
+    weights[cols + column] = if column < row_one_cutoff { 0.5 } else { -0.1 };
+    weights[2 * cols + column] = if column < truncated_at { 0.0 } else { 1.0 };
   }
   // The same matrix with Swift's truncation already applied by hand: row 2's
-  // columns 44..100 zeroed, nothing else.
+  // columns `truncated_at..cols` zeroed, nothing else.
   let mut pre_truncated = weights.clone();
-  pre_truncated[2 * cols + 44..3 * cols].fill(0.0);
+  pre_truncated[2 * cols + truncated_at..rows * cols].fill(0.0);
 
   let last_word_end = |weights: &[f32], gather| {
     let view = AlignmentView::new(weights, 3, cols);
@@ -1021,16 +1103,21 @@ fn swift_parity_gather_truncates_final_alignment_row() {
     "the gather modes must disagree, or this fixture proves nothing"
   );
   // The boundary columns the fixture is built around, at 0.02 s per encoder
-  // frame: column 44, where row 2's surviving plateau starts, against column
-  // 79, row 1's last profitable column (the diagonal step into row 2 spends
-  // the 80th).
+  // frame: `truncated_at` (44 here), where row 2's surviving plateau starts,
+  // against `row_one_cutoff - 1` (79), row 1's last profitable column (the
+  // diagonal step into row 2 spends the cutoff column itself).
+  // (Literal, not `truncated_at as f32 * 0.02`: `truncated_at == 44` is
+  // already asserted above, and `SECONDS_PER_TIME_TOKEN` arithmetic in f32
+  // would be comparing a re-derivation of the code under test.)
   assert_eq!(
     complete_end, 0.88,
-    "row 2's tail pulls the boundary to col 44"
+    "row 2's tail pulls the boundary to col {truncated_at}"
   );
   assert_eq!(
-    parity_end, 1.58,
-    "with that tail zeroed, row 1 keeps the path to col 79"
+    parity_end,
+    1.58,
+    "with that tail zeroed, row 1 keeps the path to col {}",
+    row_one_cutoff - 1
   );
   assert_eq!(
     parity_end, reference_end,

--- a/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
+++ b/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
@@ -272,28 +272,90 @@ fn is_single_punctuation_scalar(s: &str) -> bool {
 /// The number rule reaches floats too — not because floats are coerced
 /// (`Config.Data.boolean()` has no `.floating` case at all) but because
 /// `Config`'s decoder tries `Int` *before* `Float` (`Config.swift:657-666`), so
-/// a JSON number whose exact value is an integer `Int` can hold becomes
-/// `.integer` however it was spelled. `1.0` and `1e0` are therefore `true`, and
-/// `0.0`, `-0.0` and `1.5e1` are `false`, while `0.5` (a real fraction) and
-/// `1e19` (past `Int64`) stay `.floating` and yield no value. That ordering was
-/// read off the pinned oracle's own `JSONDecoder` behavior rather than inferred
-/// from the enum, which shows only the second half of it.
+/// a JSON number an `Int` can hold generally becomes `.integer` however it was
+/// spelled. `1.0` and `1e0` are therefore `true`, and `0.0`, `-0.0` and `1.5e1`
+/// are `false`, while `0.5` (a real fraction) and `1e19` (past `Int64`) stay
+/// `.floating` and yield no value. That ordering was read off the pinned
+/// oracle's own `JSONDecoder` behavior rather than inferred from the enum,
+/// which shows only the second half of it.
+///
+/// # Where this stops matching Swift
+///
+/// "However it was spelled" is *not* exact, and the gap is stated here rather
+/// than papered over. `serde_json` keeps a number's spelling only while it fits
+/// `i64`/`u64`; give it a fraction or an exponent and all that survives is an
+/// `f64`, whereas the oracle's decoder reads the digits. The two agree on every
+/// literal an `f64` carries faithfully — which is every value a real
+/// `tokenizer_config.json` holds, `true` and `false` included — and can part
+/// company on one carrying more precision than an `f64` has. What follows is
+/// measured against the pinned oracle rather than predicted, and pinned by
+/// `config_boolean_matches_swift_except_where_the_f64_lost_the_literal`.
+///
+/// **One `f64`, two oracle answers.** Three spellings arrive here as the
+/// identical `f64` `-2^63`:
+///
+/// | JSON scalar              | oracle      | oracle's `boolean()` | this fn      |
+/// |--------------------------|-------------|----------------------|--------------|
+/// | `-9223372036854775808`   | `.integer`  | `Some(false)`        | `Some(false)`|
+/// | `-9223372036854775808.0` | `.floating` | `None`               | `None`       |
+/// | `-9223372036854775809`   | `.floating` | `None`               | `None`       |
+/// | `-9223372036854775807.0` | `.integer`  | `Some(false)`        | **`None`**   |
+///
+/// Rows two to four are one `f64` and two oracle answers, so no rule reading
+/// that `f64` can serve both — the choice is which side to be right on. This
+/// arm decides only where the `f64` settles the question by itself and declines
+/// at `-2^63` exactly, which makes the first three rows exact, row one included
+/// because `serde_json` still holds its bare spelling as an `i64`. Row four is
+/// the residue: a fraction- or exponent-spelled literal whose exact value lies
+/// in `-9223372036854775807 ..= -9223372036854775296`, the 512 integers that
+/// round to `-2^63` from above. The oracle calls those `.integer`, so cleanup
+/// ends up *disabled* there and *enabled* here. The positive edge needs no such
+/// concession: the oracle's own cutoff is `9223372036854775296`, the first
+/// value that rounds up to the `f64` `2^63`, exactly where the upper bound
+/// below already sits.
+///
+/// **Fractions past the precision an `f64` carries.** The same one-eyed view
+/// shows up wherever a literal's digits outrun its `f64`, and the differences
+/// do not all run the same way. Two measured representatives, both pinned:
+/// `1844674407370955162.5` is `.floating` to the oracle (its integer path
+/// gives up just past `1844674407370955161.5`, which is `.integer`) but rounds
+/// to a whole `f64` and is taken here, so cleanup ends up *enabled* in Swift
+/// and *disabled* here — the reverse of the table above. And
+/// `0.9999999999999999` rounds all the way up to the `f64` `1.0`, so this
+/// answers `Some(true)` where the oracle, still seeing a fraction, answers
+/// nothing — which happens to resolve to the same flag, `or: true` being
+/// `true`.
+///
+/// So the honest boundary is not a range but a property: this matches the
+/// oracle wherever the `f64` is faithful to the literal. Beyond that, the list
+/// of representatives above is measured, not exhaustive. In every case
+/// measured, a divergence trades a definite answer for a default rather than
+/// inverting `true` and `false`. Closing any of it would mean keeping the
+/// lexeme — `serde_json`'s `arbitrary_precision`, which changes `Number`'s
+/// representation for every crate in the graph — and then reproducing an
+/// undocumented `JSONDecoder` numeric path exactly. For a config key whose
+/// real-world values are `true` and `false`, that trade is not worth taking.
 fn config_boolean(value: &serde_json::Value) -> Option<bool> {
   match value {
     serde_json::Value::Bool(b) => Some(*b),
     serde_json::Value::Number(n) => match n.as_i64() {
       Some(int) => Some(int == 1),
-      // Written with a fraction or an exponent: `serde_json` keeps the number
-      // a float where Swift's `Int`-first decode does not, so ask the same
-      // question that decode asks — is the exact value an integer `Int` can
-      // hold? If so it is `.integer` in Swift and `== 1` decides; if not it is
-      // `.floating`, which coerces to nothing.
+      // Written with a fraction or an exponent (or past `i64`): the spelling is
+      // gone and only an `f64` is left, so ask the question the `f64` can still
+      // answer — is it an integer strictly inside `Int`'s range? Inside, that
+      // agrees with Swift's `Int`-first decode and `== 1` decides; outside, the
+      // decode's `Int` attempt fails there too and `.floating` coerces to
+      // nothing. `2^63` is excluded because it is past `Int.max`; `-2^63` is
+      // excluded because it is the one `f64` two different Swift answers share,
+      // so declining is the only way to be right about the rest of its cell.
+      // See this function's doc for exactly what that costs and what else the
+      // lost spelling costs.
       None => {
         const INT_MIN: f64 = -9_223_372_036_854_775_808.0; // -2^63
-        const PAST_INT_MAX: f64 = 9_223_372_036_854_775_808.0; // 2^63, exclusive
+        const PAST_INT_MAX: f64 = 9_223_372_036_854_775_808.0; // 2^63
 
         let float = n.as_f64()?;
-        ((INT_MIN..PAST_INT_MAX).contains(&float) && float.fract() == 0.0).then_some(float == 1.0)
+        (float > INT_MIN && float < PAST_INT_MAX && float.fract() == 0.0).then_some(float == 1.0)
       }
     },
     // Swift lowercases (`Config.swift:160`) before matching; `str::to_lowercase`

--- a/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
+++ b/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
@@ -9,7 +9,9 @@
 //! ModelUtilities.swift:16-71`) are out of scope here, matching this
 //! crate's existing "folders are always local" scoping (see
 //! `options::Options`'s doc): [`WhisperTokenizer::from_folder`] only ever
-//! looks for `tokenizer.json` directly inside the given folder.
+//! looks directly inside the given folder, at `tokenizer.json` (required)
+//! and `tokenizer_config.json` (optional — read for one flag, see
+//! `clean_up_tokenization_spaces_from`).
 
 use std::path::Path;
 
@@ -251,6 +253,96 @@ fn is_single_punctuation_scalar(s: &str) -> bool {
   }
 }
 
+/// Resolves Swift's `cleanUpTokenizationSpaces` flag (`Tokenizer.swift:407`)
+/// for a tokenizer folder: `tokenizer_config.json`'s
+/// `clean_up_tokenization_spaces`, defaulting to `true`.
+///
+/// Swift spells that `tokenizerConfig.cleanUpTokenizationSpaces.boolean(or:
+/// true)` — a `Config` lookup that yields `true` for a missing key and for a
+/// present-but-non-boolean value alike. This reproduces both, and extends the
+/// same leniency one step further, to a missing or unparseable file. Swift
+/// cannot reach that case (its `AutoTokenizer` fails the whole load if
+/// `tokenizer_config.json` is not readable JSON), but this crate's
+/// [`WhisperTokenizer::from_folder`] requires only `tokenizer.json` — a
+/// contract predating this flag, and not worth narrowing over one boolean
+/// whose default is what every OpenAI Whisper checkpoint ships anyway
+/// (verified: `whisper-tiny` and `whisper-small` both set it to `true`
+/// explicitly). A corrupt sibling file therefore degrades to Swift's own
+/// default rather than failing a `tokenizer.json` that is perfectly good.
+fn clean_up_tokenization_spaces_from(folder: &Path) -> bool {
+  std::fs::read(folder.join("tokenizer_config.json"))
+    .ok()
+    .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+    .as_ref()
+    .and_then(|config| config.get("clean_up_tokenization_spaces"))
+    .and_then(serde_json::Value::as_bool)
+    .unwrap_or(true)
+}
+
+/// Applies Swift's `Tokenizer.cleanUp` (`Tokenizer.swift:434-449`) — the
+/// HuggingFace `clean_up_tokenization_spaces` layer, which the `tokenizers`
+/// crate has no equivalent of — to an already-joined decode.
+///
+/// Swift's rule set is exactly ten literal (non-regex), non-overlapping,
+/// left-to-right replacements, run as a chain so each one sees the previous
+/// one's output. The chain below is those ten transcribed from
+/// `Tokenizer.swift:439-448` in Swift's order, and is the only copy of the
+/// list — `swift_clean_up_reference` in this module's tests transcribes it a
+/// second time, unguarded, so the two cannot drift silently apart.
+///
+/// That order is load-bearing and is Swift's, not a re-derivation. The
+/// witness is `" ' ,"`: `" ,"` runs first and consumes the comma's space,
+/// leaving `" ',"`, where running `" ' "` first would have consumed both
+/// spaces and left `"',"`. More generally, each rule deletes a space and so
+/// brings its neighbours together, which can expose a match for a later one.
+///
+/// These ten are also exactly HuggingFace's own
+/// `PreTrainedTokenizerBase.clean_up_tokenization` set, so nothing had to be
+/// dropped to match Swift. Nothing is added either — in particular, Swift's
+/// *other* cleanup, `WordPieceDecoder.cleanUpTokenization`
+/// (`Decoder.swift:104-108`), is deliberately NOT ported: it is a different
+/// rule set (regex-driven, and with an extra `" do not"` -> `" don't"`
+/// rule), it is gated on its own `cleanup` config flag, and it belongs to
+/// the WordPiece decoder, which a Whisper `tokenizer.json` never
+/// instantiates — its `decoder` is `ByteLevel` (verified on the
+/// `whisper-tiny` and `whisper-small` fixtures). Applying it here would
+/// close this divergence by opening a new one.
+///
+/// `str::replace` matches Swift's `String.replacingOccurrences(of:with:)`
+/// with no options: literal, non-overlapping, left-to-right. Every search
+/// string here is pure ASCII, so Swift's canonical-equivalence-aware string
+/// comparison cannot differ from Rust's byte comparison on them.
+///
+/// The leading scan is a pure short-circuit, not a behavioral rule: every one
+/// of the ten patterns starts with a space followed by one of `.?!,'n`, so a
+/// text with no such pair cannot match the first rule — and, being therefore
+/// unchanged, cannot match the second, and so on down the chain. Replacements
+/// only ever *delete* the leading space of a match and never insert one, so
+/// the chain cannot manufacture a pair that the original text lacked. When
+/// the scan finds nothing, the backend's `String` is handed back untouched
+/// rather than rebuilt ten times — which matters because
+/// [`WhisperTokenizer::split_tokens_on_unicode`] decodes once per token.
+fn clean_up_tokenization(text: String) -> String {
+  let can_match = text
+    .as_bytes()
+    .windows(2)
+    .any(|pair| pair[0] == b' ' && matches!(pair[1], b'.' | b'?' | b'!' | b',' | b'\'' | b'n'));
+  if !can_match {
+    return text;
+  }
+  text
+    .replace(" .", ".")
+    .replace(" ?", "?")
+    .replace(" !", "!")
+    .replace(" ,", ",")
+    .replace(" ' ", "'")
+    .replace(" n't", "n't")
+    .replace(" 'm", "'m")
+    .replace(" 's", "'s")
+    .replace(" 've", "'ve")
+    .replace(" 're", "'re")
+}
+
 /// Whisper BPE tokenizer facade: raw encode/decode, the resolved
 /// special-token table, per-language token ids, and the word-split
 /// heuristics used to align decoder token output to words. Ports Swift's
@@ -259,6 +351,10 @@ fn is_single_punctuation_scalar(s: &str) -> bool {
 pub struct WhisperTokenizer {
   tokenizer: tokenizers::Tokenizer,
   special_tokens: SpecialTokens,
+  // Swift's `Tokenizer.cleanUpTokenizationSpaces` (`Tokenizer.swift:356`,
+  // resolved at `:407`), read once at load: see
+  // `clean_up_tokenization_spaces_from` and [`Self::decode`].
+  clean_up_tokenization_spaces: bool,
   // `language_table` is the source of truth, probed once at load
   // (`Models.swift:1219-1223`); `language_ids` is a cached view of its
   // first components, kept because `all_language_tokens` must return a
@@ -284,7 +380,8 @@ impl WhisperTokenizer {
   /// [`TokenizerError::FileNotFound`] if `folder` has no `tokenizer.json`;
   /// [`TokenizerError::Backend`] if the file exists but fails to parse.
   pub fn from_folder(folder: impl AsRef<Path>) -> Result<Self, TokenizerError> {
-    let path = folder.as_ref().join("tokenizer.json");
+    let folder = folder.as_ref();
+    let path = folder.join("tokenizer.json");
     if !path.is_file() {
       return Err(TokenizerError::FileNotFound {
         searched: vec![path],
@@ -292,6 +389,7 @@ impl WhisperTokenizer {
     }
     let tokenizer = tokenizers::Tokenizer::from_file(&path)?;
     let special_tokens = SpecialTokens::probe(&tokenizer);
+    let clean_up_tokenization_spaces = clean_up_tokenization_spaces_from(folder);
 
     let mut language_table: Vec<(u32, &'static str)> = Vec::new();
     for &(_, code) in constants::languages() {
@@ -309,6 +407,7 @@ impl WhisperTokenizer {
     Ok(Self {
       tokenizer,
       special_tokens,
+      clean_up_tokenization_spaces,
       language_table,
       language_ids,
     })
@@ -354,11 +453,43 @@ impl WhisperTokenizer {
   /// [`Self::split_to_word_tokens`]'s doc for why this module relies on
   /// that shared behavior instead of pre-filtering.
   ///
+  /// # The tokenization-space cleanup
+  /// The joined decode is then passed through Swift's `cleanUp`
+  /// (`Tokenizer.swift:434-449`) when this tokenizer folder enables it —
+  /// see `clean_up_tokenization` for the ten rules and
+  /// `clean_up_tokenization_spaces_from` for the flag. That is a real
+  /// output change, not a formality: `decode(&[1097])`, the `Ġ...` token,
+  /// is `" ..."` from the backend and `"..."` after cleanup, and the lost
+  /// leading space flips the `starts_with_space` arm of the space-based
+  /// word splitter behind [`Self::split_to_word_tokens`] (coremlit issue
+  /// #59), merging that unit into the preceding word.
+  ///
+  /// This is the single place the layer lives, because it is the single
+  /// place Swift puts it: `Tokenizer.decode` applies `cleanUp` to the
+  /// *joined* string (`Tokenizer.swift:524`), and every Swift caller —
+  /// `WhisperTokenizerWrapper.decode` (`Models.swift:1175-1176`),
+  /// `splitTokensOnUnicode`'s full and per-prefix decodes
+  /// (`Models.swift:1227`, `:1237`), and `splitToWordTokens`'s
+  /// language-detection decode (`:1294`) — reaches it through that one
+  /// method, exactly as every caller in this crate reaches it through this
+  /// one. Two consequences of the *joined* placement are load-bearing and
+  /// are why this is not instead a `tokenizers`-crate `Decoder`: that
+  /// crate's decoders run per token and only then join, so a `" ."` split
+  /// across two tokens would escape cleanup where Swift cleans it; and
+  /// `tokenizers::Tokenizer` is a concrete `TokenizerImpl<..,
+  /// DecoderWrapper>` whose `from_file` deserializes into fixed wrapper
+  /// enums, with no seam for a custom decoder at all.
+  ///
   /// # Errors
   /// [`TokenizerError::Backend`] if the tokenizer backend fails to decode
   /// `ids`.
   pub fn decode(&self, ids: &[u32], skip_special: bool) -> Result<String, TokenizerError> {
-    Ok(self.tokenizer.decode(ids, skip_special)?)
+    let decoded = self.tokenizer.decode(ids, skip_special)?;
+    Ok(if self.clean_up_tokenization_spaces {
+      clean_up_tokenization(decoded)
+    } else {
+      decoded
+    })
   }
 
   /// Looks up a token string's id, if the vocabulary has it.
@@ -536,6 +667,17 @@ impl WhisperTokenizer {
   /// is a byte-prefix-preserving operation by construction, but strictly
   /// safer than the Swift original for the same result on every reachable
   /// input.
+  ///
+  /// Note that [`Self::decode`]'s tokenization-space cleanup is the one
+  /// thing that can perturb that byte-prefix property, since it deletes
+  /// spaces from `decoded` and `decoded_full` independently (a prefix
+  /// ending in `" n"` is untouched where the full text's `" n't"` is not).
+  /// This is not a deviation to correct: Swift routes both of its decodes
+  /// through the same `cleanUp` (`Models.swift:1227`, `:1237` ->
+  /// `Tokenizer.swift:524`), so its offsets are perturbed identically. It
+  /// is only reachable at all when `decoded` holds a U+FFFD, i.e. mid
+  /// multi-byte character, and the cleanup's patterns are pure ASCII —
+  /// and where Swift would read a shifted range, this reads `None`.
   fn split_tokens_on_unicode(
     &self,
     tokens: &[u32],
@@ -570,6 +712,14 @@ impl WhisperTokenizer {
   /// ([`is_single_punctuation_scalar`]), or no word has started yet;
   /// otherwise it is appended (text and tokens both) onto the previous
   /// word. Ports `splitTokensOnSpaces` (`Models.swift:1255-1277`) exactly.
+  ///
+  /// The leading-space test reads a *cleaned* decode, which is what makes
+  /// [`Self::decode`]'s cleanup visible in word grouping rather than only
+  /// in text: `" ..."` becomes `"..."`, which is neither space-prefixed nor
+  /// a single punctuation scalar, so it joins the preceding word instead of
+  /// starting a new one. Swift groups it the same way, for the same reason
+  /// (coremlit issue #59). A single `" ."` is unaffected — it loses its
+  /// space too, but `"."` is one punctuation scalar and still starts a word.
   fn split_tokens_on_spaces(
     &self,
     tokens: &[u32],

--- a/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
+++ b/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
@@ -253,16 +253,85 @@ fn is_single_punctuation_scalar(s: &str) -> bool {
   }
 }
 
+/// Swift's `Config.boolean()` (`Config.swift:373-375`, delegating to the
+/// `Config.Data.boolean()` coercion at `:152-170`) over a `serde_json` value —
+/// the reason a tokenizer config's `true`, `"True"` and `1` are one answer:
+///
+/// - a JSON boolean is itself;
+/// - a JSON **number** is `true` iff it is `1`, because Swift coerces through
+///   `Int` (`val == 1`) — so every other integer, `0` and `2` included, is
+///   `false`, not "no value";
+/// - a JSON **string** is matched case-insensitively against `"true"`/`"t"`/
+///   `"1"` and `"false"`/`"f"`/`"0"`; anything else yields no value, and Swift
+///   does not trim, so `" true "` is nothing;
+/// - `null`, arrays and objects yield no value.
+///
+/// "No value" is emphatically not `false`: the caller supplies Swift's `or:`
+/// default for that case, which for the cleanup flag is `true`.
+///
+/// The number rule reaches floats too — not because floats are coerced
+/// (`Config.Data.boolean()` has no `.floating` case at all) but because
+/// `Config`'s decoder tries `Int` *before* `Float` (`Config.swift:657-666`), so
+/// a JSON number whose exact value is an integer `Int` can hold becomes
+/// `.integer` however it was spelled. `1.0` and `1e0` are therefore `true`, and
+/// `0.0`, `-0.0` and `1.5e1` are `false`, while `0.5` (a real fraction) and
+/// `1e19` (past `Int64`) stay `.floating` and yield no value. That ordering was
+/// read off the pinned oracle's own `JSONDecoder` behavior rather than inferred
+/// from the enum, which shows only the second half of it.
+fn config_boolean(value: &serde_json::Value) -> Option<bool> {
+  match value {
+    serde_json::Value::Bool(b) => Some(*b),
+    serde_json::Value::Number(n) => match n.as_i64() {
+      Some(int) => Some(int == 1),
+      // Written with a fraction or an exponent: `serde_json` keeps the number
+      // a float where Swift's `Int`-first decode does not, so ask the same
+      // question that decode asks — is the exact value an integer `Int` can
+      // hold? If so it is `.integer` in Swift and `== 1` decides; if not it is
+      // `.floating`, which coerces to nothing.
+      None => {
+        const INT_MIN: f64 = -9_223_372_036_854_775_808.0; // -2^63
+        const PAST_INT_MAX: f64 = 9_223_372_036_854_775_808.0; // 2^63, exclusive
+
+        let float = n.as_f64()?;
+        ((INT_MIN..PAST_INT_MAX).contains(&float) && float.fract() == 0.0).then_some(float == 1.0)
+      }
+    },
+    // Swift lowercases (`Config.swift:160`) before matching; `str::to_lowercase`
+    // is the same locale-independent full Unicode mapping as `lowercased()`.
+    serde_json::Value::String(s) => match s.to_lowercase().as_str() {
+      "true" | "t" | "1" => Some(true),
+      "false" | "f" | "0" => Some(false),
+      _ => None,
+    },
+    serde_json::Value::Null | serde_json::Value::Array(_) | serde_json::Value::Object(_) => None,
+  }
+}
+
 /// Resolves Swift's `cleanUpTokenizationSpaces` flag (`Tokenizer.swift:407`)
 /// for a tokenizer folder: `tokenizer_config.json`'s
-/// `clean_up_tokenization_spaces`, defaulting to `true`.
+/// **`cleanUpTokenizationSpaces`, else `clean_up_tokenization_spaces`**, run
+/// through [`config_boolean`], defaulting to `true` only when neither key
+/// yields a value.
 ///
 /// Swift spells that `tokenizerConfig.cleanUpTokenizationSpaces.boolean(or:
-/// true)` — a `Config` lookup that yields `true` for a missing key and for a
-/// present-but-non-boolean value alike. This reproduces both, and extends the
-/// same leniency one step further, to a missing or unparseable file. Swift
-/// cannot reach that case (its `AutoTokenizer` fails the whole load if
-/// `tokenizer_config.json` is not readable JSON), but this crate's
+/// true)`, which looks like one snake_case lookup of a strict boolean and is
+/// neither. `Config`'s dynamic-member subscript (`Config.swift:593-599`) tries
+/// the member name *verbatim* first and only then its `uncamelCase` transform
+/// (`:601-621`, which turns `cleanUpTokenizationSpaces` into exactly
+/// `clean_up_tokenization_spaces`), so a camelCase key wins outright — and wins
+/// on **presence**, not on coercibility, because `??` chains the two dictionary
+/// lookups rather than their booleans. `{"cleanUpTokenizationSpaces": "yes",
+/// "clean_up_tokenization_spaces": false}` is thus `true` in Swift, never
+/// `false`, and a key present with `null` shadows the other spelling just as
+/// firmly. Both lookups are byte-exact (`BinaryDistinctString`, the whole point
+/// of that type), matching `serde_json`'s map keys with no normalization gap.
+///
+/// A root that is not a JSON object misses both keys and defaults, matching the
+/// `dictionary()`-returned-nil arm of that same subscript (`Config.swift:598`).
+///
+/// This extends the same leniency one step further, to a missing or unparseable
+/// file. Swift cannot reach that case (its `AutoTokenizer` fails the whole load
+/// if `tokenizer_config.json` is not readable JSON), but this crate's
 /// [`WhisperTokenizer::from_folder`] requires only `tokenizer.json` — a
 /// contract predating this flag, and not worth narrowing over one boolean
 /// whose default is what every OpenAI Whisper checkpoint ships anyway
@@ -270,12 +339,16 @@ fn is_single_punctuation_scalar(s: &str) -> bool {
 /// explicitly). A corrupt sibling file therefore degrades to Swift's own
 /// default rather than failing a `tokenizer.json` that is perfectly good.
 fn clean_up_tokenization_spaces_from(folder: &Path) -> bool {
-  std::fs::read(folder.join("tokenizer_config.json"))
+  let Some(config) = std::fs::read(folder.join("tokenizer_config.json"))
     .ok()
     .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
-    .as_ref()
-    .and_then(|config| config.get("clean_up_tokenization_spaces"))
-    .and_then(serde_json::Value::as_bool)
+  else {
+    return true;
+  };
+  config
+    .get("cleanUpTokenizationSpaces")
+    .or_else(|| config.get("clean_up_tokenization_spaces"))
+    .and_then(config_boolean)
     .unwrap_or(true)
 }
 

--- a/crates/coremlit/src/audio/whisper/tokenizer/tests.rs
+++ b/crates/coremlit/src/audio/whisper/tokenizer/tests.rs
@@ -451,6 +451,283 @@ fn swift_parity_unicode_splits_every_cjk_language_except_chinese() {
   }
 }
 
+// ---------------------------------------------------------------------
+// clean_up_tokenization_spaces (coremlit issue #59)
+// ---------------------------------------------------------------------
+
+/// Swift's ten rules written out again, unguarded and in Swift's order — the
+/// literal transcription of `Tokenizer.swift:439-448`. `clean_up_tokenization`
+/// must equal this for every input; it only adds a short-circuit.
+fn swift_clean_up_reference(text: &str) -> String {
+  text
+    .replace(" .", ".")
+    .replace(" ?", "?")
+    .replace(" !", "!")
+    .replace(" ,", ",")
+    .replace(" ' ", "'")
+    .replace(" n't", "n't")
+    .replace(" 'm", "'m")
+    .replace(" 's", "'s")
+    .replace(" 've", "'ve")
+    .replace(" 're", "'re")
+}
+
+#[test]
+fn clean_up_applies_swifts_ten_rules_and_only_those() {
+  // One case per rule, in Swift's order (`Tokenizer.swift:439-448`), each
+  // paired with a near-miss that must NOT be touched. The near-misses are the
+  // point: this layer's failure mode is doing MORE than Swift, which would
+  // trade issue #59's divergence for a new one.
+  for (input, expected) in [
+    (" a .", " a."),
+    (" a ?", " a?"),
+    (" a !", " a!"),
+    (" a ,", " a,"),
+    ("it ' s", "it's"),
+    ("do n't", "don't"),
+    ("I 'm", "I'm"),
+    ("it 's", "it's"),
+    ("we 've", "we've"),
+    ("we 're", "we're"),
+    // Near-misses: punctuation Swift does not list, and apostrophe forms
+    // Swift does not list. HuggingFace does not list them either.
+    (" a ;", " a ;"),
+    (" a :", " a :"),
+    (" a -", " a -"),
+    (" a \"", " a \""),
+    (" a …", " a …"),
+    ("we 'll", "we 'll"),
+    ("we 'd", "we 'd"),
+    // Swift's `WordPieceDecoder` cleanup has a `" do not"` -> `" don't"`
+    // rule (`Decoder.swift:107`). Whisper's decoder is `ByteLevel`, so that
+    // rule is not in force here and this must pass through unchanged.
+    ("I do not care", "I do not care"),
+    // No space before the punctuation: nothing to clean.
+    ("a. b? c! d,", "a. b? c! d,"),
+    // Interior/leading whitespace that is not a plain space is untouched:
+    // every Swift pattern starts with U+0020 specifically.
+    ("a\t.", "a\t."),
+    ("a\n.", "a\n."),
+    ("a\u{a0}.", "a\u{a0}."),
+    ("", ""),
+    (" ", " "),
+  ] {
+    assert_eq!(
+      clean_up_tokenization(input.to_owned()),
+      expected,
+      "input {input:?}"
+    );
+  }
+}
+
+#[test]
+fn clean_up_is_swifts_chain_including_its_order() {
+  // Swift chains the ten, so each rule sees the previous one's output and a
+  // deletion can expose a later match. These are the cases that distinguish
+  // "chain" from "ten independent passes over the original".
+  //
+  // The order witness, found by replaying every adjacent transposition of
+  // Swift's ten over all short strings drawn from their own alphabet: `" ,"`
+  // and `" ' "` are the one adjacent pair that does not commute. Swift runs
+  // `" ,"` first, so it takes the comma's space and leaves `" ',"`; running
+  // `" ' "` first would take both spaces and leave `"',"`. If these ten are
+  // ever reordered, this is the assertion that notices.
+  assert_eq!(clean_up_tokenization(" ' ,".to_owned()), " ',");
+  // A token-spaced possessive still collapses to one apostrophe.
+  assert_eq!(clean_up_tokenization(" ' s".to_owned()), "'s");
+  // A match CREATED by an earlier rule, which only a chain can reach: the
+  // original has no `" 's"` anywhere (its apostrophe and `s` are separated),
+  // but `" ' "` collapsing to `"'"` puts one there for `" 's"` to take.
+  assert_eq!(clean_up_tokenization("a  ' s".to_owned()), "a's");
+  // Two independent rules, each firing once on its own region.
+  assert_eq!(clean_up_tokenization("a . ,".to_owned()), "a.,");
+  // Repeated matches of the same rule: each deletes only the space BEFORE
+  // its punctuation, so the separating spaces after them survive.
+  assert_eq!(clean_up_tokenization("a . b . c .".to_owned()), "a. b. c.");
+  // Two spaces: `replace` is non-overlapping and left-to-right, so only the
+  // pair adjacent to the `.` matches, leaving one space behind.
+  assert_eq!(clean_up_tokenization("a  .".to_owned()), "a .");
+
+  // And the whole table agrees with the unguarded transcription of Swift.
+  for text in [
+    " ...",
+    " ' ",
+    " n't",
+    "a . ,",
+    " ' s",
+    "a  .",
+    " . ? ! , 'm 's 've 're n't",
+    "we ' re",
+    " no trigger here",
+    "こんにちは、世界！",
+    "¿Qué ? ¡Sí !",
+    "a\u{FFFD} .",
+  ] {
+    assert_eq!(
+      clean_up_tokenization(text.to_owned()),
+      swift_clean_up_reference(text),
+      "guarded and unguarded must agree on {text:?}"
+    );
+  }
+}
+
+#[test]
+fn clean_up_short_circuit_never_changes_the_answer() {
+  // The short-circuit's soundness claim, exercised: over every string built
+  // from an alphabet that contains each rule's first two bytes plus a few
+  // decoys, the guarded implementation equals the unguarded transcription.
+  // If the guard ever skipped a string a rule would have matched, or a
+  // replacement ever manufactured a newly-matchable pair, this fails.
+  let alphabet = [
+    " ", ".", "?", "!", ",", "'", "n", "t", "m", "s", "v", "r", "e", "a",
+  ];
+  let mut checked = 0usize;
+  for a in alphabet {
+    for b in alphabet {
+      for c in alphabet {
+        for d in alphabet {
+          let text = format!("{a}{b}{c}{d}");
+          assert_eq!(
+            clean_up_tokenization(text.clone()),
+            swift_clean_up_reference(&text),
+            "guard diverged on {text:?}"
+          );
+          checked += 1;
+        }
+      }
+    }
+  }
+  assert_eq!(checked, alphabet.len().pow(4));
+}
+
+#[test]
+fn clean_up_flag_follows_tokenizer_config_like_swift() {
+  // Swift: `tokenizerConfig.cleanUpTokenizationSpaces.boolean(or: true)`
+  // (`Tokenizer.swift:407`) — `true` unless the file says otherwise.
+  let dir = tempfile::tempdir().unwrap();
+  let path = dir.path().join("tokenizer_config.json");
+
+  // No file at all: this crate's folders need only `tokenizer.json`.
+  assert!(clean_up_tokenization_spaces_from(dir.path()));
+
+  for (body, expected) in [
+    (r#"{"clean_up_tokenization_spaces": true}"#, true),
+    (r#"{"clean_up_tokenization_spaces": false}"#, false),
+    // Key absent -> Swift's `or: true`.
+    (r#"{"model_max_length": 448}"#, true),
+    // Present but not a boolean -> `.boolean()` yields nil, so `or: true`.
+    (r#"{"clean_up_tokenization_spaces": "false"}"#, true),
+    (r#"{"clean_up_tokenization_spaces": null}"#, true),
+    (r#"{"clean_up_tokenization_spaces": 0}"#, true),
+    // Unparseable, and valid JSON that is not an object: same default.
+    ("{ not json", true),
+    ("[]", true),
+  ] {
+    std::fs::write(&path, body).unwrap();
+    assert_eq!(
+      clean_up_tokenization_spaces_from(dir.path()),
+      expected,
+      "config {body}"
+    );
+  }
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn decode_cleans_the_leading_space_off_the_ellipsis_token() {
+  // coremlit issue #59's whole case, pinned at the token that produces it.
+  // Token 1097 is byte-level BPE's `Ġ...`, i.e. a space plus an ellipsis of
+  // three ASCII periods. The `tokenizers` backend decodes it literally; Swift
+  // then strips the space via the `" ."` -> `"."` rule, and so must this.
+  let t = tiny();
+  assert_eq!(t.id_to_token(1097).as_deref(), Some("Ġ..."));
+
+  // The backend still returns the uncleaned string -- this layer is what
+  // changes the answer, not a different tokenizer configuration.
+  assert_eq!(t.tokenizer.decode(&[1097], false).unwrap(), " ...");
+  assert!(t.clean_up_tokenization_spaces);
+  assert_eq!(t.decode(&[1097], false).unwrap(), "...");
+
+  // And the real fixture folder is what turns it on.
+  let root = std::env::var_os("WHISPERKIT_TEST_MODELS").map_or_else(
+    || {
+      PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("Models")
+    },
+    PathBuf::from,
+  );
+  assert!(clean_up_tokenization_spaces_from(
+    &root.join("tokenizers/whisper-tiny")
+  ));
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn cleaned_ellipsis_joins_the_previous_word_but_a_period_still_starts_one() {
+  // The consequence of the test above, in `splitTokensOnSpaces` terms
+  // (`Models.swift:1255-1276`) -- this is the one grouping decision that
+  // moved LuYu's word edit distance.
+  let t = tiny();
+  let hi = t.encode(" hi").unwrap();
+
+  // `" ..."` -> `"..."`: not space-prefixed, and three scalars rather than
+  // one, so neither the `withSpace` nor the `punctuation` arm fires and it
+  // is appended to the preceding word.
+  let mut with_ellipsis = hi.clone();
+  with_ellipsis.push(1097);
+  let words = t
+    .split_to_word_tokens(&with_ellipsis, "en", WordGrouping::SwiftParity)
+    .unwrap();
+  let texts: Vec<&str> = words.iter().map(|(w, _)| w.as_str()).collect();
+  assert_eq!(texts, vec![" hi..."]);
+  assert_eq!(words.last().unwrap().1, vec![*hi.last().unwrap(), 1097]);
+
+  // Contrast: a lone `" ."` is cleaned to `"."` too, but one punctuation
+  // scalar still starts its own word, so grouping there is unchanged.
+  let period = t.token_to_id("Ġ.").unwrap();
+  let mut with_period = hi.clone();
+  with_period.push(period);
+  assert_eq!(t.decode(&[period], false).unwrap(), ".");
+  let words = t
+    .split_to_word_tokens(&with_period, "en", WordGrouping::SwiftParity)
+    .unwrap();
+  let texts: Vec<&str> = words.iter().map(|(w, _)| w.as_str()).collect();
+  assert_eq!(texts, vec![" hi", "."]);
+
+  // Both groupings agree: this is a decode-level change, not a mode-level one.
+  assert_eq!(
+    t.split_to_word_tokens(&with_ellipsis, "en", WordGrouping::FineGrained)
+      .unwrap(),
+    t.split_to_word_tokens(&with_ellipsis, "en", WordGrouping::SwiftParity)
+      .unwrap()
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn cleanup_leaves_special_and_timestamp_token_decodes_alone() {
+  // Blast-radius check: the cleanup runs on EVERY decode, including the ones
+  // that carry `<|...|>` markers, and those must survive it intact -- segment
+  // text and the word splitter both parse them.
+  let t = tiny();
+  let s = t.special_tokens();
+  let ids = [
+    s.start_of_transcript_token(),
+    s.english_token(),
+    s.transcribe_token(),
+    s.time_token_begin(),
+    s.no_timestamps_token(),
+    s.end_token(),
+  ];
+  let decoded = t.decode(&ids, false).unwrap();
+  assert_eq!(
+    decoded,
+    "<|startoftranscript|><|en|><|transcribe|><|0.00|><|notimestamps|><|endoftext|>"
+  );
+  assert_eq!(decoded, t.tokenizer.decode(&ids, false).unwrap());
+}
+
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn word_grouping_is_inert_for_whitespace_delimited_languages() {

--- a/crates/coremlit/src/audio/whisper/tokenizer/tests.rs
+++ b/crates/coremlit/src/audio/whisper/tokenizer/tests.rs
@@ -630,6 +630,10 @@ fn config_boolean_coerces_like_swift() {
     ("0.5", None),
     ("1e19", None),
     ("9223372036854775808", None), // 2^63, one past `Int.max`
+    // The spellings at the edges of `Int`'s range, where this port and the
+    // oracle do not agree everywhere, are tabulated in
+    // `config_boolean_matches_swift_except_where_the_f64_lost_the_literal` instead --
+    // every row of THIS table is a row the two answer alike.
     // `.string`: lowercased (`Config.swift:160`), then two fixed sets.
     (r#""true""#, Some(true)),
     (r#""t""#, Some(true)),
@@ -656,6 +660,105 @@ fn config_boolean_coerces_like_swift() {
       config_boolean(&serde_json::from_str(json).unwrap()),
       expected,
       "value {json}"
+    );
+  }
+}
+
+#[test]
+fn config_boolean_matches_swift_except_where_the_f64_lost_the_literal() {
+  // `serde_json` keeps a number's spelling only while it fits `i64`/`u64`. A
+  // fraction or an exponent leaves an `f64`, while the oracle's decoder reads
+  // the digits, so a literal carrying more precision than an `f64` holds can
+  // land differently on the two sides. This table carries BOTH columns -- what
+  // the pinned oracle answers and what this port answers -- so the residue is
+  // visible rather than asserted away.
+  //
+  // The oracle column was measured the same way the other tables were --
+  // compiling its `Config.swift` and `BinaryDistinct.swift` against
+  // `JSONDecoder` and reading back `Config.boolean()` -- not predicted from
+  // this port. `9223372036854775296` and `9223372036854775807` are the two
+  // magnitudes the oracle actually flips at near `Int`'s edge, and
+  // `1844674407370955161` the one it flips at for a nonzero fraction; all
+  // three were found by sweeping magnitudes, not by modelling the decoder.
+  //
+  // A row where the two columns differ is not automatically a gate that moves:
+  // `or: true` can absorb the difference. The rows where the RESOLVED flag
+  // really does differ are enumerated separately below, so that set stays
+  // small, explicit and reviewable.
+  const GATE_MOVES: &[&str] = &[
+    "-9223372036854775807.0",
+    "-9.223372036854775807e18",
+    "-9223372036854775296.0",
+    "1844674407370955162.5",
+  ];
+
+  for (json, swift, port) in [
+    // Bare integers inside `i64`: `serde_json` holds these exactly, so the
+    // `as_i64` arm answers and the two agree by construction.
+    ("-9223372036854775807", Some(false), Some(false)),
+    ("-9223372036854775808", Some(false), Some(false)), // `Int.min`
+    // Bare integers past `i64` reach the float arm with `|f64| >= 2^63`. The
+    // oracle's own `Int` decode fails on them too, so both decline.
+    ("-9223372036854775809", None, None),
+    ("-9223372036854776832", None, None), // -2^63 - 1024, still the `-2^63` f64
+    ("-9223372036854776833", None, None), // one step further, a distinct f64
+    // Fraction and exponent spellings landing on the `-2^63` f64 whose exact
+    // magnitude is `2^63` or more. The oracle declines these as well, and this
+    // is the larger half of that f64's cell.
+    ("-9223372036854775808.0", None, None),
+    ("-9223372036854775809.0", None, None),
+    ("-9.223372036854775808e18", None, None),
+    // THE RESIDUE. Same f64, exact magnitude below `2^63`, so the oracle
+    // decodes `.integer` and DISABLES the cleanup while this port declines and
+    // leaves the caller's `or: true` in place. The band runs from
+    // `-(2^63 - 1)` to `-(2^63 - 512)`; both ends are pinned here.
+    ("-9223372036854775807.0", Some(false), None),
+    ("-9.223372036854775807e18", Some(false), None),
+    ("-9223372036854775296.0", Some(false), None),
+    // One integer past that band the value rounds to a different f64, which is
+    // decisive again -- so the divergence really is bounded, not a cliff.
+    ("-9223372036854775295.0", Some(false), Some(false)),
+    ("-9223372036854774784.0", Some(false), Some(false)),
+    // The positive edge has no such band: the oracle's cutoff is exactly the
+    // first magnitude that rounds up to the f64 `2^63`, which is where the
+    // port's exclusive upper bound already puts it.
+    ("9223372036854775295.0", Some(false), Some(false)),
+    ("9223372036854775296.0", None, None),
+    ("9223372036854775807", Some(false), Some(false)), // `Int.max`, bare
+    ("9223372036854775807.0", None, None),             // ...but not spelled `.0`
+    ("9223372036854775808.0", None, None),
+    // The SECOND divergence class, and it runs the opposite way. Past
+    // `1844674407370955161` a nonzero fractional part stops decoding as
+    // `.integer` in the oracle, while both spellings below still round to a
+    // whole `f64` and are accepted here. The two rows straddle that flip.
+    ("1844674407370955161.5", Some(false), Some(false)),
+    ("1844674407370955162.5", None, Some(false)),
+    // Nearby fractions that do agree, so the class above is pinned as a
+    // boundary rather than as "fractions are unreliable": a fraction the `f64`
+    // keeps is declined by both, and one it rounds away is taken by both.
+    ("2251799813685248.5", None, None),
+    ("9007199254740993.5", Some(false), Some(false)),
+    ("4503599627370496.0001", Some(false), Some(false)),
+    // A THIRD class, and the reason "they differ" and "the gate moves" have to
+    // be asked separately. At 16 nines the `f64` has rounded all the way up to
+    // `1.0` while the oracle still sees a fraction, so the two disagree -- yet
+    // `Some(true)` and `or: true` are the same flag, and nothing moves. 15
+    // nines is the control the `f64` still keeps apart from 1, and 19 is where
+    // the oracle's own decode has rounded up too.
+    ("0.999999999999999", None, None),
+    ("0.9999999999999999", None, Some(true)),
+    ("0.9999999999999999999", Some(true), Some(true)),
+  ] {
+    assert_eq!(
+      config_boolean(&serde_json::from_str(json).unwrap()),
+      port,
+      "port's answer for {json}"
+    );
+    assert_eq!(
+      swift.unwrap_or(true) != port.unwrap_or(true),
+      GATE_MOVES.contains(&json),
+      "whether the RESOLVED cleanup flag differs from Swift's for {json} \
+       (swift={swift:?}, port={port:?})"
     );
   }
 }
@@ -720,6 +823,27 @@ fn clean_up_flag_follows_tokenizer_config_like_swift() {
     ("{ not json", true),
     ("[]", true),
     ("3", true),
+    // The `Int`-range edge, at the call site that actually gates the cleanup.
+    // The first three match the oracle; the fourth is the documented residue,
+    // where Swift resolves `false` and this resolves `true` because the `.0`
+    // spelling did not survive `serde_json`. See
+    // `config_boolean_matches_swift_except_where_the_f64_lost_the_literal`.
+    (
+      r#"{"clean_up_tokenization_spaces": -9223372036854775808}"#,
+      false,
+    ),
+    (
+      r#"{"clean_up_tokenization_spaces": -9223372036854775808.0}"#,
+      true,
+    ),
+    (
+      r#"{"clean_up_tokenization_spaces": -9223372036854775809}"#,
+      true,
+    ),
+    (
+      r#"{"clean_up_tokenization_spaces": -9223372036854775807.0}"#,
+      true,
+    ),
   ] {
     std::fs::write(&path, body).unwrap();
     assert_eq!(

--- a/crates/coremlit/src/audio/whisper/tokenizer/tests.rs
+++ b/crates/coremlit/src/audio/whisper/tokenizer/tests.rs
@@ -601,9 +601,73 @@ fn clean_up_short_circuit_never_changes_the_answer() {
 }
 
 #[test]
+fn config_boolean_coerces_like_swift() {
+  // `Config.Data.boolean()` (`Config.swift:152-170`) as a table. Every row is
+  // the answer the pinned oracle's own `Config` gives for that JSON scalar --
+  // read back from it, not derived from what this port happens to return.
+  for (json, expected) in [
+    // `.boolean`: itself.
+    ("true", Some(true)),
+    ("false", Some(false)),
+    // `.integer`: `val == 1`. `0`, `2` and `-1` are all a definite `false`,
+    // not "no value" -- which is the whole reason a `0` disables the cleanup.
+    ("1", Some(true)),
+    ("0", Some(false)),
+    ("2", Some(false)),
+    ("-1", Some(false)),
+    // An integer spelled with a fraction or an exponent is still `.integer`:
+    // `Config`'s decoder tries `Int` before `Float` (`Config.swift:657-666`).
+    ("1.0", Some(true)),
+    ("1e0", Some(true)),
+    ("0.0", Some(false)),
+    ("-0.0", Some(false)),
+    ("1.5e1", Some(false)), // = 15
+    // `Int.max` and `Int.min` are integers, and are not 1.
+    ("9223372036854775807", Some(false)),
+    ("-9223372036854775808", Some(false)),
+    // A real fraction, or a value past `Int64`, stays `.floating` -- and
+    // `boolean()` has no `.floating` case, so it coerces to nothing.
+    ("0.5", None),
+    ("1e19", None),
+    ("9223372036854775808", None), // 2^63, one past `Int.max`
+    // `.string`: lowercased (`Config.swift:160`), then two fixed sets.
+    (r#""true""#, Some(true)),
+    (r#""t""#, Some(true)),
+    (r#""1""#, Some(true)),
+    (r#""false""#, Some(false)),
+    (r#""f""#, Some(false)),
+    (r#""0""#, Some(false)),
+    (r#""True""#, Some(true)),
+    (r#""TRUE""#, Some(true)),
+    (r#""FALSE""#, Some(false)),
+    (r#""T""#, Some(true)),
+    // Every other string is nothing -- Swift matches the whole string and
+    // does not trim it first.
+    (r#""yes""#, None),
+    (r#""maybe""#, None),
+    (r#""""#, None),
+    (r#"" true ""#, None),
+    // `boolean()` has no case for these three either.
+    ("null", None),
+    ("[]", None),
+    ("{}", None),
+  ] {
+    assert_eq!(
+      config_boolean(&serde_json::from_str(json).unwrap()),
+      expected,
+      "value {json}"
+    );
+  }
+}
+
+#[test]
 fn clean_up_flag_follows_tokenizer_config_like_swift() {
   // Swift: `tokenizerConfig.cleanUpTokenizationSpaces.boolean(or: true)`
-  // (`Tokenizer.swift:407`) — `true` unless the file says otherwise.
+  // (`Tokenizer.swift:407`). The member name is camelCase, and `Config`'s
+  // dynamic-member subscript (`Config.swift:593-599`) tries it verbatim before
+  // falling back to its `uncamelCase` form (`:601-621`), which for this name
+  // is exactly `clean_up_tokenization_spaces`. `or: true` then applies only
+  // where the chosen value coerces to nothing.
   let dir = tempfile::tempdir().unwrap();
   let path = dir.path().join("tokenizer_config.json");
 
@@ -611,17 +675,51 @@ fn clean_up_flag_follows_tokenizer_config_like_swift() {
   assert!(clean_up_tokenization_spaces_from(dir.path()));
 
   for (body, expected) in [
+    // The snake_case spelling every OpenAI checkpoint ships.
     (r#"{"clean_up_tokenization_spaces": true}"#, true),
     (r#"{"clean_up_tokenization_spaces": false}"#, false),
-    // Key absent -> Swift's `or: true`.
-    (r#"{"model_max_length": 448}"#, true),
-    // Present but not a boolean -> `.boolean()` yields nil, so `or: true`.
-    (r#"{"clean_up_tokenization_spaces": "false"}"#, true),
+    // The camelCase spelling Swift actually looks for FIRST.
+    (r#"{"cleanUpTokenizationSpaces": true}"#, true),
+    (r#"{"cleanUpTokenizationSpaces": false}"#, false),
+    // The value is coerced, not required to be a JSON boolean: `0` and
+    // `"false"` DISABLE the cleanup in Swift. Pinning those two as `true` here
+    // was this port's bug, so they are the regression rows.
+    (r#"{"clean_up_tokenization_spaces": 0}"#, false),
+    (r#"{"clean_up_tokenization_spaces": "false"}"#, false),
+    (r#"{"cleanUpTokenizationSpaces": "0"}"#, false),
+    (r#"{"clean_up_tokenization_spaces": 1}"#, true),
+    (r#"{"clean_up_tokenization_spaces": "TRUE"}"#, true),
+    // Present but uncoercible -> `or: true`, which is the default and not a
+    // `false` in disguise.
     (r#"{"clean_up_tokenization_spaces": null}"#, true),
-    (r#"{"clean_up_tokenization_spaces": 0}"#, true),
+    (r#"{"clean_up_tokenization_spaces": "maybe"}"#, true),
+    // Key absent -> `or: true`.
+    (r#"{"model_max_length": 448}"#, true),
+    ("{}", true),
+    // Precedence: camelCase wins outright when both spellings are present...
+    (
+      r#"{"cleanUpTokenizationSpaces": false, "clean_up_tokenization_spaces": true}"#,
+      false,
+    ),
+    (
+      r#"{"cleanUpTokenizationSpaces": true, "clean_up_tokenization_spaces": false}"#,
+      true,
+    ),
+    // ...and it wins on PRESENCE, not on coercibility: Swift's `??` chains the
+    // two dictionary lookups, not their booleans, so an uncoercible camelCase
+    // value falls through to `or: true` and never to the snake_case key.
+    (
+      r#"{"cleanUpTokenizationSpaces": "yes", "clean_up_tokenization_spaces": false}"#,
+      true,
+    ),
+    (
+      r#"{"cleanUpTokenizationSpaces": null, "clean_up_tokenization_spaces": false}"#,
+      true,
+    ),
     // Unparseable, and valid JSON that is not an object: same default.
     ("{ not json", true),
     ("[]", true),
+    ("3", true),
   ] {
     std::fs::write(&path, body).unwrap();
     assert_eq!(
@@ -648,7 +746,12 @@ fn decode_cleans_the_leading_space_off_the_ellipsis_token() {
   assert!(t.clean_up_tokenization_spaces);
   assert_eq!(t.decode(&[1097], false).unwrap(), "...");
 
-  // And the real fixture folder is what turns it on.
+  // And the real fixture folder resolves to `true` -- by Swift's `or:` default
+  // rather than by reading the flag, which is worth saying out loud: the folder
+  // `from_folder` is handed holds only `tokenizer.json`. The checkpoint's own
+  // `tokenizer_config.json` does set `"clean_up_tokenization_spaces": true`,
+  // i.e. the same answer, but it sits a HuggingFace snapshot layer below (at
+  // `models/openai/whisper-tiny/`) and is not on the path this function reads.
   let root = std::env::var_os("WHISPERKIT_TEST_MODELS").map_or_else(
     || {
       PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -657,9 +760,9 @@ fn decode_cleans_the_leading_space_off_the_ellipsis_token() {
     },
     PathBuf::from,
   );
-  assert!(clean_up_tokenization_spaces_from(
-    &root.join("tokenizers/whisper-tiny")
-  ));
+  let folder = root.join("tokenizers/whisper-tiny");
+  assert!(!folder.join("tokenizer_config.json").exists());
+  assert!(clean_up_tokenization_spaces_from(&folder));
 }
 
 #[test]

--- a/crates/coremlit/src/audio/whisper/transcribe/mod.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/mod.rs
@@ -553,6 +553,7 @@ where
             self.tokenizer,
             language,
             options.word_grouping(), // coremlit issue #14; default: swift-parity (#41)
+            options.alignment_gather(), // coremlit issue #41; default: swift-parity
             previous_seek,
             PREPEND_PUNCTUATION,
             APPEND_PUNCTUATION,

--- a/crates/coremlit/src/audio/whisper/transcribe/mod.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/mod.rs
@@ -553,7 +553,15 @@ where
             self.tokenizer,
             language,
             options.word_grouping(), // coremlit issue #14; default: swift-parity (#41)
-            options.alignment_gather(), // coremlit issue #41; default: swift-parity
+            options.alignment_gather(), // coremlit issue #41; default: complete
+            // Swift's PHYSICAL `alignmentWeights` height
+            // (`kvCacheMaxSequenceLength`, `TextDecoder.swift:141`), which is
+            // one row SHORTER than the view above -- this port commits step
+            // `position`'s row at `position + 1` and so allocates
+            // `max_token_context + 1`. Only `SwiftParity` reads it, and it
+            // must be Swift's height or the pitch probe describes a surface
+            // Swift never allocated (whisper #41, codex round 3, F2).
+            self.backend.dims().max_token_context(),
             previous_seek,
             PREPEND_PUNCTUATION,
             APPEND_PUNCTUATION,

--- a/crates/coremlit/src/audio/whisper/transcribe/tests.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/tests.rs
@@ -3029,7 +3029,8 @@ fn four_window_shapes_read_stale_and_dropped_alignment_rows() {
   // `AlignmentGather::Complete` is REQUIRED here, not incidental: this pins
   // which alignment ROWS the accumulator hands over, and the #41 gather
   // (`SwiftParity`, the pipeline default) zeroes the tail of the last gathered
-  // row before DTW ever sees it. With 100 columns the pitch is 128, so the
+  // row before DTW ever sees it. At any measured pitch above the column count
+  // (128 for 100 columns on the reference host) that erasure lands, so the
   // discriminating column of the last row — the whole signal above — is
   // erased and every mutation in the matrix reads the same. The gather is
   // pinned separately by `swift_parity_gather_moves_the_next_window_seek`.
@@ -3122,7 +3123,8 @@ fn cap_hit_window_drops_the_completing_row() {
   // attempt and `decode_steps` reads the cap directly.
   //
   // `AlignmentGather::Complete` is REQUIRED for this pin to discriminate. At
-  // N = 224 gathered rows over 100 columns (pitch 128) the #41 gather's copied
+  // N = 224 gathered rows over 100 columns (measured pitch 128 on the
+  // reference host) the #41 gather's copied
   // prefix runs dry at row 175, so under the pipeline default rows 175..=223 —
   // including the predecessor/last-word/dropped triple this test is built on —
   // arrive entirely zeroed and Mutation A becomes invisible. The gather itself
@@ -3354,18 +3356,39 @@ fn swift_parity_gather_moves_the_next_window_seek() {
   // turned a 476-column tail into 984 words of edit distance and one extra
   // window across the 1417 s fixture.
   //
-  // Shape: 100 encoder columns (pitch 128), a segment of 6 gathered tokens
+  // Shape: 100 encoder columns, a segment of 6 gathered tokens
   // (`<|startoftranscript|><|en|><|transcribe|><|0.00|> Hello<|0.80|>` — the
-  // prompt rides along, `SegmentSeeker.swift:427-442`), so the copied prefix
-  // runs out 88 columns into row 4 and never reaches row 5 at all. Rows 4 and
-  // 5 are the pair that brackets the only text word, and the mock commits
-  // script step `k`'s row at accumulator row `k + 1`, so they are scripted at
-  // steps 3 and 4. Row 4 pays for every column past 59; row 5 has a +1.0
-  // plateau from column 44 that only the un-truncated gather can see.
+  // prompt rides along, `SegmentSeeker.swift:427-442`), so at the reference
+  // host's measured pitch of 128 the copied prefix runs out 88 columns into
+  // row 4 and never reaches row 5 at all. Rows 4 and 5 are the pair that
+  // brackets the only text word, and the mock commits script step `k`'s row at
+  // accumulator row `k + 1`, so they are scripted at steps 3 and 4. Row 4 pays
+  // for every column past 59; row 5 has a +1.0 plateau from column 44 that
+  // only the un-truncated gather can see.
+  //
+  // Those columns straddle a truncation point the SHIPPING gather measures on
+  // the running host rather than assumes, so the fixture states the layout it
+  // was built for and fails there first if this host pads differently — see
+  // `segment::tests::the_recorded_swift_probe_still_describes_this_host`,
+  // which is the single place that check belongs.
   let t = tiny_tokenizer();
   let s = special();
   let hello = t.encode(" Hello").unwrap()[0];
   let cols = 100usize;
+  let rows = 6usize;
+  let pitch = crate::audio::whisper::segment::coreml_f16_row_pitch(rows, cols).unwrap();
+  assert_eq!(
+    (rows * cols).saturating_sub(4 * pitch).min(cols),
+    88,
+    "this host measured a Float16 row pitch of {pitch} for {cols} columns; the reference \
+     host's 128 is what puts the gather's cut inside row 4 and past row 5, which is the \
+     whole discriminating shape of this fixture"
+  );
+  assert_eq!(
+    (rows * cols).saturating_sub(5 * pitch).min(cols),
+    0,
+    "row 5 must be gathered entirely blank under `SwiftParity`"
+  );
 
   let run = |gather| {
     let mut mock = MockBackend::new().with_dims(

--- a/crates/coremlit/src/audio/whisper/transcribe/tests.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/tests.rs
@@ -3035,7 +3035,7 @@ fn four_window_shapes_read_stale_and_dropped_alignment_rows() {
   // that erasure lands, so the discriminating column of the last row — the
   // whole signal above — would be erased and every mutation in the matrix
   // would read the same. The opt-in gather is pinned separately by
-  // `swift_parity_gather_moves_the_next_window_seek`.
+  // `swift_parity_gather_moves_the_first_windows_end_and_the_next_seek`.
   let t = tiny_tokenizer();
   let options = DecodingOptions::new()
     .with_word_timestamps()
@@ -3131,7 +3131,7 @@ fn cap_hit_window_drops_the_completing_row() {
   // row 175, so under `SwiftParity` rows 175..=223 — including the
   // predecessor/last-word/dropped triple this test is built on — would arrive
   // entirely zeroed and Mutation A would become invisible. That gather is
-  // pinned by `swift_parity_gather_moves_the_next_window_seek`.
+  // pinned by `swift_parity_gather_moves_the_first_windows_end_and_the_next_seek`.
   let options = DecodingOptions::new()
     .with_word_timestamps()
     .with_without_timestamps()
@@ -3349,7 +3349,7 @@ fn skip_special_tokens_governs_segment_text_on_both_writer_branches() {
 
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
-fn swift_parity_gather_moves_the_next_window_seek() {
+fn swift_parity_gather_moves_the_first_windows_end_and_the_next_seek() {
   // whisper #41 in miniature, on the mock backend: the OPT-IN alignment gather
   // is not confined to one window's word list. The final gathered row's tail
   // moves the last word's end (`SegmentSeeker.swift:642-649` hands it to the
@@ -3358,6 +3358,16 @@ fn swift_parity_gather_moves_the_next_window_seek() {
   // window therefore decodes a different slice of audio. That cascade is what
   // turned a 476-column tail into 984 words of edit distance and one extra
   // window across the 1417 s fixture.
+  //
+  // Both halves of the name are asserted, and the FIRST half is the one that
+  // bounds the public doc claim: window 1 already ends somewhere else, on
+  // identical audio and an identical decoded script, with `seek` 0 under both
+  // gathers and no preceding window to have moved anything. The divergence
+  // therefore does NOT need a cascade to appear — the cascade is only what
+  // compounds it. `AlignmentGather::SwiftParity`'s "Short-form" section cites
+  // this alongside `segment::tests::
+  // swift_parity_gather_truncates_final_alignment_row`, which shows the same
+  // thing over a single `add_word_timestamps` call with no pipeline at all.
   //
   // Shape: 100 encoder columns, a segment of 6 gathered tokens
   // (`<|startoftranscript|><|en|><|transcribe|><|0.00|> Hello<|0.80|>` — the

--- a/crates/coremlit/src/audio/whisper/transcribe/tests.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/tests.rs
@@ -5,7 +5,7 @@ use crate::audio::whisper::{
   audio::vad::VoiceActivityDetector,
   backend::{ModelDims, mock::MockBackend},
   error::{SegmentError, TranscribeError, VadError},
-  options::{ChunkingStrategy, DecodingOptions},
+  options::{AlignmentGather, ChunkingStrategy, DecodingOptions},
   tokenizer::{SpecialTokens, WhisperTokenizer},
 };
 
@@ -3025,11 +3025,20 @@ fn four_window_shapes_read_stale_and_dropped_alignment_rows() {
   //   B. re-add `alignment.fill(0.0)` in reset: ONLY W2 `gamma` 1.4 -> 1.8
   //      (W1's row 10 was already zero; W2 loses its stale row 7).
   //   D. move the loop's commit above the completion break: same as A.
+  //
+  // `AlignmentGather::Complete` is REQUIRED here, not incidental: this pins
+  // which alignment ROWS the accumulator hands over, and the #41 gather
+  // (`SwiftParity`, the pipeline default) zeroes the tail of the last gathered
+  // row before DTW ever sees it. With 100 columns the pitch is 128, so the
+  // discriminating column of the last row — the whole signal above — is
+  // erased and every mutation in the matrix reads the same. The gather is
+  // pinned separately by `swift_parity_gather_moves_the_next_window_seek`.
   let t = tiny_tokenizer();
   let options = DecodingOptions::new()
     .with_word_timestamps()
     .with_without_timestamps()
-    .maybe_drop_blank_audio(false);
+    .maybe_drop_blank_audio(false)
+    .with_alignment_gather(AlignmentGather::Complete);
   let mock = four_shape_alignment_fixture(&t);
   let result = TranscribeTask::new(&mock, &t)
     .run(&vec![0.1; 80_000], &options)
@@ -3111,13 +3120,21 @@ fn cap_hit_window_drops_the_completing_row() {
   // Identical tokens would trip the compression/logprob fallback and replay
   // the window; disable those thresholds so the run is a single 223-step
   // attempt and `decode_steps` reads the cap directly.
+  //
+  // `AlignmentGather::Complete` is REQUIRED for this pin to discriminate. At
+  // N = 224 gathered rows over 100 columns (pitch 128) the #41 gather's copied
+  // prefix runs dry at row 175, so under the pipeline default rows 175..=223 —
+  // including the predecessor/last-word/dropped triple this test is built on —
+  // arrive entirely zeroed and Mutation A becomes invisible. The gather itself
+  // is pinned by `swift_parity_gather_moves_the_next_window_seek`.
   let options = DecodingOptions::new()
     .with_word_timestamps()
     .with_without_timestamps()
     .maybe_drop_blank_audio(false)
     .maybe_compression_ratio_threshold(None)
     .maybe_logprob_threshold(None)
-    .maybe_first_token_logprob_threshold(None);
+    .maybe_first_token_logprob_threshold(None)
+    .with_alignment_gather(AlignmentGather::Complete);
   let result = TranscribeTask::new(&mock, &t)
     .run(&vec![0.1; 480_000], &options)
     .unwrap();
@@ -3323,4 +3340,103 @@ fn skip_special_tokens_governs_segment_text_on_both_writer_branches() {
     !off.text().contains("<|"),
     "joined transcript is special-filtered regardless of the flag"
   );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn swift_parity_gather_moves_the_next_window_seek() {
+  // whisper #41 in miniature, on the mock backend: the alignment gather is
+  // not confined to one window's word list. The final gathered row's tail
+  // moves the last word's end (`SegmentSeeker.swift:642-649` hands it to the
+  // segment), the segment's end moves `seek` (`:221-223`'s
+  // `seek = max(seek, Int(lastSpeechTimestamp * sampleRate))`), and the next
+  // window therefore decodes a different slice of audio. That cascade is what
+  // turned a 476-column tail into 984 words of edit distance and one extra
+  // window across the 1417 s fixture.
+  //
+  // Shape: 100 encoder columns (pitch 128), a segment of 6 gathered tokens
+  // (`<|startoftranscript|><|en|><|transcribe|><|0.00|> Hello<|0.80|>` — the
+  // prompt rides along, `SegmentSeeker.swift:427-442`), so the copied prefix
+  // runs out 88 columns into row 4 and never reaches row 5 at all. Rows 4 and
+  // 5 are the pair that brackets the only text word, and the mock commits
+  // script step `k`'s row at accumulator row `k + 1`, so they are scripted at
+  // steps 3 and 4. Row 4 pays for every column past 59; row 5 has a +1.0
+  // plateau from column 44 that only the un-truncated gather can see.
+  let t = tiny_tokenizer();
+  let s = special();
+  let hello = t.encode(" Hello").unwrap()[0];
+  let cols = 100usize;
+
+  let run = |gather| {
+    let mut mock = MockBackend::new().with_dims(
+      ModelDims::new()
+        .with_window_samples(16_000)
+        .with_n_audio_ctx(cols),
+    );
+    let script = [
+      s.english_token(),
+      s.transcribe_token(),
+      ts(0),
+      hello,
+      ts(40),
+      ts(40),
+      s.end_token(),
+    ];
+    for (step, token) in script.iter().enumerate() {
+      let row: Vec<f32> = (0..cols)
+        .map(|column| match step {
+          3 if column < 60 => 0.5,
+          3 => -0.1,
+          4 if column >= 44 => 1.0,
+          _ => 0.0,
+        })
+        .collect();
+      mock.push_step_with_alignment(one_hot(*token), row);
+    }
+    let task = TranscribeTask::new(&mock, &t);
+    let options = DecodingOptions::new()
+      .with_word_timestamps()
+      .with_alignment_gather(gather);
+    // 3 s of audio: how far it gets is itself an output here, so the window
+    // count is not scripted but observed.
+    let result = task.run(&vec![0.1; 48_000], &options).unwrap();
+    let seeks: Vec<usize> = result
+      .segments_slice()
+      .iter()
+      .map(TranscriptionSegment::seek)
+      .collect();
+    let ends: Vec<f32> = result
+      .segments_slice()
+      .iter()
+      .map(TranscriptionSegment::end)
+      .collect();
+    (mock.counters().encode_calls(), seeks, ends)
+  };
+
+  let (complete_windows, complete_seeks, complete_ends) = run(AlignmentGather::Complete);
+  let (parity_windows, parity_seeks, parity_ends) = run(AlignmentGather::SwiftParity);
+
+  // Window 1 is identical audio and an identical script under both gathers,
+  // and still ends somewhere else.
+  assert_eq!(
+    complete_ends[0], 0.88,
+    "row 5's plateau ends window 1 at col 44"
+  );
+  assert_eq!(
+    parity_ends[0], 1.18,
+    "with row 5 blank, row 4 holds it to col 59"
+  );
+
+  // ... so window 2 starts somewhere else. THE assertion: the next window's
+  // seek is a function of the gather.
+  assert_eq!(complete_seeks[1], 14_080, "0.88 s * 16 kHz");
+  assert_eq!(parity_seeks[1], 18_880, "1.18 s * 16 kHz");
+  assert_ne!(complete_seeks[1], parity_seeks[1]);
+
+  // ... and the drift compounds: the un-truncated gather advances in smaller
+  // steps and fits one more window into the same 3 s, exactly as the port did
+  // against Swift's 51 windows before #41.
+  assert_eq!((complete_windows, parity_windows), (3, 2));
+  assert_eq!(complete_seeks, vec![0, 14_080, 28_160]);
+  assert_eq!(parity_seeks, vec![0, 18_880]);
 }

--- a/crates/coremlit/src/audio/whisper/transcribe/tests.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/tests.rs
@@ -3366,11 +3366,14 @@ fn swift_parity_gather_moves_the_next_window_seek() {
   // for every column past 59; row 5 has a +1.0 plateau from column 44 that
   // only the un-truncated gather can see.
   //
-  // Those columns straddle a truncation point the SHIPPING gather measures on
-  // the running host rather than assumes, so the fixture states the layout it
-  // was built for and fails there first if this host pads differently — see
-  // `segment::tests::the_recorded_swift_probe_still_describes_this_host`,
-  // which is the single place that check belongs.
+  // Those columns straddle a cut the SHIPPING gather measures on the running
+  // host rather than assumes, so the fixture states the layout it was built
+  // for and fails here first if this host pads differently — see
+  // `segment::tests::reference_host_pitch_table`, the (ignored) probe that
+  // records what that layout was. The assertions below use ONE pitch because
+  // this fixture's source and destination shapes share the accumulator width;
+  // where a host pitches the two heights differently, `gather_swift_rows`
+  // reproduces the shifted read and the numbers below stop describing it.
   let t = tiny_tokenizer();
   let s = special();
   let hello = t.encode(" Hello").unwrap()[0];

--- a/crates/coremlit/src/audio/whisper/transcribe/tests.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/tests.rs
@@ -3351,13 +3351,17 @@ fn skip_special_tokens_governs_segment_text_on_both_writer_branches() {
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn swift_parity_gather_moves_the_first_windows_end_and_the_next_seek() {
   // whisper #41 in miniature, on the mock backend: the OPT-IN alignment gather
-  // is not confined to one window's word list. The final gathered row's tail
-  // moves the last word's end (`SegmentSeeker.swift:642-649` hands it to the
-  // segment), the segment's end moves `seek` (`:221-223`'s
-  // `seek = max(seek, Int(lastSpeechTimestamp * sampleRate))`), and the next
-  // window therefore decodes a different slice of audio. That cascade is what
-  // turned a 476-column tail into 984 words of edit distance and one extra
-  // window across the 1417 s fixture.
+  // is not confined to one window's word list. In THIS fixture every link of
+  // that reach moves — the final gathered row's tail moves the last word's end
+  // (`SegmentSeeker.swift:642-649` hands it to the segment), that segment end
+  // lands later than the standing `seek` (`:221-223`'s
+  // `seek = max(seek, Int(lastSpeechTimestamp * sampleRate))`) and so replaces
+  // it, and the next window therefore decodes a different slice of audio. None
+  // of those links is automatic: each moves only if the one before it moved
+  // something far enough, and the `max` discards a segment end that does not
+  // land later. Where they all do move they compound, which is what turned a
+  // 476-column tail into 984 words of edit distance and one extra window
+  // across the 1417 s fixture.
   //
   // Both halves of the name are asserted, and the FIRST half is the one that
   // bounds the public doc claim: window 1 already ends somewhere else, on

--- a/crates/coremlit/src/audio/whisper/transcribe/tests.rs
+++ b/crates/coremlit/src/audio/whisper/transcribe/tests.rs
@@ -3026,14 +3026,16 @@ fn four_window_shapes_read_stale_and_dropped_alignment_rows() {
   //      (W1's row 10 was already zero; W2 loses its stale row 7).
   //   D. move the loop's commit above the completion break: same as A.
   //
-  // `AlignmentGather::Complete` is REQUIRED here, not incidental: this pins
-  // which alignment ROWS the accumulator hands over, and the #41 gather
-  // (`SwiftParity`, the pipeline default) zeroes the tail of the last gathered
-  // row before DTW ever sees it. At any measured pitch above the column count
-  // (128 for 100 columns on the reference host) that erasure lands, so the
-  // discriminating column of the last row — the whole signal above — is
-  // erased and every mutation in the matrix reads the same. The gather is
-  // pinned separately by `swift_parity_gather_moves_the_next_window_seek`.
+  // `AlignmentGather::Complete` is named explicitly, not incidentally: it is
+  // the pipeline DEFAULT (round-3 owner decision) but this pin depends on it
+  // rather than merely inheriting it. This test pins which alignment ROWS the
+  // accumulator hands over, and the opt-in #41 gather (`SwiftParity`) zeroes
+  // the tail of the last gathered row before DTW ever sees it. At any measured
+  // pitch above the column count (128 for 100 columns on the reference host)
+  // that erasure lands, so the discriminating column of the last row — the
+  // whole signal above — would be erased and every mutation in the matrix
+  // would read the same. The opt-in gather is pinned separately by
+  // `swift_parity_gather_moves_the_next_window_seek`.
   let t = tiny_tokenizer();
   let options = DecodingOptions::new()
     .with_word_timestamps()
@@ -3122,13 +3124,14 @@ fn cap_hit_window_drops_the_completing_row() {
   // the window; disable those thresholds so the run is a single 223-step
   // attempt and `decode_steps` reads the cap directly.
   //
-  // `AlignmentGather::Complete` is REQUIRED for this pin to discriminate. At
-  // N = 224 gathered rows over 100 columns (measured pitch 128 on the
-  // reference host) the #41 gather's copied
-  // prefix runs dry at row 175, so under the pipeline default rows 175..=223 —
-  // including the predecessor/last-word/dropped triple this test is built on —
-  // arrive entirely zeroed and Mutation A becomes invisible. The gather itself
-  // is pinned by `swift_parity_gather_moves_the_next_window_seek`.
+  // `AlignmentGather::Complete` — the pipeline default — is REQUIRED for this
+  // pin to discriminate, and is named rather than inherited so the dependency
+  // is legible. At N = 224 gathered rows over 100 columns (measured pitch 128
+  // on the reference host) the opt-in #41 gather's copied prefix runs dry at
+  // row 175, so under `SwiftParity` rows 175..=223 — including the
+  // predecessor/last-word/dropped triple this test is built on — would arrive
+  // entirely zeroed and Mutation A would become invisible. That gather is
+  // pinned by `swift_parity_gather_moves_the_next_window_seek`.
   let options = DecodingOptions::new()
     .with_word_timestamps()
     .with_without_timestamps()
@@ -3347,8 +3350,8 @@ fn skip_special_tokens_governs_segment_text_on_both_writer_branches() {
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn swift_parity_gather_moves_the_next_window_seek() {
-  // whisper #41 in miniature, on the mock backend: the alignment gather is
-  // not confined to one window's word list. The final gathered row's tail
+  // whisper #41 in miniature, on the mock backend: the OPT-IN alignment gather
+  // is not confined to one window's word list. The final gathered row's tail
   // moves the last word's end (`SegmentSeeker.swift:642-649` hands it to the
   // segment), the segment's end moves `seek` (`:221-223`'s
   // `seek = max(seek, Int(lastSpeechTimestamp * sampleRate))`), and the next
@@ -3366,7 +3369,7 @@ fn swift_parity_gather_moves_the_next_window_seek() {
   // for every column past 59; row 5 has a +1.0 plateau from column 44 that
   // only the un-truncated gather can see.
   //
-  // Those columns straddle a cut the SHIPPING gather measures on the running
+  // Those columns straddle a cut the opt-in gather measures on the running
   // host rather than assumes, so the fixture states the layout it was built
   // for and fails here first if this host pads differently — see
   // `segment::tests::reference_host_pitch_table`, the (ignored) probe that

--- a/crates/coremlit/src/model/mod.rs
+++ b/crates/coremlit/src/model/mod.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use objc2::rc::Retained;
+use objc2::rc::{Retained, autoreleasepool};
 use objc2_core_ml::{MLDictionaryFeatureProvider, MLModel, MLModelConfiguration};
 use objc2_foundation::NSURL;
 
@@ -206,18 +206,55 @@ impl Model {
 
   /// Runs a synchronous prediction.
   ///
+  /// # Autorelease pool
+  ///
+  /// The whole body runs inside an [`autoreleasepool`], and so do
+  /// [`Self::predict_with`] and [`Self::predict_with_state`]. These three
+  /// are the only places this crate crosses into CoreML's prediction API,
+  /// and every kit — whisper, speaker, siglip, granite, clap, vad, ced,
+  /// align — reaches the ANE through one of them, so draining here bounds
+  /// every consumer at once rather than one caller's loop.
+  ///
+  /// A pool is needed because a Rust binary has no ambient one. Objective-C
+  /// hosts get theirs from the run loop or from the `@autoreleasepool` the
+  /// caller writes; a plain `main` has neither, and libobjc's response to
+  /// an `autorelease` with no pool in place is to install a first page and
+  /// accumulate into it *for the lifetime of the process* — nothing ever
+  /// pops it. Every object CoreML autoreleases per prediction (and every
+  /// one this crate's own bridging autoreleases: the `MLFeatureValue`s
+  /// `provider_from_pairs` builds, the `NSArray` shape/stride reads behind
+  /// [`MultiArray`], the `NSString` names `Features::from_provider`
+  /// converts) therefore stays live until the process exits. That is
+  /// coremlit issue #62: the live count grows strictly with the number of
+  /// predictions, so a long-form transcription's footprint is a function of
+  /// audio length with no ceiling.
+  ///
+  /// **Draining does not invalidate anything this returns.** [`Features`]
+  /// owns its arrays through `Retained<MLMultiArray>` — a `+1` strong
+  /// reference that is entirely independent of the pool's — and
+  /// [`PredictionError`] carries only owned `String`/`isize`
+  /// ([`NsErrorInfo`]). Nothing pool-bound can escape by construction
+  /// either: [`autoreleasepool`]'s bound is
+  /// `for<'pool> F: FnOnce(AutoreleasePool<'pool>) -> T`, so `T` is chosen
+  /// independently of `'pool` and a `&T` borrowed from the pool token
+  /// cannot appear in the return type. This crate never calls the borrowing
+  /// APIs (`Retained::autorelease*`) that would produce such a reference in
+  /// the first place — the token is ignored at all three sites.
+  ///
   /// # Errors
   /// [`PredictionError::Native`] if CoreML fails; missing/mistyped outputs
   /// surface as structured variants when extracted;
   /// [`PredictionError::AliasCopyFailed`] if de-aliasing an output that
   /// shared a buffer with an input (or another output) fails.
   pub fn predict(&self, inputs: &Features) -> Result<Features, PredictionError> {
-    let provider = inputs.to_provider()?;
-    // Seed with every input's buffer identity: inputs outlive this call (the
-    // caller still owns `inputs`), so an identity/zero-copy model echoing
-    // one back as an output is the same aliasing hazard as two output names
-    // sharing one array, which `from_provider` also catches on its own.
-    self.predict_from_provider(&provider, inputs.byte_ranges())
+    autoreleasepool(|_| {
+      let provider = inputs.to_provider()?;
+      // Seed with every input's buffer identity: inputs outlive this call (the
+      // caller still owns `inputs`), so an identity/zero-copy model echoing
+      // one back as an output is the same aliasing hazard as two output names
+      // sharing one array, which `from_provider` also catches on its own.
+      self.predict_from_provider(&provider, inputs.byte_ranges())
+    })
   }
 
   /// Runs a synchronous prediction from borrowed inputs.
@@ -244,13 +281,20 @@ impl Model {
   /// the aliasing detector either way.
   ///
   /// # Errors
-  /// As [`Self::predict`].
+  /// As [`Self::predict`], whose `# Autorelease pool` section also covers
+  /// this method's pool.
   pub fn predict_with(&self, inputs: &[(&str, &MultiArray)]) -> Result<Features, PredictionError> {
-    let provider = crate::features::provider_from_pairs(inputs.iter().copied())?;
-    // As in `predict`: these borrowed inputs outlive this call too (the
-    // caller still owns each array), so seed `known_regions` the same way.
-    let known_regions = inputs.iter().map(|(_, a)| a.byte_range()).collect();
-    self.predict_from_provider(&provider, known_regions)
+    // Per-prediction pool: see `predict`'s `# Autorelease pool`. This is the
+    // per-step decoder entry, so it is also the site the accumulation scales
+    // with — one pool per prediction, not one per window, is what keeps the
+    // live count flat across a transcription of any length.
+    autoreleasepool(|_| {
+      let provider = crate::features::provider_from_pairs(inputs.iter().copied())?;
+      // As in `predict`: these borrowed inputs outlive this call too (the
+      // caller still owns each array), so seed `known_regions` the same way.
+      let known_regions = inputs.iter().map(|(_, a)| a.byte_range()).collect();
+      self.predict_from_provider(&provider, known_regions)
+    })
   }
 
   // Shared prediction tail for `predict`/`predict_with`: runs
@@ -348,6 +392,10 @@ impl Model {
   /// [`PredictionError::Native`] on CoreML failure;
   /// [`PredictionError::AliasCopyFailed`] if de-aliasing an output that
   /// shared a buffer with an input (or another output) fails.
+  ///
+  /// The body runs inside an [`autoreleasepool`] for the same reason
+  /// [`Self::predict`]'s does; `state` is mutated in place and outlives the
+  /// pool as a `Retained<MLState>`, so the drain does not touch it.
   pub fn predict_with_state(
     &self,
     inputs: &Features,
@@ -356,19 +404,21 @@ impl Model {
     if !self.supports_state() {
       return Err(PredictionError::StateUnsupported);
     }
-    let provider = inputs.to_provider()?;
-    // SAFETY: provider + state are live; &mut state gives exclusivity.
-    let outputs = unsafe {
-      self.inner.predictionFromFeatures_usingState_error(
-        objc2::runtime::ProtocolObject::from_ref(&*provider),
-        state.raw(),
-      )
-    }
-    .map_err(|e| PredictionError::Native(NsErrorInfo::from_ns_error(&e)))?;
-    // See `predict`'s comment: inputs outlive this call, so seed known_regions
-    // with their buffer identities too.
-    let mut known_regions = inputs.byte_ranges();
-    Features::from_provider(&outputs, &mut known_regions)
+    autoreleasepool(|_| {
+      let provider = inputs.to_provider()?;
+      // SAFETY: provider + state are live; &mut state gives exclusivity.
+      let outputs = unsafe {
+        self.inner.predictionFromFeatures_usingState_error(
+          objc2::runtime::ProtocolObject::from_ref(&*provider),
+          state.raw(),
+        )
+      }
+      .map_err(|e| PredictionError::Native(NsErrorInfo::from_ns_error(&e)))?;
+      // See `predict`'s comment: inputs outlive this call, so seed known_regions
+      // with their buffer identities too.
+      let mut known_regions = inputs.byte_ranges();
+      Features::from_provider(&outputs, &mut known_regions)
+    })
   }
 }
 

--- a/crates/coremlit/src/multi_array/mod.rs
+++ b/crates/coremlit/src/multi_array/mod.rs
@@ -677,6 +677,20 @@ impl MultiArray {
   /// inter-row padding — before returning, so every logical element is safe
   /// to read immediately, whether or not the layout turned out padded.
   ///
+  /// # Initialization is write-only, deliberately
+  ///
+  /// Nothing here READS the freshly created buffer. CoreVideo does not
+  /// promise a new `CVPixelBuffer`'s bytes are initialized, and reading an
+  /// uninitialized byte is undefined behavior in Rust whatever the read is
+  /// spelled as — `read_volatile` suppresses elision and reordering, not
+  /// undefinedness, and `MaybeUninit` only moves the obligation to whatever
+  /// would inspect the value. An earlier revision of this constructor scanned
+  /// the allocation's tail before zeroing it in order to report what CoreVideo
+  /// had left there; that scan was UB on exactly the hosts it existed to
+  /// detect, so this safe constructor now performs a single `write_bytes`
+  /// over `CVPixelBufferGetDataSize` bytes and never observes the prior
+  /// contents (whisper #41, codex round 3, F1).
+  ///
   /// # Errors
   /// [`TensorError::UnsupportedShape`] (reason
   /// [`ShapeRequirement::NonEmpty`]) if `shape` is empty — a rank-0 shape
@@ -697,35 +711,6 @@ impl MultiArray {
   /// the unrecognized selector surfaces as an error, never an Objective-C
   /// exception.
   pub fn f16_surface(shape: &[usize]) -> Result<Self, TensorError> {
-    Self::f16_surface_probing_fresh_tail(shape).map(|(array, _)| array)
-  }
-
-  /// [`Self::f16_surface`], plus the one thing that constructor's own zero
-  /// fill destroys: how many bytes CoreVideo left **nonzero** in the storage
-  /// PAST the array's logical `count()` elements, sampled between the
-  /// allocation and the fill.
-  ///
-  /// That region is exactly the storage a caller replicating Swift's
-  /// `MLMultiArray(shape:dataType:initialValue:)`
-  /// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`) would inherit
-  /// untouched: for `.float16` that initializer allocates this same
-  /// `CVPixelBuffer` and then fills `dataPointer` with `initialize(repeating:
-  /// count: count)` — `count` being the array's LOGICAL element count, so
-  /// everything the row pitch adds on top of it keeps whatever CoreVideo
-  /// returned. Nothing in CoreVideo promises that is zero (see the zero-fill
-  /// rationale in [`Self::f16_surface`]), so a caller that needs to know
-  /// rather than hope has to look before the fill — which is the only reason
-  /// this variant exists.
-  ///
-  /// A `0` result means CoreVideo's fresh allocation was already all-zero
-  /// there. The returned array is fully zero-filled either way, exactly as
-  /// [`Self::f16_surface`] promises.
-  ///
-  /// # Errors
-  /// Identical to [`Self::f16_surface`].
-  pub(crate) fn f16_surface_probing_fresh_tail(
-    shape: &[usize],
-  ) -> Result<(Self, usize), TensorError> {
     use objc2_core_foundation::{CFDictionary, CFRetained, CFType};
     use objc2_core_video::{
       CVPixelBuffer, CVPixelBufferCreate, kCVPixelBufferIOSurfacePropertiesKey,
@@ -762,15 +747,19 @@ impl MultiArray {
     // is the exact final dimension with no clamping.
     let width = *shape.last().expect("shape checked non-empty above");
     let height = checked_element_count(&shape[..shape.len() - 1])?;
-    // The array's logical element count, in bytes: where a replication of
-    // Swift's `initialValue:` fill stops and the untouched tail this
-    // constructor reports on begins.
-    let logical_bytes = height
+    // Overflow guard, not a size the fill below uses: the byte count actually
+    // zeroed is CoreVideo's own `CVPixelBufferGetDataSize`. A shape whose
+    // element count (or that count's byte size) is unrepresentable is refused
+    // here, before any native allocation is attempted.
+    if height
       .checked_mul(width)
       .and_then(|count| count.checked_mul(size_of::<f16>()))
-      .ok_or_else(|| TensorError::ShapeOverflow {
+      .is_none()
+    {
+      return Err(TensorError::ShapeOverflow {
         shape: shape.to_vec(),
-      })?;
+      });
+    }
 
     // An empty IOSurface-properties dictionary as the value of
     // `kCVPixelBufferIOSurfacePropertiesKey` opts the buffer into IOSurface
@@ -830,15 +819,13 @@ impl MultiArray {
     // uninitialized bytes.
     // SAFETY: `buffer` is the live pixel buffer created above; lock/base/
     // size/unlock is the documented CPU-access protocol, base is non-null
-    // after a successful lock of a successfully created buffer, and both the
-    // tail scan and `write_bytes` stay within `CVPixelBufferGetDataSize`
-    // bytes of the locked base. The scan reads bytes CoreVideo allocated but
-    // may not have written, so it goes through `read_volatile`: every bit
-    // pattern is a valid `u8`, and the volatile read keeps the compiler from
-    // folding the comparison away on the grounds that the content is
-    // unspecified — the whole point of the scan is to report what is there.
-    // All-zero bits are valid `f16` (0.0).
-    let fresh_tail_nonzero_bytes = unsafe {
+    // after a successful lock of a successfully created buffer, and the
+    // `write_bytes` stays within `CVPixelBufferGetDataSize` bytes of the
+    // locked base. The buffer's prior contents are never read — the only
+    // access is this write, so no uninitialized byte is ever observed (see
+    // the constructor doc's write-only section). All-zero bits are valid
+    // `f16` (0.0).
+    unsafe {
       use objc2_core_video::{
         CVPixelBufferGetBaseAddress, CVPixelBufferGetDataSize, CVPixelBufferLockBaseAddress,
         CVPixelBufferLockFlags, CVPixelBufferUnlockBaseAddress,
@@ -853,14 +840,9 @@ impl MultiArray {
         return Err(TensorError::PixelBuffer { code: lock });
       }
       let data_size = CVPixelBufferGetDataSize(&buffer);
-      let bytes = base.cast::<u8>();
-      let nonzero = (logical_bytes..data_size)
-        .filter(|&offset| bytes.add(offset).read_volatile() != 0)
-        .count();
-      core::ptr::write_bytes(bytes, 0, data_size);
+      core::ptr::write_bytes(base.cast::<u8>(), 0, data_size);
       CVPixelBufferUnlockBaseAddress(&buffer, CVPixelBufferLockFlags::empty());
-      nonzero
-    };
+    }
 
     // SAFETY: `buffer`'s pixel format matches Float16, `shape`'s last
     // dimension equals `width` exactly (zero dims were rejected above, so
@@ -871,7 +853,7 @@ impl MultiArray {
     let inner = unsafe {
       MLMultiArray::initWithPixelBuffer_shape(MLMultiArray::alloc(), &buffer, &ns_shape(shape))
     };
-    Ok((Self::from_raw(inner), fresh_tail_nonzero_bytes))
+    Ok(Self::from_raw(inner))
   }
 }
 

--- a/crates/coremlit/src/multi_array/mod.rs
+++ b/crates/coremlit/src/multi_array/mod.rs
@@ -697,6 +697,35 @@ impl MultiArray {
   /// the unrecognized selector surfaces as an error, never an Objective-C
   /// exception.
   pub fn f16_surface(shape: &[usize]) -> Result<Self, TensorError> {
+    Self::f16_surface_probing_fresh_tail(shape).map(|(array, _)| array)
+  }
+
+  /// [`Self::f16_surface`], plus the one thing that constructor's own zero
+  /// fill destroys: how many bytes CoreVideo left **nonzero** in the storage
+  /// PAST the array's logical `count()` elements, sampled between the
+  /// allocation and the fill.
+  ///
+  /// That region is exactly the storage a caller replicating Swift's
+  /// `MLMultiArray(shape:dataType:initialValue:)`
+  /// (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`) would inherit
+  /// untouched: for `.float16` that initializer allocates this same
+  /// `CVPixelBuffer` and then fills `dataPointer` with `initialize(repeating:
+  /// count: count)` — `count` being the array's LOGICAL element count, so
+  /// everything the row pitch adds on top of it keeps whatever CoreVideo
+  /// returned. Nothing in CoreVideo promises that is zero (see the zero-fill
+  /// rationale in [`Self::f16_surface`]), so a caller that needs to know
+  /// rather than hope has to look before the fill — which is the only reason
+  /// this variant exists.
+  ///
+  /// A `0` result means CoreVideo's fresh allocation was already all-zero
+  /// there. The returned array is fully zero-filled either way, exactly as
+  /// [`Self::f16_surface`] promises.
+  ///
+  /// # Errors
+  /// Identical to [`Self::f16_surface`].
+  pub(crate) fn f16_surface_probing_fresh_tail(
+    shape: &[usize],
+  ) -> Result<(Self, usize), TensorError> {
     use objc2_core_foundation::{CFDictionary, CFRetained, CFType};
     use objc2_core_video::{
       CVPixelBuffer, CVPixelBufferCreate, kCVPixelBufferIOSurfacePropertiesKey,
@@ -733,8 +762,12 @@ impl MultiArray {
     // is the exact final dimension with no clamping.
     let width = *shape.last().expect("shape checked non-empty above");
     let height = checked_element_count(&shape[..shape.len() - 1])?;
-    height
+    // The array's logical element count, in bytes: where a replication of
+    // Swift's `initialValue:` fill stops and the untouched tail this
+    // constructor reports on begins.
+    let logical_bytes = height
       .checked_mul(width)
+      .and_then(|count| count.checked_mul(size_of::<f16>()))
       .ok_or_else(|| TensorError::ShapeOverflow {
         shape: shape.to_vec(),
       })?;
@@ -797,10 +830,15 @@ impl MultiArray {
     // uninitialized bytes.
     // SAFETY: `buffer` is the live pixel buffer created above; lock/base/
     // size/unlock is the documented CPU-access protocol, base is non-null
-    // after a successful lock of a successfully created buffer, and
-    // `write_bytes` stays within `CVPixelBufferGetDataSize` bytes of the
-    // locked base. All-zero bits are valid `f16` (0.0).
-    unsafe {
+    // after a successful lock of a successfully created buffer, and both the
+    // tail scan and `write_bytes` stay within `CVPixelBufferGetDataSize`
+    // bytes of the locked base. The scan reads bytes CoreVideo allocated but
+    // may not have written, so it goes through `read_volatile`: every bit
+    // pattern is a valid `u8`, and the volatile read keeps the compiler from
+    // folding the comparison away on the grounds that the content is
+    // unspecified — the whole point of the scan is to report what is there.
+    // All-zero bits are valid `f16` (0.0).
+    let fresh_tail_nonzero_bytes = unsafe {
       use objc2_core_video::{
         CVPixelBufferGetBaseAddress, CVPixelBufferGetDataSize, CVPixelBufferLockBaseAddress,
         CVPixelBufferLockFlags, CVPixelBufferUnlockBaseAddress,
@@ -814,9 +852,15 @@ impl MultiArray {
         CVPixelBufferUnlockBaseAddress(&buffer, CVPixelBufferLockFlags::empty());
         return Err(TensorError::PixelBuffer { code: lock });
       }
-      core::ptr::write_bytes(base.cast::<u8>(), 0, CVPixelBufferGetDataSize(&buffer));
+      let data_size = CVPixelBufferGetDataSize(&buffer);
+      let bytes = base.cast::<u8>();
+      let nonzero = (logical_bytes..data_size)
+        .filter(|&offset| bytes.add(offset).read_volatile() != 0)
+        .count();
+      core::ptr::write_bytes(bytes, 0, data_size);
       CVPixelBufferUnlockBaseAddress(&buffer, CVPixelBufferLockFlags::empty());
-    }
+      nonzero
+    };
 
     // SAFETY: `buffer`'s pixel format matches Float16, `shape`'s last
     // dimension equals `width` exactly (zero dims were rejected above, so
@@ -827,7 +871,7 @@ impl MultiArray {
     let inner = unsafe {
       MLMultiArray::initWithPixelBuffer_shape(MLMultiArray::alloc(), &buffer, &ns_shape(shape))
     };
-    Ok(Self::from_raw(inner))
+    Ok((Self::from_raw(inner), fresh_tail_nonzero_bytes))
   }
 }
 

--- a/crates/coremlit/src/multi_array/tests.rs
+++ b/crates/coremlit/src/multi_array/tests.rs
@@ -320,6 +320,37 @@ fn f16_surface_contiguous_is_zero_before_any_write() {
 }
 
 #[test]
+fn f16_surface_probing_fresh_tail_still_zero_fills_everything() {
+  // The probe variant exists to report what CoreVideo left past the logical
+  // element count BEFORE the zero fill; the array it hands back must still
+  // honor `f16_surface`'s contract that every logical element (and every
+  // padding byte) reads zero. Both must hold at once, or a caller reading a
+  // padded row would see whatever the tail report was describing.
+  for shape in [[1usize, 4], [3, 9], [225, 100]] {
+    let (arr, nonzero) = MultiArray::f16_surface_probing_fresh_tail(&shape).unwrap();
+    assert_eq!(arr.shape(), shape, "shape must survive the probe");
+    for i0 in 0..shape[0] {
+      for i1 in 0..shape[1] {
+        assert_eq!(
+          arr.read_at::<f16>(&[i0, i1]).unwrap(),
+          f16::from_f32(0.0),
+          "shape {shape:?} index [{i0}, {i1}] was not zeroed"
+        );
+      }
+    }
+    // Not an assertion about CoreVideo — a report about it. The whisper
+    // gather is the caller that cares, and it fails closed on nonzero rather
+    // than pretending; recorded here so a host where this stops being 0 is
+    // diagnosable at the tensor layer too.
+    assert_eq!(
+      nonzero, 0,
+      "shape {shape:?}: CoreVideo left {nonzero} nonzero byte(s) past the logical element count \
+       on this host, so `AlignmentGather::SwiftParity` will refuse to run here"
+    );
+  }
+}
+
+#[test]
 fn zeros_rejects_shape_overflow() {
   let err = MultiArray::zeros(&[usize::MAX, 2], DataType::F32).unwrap_err();
   assert_eq!(

--- a/crates/coremlit/src/multi_array/tests.rs
+++ b/crates/coremlit/src/multi_array/tests.rs
@@ -320,15 +320,18 @@ fn f16_surface_contiguous_is_zero_before_any_write() {
 }
 
 #[test]
-fn f16_surface_probing_fresh_tail_still_zero_fills_everything() {
-  // The probe variant exists to report what CoreVideo left past the logical
-  // element count BEFORE the zero fill; the array it hands back must still
-  // honor `f16_surface`'s contract that every logical element (and every
-  // padding byte) reads zero. Both must hold at once, or a caller reading a
-  // padded row would see whatever the tail report was describing.
-  for shape in [[1usize, 4], [3, 9], [225, 100]] {
-    let (arr, nonzero) = MultiArray::f16_surface_probing_fresh_tail(&shape).unwrap();
-    assert_eq!(arr.shape(), shape, "shape must survive the probe");
+fn f16_surface_zero_fills_every_logical_element_at_every_shape() {
+  // `f16_surface`'s contract at the shapes the whisper alignment gather uses,
+  // including the tall 225-row accumulator: every logical element reads zero
+  // immediately after construction, whether or not CoreVideo padded the rows.
+  //
+  // This asserts what THIS crate wrote, and nothing about what CoreVideo left
+  // behind first — the constructor is write-only by design (reading a fresh
+  // pixel buffer's bytes is UB, whatever the read is spelled as), so there is
+  // no prior content any test could legitimately observe.
+  for shape in [[1usize, 4], [3, 9], [225, 100], [224, 100]] {
+    let arr = MultiArray::f16_surface(&shape).unwrap();
+    assert_eq!(arr.shape(), shape);
     for i0 in 0..shape[0] {
       for i1 in 0..shape[1] {
         assert_eq!(
@@ -338,15 +341,6 @@ fn f16_surface_probing_fresh_tail_still_zero_fills_everything() {
         );
       }
     }
-    // Not an assertion about CoreVideo — a report about it. The whisper
-    // gather is the caller that cares, and it fails closed on nonzero rather
-    // than pretending; recorded here so a host where this stops being 0 is
-    // diagnosable at the tensor layer too.
-    assert_eq!(
-      nonzero, 0,
-      "shape {shape:?}: CoreVideo left {nonzero} nonzero byte(s) past the logical element count \
-       on this host, so `AlignmentGather::SwiftParity` will refuse to run here"
-    );
   }
 }
 

--- a/crates/coremlit/tests/whisper/fixtures/golden/jfk_tiny_words_golden.json
+++ b/crates/coremlit/tests/whisper/fixtures/golden/jfk_tiny_words_golden.json
@@ -1,0 +1,255 @@
+{
+  "model": "openai_whisper-tiny",
+  "source": "official Swift WhisperKit (argmax-oss-swift@dcf3a00), captured verbatim on macOS 26.5 / M1 Max; see crates/coremlit/tests/whisper_swift_probes/README.md",
+  "options": "task=transcribe language=nil temperature=0 temperatureFallbackCount=0 usePrefillPrompt=true skipSpecialTokens=true withoutTimestamps=false wordTimestamps=true concurrentWorkerCount=1 chunkingStrategy=none; ModelComputeOptions(audioEncoderCompute: .cpuAndNeuralEngine, textDecoderCompute: .cpuAndNeuralEngine)",
+  "text": "And so my fellow Americans ask not what your country can do for you, ask what you can do for your country.",
+  "language": "en",
+  "totalDecodingLoops": 29,
+  "totalDecodingWindows": 1,
+  "segments": [
+    {
+      "avgLogprob": -0.24543896,
+      "compressionRatio": 1.6271186,
+      "end": 10.46,
+      "id": 0,
+      "seek": 0,
+      "start": 0.32,
+      "temperature": 0,
+      "text": " And so my fellow Americans ask not what your country can do for you, ask what you can do for your country.",
+      "tokens": [
+        50258,
+        50259,
+        50359,
+        50364,
+        400,
+        370,
+        452,
+        7177,
+        6280,
+        1029,
+        406,
+        437,
+        428,
+        1941,
+        393,
+        360,
+        337,
+        291,
+        11,
+        1029,
+        437,
+        291,
+        393,
+        360,
+        337,
+        428,
+        1941,
+        13,
+        50889,
+        50257
+      ],
+      "words": [
+        {
+          "end": 0.68,
+          "probability": 0.75,
+          "start": 0.32,
+          "tokens": [
+            400
+          ],
+          "word": " And"
+        },
+        {
+          "end": 1.1,
+          "probability": 0.93,
+          "start": 0.68,
+          "tokens": [
+            370
+          ],
+          "word": " so"
+        },
+        {
+          "end": 1.34,
+          "probability": 0.68,
+          "start": 1.1,
+          "tokens": [
+            452
+          ],
+          "word": " my"
+        },
+        {
+          "end": 1.74,
+          "probability": 1,
+          "start": 1.34,
+          "tokens": [
+            7177
+          ],
+          "word": " fellow"
+        },
+        {
+          "end": 2.26,
+          "probability": 0.96,
+          "start": 1.74,
+          "tokens": [
+            6280
+          ],
+          "word": " Americans"
+        },
+        {
+          "end": 3.82,
+          "probability": 0.49,
+          "start": 2.26,
+          "tokens": [
+            1029
+          ],
+          "word": " ask"
+        },
+        {
+          "end": 4.56,
+          "probability": 0.82,
+          "start": 3.82,
+          "tokens": [
+            406
+          ],
+          "word": " not"
+        },
+        {
+          "end": 5.68,
+          "probability": 0.72,
+          "start": 4.56,
+          "tokens": [
+            437
+          ],
+          "word": " what"
+        },
+        {
+          "end": 5.92,
+          "probability": 0.93,
+          "start": 5.68,
+          "tokens": [
+            428
+          ],
+          "word": " your"
+        },
+        {
+          "end": 6.38,
+          "probability": 0.99,
+          "start": 5.92,
+          "tokens": [
+            1941
+          ],
+          "word": " country"
+        },
+        {
+          "end": 6.76,
+          "probability": 0.98,
+          "start": 6.38,
+          "tokens": [
+            393
+          ],
+          "word": " can"
+        },
+        {
+          "end": 6.98,
+          "probability": 0.99,
+          "start": 6.76,
+          "tokens": [
+            360
+          ],
+          "word": " do"
+        },
+        {
+          "end": 7.22,
+          "probability": 0.97,
+          "start": 6.98,
+          "tokens": [
+            337
+          ],
+          "word": " for"
+        },
+        {
+          "end": 8.06,
+          "probability": 0.99,
+          "start": 7.22,
+          "tokens": [
+            291,
+            11
+          ],
+          "word": " you,"
+        },
+        {
+          "end": 8.66,
+          "probability": 0.78,
+          "start": 8.36,
+          "tokens": [
+            1029
+          ],
+          "word": " ask"
+        },
+        {
+          "end": 8.86,
+          "probability": 0.94,
+          "start": 8.66,
+          "tokens": [
+            437
+          ],
+          "word": " what"
+        },
+        {
+          "end": 9.22,
+          "probability": 0.98,
+          "start": 8.86,
+          "tokens": [
+            291
+          ],
+          "word": " you"
+        },
+        {
+          "end": 9.44,
+          "probability": 0.98,
+          "start": 9.22,
+          "tokens": [
+            393
+          ],
+          "word": " can"
+        },
+        {
+          "end": 9.64,
+          "probability": 0.96,
+          "start": 9.44,
+          "tokens": [
+            360
+          ],
+          "word": " do"
+        },
+        {
+          "end": 9.86,
+          "probability": 0.96,
+          "start": 9.64,
+          "tokens": [
+            337
+          ],
+          "word": " for"
+        },
+        {
+          "end": 10.06,
+          "probability": 0.95,
+          "start": 9.86,
+          "tokens": [
+            428
+          ],
+          "word": " your"
+        },
+        {
+          "end": 10.46,
+          "probability": 0.99,
+          "start": 10.06,
+          "tokens": [
+            1941,
+            13
+          ],
+          "word": " country."
+        }
+      ]
+    }
+  ]
+}

--- a/crates/coremlit/tests/whisper/parity_jfk.rs
+++ b/crates/coremlit/tests/whisper/parity_jfk.rs
@@ -283,14 +283,14 @@ fn oracle_options() -> DecodingOptions {
 /// the first: `TranscribeTask::run` passes `options.alignment_gather()`
 /// straight into `add_word_timestamps` with no guard. So a caller who opts
 /// into `SwiftParity` runs a single-window clip through the truncating gather
-/// too — and it is genuinely truncated here, not vacuously: 30 gathered rows
-/// over 1500 columns at the measured pitch of 1504 leaves the copied prefix
-/// ending inside the last row, which keeps 1384 of its 1500 columns. The DTW
-/// input on this clip therefore really does differ between the modes; only
-/// the path through it happens not to. #41 asserted the short-form outcome
-/// with nothing committed checking it — the sibling
-/// `jfk_tiny_matches_golden_tokens_and_segments` runs with `word_timestamps`
-/// OFF.
+/// too: at 30 gathered rows over 1500 columns and the measured pitch of 1504
+/// the copied prefix ends inside the last row, which keeps 1384 of its 1500
+/// columns. What this test then compares is the two modes' WORD LISTS — it
+/// inspects neither mode's DTW input, so what it records is that the OUTPUTS
+/// agree on this clip, not anything about whether the inputs did. #41
+/// asserted the short-form outcome with nothing committed checking it — the
+/// sibling `jfk_tiny_matches_golden_tokens_and_segments` runs with
+/// `word_timestamps` OFF.
 ///
 /// Two assertions, in the order that matters:
 ///

--- a/crates/coremlit/tests/whisper/parity_jfk.rs
+++ b/crates/coremlit/tests/whisper/parity_jfk.rs
@@ -249,7 +249,8 @@ fn result_word_rows(
 /// set covers the short-form and long-form halves of the same claim.
 ///
 /// `alignment_gather` is deliberately NOT set — the point is to exercise the
-/// shipping default.
+/// shipping default, which after the round-3 owner decision is
+/// [`AlignmentGather::Complete`].
 fn oracle_options() -> DecodingOptions {
   DecodingOptions::new()
     .with_temperature(0.0)
@@ -267,26 +268,28 @@ fn oracle_options() -> DecodingOptions {
 /// **Why this exists.** `alignment_gather` (whisper #41) is selected for
 /// EVERY word-timestamp window, not only for long-form or for windows after
 /// the first: `TranscribeTask::run` passes `options.alignment_gather()`
-/// straight into `add_word_timestamps` with no guard. So a single-window
-/// clip goes through the truncating gather too — and it is genuinely
-/// truncated here, not vacuously: 30 gathered rows over 1500 columns at the
-/// measured pitch of 1504 leaves the copied prefix ending inside the last
-/// row, which keeps 1384 of its 1500 columns. #41's claim that short-form
-/// output is unchanged was therefore a real claim about a real code path,
-/// and before this test nothing committed checked it — the sibling
-/// `jfk_tiny_matches_golden_tokens_and_segments` runs with
+/// straight into `add_word_timestamps` with no guard. So a caller who opts
+/// into `SwiftParity` runs a single-window clip through the truncating gather
+/// too — and it is genuinely truncated here, not vacuously: 30 gathered rows
+/// over 1500 columns at the measured pitch of 1504 leaves the copied prefix
+/// ending inside the last row, which keeps 1384 of its 1500 columns. #41's
+/// claim that short-form output is unchanged was therefore a real claim about
+/// a real code path, and before this test nothing committed checked it — the
+/// sibling `jfk_tiny_matches_golden_tokens_and_segments` runs with
 /// `word_timestamps` OFF.
 ///
 /// Two assertions, in the order that matters:
 ///
-/// 1. Under the shipping default ([`AlignmentGather::SwiftParity`]) every
-///    word matches the Swift oracle exactly — text, start, end, probability
-///    and token ids, no epsilon.
-/// 2. [`AlignmentGather::Complete`] produces the identical word list. That
-///    is what "the gather does not change short-form output" means, and it
-///    is an assertion rather than a comment: if the truncated final row ever
-///    does move a short-form boundary, this fails instead of the claim
-///    quietly becoming false.
+/// 1. Under the shipping default ([`AlignmentGather::Complete`]) every word
+///    matches the Swift oracle exactly — text, start, end, probability and
+///    token ids, no epsilon. The default flipped in round 3 of the #41
+///    review, so THIS is the claim that had to be re-established: the
+///    correct-everywhere gather still reproduces official Swift on this clip.
+/// 2. The opt-in [`AlignmentGather::SwiftParity`] produces the identical word
+///    list. That is what "the gather does not change short-form output"
+///    means, and it is an assertion rather than a comment: if the truncated
+///    final row ever does move a short-form boundary, this fails instead of
+///    the claim quietly becoming false.
 ///
 /// Compute path: the shipping default, for the same reason this file's
 /// module doc gives — the oracle was captured on the ANE, so the gate runs
@@ -316,21 +319,21 @@ fn jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather() {
   let default_options = oracle_options();
   assert_eq!(
     default_options.alignment_gather(),
-    AlignmentGather::SwiftParity,
+    AlignmentGather::Complete,
     "this gate must run the shipping gather, not an explicit one"
   );
-  let parity = kit.transcribe(&audio, &default_options).unwrap();
+  let default_result = kit.transcribe(&audio, &default_options).unwrap();
 
-  // (1) exact parity with Swift.
-  assert_eq!(parity.language(), golden.language);
-  assert_eq!(parity.text(), golden.text);
+  // (1) exact parity with Swift, under the DEFAULT (un-truncated) gather.
+  assert_eq!(default_result.language(), golden.language);
+  assert_eq!(default_result.text(), golden.text);
   assert_eq!(
-    parity.timings().total_decoding_windows(),
+    default_result.timings().total_decoding_windows(),
     golden.total_decoding_windows,
     "jfk is a single window; a second one would mean the seek moved"
   );
-  assert_eq!(parity.segments_slice().len(), golden.segments.len());
-  for (rust, gold) in parity.segments_slice().iter().zip(&golden.segments) {
+  assert_eq!(default_result.segments_slice().len(), golden.segments.len());
+  for (rust, gold) in default_result.segments_slice().iter().zip(&golden.segments) {
     assert_eq!(rust.id(), gold.id);
     assert_eq!(rust.seek(), gold.seek);
     assert_eq!(rust.tokens_slice(), gold.tokens.as_slice());
@@ -340,35 +343,35 @@ fn jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather() {
     // away and a tolerance would only hide it.
     assert_eq!((rust.start(), rust.end()), (gold.start, gold.end));
   }
-  let parity_words = result_word_rows(&parity);
+  let default_words = result_word_rows(&default_result);
   assert_eq!(
-    parity_words,
+    default_words,
     golden_word_rows(&golden),
-    "short-form word timestamps must match official Swift exactly"
+    "short-form word timestamps under the DEFAULT gather must match official Swift exactly"
   );
-  assert_eq!(parity_words.len(), 22, "jfk/tiny yields 22 words");
+  assert_eq!(default_words.len(), 22, "jfk/tiny yields 22 words");
 
-  // (2) the gather does not move any of it.
-  let complete = kit
+  // (2) the opt-in gather does not move any of it.
+  let parity = kit
     .transcribe(
       &audio,
-      &oracle_options().with_alignment_gather(AlignmentGather::Complete),
+      &oracle_options().with_alignment_gather(AlignmentGather::SwiftParity),
     )
     .unwrap();
   assert_eq!(
-    result_word_rows(&complete),
-    parity_words,
+    result_word_rows(&parity),
+    default_words,
     "the #41 gather changed a SHORT-FORM word timing: the branch's \
      short-form-is-unaffected claim no longer holds"
   );
-  assert_eq!(complete.text(), parity.text());
+  assert_eq!(parity.text(), default_result.text());
   assert_eq!(
-    complete
+    parity
       .segments_slice()
       .iter()
       .map(|s| (s.seek(), s.start(), s.end(), s.tokens_slice().to_vec()))
       .collect::<Vec<_>>(),
-    parity
+    default_result
       .segments_slice()
       .iter()
       .map(|s| (s.seek(), s.start(), s.end(), s.tokens_slice().to_vec()))

--- a/crates/coremlit/tests/whisper/parity_jfk.rs
+++ b/crates/coremlit/tests/whisper/parity_jfk.rs
@@ -285,9 +285,10 @@ fn oracle_options() -> DecodingOptions {
 /// into `SwiftParity` runs a single-window clip through the truncating gather
 /// too: at 30 gathered rows over 1500 columns and the measured pitch of 1504
 /// the copied prefix ends inside the last row, which keeps 1384 of its 1500
-/// columns. What this test then compares is the two modes' WORD LISTS — it
-/// inspects neither mode's DTW input, so what it records is that the OUTPUTS
-/// agree on this clip, not anything about whether the inputs did. #41
+/// columns. What this test then compares is the two modes' WORD LISTS,
+/// transcript text, and segment seeks, bounds and tokens — it inspects
+/// neither mode's DTW input, so what it records is that the OUTPUTS agree on
+/// this clip, not anything about whether the inputs did. #41
 /// asserted the short-form outcome with nothing committed checking it — the
 /// sibling `jfk_tiny_matches_golden_tokens_and_segments` runs with
 /// `word_timestamps` OFF.

--- a/crates/coremlit/tests/whisper/parity_jfk.rs
+++ b/crates/coremlit/tests/whisper/parity_jfk.rs
@@ -5,6 +5,15 @@
 //! ids; segment boundaries within epsilon (timestamps are quantized to
 //! 0.02 s tokens, so epsilon 1e-3 catches any real divergence).
 //!
+//! Second golden: tests/whisper/fixtures/golden/jfk_tiny_words_golden.json —
+//! the same clip and model with **word timestamps on**, captured from the
+//! same Swift library at the same pin (provenance and the exact
+//! `DecodingOptions` in `tests/whisper_swift_probes/README.md`). It carries a
+//! stricter contract than the token golden: every word matches exactly, no
+//! epsilon. It exists because `alignment_gather` (whisper #41) runs on every
+//! word-timestamp window, short-form included, and the token golden above
+//! leaves `word_timestamps` off — so nothing here covered that path.
+//!
 //! Compute path — THE RULE: **a gate validating a shipping default must run
 //! on the shipping default.** This test runs on the DEFAULT compute units
 //! (mel CPU+GPU, encoder/decoder CPU+ANE — spec Goal 2, and byte-identical
@@ -40,8 +49,8 @@ mod common;
 
 use coremlit::audio::whisper::{
   options::{
-    DEFAULT_DECODER_COMPUTE_UNITS, DEFAULT_ENCODER_COMPUTE_UNITS, DEFAULT_MEL_COMPUTE_UNITS,
-    DecodingOptions, Options,
+    AlignmentGather, ChunkingStrategy, DEFAULT_DECODER_COMPUTE_UNITS,
+    DEFAULT_ENCODER_COMPUTE_UNITS, DEFAULT_MEL_COMPUTE_UNITS, DecodingOptions, Options,
   },
   transcribe::WhisperKit,
 };
@@ -155,4 +164,215 @@ fn jfk_tiny_matches_golden_tokens_and_segments() {
     assert_eq!(rust.text(), gold.text);
   }
   assert_eq!(result.text(), golden.text);
+}
+
+// ---------------------------------------------------------------------
+// Short-form word timestamps (whisper #41 follow-up)
+// ---------------------------------------------------------------------
+
+/// The Swift oracle's own word record, verbatim from
+/// `fixtures/golden/jfk_tiny_words_golden.json`.
+#[derive(serde::Deserialize)]
+struct WordsGolden {
+  text: String,
+  language: String,
+  #[serde(rename = "totalDecodingWindows")]
+  total_decoding_windows: f64,
+  segments: Vec<WordsGoldenSegment>,
+}
+
+#[derive(serde::Deserialize)]
+struct WordsGoldenSegment {
+  id: usize,
+  seek: usize,
+  start: f32,
+  end: f32,
+  text: String,
+  tokens: Vec<u32>,
+  words: Vec<GoldenWord>,
+}
+
+#[derive(serde::Deserialize)]
+struct GoldenWord {
+  word: String,
+  start: f32,
+  end: f32,
+  probability: f32,
+  tokens: Vec<u32>,
+}
+
+/// `(word, start, end, probability, tokens)` for every word of every
+/// segment, flattened — the comparison unit for both directions below.
+type WordRow = (String, f32, f32, f32, Vec<u32>);
+
+fn golden_word_rows(golden: &WordsGolden) -> Vec<WordRow> {
+  golden
+    .segments
+    .iter()
+    .flat_map(|segment| {
+      segment.words.iter().map(|word| {
+        (
+          word.word.clone(),
+          word.start,
+          word.end,
+          word.probability,
+          word.tokens.clone(),
+        )
+      })
+    })
+    .collect()
+}
+
+fn result_word_rows(
+  result: &coremlit::audio::whisper::result::TranscriptionResult,
+) -> Vec<WordRow> {
+  result
+    .segments_slice()
+    .iter()
+    .flat_map(|segment| {
+      segment.words_slice().iter().map(|word| {
+        (
+          word.word().to_string(),
+          word.start(),
+          word.end(),
+          word.probability(),
+          word.tokens_slice().to_vec(),
+        )
+      })
+    })
+    .collect()
+}
+
+/// The options the Swift oracle ran under, mirrored exactly: this is the
+/// same pinned invocation the whisper #41 long-form evidence used
+/// (`crates/coremlit/tests/whisper_swift_probes/README.md`), so one option
+/// set covers the short-form and long-form halves of the same claim.
+///
+/// `alignment_gather` is deliberately NOT set — the point is to exercise the
+/// shipping default.
+fn oracle_options() -> DecodingOptions {
+  DecodingOptions::new()
+    .with_temperature(0.0)
+    .with_temperature_fallback_count(0)
+    .with_use_prefill_prompt()
+    .with_skip_special_tokens()
+    .with_word_timestamps()
+    .with_concurrent_worker_count(std::num::NonZeroUsize::new(1).unwrap())
+    .with_chunking_strategy(ChunkingStrategy::Disabled)
+}
+
+/// Short-form word timestamps, pinned against official Swift and against
+/// themselves across both [`AlignmentGather`] modes.
+///
+/// **Why this exists.** `alignment_gather` (whisper #41) is selected for
+/// EVERY word-timestamp window, not only for long-form or for windows after
+/// the first: `TranscribeTask::run` passes `options.alignment_gather()`
+/// straight into `add_word_timestamps` with no guard. So a single-window
+/// clip goes through the truncating gather too — and it is genuinely
+/// truncated here, not vacuously: 30 gathered rows over 1500 columns at the
+/// measured pitch of 1504 leaves the copied prefix ending inside the last
+/// row, which keeps 1384 of its 1500 columns. #41's claim that short-form
+/// output is unchanged was therefore a real claim about a real code path,
+/// and before this test nothing committed checked it — the sibling
+/// `jfk_tiny_matches_golden_tokens_and_segments` runs with
+/// `word_timestamps` OFF.
+///
+/// Two assertions, in the order that matters:
+///
+/// 1. Under the shipping default ([`AlignmentGather::SwiftParity`]) every
+///    word matches the Swift oracle exactly — text, start, end, probability
+///    and token ids, no epsilon.
+/// 2. [`AlignmentGather::Complete`] produces the identical word list. That
+///    is what "the gather does not change short-form output" means, and it
+///    is an assertion rather than a comment: if the truncated final row ever
+///    does move a short-form boundary, this fails instead of the claim
+///    quietly becoming false.
+///
+/// Compute path: the shipping default, for the same reason this file's
+/// module doc gives — the oracle was captured on the ANE, so the gate runs
+/// there too.
+#[test]
+#[ignore = "requires local tiny model (WHISPERKIT_TEST_MODELS)"]
+fn jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather() {
+  let audio = common::load_wav_mono_f32(&common::fixtures_dir().join("audio/jfk.wav"));
+  let model_options = Options::new(common::tiny_dir(), common::tokenizer_dir());
+  assert_eq!(model_options.compute().mel(), DEFAULT_MEL_COMPUTE_UNITS);
+  assert_eq!(
+    model_options.compute().encoder(),
+    DEFAULT_ENCODER_COMPUTE_UNITS
+  );
+  assert_eq!(
+    model_options.compute().decoder(),
+    DEFAULT_DECODER_COMPUTE_UNITS
+  );
+  let kit = WhisperKit::new(&model_options).unwrap();
+
+  let golden: WordsGolden = serde_json::from_str(
+    &std::fs::read_to_string(common::fixtures_dir().join("golden/jfk_tiny_words_golden.json"))
+      .unwrap(),
+  )
+  .unwrap();
+
+  let default_options = oracle_options();
+  assert_eq!(
+    default_options.alignment_gather(),
+    AlignmentGather::SwiftParity,
+    "this gate must run the shipping gather, not an explicit one"
+  );
+  let parity = kit.transcribe(&audio, &default_options).unwrap();
+
+  // (1) exact parity with Swift.
+  assert_eq!(parity.language(), golden.language);
+  assert_eq!(parity.text(), golden.text);
+  assert_eq!(
+    parity.timings().total_decoding_windows(),
+    golden.total_decoding_windows,
+    "jfk is a single window; a second one would mean the seek moved"
+  );
+  assert_eq!(parity.segments_slice().len(), golden.segments.len());
+  for (rust, gold) in parity.segments_slice().iter().zip(&golden.segments) {
+    assert_eq!(rust.id(), gold.id);
+    assert_eq!(rust.seek(), gold.seek);
+    assert_eq!(rust.tokens_slice(), gold.tokens.as_slice());
+    assert_eq!(rust.text(), gold.text);
+    // Exact, not epsilon: the word-timestamp path is integer encoder
+    // columns times a constant, so a real divergence lands whole frames
+    // away and a tolerance would only hide it.
+    assert_eq!((rust.start(), rust.end()), (gold.start, gold.end));
+  }
+  let parity_words = result_word_rows(&parity);
+  assert_eq!(
+    parity_words,
+    golden_word_rows(&golden),
+    "short-form word timestamps must match official Swift exactly"
+  );
+  assert_eq!(parity_words.len(), 22, "jfk/tiny yields 22 words");
+
+  // (2) the gather does not move any of it.
+  let complete = kit
+    .transcribe(
+      &audio,
+      &oracle_options().with_alignment_gather(AlignmentGather::Complete),
+    )
+    .unwrap();
+  assert_eq!(
+    result_word_rows(&complete),
+    parity_words,
+    "the #41 gather changed a SHORT-FORM word timing: the branch's \
+     short-form-is-unaffected claim no longer holds"
+  );
+  assert_eq!(complete.text(), parity.text());
+  assert_eq!(
+    complete
+      .segments_slice()
+      .iter()
+      .map(|s| (s.seek(), s.start(), s.end(), s.tokens_slice().to_vec()))
+      .collect::<Vec<_>>(),
+    parity
+      .segments_slice()
+      .iter()
+      .map(|s| (s.seek(), s.start(), s.end(), s.tokens_slice().to_vec()))
+      .collect::<Vec<_>>(),
+    "and neither the seek nor the segment bounds move with it"
+  );
 }

--- a/crates/coremlit/tests/whisper/parity_jfk.rs
+++ b/crates/coremlit/tests/whisper/parity_jfk.rs
@@ -262,21 +262,35 @@ fn oracle_options() -> DecodingOptions {
     .with_chunking_strategy(ChunkingStrategy::Disabled)
 }
 
-/// Short-form word timestamps, pinned against official Swift and against
+/// jfk/tiny's word timestamps, pinned against official Swift and against
 /// themselves across both [`AlignmentGather`] modes.
 ///
-/// **Why this exists.** `alignment_gather` (whisper #41) is selected for
+/// **Scope, stated first because it was once overstated.** This pins ONE
+/// clip on ONE model. It does not establish — and must not be cited as
+/// establishing — that the gather leaves short-form output alone in general.
+/// It does not: `segment::tests::
+/// swift_parity_gather_truncates_final_alignment_row` measures the two
+/// gathers producing last-word and segment ends of 0.88 s against 1.58 s
+/// over a single `add_word_timestamps` call, and `transcribe::tests::
+/// swift_parity_gather_moves_the_first_windows_end_and_the_next_seek`
+/// measures a first-window divergence with no cascade behind it. What this
+/// test establishes is that jfk/tiny is not one of the clips where that
+/// happens, and that under the shipping default it reproduces official
+/// Swift.
+///
+/// **Why it exists.** `alignment_gather` (whisper #41) is selected for
 /// EVERY word-timestamp window, not only for long-form or for windows after
 /// the first: `TranscribeTask::run` passes `options.alignment_gather()`
 /// straight into `add_word_timestamps` with no guard. So a caller who opts
 /// into `SwiftParity` runs a single-window clip through the truncating gather
 /// too — and it is genuinely truncated here, not vacuously: 30 gathered rows
 /// over 1500 columns at the measured pitch of 1504 leaves the copied prefix
-/// ending inside the last row, which keeps 1384 of its 1500 columns. #41's
-/// claim that short-form output is unchanged was therefore a real claim about
-/// a real code path, and before this test nothing committed checked it — the
-/// sibling `jfk_tiny_matches_golden_tokens_and_segments` runs with
-/// `word_timestamps` OFF.
+/// ending inside the last row, which keeps 1384 of its 1500 columns. The DTW
+/// input on this clip therefore really does differ between the modes; only
+/// the path through it happens not to. #41 asserted the short-form outcome
+/// with nothing committed checking it — the sibling
+/// `jfk_tiny_matches_golden_tokens_and_segments` runs with `word_timestamps`
+/// OFF.
 ///
 /// Two assertions, in the order that matters:
 ///
@@ -286,17 +300,18 @@ fn oracle_options() -> DecodingOptions {
 ///    review, so THIS is the claim that had to be re-established: the
 ///    correct-everywhere gather still reproduces official Swift on this clip.
 /// 2. The opt-in [`AlignmentGather::SwiftParity`] produces the identical word
-///    list. That is what "the gather does not change short-form output"
-///    means, and it is an assertion rather than a comment: if the truncated
-///    final row ever does move a short-form boundary, this fails instead of
-///    the claim quietly becoming false.
+///    list *on this clip*. That is the whole of the gather-invariance the
+///    branch has measured on real model output, and it is an assertion rather
+///    than a comment: if the truncated final row ever does move this clip's
+///    boundaries, this fails instead of the documented scope quietly becoming
+///    wrong.
 ///
 /// Compute path: the shipping default, for the same reason this file's
 /// module doc gives — the oracle was captured on the ANE, so the gate runs
 /// there too.
 #[test]
 #[ignore = "requires local tiny model (WHISPERKIT_TEST_MODELS)"]
-fn jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather() {
+fn jfk_tiny_word_timestamps_match_swift_and_this_clip_is_gather_invariant() {
   let audio = common::load_wav_mono_f32(&common::fixtures_dir().join("audio/jfk.wav"));
   let model_options = Options::new(common::tiny_dir(), common::tokenizer_dir());
   assert_eq!(model_options.compute().mel(), DEFAULT_MEL_COMPUTE_UNITS);
@@ -347,7 +362,7 @@ fn jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather() {
   assert_eq!(
     default_words,
     golden_word_rows(&golden),
-    "short-form word timestamps under the DEFAULT gather must match official Swift exactly"
+    "jfk/tiny's word timestamps under the DEFAULT gather must match official Swift exactly"
   );
   assert_eq!(default_words.len(), 22, "jfk/tiny yields 22 words");
 
@@ -361,8 +376,9 @@ fn jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather() {
   assert_eq!(
     result_word_rows(&parity),
     default_words,
-    "the #41 gather changed a SHORT-FORM word timing: the branch's \
-     short-form-is-unaffected claim no longer holds"
+    "the #41 gather moved a word timing on jfk/tiny: the one clip on which the two gathers \
+     were measured to agree no longer agrees, so the scope documented on \
+     `AlignmentGather::SwiftParity` is now wrong too"
   );
   assert_eq!(parity.text(), default_result.text());
   assert_eq!(
@@ -376,6 +392,6 @@ fn jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather() {
       .iter()
       .map(|s| (s.seek(), s.start(), s.end(), s.tokens_slice().to_vec()))
       .collect::<Vec<_>>(),
-    "and neither the seek nor the segment bounds move with it"
+    "and on this clip neither the seek nor the segment bounds move with it"
   );
 }

--- a/crates/coremlit/tests/whisper/pipeline.rs
+++ b/crates/coremlit/tests/whisper/pipeline.rs
@@ -125,28 +125,87 @@ fn reset_restores_step_zero_logits_exactly() {
 
 #[test]
 #[ignore = "requires local tiny model (WHISPERKIT_TEST_MODELS)"]
-fn alignment_weights_accumulate_when_supported() {
+fn alignment_row_stages_on_decode_step_and_lands_only_on_commit() {
+  // The stage/commit split (whisper #41) against the REAL decoder — until
+  // now only `backend/mock/tests.rs` pinned it, so nothing checked that
+  // CoreML honours it on a live prediction.
+  //
+  // ONE PREDICTION MUST NOT MAKE WEIGHTS READABLE. Swift's decode loop
+  // breaks on a completed segment BEFORE the `else` branch that runs
+  // `updateAlignmentWeights` and sets `hasAlignment`
+  // (`TextDecoder.swift:673-717`), and exposes the tensor to the caller
+  // only as `hasAlignment ? inputs.alignmentWeights : nil` (`:764-771`),
+  // which the word-timestamp block consumes through an `if let`
+  // (`TranscribeTask.swift:197-199`). So a completing step's row must never
+  // reach `add_word_timestamps` — letting it through is the divergence #41
+  // reported and #47 fixed — and a window that committed nothing must yield
+  // no view at all rather than an empty or stale one.
   let backend = load_backend();
   if !backend.supports_word_timestamps() {
     eprintln!("skipping: model lacks alignment_heads_weights (recorded in Task 1)");
     return;
   }
+  let dims = backend.dims();
   let mut window = common::load_wav_mono_f32(&common::fixtures_dir().join("audio/jfk.wav"));
-  window.resize(480_000, 0.0);
+  window.resize(dims.window_samples(), 0.0);
   let encoded = backend
     .encode(&backend.extract_features(&window).unwrap())
     .unwrap();
   let mut state = backend.new_decoder_state().unwrap();
   let mut logits = Vec::new();
+
   backend
     .decode_step(50258, 0, &encoded, &mut state, &mut logits)
     .unwrap();
+  assert!(
+    backend.alignment_weights(&state).is_none(),
+    "a staged row must leave the hasAlignment gate shut"
+  );
+
+  backend.commit_alignment_row(&mut state);
+  {
+    let view = backend
+      .alignment_weights(&state)
+      .expect("the commit opens the hasAlignment gate");
+    // The view is the whole once-allocated accumulator, never a written
+    // prefix (Swift's `[kvCacheMaxSequenceLength, n_audio_ctx]` tensor,
+    // `TextDecoder.swift:141`); a row cap here is what truncated the final
+    // window's alignment in #41.
+    assert_eq!(view.rows(), dims.max_token_context() + 1);
+    assert_eq!(view.cols(), dims.n_audio_ctx());
+    assert!(
+      view.row(1).iter().any(|&v| v != 0.0),
+      "the committed row landed at position + 1 (updateAlignmentWeights, :286)"
+    );
+    assert!(
+      view.row(0).iter().all(|&v| v == 0.0),
+      "row 0 is never a commit target"
+    );
+  }
+
+  // The other half of the split: the row a step stages is inert until the
+  // decode loop commits it, which is what keeps Swift's completing step —
+  // the one that breaks before `:709-717` — out of the accumulator.
+  backend
+    .decode_step(50259, 1, &encoded, &mut state, &mut logits)
+    .unwrap();
+  {
+    let view = backend
+      .alignment_weights(&state)
+      .expect("the gate stays open once this window has committed a row");
+    assert!(
+      view.row(2).iter().all(|&v| v == 0.0),
+      "an uncommitted step's staged row must not reach the accumulator"
+    );
+  }
+  backend.commit_alignment_row(&mut state);
   let view = backend
     .alignment_weights(&state)
-    .expect("supported => view");
-  assert_eq!(view.cols(), 1500);
-  assert!(view.rows() >= 2, "row position+1 written");
-  assert!(view.row(1).iter().any(|&v| v != 0.0), "weights landed");
+    .expect("the gate stays open");
+  assert!(
+    view.row(2).iter().any(|&v| v != 0.0),
+    "the commit, and only the commit, lands the staged row"
+  );
 }
 
 #[test]
@@ -169,9 +228,10 @@ fn last_kv_slot_decode_step_succeeds() {
   // Regression (task-9 review, Critical): the trait legalizes every
   // position in 0..max_token_context, but the mask flips prepare
   // position + 1 — at the last slot there is no next slot to prepare and
-  // the flips must be skipped, while the KV append and the alignment row
-  // (headroom row max_ctx) still land. Pre-fix this returned a structured
-  // IndexOutOfBounds AFTER mutating the KV cache.
+  // the flips must be skipped, while the KV append still lands and the
+  // staged alignment row stays committable into its headroom row max_ctx.
+  // Pre-fix this returned a structured IndexOutOfBounds AFTER mutating the
+  // KV cache.
   let backend = load_backend();
   let dims = backend.dims();
   let last = dims.max_token_context() - 1;
@@ -185,9 +245,20 @@ fn last_kv_slot_decode_step_succeeds() {
     .decode_step(50258, last, &encoded, &mut state, &mut logits)
     .expect("the last KV slot is a legal position");
   assert_eq!(logits.len(), dims.vocab());
-  if let Some(view) = backend.alignment_weights(&state) {
+  if backend.supports_word_timestamps() {
+    // The commit is load-bearing, not ceremony: the view is `None` until a
+    // row lands (the stage/commit split above), so reading the weights
+    // without it asserts nothing at all.
+    backend.commit_alignment_row(&mut state);
+    let view = backend
+      .alignment_weights(&state)
+      .expect("the last slot's committed row opens the gate");
     assert_eq!(view.rows(), dims.max_token_context() + 1);
     assert_eq!(view.cols(), dims.n_audio_ctx());
+    assert!(
+      view.row(dims.max_token_context()).iter().any(|&v| v != 0.0),
+      "the headroom row is the last legal position's commit target"
+    );
   }
 }
 

--- a/crates/coremlit/tests/whisper_swift_probes/README.md
+++ b/crates/coremlit/tests/whisper_swift_probes/README.md
@@ -129,6 +129,39 @@ identical in both.
   (`SegmentError::AlignmentPitchUnavailable`) rather than quietly degrading to
   `AlignmentGather::Complete`.
 
+## The Swift short-form word-timestamp golden
+
+`crates/coremlit/tests/whisper/fixtures/golden/jfk_tiny_words_golden.json` is a
+verbatim capture of the same oracle (`argmax-oss-swift @ dcf3a00`, same host)
+running `jfk.wav` on `openai_whisper-tiny` with **word timestamps on**, taken
+through an out-of-tree SwiftPM driver that depends on the pinned checkout by
+path and writes nothing into it (the `crates/coremlit/tests/speaker/swift/`
+precedent). The driver calls `WhisperKit.transcribe(audioArray:decodeOptions:)`
+with:
+
+```swift
+DecodingOptions(
+  verbose: true, task: .transcribe, language: nil,
+  temperature: 0.0, temperatureFallbackCount: 0,
+  usePrefillPrompt: true, skipSpecialTokens: true, withoutTimestamps: false,
+  wordTimestamps: true, concurrentWorkerCount: 1,
+  chunkingStrategy: ChunkingStrategy.none)
+```
+
+under `ModelComputeOptions(audioEncoderCompute: .cpuAndNeuralEngine,
+textDecoderCompute: .cpuAndNeuralEngine)` — the same pinned invocation the #41
+long-form evidence used, so short-form and long-form are one option set.
+`whisper_parity_jfk`'s
+`jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather` mirrors
+those options exactly and asserts every word (text, start, end, probability,
+token ids) with no epsilon, plus that `AlignmentGather::Complete` yields the
+identical list. That second half is what makes "the #41 gather does not change
+short-form output" a checked claim rather than a comment: the gather runs on
+every word-timestamp window, long-form or not, and at 30 gathered rows over
+1500 columns the measured pitch of 1504 does truncate the final row here (it
+keeps 1384 of 1500 columns) — the truncation simply does not move this clip's
+DTW path.
+
 ## Rust transfer check (superseded by hermetic tests)
 
 An exploratory Rust probe (`half 2.7.1` + system libm) confirmed every dumped

--- a/crates/coremlit/tests/whisper_swift_probes/README.md
+++ b/crates/coremlit/tests/whisper_swift_probes/README.md
@@ -245,12 +245,13 @@ The second half establishes gather-invariance **for this clip and nothing
 wider**, and the wording matters because an earlier revision generalized it.
 The gather runs on every word-timestamp window, long-form or not, and at 30
 gathered rows over 1500 columns the measured pitch of 1504 does truncate the
-final row under `SwiftParity` (it keeps 1384 of 1500 columns) — so the matrix
-DTW consumes here genuinely differs between the modes, and it is only the path
-through it that coincides. That coincidence is a property of this clip's
-numbers: the port's own fixtures measure the modes producing different
-word/segment ends **inside a single window** (0.88 s vs 1.58 s over one
-`add_word_timestamps` call in `segment::tests::
+final row under `SwiftParity` (it keeps 1384 of 1500 columns). The test
+compares the two modes' word lists and nothing else — it inspects neither
+mode's DTW input — so the agreement it records is an agreement of outputs on
+this clip. That does not carry to short form in general: the port's own
+fixtures measure the modes producing different word/segment ends **inside a
+single window** (0.88 s vs 1.58 s over one `add_word_timestamps` call in
+`segment::tests::
 swift_parity_gather_truncates_final_alignment_row`; 0.88 s vs 1.18 s in the
 first window of `transcribe::tests::
 swift_parity_gather_moves_the_first_windows_end_and_the_next_seek`, with no

--- a/crates/coremlit/tests/whisper_swift_probes/README.md
+++ b/crates/coremlit/tests/whisper_swift_probes/README.md
@@ -229,18 +229,30 @@ under `ModelComputeOptions(audioEncoderCompute: .cpuAndNeuralEngine,
 textDecoderCompute: .cpuAndNeuralEngine)` — the same pinned invocation the #41
 long-form evidence used, so short-form and long-form are one option set.
 `whisper_parity_jfk`'s
-`jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather` mirrors
-those options exactly and asserts every word (text, start, end, probability,
-token ids) with no epsilon **under the shipping default,
+`jfk_tiny_word_timestamps_match_swift_and_this_clip_is_gather_invariant`
+mirrors those options exactly and asserts every word (text, start, end,
+probability, token ids) with no epsilon **under the shipping default,
 `AlignmentGather::Complete`**, plus that the opt-in `AlignmentGather::
 SwiftParity` yields the identical list. The first half is what the round-3
 default flip had to re-establish — the correct-everywhere gather still
-reproduces official Swift on this clip. The second is what makes "the #41
-gather does not change short-form output" a checked claim rather than a
-comment: the gather runs on every word-timestamp window, long-form or not, and
-at 30 gathered rows over 1500 columns the measured pitch of 1504 does truncate
-the final row under `SwiftParity` (it keeps 1384 of 1500 columns) — the
-truncation simply does not move this clip's DTW path.
+reproduces official Swift on this clip.
+
+The second half establishes gather-invariance **for this clip and nothing
+wider**, and the wording matters because an earlier revision generalized it.
+The gather runs on every word-timestamp window, long-form or not, and at 30
+gathered rows over 1500 columns the measured pitch of 1504 does truncate the
+final row under `SwiftParity` (it keeps 1384 of 1500 columns) — so the matrix
+DTW consumes here genuinely differs between the modes, and it is only the path
+through it that coincides. That coincidence is a property of this clip's
+numbers: the port's own fixtures measure the modes producing different
+word/segment ends **inside a single window** (0.88 s vs 1.58 s over one
+`add_word_timestamps` call in `segment::tests::
+swift_parity_gather_truncates_final_alignment_row`; 0.88 s vs 1.18 s in the
+first window of `transcribe::tests::
+swift_parity_gather_moves_the_first_windows_end_and_the_next_seek`, with no
+cascade behind it). Settling the general short-form question needs a corpus of
+Swift word goldens across clips, models and window occupancies; this golden is
+one point in it. See `AlignmentGather::SwiftParity`'s "Short-form" section.
 
 ## Rust transfer check (superseded by hermetic tests)
 

--- a/crates/coremlit/tests/whisper_swift_probes/README.md
+++ b/crates/coremlit/tests/whisper_swift_probes/README.md
@@ -1,4 +1,4 @@
-# Whisper Swift oracle probes (H1 f16 mass-rule + H2 argmax tie-break)
+# Whisper Swift oracle probes (H1 f16 mass-rule + H2 argmax tie-break + H6 alignment-gather row pitch)
 
 Documentation-grade reference evidence for the pinned numeric values in the
 coremlit issue #41 parity fixes:
@@ -7,15 +7,19 @@ coremlit issue #41 parity fixes:
   (H1: BNNS f16 timestamp-mass rule replication)
 - `crates/coremlit/src/audio/whisper/decode/sampler/mod.rs` — `argmax`
   (H2: first-index, NaN-skipping tie-break)
+- `crates/coremlit/src/audio/whisper/segment/mod.rs` — `coreml_f16_row_pitch` /
+  `add_word_timestamps`, and `options/mod.rs` — `AlignmentGather`
+  (H6: the CoreVideo row pitch Swift's alignment gather ignores)
 
 These files are **captured verbatim** from a one-off probe run and are **not
 compiled or run in CI** (they are `.swift`/`.out`, never `.rs`, so `cargo` never
 picks them up as integration tests). They exist so every "probe-verified" claim
-in the two functions' doc comments and in their hermetic tests can be traced to
+in these functions' doc comments and in their hermetic tests can be traced to
 a concrete oracle capture, following the `crates/coremlit/tests/speaker/swift/`
-precedent. The hermetic Rust tests in `decode/filter/tests.rs` and
-`decode/sampler/tests.rs` are the executable, CI-enforced form of this evidence;
-these captures are the human-readable provenance behind their pinned hex.
+precedent. The hermetic Rust tests in `decode/filter/tests.rs`,
+`decode/sampler/tests.rs` and `segment/tests.rs` are the executable, CI-enforced
+form of this evidence; these captures are the human-readable provenance behind
+their pinned hex and pitches.
 
 ## Provenance
 
@@ -29,6 +33,7 @@ these captures are the human-readable provenance behind their pinned hex.
 - **Build/run:**
   - `swiftc -O -parse-as-library probe_argmax.swift   -o probe_argmax   && ./probe_argmax`
   - `swiftc -O -parse-as-library probe_massrule.swift -o probe_massrule && ./probe_massrule`
+  - `swiftc -O -parse-as-library probe_alignment_stride.swift -o probe_alignment_stride && ./probe_alignment_stride`
 
 The probes mirror the oracle's exact API shapes: `BNNSNDArrayDescriptor(...,
 scalarType: Float16.self, shape: .vector(n, stride: 1))`, `allocateUninitialized`
@@ -51,6 +56,8 @@ path; BNNS f16 `argMax` is the legacy path. Both are probed here.
 | `probe_massrule.swift` | H1 | Source: Q1–Q4 decisive probes (internal-precision, max-subtract, edge semantics, random sweeps, near-margin scans, V3 bit-pinned dump). |
 | `probe_massrule.out`   | H1 | Earlier partial run — flip-point scans empty, truncated before the V3 dump. |
 | `probe_massrule2.out`  | H1 | **Complete run** — the authoritative capture: flip points `0xb17c` (scan1) / `0xc05e` (scan2), the V3 pins `lse=0xb7ae max=0xc4f2`, and the NaN / all-`-inf` edge semantics. |
+| `probe_alignment_stride.swift` | H6 | Source: `MLMultiArray.strides` for ten pixel-buffer-backed Float16 shapes against the plain initializer, plus a write-at-true-stride / read-at-`columnCount` replay of the gather at the shipping 120 × 1500. |
+| `probe_alignment_stride.out`   | H6 | Complete run — the pitch table (1500 → **1504**, 100 → 128, 8/9 → 32) and the per-row overrun (`logical row 119 reads 476 element(s) past the copied prefix (kept columns = 1024)`). |
 
 Both `.out` variants are kept for each probe: the base `.out` is an earlier
 partial capture, and the `2.out` is the complete, final run. **The pinned values
@@ -77,6 +84,32 @@ identical in both.
   f16-input flip points (`0xb17c`, `0xc05e`) and on 1500/1500 + 299/300
   adversarially margin-tuned sweeps. Probed edge quirks: `.max(all -inf)` returns
   `-65504` (lowest finite f16), not `-inf` — boolean-immaterial.
+- **H6 (`probe_alignment_stride.out`):** WhisperKit's Float16 `MLMultiArray`s
+  are **not contiguous**. `MLMultiArray(shape:dataType:initialValue:)`
+  (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`) backs `.float16` with an
+  IOSurface `CVPixelBuffer` (`:121-136`), and CoreVideo pads each row to a
+  64-byte boundary — 32 Float16 elements — so `strides[0]` is **1504** for
+  `cols = 1500` (and 128 for 100, 32 for 8 and for 9), while the plain
+  `MLMultiArray(shape:dataType:)` initializer reports the contiguous 1500.
+  `SegmentSeeker.addWordTimestamps` binds both stride arrays and then pitches
+  its `memcpy` by `columnCount` (`:444-461`), so the gather writes only storage
+  `[0, N * cols)`; `dynamicTimeWarping`'s flat subscript (`:217`) is
+  stride-aware and reads logical row `r` at `[r * pitch, r * pitch + cols)`.
+  The two errors cancel wherever that read window still lies inside the copied
+  prefix: row `r` is truncated exactly when `r * pitch + cols > N * cols`, and
+  only the LAST row can be while `cols >= (N - 2) * (pitch - cols)`. That bound
+  is a property of the shipping shape rather than a general one — it holds at
+  1500/1504 for any `N <= 224` (the second-to-last row would need `N > 377`)
+  and fails at the small `n_audio_ctx` a test backend can set, where a run of
+  whole rows goes. At `N = 120` the final row keeps **1024** of its 1500
+  columns and reads the other 476 out of storage neither the `memcpy` nor the
+  `initialValue:` fill ever wrote (zero in practice — an observation, not a
+  CoreVideo guarantee). That row is the whole of the
+  long-form divergence: it moves the last word's end, hence the segment's end,
+  hence the next window's seek. Pinned in `segment/tests.rs` by
+  `coreml_f16_row_pitch_matches_the_probed_core_video_padding`,
+  `swift_gather_keeps_only_the_final_rows_prefix` and
+  `swift_parity_gather_truncates_final_alignment_row`.
 
 ## Rust transfer check (superseded by hermetic tests)
 

--- a/crates/coremlit/tests/whisper_swift_probes/README.md
+++ b/crates/coremlit/tests/whisper_swift_probes/README.md
@@ -108,9 +108,13 @@ identical in both.
   and fails at the small `n_audio_ctx` a test backend can set, where a run of
   whole rows goes. At `N = 120` the final row keeps **1024** of its 1500
   columns and reads the other 476 out of storage neither the `memcpy` nor the
-  `initialValue:` fill ever wrote. That row is the whole of the
-  long-form divergence: it moves the last word's end, hence the segment's end,
-  hence the next window's seek. Pinned in `segment/tests.rs` by
+  `initialValue:` fill ever wrote. That row is the whole of the mechanism
+  behind the measured long-form divergence, and every link in it is
+  conditional: the row's tail can change the DTW path; a changed path can move
+  the last word's end and with it the segment's end; and because the update is
+  `seek = max(seek, ...)`, a segment end that lands later than the standing
+  seek can carry the next window with it, while one that does not leaves the
+  seek alone. Pinned in `segment/tests.rs` by
   `coreml_f16_row_pitch_answers_with_a_usable_pitch_or_a_typed_refusal`,
   `swift_gather_keeps_only_the_final_rows_prefix` and
   `swift_parity_gather_truncates_final_alignment_row`.

--- a/crates/coremlit/tests/whisper_swift_probes/README.md
+++ b/crates/coremlit/tests/whisper_swift_probes/README.md
@@ -8,8 +8,8 @@ coremlit issue #41 parity fixes:
 - `crates/coremlit/src/audio/whisper/decode/sampler/mod.rs` — `argmax`
   (H2: first-index, NaN-skipping tie-break)
 - `crates/coremlit/src/audio/whisper/segment/mod.rs` — `coreml_f16_row_pitch` /
-  `coreml_f16_gather_destination_pitch` / `gather_swift_rows` /
-  `add_word_timestamps`, and `options/mod.rs` — `AlignmentGather`
+  `gather_swift_parity_into` / `gather_swift_rows` / `add_word_timestamps`, and
+  `options/mod.rs` — `AlignmentGather`
   (H6: the CoreVideo row pitch Swift's alignment gather ignores)
 
 These files are **captured verbatim** from a one-off probe run and are **not
@@ -111,7 +111,7 @@ identical in both.
   `initialValue:` fill ever wrote. That row is the whole of the
   long-form divergence: it moves the last word's end, hence the segment's end,
   hence the next window's seek. Pinned in `segment/tests.rs` by
-  `coreml_f16_row_pitch_is_measured_from_a_live_pixel_buffer_allocation`,
+  `coreml_f16_row_pitch_answers_with_a_usable_pitch_or_a_typed_refusal`,
   `swift_gather_keeps_only_the_final_rows_prefix` and
   `swift_parity_gather_truncates_final_alignment_row`.
 
@@ -119,18 +119,34 @@ identical in both.
   reads a shifted window that splices one logical source row's tail onto the
   next one's head across the source's own padding. Row-count invariance is
   something this host was measured to have, not something CoreVideo promises,
-  so the port probes BOTH shapes — the once-allocated `[max_token_context + 1,
-  cols]` source (`TextDecoder.swift:141`) and the per-call `[N, cols]`
-  destination (`:450`) — and `segment::gather_swift_rows` reproduces the
-  general mapping. `swift_gather_reproduces_the_copy_when_the_two_surfaces_
-  pitch_differently` drives it against a storage-level replay at pitches this
-  host will never choose. The source's padding needs no probe: the same
-  `initialValue: FloatType(0)` initializer zeroes the LOGICAL element count
-  flat over a pitched buffer, so storage `[0, src_rows * cols)` — padding
-  included — starts at zero, and `TextDecoder.updateAlignmentWeights`
-  (`:272-295`), the array's only writer, is stride-aware. The gather never
-  reads past `N * cols <= src_rows * cols`, so every source padding cell it
-  can reach is zero on any host.
+  so the port probes BOTH shapes — the once-allocated **`[kvCacheMaxSequence
+  Length, cols]` = `[224, cols]`** source (`TextDecoder.swift:141`) and the
+  per-call `[N, cols]` destination (`:450`) — and
+  `segment::gather_swift_parity_into`/`gather_swift_rows` reproduce the general
+  mapping. `swift_gather_reproduces_the_copy_when_the_two_surfaces_pitch_
+  differently` drives it against a storage-level replay at pitches this host
+  will never choose.
+
+  **The source height is Swift's 224, not the port's 225.** This port's
+  accumulator is `max_token_context + 1` rows because it commits step
+  `position`'s row at `position + 1`; Swift has no such headroom. Probing the
+  port's height would decode Swift's storage offsets with a pitch Swift's
+  array never had wherever `pitch(224, cols) != pitch(225, cols)`, which the
+  branch explicitly allows. `swift_parity_probes_swifts_source_height_not_
+  this_ports_commit_headroom` injects exactly such a host and asserts which
+  height the probe names (round-3 finding #2).
+
+  **`AlignmentGather::Complete` is the DEFAULT; `SwiftParity` is an opt-in
+  that fails closed** (owner decision, round 3 of the #41 review). `Complete`
+  is the numerically correct gather and has no platform dependency at all — no
+  IOSurface allocation, no pitch measurement, no inspection of storage it did
+  not write, no `unsafe`. `SwiftParity` reproduces a Swift defect whose
+  behavior rests on unspecified CoreVideo layout, and three review rounds each
+  uncovered a further unspecified layer beneath the previous one, so it is
+  what a caller explicitly asks for having accepted three stated assumptions
+  (A1 layout determinism, A2 fresh-allocation zero fill, A3 layout stability
+  across `withUnsafeMutableBytes`) enumerated on the variant itself. Nothing
+  below claims those assumptions are established.
 
   **The pitch table above is evidence about this host, not a compiled-in
   rule.** `coreml_f16_row_pitch` MEASURES the running host — it allocates the
@@ -144,22 +160,51 @@ identical in both.
   **`#[ignore]`d** `reference_host_pitch_table` as provenance for the
   hand-computed columns in the model-gated gather fixtures — ignored because
   it compares this machine against one recorded machine, which no production
-  path depends on. If a measurement cannot be made at all,
+  path depends on. The live-allocation diagnostics
+  (`coreml_f16_row_pitch_reports_this_hosts_live_allocation_layout`) are
+  `#[ignore]`d for the same reason: they assert that two independent
+  allocations of one shape pitch identically, which is assumption A1 holding
+  here rather than anything CoreVideo owes. The portable gate,
+  `coreml_f16_row_pitch_answers_with_a_usable_pitch_or_a_typed_refusal`,
+  accepts the typed refusals as legitimate outcomes on a valid host (round-3
+  finding #5). If a measurement cannot be made at all,
   `AlignmentGather::SwiftParity` fails closed
   (`SegmentError::AlignmentPitchUnavailable`) rather than quietly degrading to
   `AlignmentGather::Complete`.
 
-  **The destination's untouched tail is verified, not assumed.** The storage
-  past `N * cols` is read by `dynamicTimeWarping` and written by nobody — the
-  `initialValue:` fill covers only the logical `count`, and the `memcpy`
-  covers the same prefix — so it is whatever `CVPixelBufferCreate` returned,
-  and no part of CoreVideo promises that is zero.
-  `MultiArray::f16_surface_probing_fresh_tail` reports what a real allocation
-  of the same shape held there before anything touched it; a dirty tail fails
-  the gather closed (`SegmentError::AlignmentGatherTailNotZero`) instead of
-  substituting zeros for values this port cannot reproduce.
-  `coreml_f16_gather_destination_probe_reports_a_clean_tail_on_this_host`
-  pins that the verification passes here.
+  **The destination's untouched tail is ASSUMED zero, and that assumption is
+  stated rather than disguised (A2).** The storage past `N * cols` is read by
+  `dynamicTimeWarping` and written by nobody — the `initialValue:` fill covers
+  only the logical `count`, and the `memcpy` covers the same prefix — so it is
+  whatever `CVPixelBufferCreate` returned, and no part of CoreVideo promises
+  that is zero. An earlier revision claimed to VERIFY it by sampling a freshly
+  allocated surface's tail before zeroing it. That was wrong twice over, and
+  both errors are now removed:
+
+  - reading those bytes was **undefined behavior** — `read_volatile` prevents
+    elision and reordering, not undefinedness, and the safe `f16_surface`
+    constructor could execute it under exactly the dirty-tail condition the
+    scan existed to detect (round-3 finding #1). `f16_surface` is now
+    write-only: it zeroes `CVPixelBufferGetDataSize` bytes and never observes
+    the prior contents.
+  - one clean allocation proves nothing about a **different** allocation. The
+    probe sampled a disposable surface, dropped it, and then synthesized zeros
+    for the surface the gather actually described; reuse or a concurrent
+    allocation yields a clean probe and a dirty real tail (round-3
+    finding #3). No probe replaces it, because none can: the allocation Swift
+    gathered into lives in another process.
+
+  **The source padding's zero is likewise an assumption past construction
+  (A3).** The `initialValue: FloatType(0)` initializer zeroes the LOGICAL
+  element count flat over a pitched buffer, so storage `[0, src_rows * cols)`
+  — padding included — *starts* at zero, and `TextDecoder.updateAlignment
+  Weights` (`:272-295`), the array's only writer, is stride-aware. That the
+  zero SURVIVES is unverified: writer and gather both reach the array through
+  `withUnsafeMutableBytes`, whose contract states the closure-provided strides
+  may differ from the value before invocation, so no cited contract rules out
+  a relayout introducing padding construction never zeroed (round-3
+  finding #4). A lifecycle-equivalent native probe at the 224-row height would
+  upgrade this to a one-host observation; it would still not be a contract.
 
 ## The Swift short-form word-timestamp golden
 
@@ -186,13 +231,16 @@ long-form evidence used, so short-form and long-form are one option set.
 `whisper_parity_jfk`'s
 `jfk_tiny_word_timestamps_match_swift_and_do_not_move_with_the_gather` mirrors
 those options exactly and asserts every word (text, start, end, probability,
-token ids) with no epsilon, plus that `AlignmentGather::Complete` yields the
-identical list. That second half is what makes "the #41 gather does not change
-short-form output" a checked claim rather than a comment: the gather runs on
-every word-timestamp window, long-form or not, and at 30 gathered rows over
-1500 columns the measured pitch of 1504 does truncate the final row here (it
-keeps 1384 of 1500 columns) — the truncation simply does not move this clip's
-DTW path.
+token ids) with no epsilon **under the shipping default,
+`AlignmentGather::Complete`**, plus that the opt-in `AlignmentGather::
+SwiftParity` yields the identical list. The first half is what the round-3
+default flip had to re-establish — the correct-everywhere gather still
+reproduces official Swift on this clip. The second is what makes "the #41
+gather does not change short-form output" a checked claim rather than a
+comment: the gather runs on every word-timestamp window, long-form or not, and
+at 30 gathered rows over 1500 columns the measured pitch of 1504 does truncate
+the final row under `SwiftParity` (it keeps 1384 of 1500 columns) — the
+truncation simply does not move this clip's DTW path.
 
 ## Rust transfer check (superseded by hermetic tests)
 

--- a/crates/coremlit/tests/whisper_swift_probes/README.md
+++ b/crates/coremlit/tests/whisper_swift_probes/README.md
@@ -8,7 +8,8 @@ coremlit issue #41 parity fixes:
 - `crates/coremlit/src/audio/whisper/decode/sampler/mod.rs` — `argmax`
   (H2: first-index, NaN-skipping tie-break)
 - `crates/coremlit/src/audio/whisper/segment/mod.rs` — `coreml_f16_row_pitch` /
-  `add_word_timestamps`, and `options/mod.rs` — `AlignmentGather`
+  `truncate_gathered_rows` / `add_word_timestamps`, and `options/mod.rs` —
+  `AlignmentGather`
   (H6: the CoreVideo row pitch Swift's alignment gather ignores)
 
 These files are **captured verbatim** from a one-off probe run and are **not
@@ -87,10 +88,11 @@ identical in both.
 - **H6 (`probe_alignment_stride.out`):** WhisperKit's Float16 `MLMultiArray`s
   are **not contiguous**. `MLMultiArray(shape:dataType:initialValue:)`
   (`ArgmaxCore/MLMultiArrayExtensions.swift:11-53`) backs `.float16` with an
-  IOSurface `CVPixelBuffer` (`:121-136`), and CoreVideo pads each row to a
-  64-byte boundary — 32 Float16 elements — so `strides[0]` is **1504** for
-  `cols = 1500` (and 128 for 100, 32 for 8 and for 9), while the plain
-  `MLMultiArray(shape:dataType:)` initializer reports the contiguous 1500.
+  IOSurface `CVPixelBuffer` (`:121-136`), and CoreVideo pads each row out to a
+  platform-chosen boundary — 64 bytes, i.e. 32 Float16 elements, **on this
+  host** — so `strides[0]` is 1504 for `cols = 1500` (and 128 for 100, 32 for 8
+  and for 9), while the plain `MLMultiArray(shape:dataType:)` initializer
+  reports the contiguous 1500.
   `SegmentSeeker.addWordTimestamps` binds both stride arrays and then pitches
   its `memcpy` by `columnCount` (`:444-461`), so the gather writes only storage
   `[0, N * cols)`; `dynamicTimeWarping`'s flat subscript (`:217`) is
@@ -107,9 +109,25 @@ identical in both.
   CoreVideo guarantee). That row is the whole of the
   long-form divergence: it moves the last word's end, hence the segment's end,
   hence the next window's seek. Pinned in `segment/tests.rs` by
-  `coreml_f16_row_pitch_matches_the_probed_core_video_padding`,
+  `coreml_f16_row_pitch_is_measured_from_a_live_pixel_buffer_allocation`,
+  `the_recorded_swift_probe_still_describes_this_host`,
   `swift_gather_keeps_only_the_final_rows_prefix` and
   `swift_parity_gather_truncates_final_alignment_row`.
+
+  **The pitch table above is evidence about this host, not a compiled-in
+  rule.** `coreml_f16_row_pitch` MEASURES the running host — it allocates the
+  same `[N, cols]` Float16 IOSurface Swift's gather allocates
+  (`MultiArray::f16_surface`) and reads CoreVideo's own strides back — because
+  Apple's QA1829 states `CVPixelBuffer` row alignment is hardware-dependent and
+  must be queried. An earlier cut of this fix promoted the 32-element quantum
+  observed here into a `const fn`, which would have zeroed the WRONG cells (and
+  so silently produced non-parity word timings, segment ends and seeks) on a
+  host that pads differently. The recorded table survives here and in
+  `the_recorded_swift_probe_still_describes_this_host` as the environment check
+  behind the hand-computed columns in the gather fixtures; if the measurement
+  cannot be made at all, `AlignmentGather::SwiftParity` fails closed
+  (`SegmentError::AlignmentPitchUnavailable`) rather than quietly degrading to
+  `AlignmentGather::Complete`.
 
 ## Rust transfer check (superseded by hermetic tests)
 

--- a/crates/coremlit/tests/whisper_swift_probes/README.md
+++ b/crates/coremlit/tests/whisper_swift_probes/README.md
@@ -246,9 +246,9 @@ wider**, and the wording matters because an earlier revision generalized it.
 The gather runs on every word-timestamp window, long-form or not, and at 30
 gathered rows over 1500 columns the measured pitch of 1504 does truncate the
 final row under `SwiftParity` (it keeps 1384 of 1500 columns). The test
-compares the two modes' word lists and nothing else — it inspects neither
-mode's DTW input — so the agreement it records is an agreement of outputs on
-this clip. That does not carry to short form in general: the port's own
+compares the two modes' word lists, transcript text, and segment seeks,
+bounds and tokens — it inspects neither mode's DTW input — so the agreement
+it records is an agreement of outputs on this clip. That does not carry to short form in general: the port's own
 fixtures measure the modes producing different word/segment ends **inside a
 single window** (0.88 s vs 1.58 s over one `add_word_timestamps` call in
 `segment::tests::

--- a/crates/coremlit/tests/whisper_swift_probes/README.md
+++ b/crates/coremlit/tests/whisper_swift_probes/README.md
@@ -8,8 +8,8 @@ coremlit issue #41 parity fixes:
 - `crates/coremlit/src/audio/whisper/decode/sampler/mod.rs` — `argmax`
   (H2: first-index, NaN-skipping tie-break)
 - `crates/coremlit/src/audio/whisper/segment/mod.rs` — `coreml_f16_row_pitch` /
-  `truncate_gathered_rows` / `add_word_timestamps`, and `options/mod.rs` —
-  `AlignmentGather`
+  `coreml_f16_gather_destination_pitch` / `gather_swift_rows` /
+  `add_word_timestamps`, and `options/mod.rs` — `AlignmentGather`
   (H6: the CoreVideo row pitch Swift's alignment gather ignores)
 
 These files are **captured verbatim** from a one-off probe run and are **not
@@ -94,40 +94,72 @@ identical in both.
   and for 9), while the plain `MLMultiArray(shape:dataType:)` initializer
   reports the contiguous 1500.
   `SegmentSeeker.addWordTimestamps` binds both stride arrays and then pitches
-  its `memcpy` by `columnCount` (`:444-461`), so the gather writes only storage
-  `[0, N * cols)`; `dynamicTimeWarping`'s flat subscript (`:217`) is
-  stride-aware and reads logical row `r` at `[r * pitch, r * pitch + cols)`.
-  The two errors cancel wherever that read window still lies inside the copied
-  prefix: row `r` is truncated exactly when `r * pitch + cols > N * cols`, and
+  its `memcpy` by `columnCount` (`:452-460`), so the gather writes only storage
+  `[0, N * cols)` and, because `filteredIndices` are `0..<N`, destination
+  storage offset `o` ends up holding SOURCE storage offset `o`;
+  `dynamicTimeWarping`'s flat subscript (`:217`) is stride-aware and reads
+  logical row `r` at `[r * dst_pitch, r * dst_pitch + cols)`.
+  **When the two surfaces share a pitch** the two errors cancel wherever that
+  read window still lies inside the copied prefix: row `r` is truncated
+  exactly when `r * pitch + cols > N * cols`, and
   only the LAST row can be while `cols >= (N - 2) * (pitch - cols)`. That bound
   is a property of the shipping shape rather than a general one — it holds at
   1500/1504 for any `N <= 224` (the second-to-last row would need `N > 377`)
   and fails at the small `n_audio_ctx` a test backend can set, where a run of
   whole rows goes. At `N = 120` the final row keeps **1024** of its 1500
   columns and reads the other 476 out of storage neither the `memcpy` nor the
-  `initialValue:` fill ever wrote (zero in practice — an observation, not a
-  CoreVideo guarantee). That row is the whole of the
+  `initialValue:` fill ever wrote. That row is the whole of the
   long-form divergence: it moves the last word's end, hence the segment's end,
   hence the next window's seek. Pinned in `segment/tests.rs` by
   `coreml_f16_row_pitch_is_measured_from_a_live_pixel_buffer_allocation`,
-  `the_recorded_swift_probe_still_describes_this_host`,
   `swift_gather_keeps_only_the_final_rows_prefix` and
   `swift_parity_gather_truncates_final_alignment_row`.
 
+  **When they do NOT share a pitch it is not a truncation at all** — row `r`
+  reads a shifted window that splices one logical source row's tail onto the
+  next one's head across the source's own padding. Row-count invariance is
+  something this host was measured to have, not something CoreVideo promises,
+  so the port probes BOTH shapes — the once-allocated `[max_token_context + 1,
+  cols]` source (`TextDecoder.swift:141`) and the per-call `[N, cols]`
+  destination (`:450`) — and `segment::gather_swift_rows` reproduces the
+  general mapping. `swift_gather_reproduces_the_copy_when_the_two_surfaces_
+  pitch_differently` drives it against a storage-level replay at pitches this
+  host will never choose. The source's padding needs no probe: the same
+  `initialValue: FloatType(0)` initializer zeroes the LOGICAL element count
+  flat over a pitched buffer, so storage `[0, src_rows * cols)` — padding
+  included — starts at zero, and `TextDecoder.updateAlignmentWeights`
+  (`:272-295`), the array's only writer, is stride-aware. The gather never
+  reads past `N * cols <= src_rows * cols`, so every source padding cell it
+  can reach is zero on any host.
+
   **The pitch table above is evidence about this host, not a compiled-in
   rule.** `coreml_f16_row_pitch` MEASURES the running host — it allocates the
-  same `[N, cols]` Float16 IOSurface Swift's gather allocates
+  same Float16 IOSurface Swift's gather allocates
   (`MultiArray::f16_surface`) and reads CoreVideo's own strides back — because
   Apple's QA1829 states `CVPixelBuffer` row alignment is hardware-dependent and
   must be queried. An earlier cut of this fix promoted the 32-element quantum
   observed here into a `const fn`, which would have zeroed the WRONG cells (and
   so silently produced non-parity word timings, segment ends and seeks) on a
-  host that pads differently. The recorded table survives here and in
-  `the_recorded_swift_probe_still_describes_this_host` as the environment check
-  behind the hand-computed columns in the gather fixtures; if the measurement
-  cannot be made at all, `AlignmentGather::SwiftParity` fails closed
+  host that pads differently. The recorded table survives here and in the
+  **`#[ignore]`d** `reference_host_pitch_table` as provenance for the
+  hand-computed columns in the model-gated gather fixtures — ignored because
+  it compares this machine against one recorded machine, which no production
+  path depends on. If a measurement cannot be made at all,
+  `AlignmentGather::SwiftParity` fails closed
   (`SegmentError::AlignmentPitchUnavailable`) rather than quietly degrading to
   `AlignmentGather::Complete`.
+
+  **The destination's untouched tail is verified, not assumed.** The storage
+  past `N * cols` is read by `dynamicTimeWarping` and written by nobody — the
+  `initialValue:` fill covers only the logical `count`, and the `memcpy`
+  covers the same prefix — so it is whatever `CVPixelBufferCreate` returned,
+  and no part of CoreVideo promises that is zero.
+  `MultiArray::f16_surface_probing_fresh_tail` reports what a real allocation
+  of the same shape held there before anything touched it; a dirty tail fails
+  the gather closed (`SegmentError::AlignmentGatherTailNotZero`) instead of
+  substituting zeros for values this port cannot reproduce.
+  `coreml_f16_gather_destination_probe_reports_a_clean_tail_on_this_host`
+  pins that the verification passes here.
 
 ## The Swift short-form word-timestamp golden
 

--- a/crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.out
+++ b/crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.out
@@ -1,0 +1,26 @@
+== Float16, pixel-buffer backed (WhisperKit's initialValue: path) ==
+rows cols | shape strides count  storage_rows*pitch
+224 1500 | shape=[224, 1500] strides=[1504, 1] count=336000 storage=336896
+120 1500 | shape=[120, 1500] strides=[1504, 1] count=180000 storage=180480
+31 1500 | shape=[31, 1500] strides=[1504, 1] count=46500 storage=46624
+2 1500 | shape=[2, 1500] strides=[1504, 1] count=3000 storage=3008
+1 1500 | shape=[1, 1500] strides=[1504, 1] count=1500 storage=1504
+224 1496 | shape=[224, 1496] strides=[1504, 1] count=335104 storage=336896
+224 1504 | shape=[224, 1504] strides=[1504, 1] count=336896 storage=336896
+224 100 | shape=[224, 100] strides=[128, 1] count=22400 storage=28672
+224 8 | shape=[224, 8] strides=[32, 1] count=1792 storage=7168
+224 9 | shape=[224, 9] strides=[32, 1] count=2016 storage=7168
+
+== Float16, plain MLMultiArray(shape:dataType:) ==
+224 1500 | strides=[1500, 1] count=336000
+120 1500 | strides=[1500, 1] count=180000
+
+== gather mismatch, rows=120 cols=1500 ==
+row 0: true-stride first/last=0.0/0.0  columnCount-stride first/last=0.0/0.0  mismatched=0
+row 1: true-stride first/last=1.0/1.0  columnCount-stride first/last=0.0/1.0  mismatched=4
+row 2: true-stride first/last=2.0/2.0  columnCount-stride first/last=1.0/2.0  mismatched=8
+row 118: true-stride first/last=118.0/118.0  columnCount-stride first/last=117.0/118.0  mismatched=472
+row 119: true-stride first/last=119.0/119.0  columnCount-stride first/last=118.0/119.0  mismatched=476
+logical row 117 reads 0 element(s) past the copied prefix (kept columns = 1500)
+logical row 118 reads 0 element(s) past the copied prefix (kept columns = 1500)
+logical row 119 reads 476 element(s) past the copied prefix (kept columns = 1024)

--- a/crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.swift
+++ b/crates/coremlit/tests/whisper_swift_probes/probe_alignment_stride.swift
@@ -1,0 +1,76 @@
+// H6 probe (coremlit issue #41): the MLMultiArray row pitch that
+// `SegmentSeeker.addWordTimestamps`' alignment-gather memcpy ignores.
+//
+//   swiftc -O -parse-as-library probe_alignment_stride.swift -o probe_alignment_stride
+//   ./probe_alignment_stride
+//
+// WhisperKit allocates every Float16 MLMultiArray through
+// `MLMultiArray(shape:dataType:initialValue:)`
+// (ArgmaxCore/MLMultiArrayExtensions.swift:11-53), which for `.float16` backs
+// the array with an IOSurface CVPixelBuffer (`:121-136`,
+// kCVPixelFormatType_OneComponent16Half). CoreVideo pads each row; the plain
+// `MLMultiArray(shape:dataType:)` initializer does not. `addWordTimestamps`
+// (SegmentSeeker.swift:444-461) binds both stride arrays and then indexes with
+// `columnCount` instead, so the gather is only correct while pitch == columns.
+
+import CoreML
+import CoreVideo
+import Foundation
+
+@main
+struct Probe {
+  static func pixelBufferBacked(_ rows: Int, _ cols: Int) -> MLMultiArray? {
+    var pb: CVPixelBuffer?
+    let rc = CVPixelBufferCreate(
+      kCFAllocatorDefault, cols, rows, kCVPixelFormatType_OneComponent16Half,
+      [kCVPixelBufferIOSurfacePropertiesKey: [:]] as CFDictionary, &pb)
+    guard rc == kCVReturnSuccess, let pb else { return nil }
+    return MLMultiArray(pixelBuffer: pb, shape: [rows as NSNumber, cols as NSNumber])
+  }
+
+  static func main() {
+    print("== Float16, pixel-buffer backed (WhisperKit's initialValue: path) ==")
+    print("rows cols | shape strides count  storage_rows*pitch")
+    for (rows, cols) in [(224, 1500), (120, 1500), (31, 1500), (2, 1500), (1, 1500),
+                         (224, 1496), (224, 1504), (224, 100), (224, 8), (224, 9)] {
+      guard let a = pixelBufferBacked(rows, cols) else { print("\(rows) \(cols) | FAILED"); continue }
+      let st = a.strides.map { $0.intValue }
+      print("\(rows) \(cols) | shape=\(a.shape.map { $0.intValue }) strides=\(st) count=\(a.count) storage=\(rows * st[0])")
+    }
+
+    print("\n== Float16, plain MLMultiArray(shape:dataType:) ==")
+    for (rows, cols) in [(224, 1500), (120, 1500)] {
+      guard let a = try? MLMultiArray(shape: [rows as NSNumber, cols as NSNumber], dataType: .float16)
+      else { continue }
+      print("\(rows) \(cols) | strides=\(a.strides.map { $0.intValue }) count=\(a.count)")
+    }
+
+    // The observable consequence: write logical row r via the true stride, read
+    // it back the way addWordTimestamps' memcpy does (pitch = columnCount).
+    print("\n== gather mismatch, rows=120 cols=1500 ==")
+    guard let src = pixelBufferBacked(120, 1500) else { return }
+    let pitch = src.strides[0].intValue
+    src.withUnsafeMutableBytes { p, _ in
+      let base = p.baseAddress!.assumingMemoryBound(to: Float16.self)
+      for i in 0..<(120 * pitch) { base[i] = Float16(0) }
+      for r in 0..<120 { for c in 0..<1500 { base[r * pitch + c] = Float16(r) } }
+    }
+    src.withUnsafeBytes { p in
+      let base = p.baseAddress!.assumingMemoryBound(to: Float16.self)
+      for r in [0, 1, 2, 118, 119] {
+        let viaPitch = (0..<1500).map { Float(base[r * pitch + $0]) }
+        let viaCols = (0..<1500).map { Float(base[r * 1500 + $0]) }
+        let mismatches = zip(viaPitch, viaCols).filter { $0 != $1 }.count
+        print("row \(r): true-stride first/last=\(viaPitch[0])/\(viaPitch[1499])  "
+              + "columnCount-stride first/last=\(viaCols[0])/\(viaCols[1499])  mismatched=\(mismatches)")
+      }
+      // ... and the destination overrun: only storage [0, 120*1500) is ever
+      // written by the memcpy, so logical row r reads past it by r*pitch+1500-120*1500.
+      for r in [117, 118, 119] {
+        let overrun = max(0, r * pitch + 1500 - 120 * 1500)
+        print("logical row \(r) reads \(overrun) element(s) past the copied prefix "
+              + "(kept columns = \(1500 - overrun))")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #41, #59, #60.