### PR TITLE
chore(deps): move the colconv dependency onto the published pixon 0.1.0

### DIFF
--- a/crates/coremlit/Cargo.toml
+++ b/crates/coremlit/Cargo.toml
@@ -104,7 +104,7 @@ granite = ["dep:tokenizers", "dep:windit", "windit/text", "dep:sha2"]
 # SigLIP 2 (`siglip2-base-patch16-naflex`) dual-tower image+text embeddings on
 # CoreML: a shared 768-dim joint space. A Rust NaFlex vision front-end
 # (aspect-preserving patch-budget solver + antialiased-bilinear resize +
-# position-embedding lift; the u8 image resize is delegated to `colconv`'s
+# position-embedding lift; the u8 image resize is delegated to `pixon`'s
 # byte-exact PIL-parity q8 resampler, while the patch-budget solver / patchify /
 # pos-emb lift stay hand-rolled — no `image`/decoder dep) around two fp16 graphs,
 # plus a bundled Gemma tokenizer (`tokenizers`, shared with
@@ -114,11 +114,11 @@ granite = ["dep:tokenizers", "dep:windit", "windit/text", "dep:sha2"]
 # crate — so there is NO `siglip-oracle` feature and NO `ort` in this path.
 # `default = []` pulls none of it.
 #
-# LICENSE PREREQUISITE (owner-gated, NOT resolved by this change): `colconv` is
+# LICENSE PREREQUISITE (owner-gated, NOT resolved by this change): `pixon` is
 # currently licensed GPL-3.0-or-later; the owner will relicense it permissive
 # (MIT OR Apache-2.0) before this branch merges. It is a flagged merge blocker
 # tracked outside this change, not something wired here.
-siglip = ["dep:tokenizers", "dep:colconv"]
+siglip = ["dep:tokenizers", "dep:pixon"]
 
 # --- audio::ced (CED tiny/mini/small/base AudioSet sound-event tagging) ---
 # Native CoreML CED multi-label classifier (tiny/mini/small/base — one
@@ -292,25 +292,27 @@ windit = { git = "https://github.com/findit-studio/windit", rev = "b49888002bcbf
 sha2 = { workspace = true, optional = true }
 
 # --- embeddings::siglip image resampler (the `siglip` feature) ---
-# `colconv` supplies the byte-exact PIL-parity q8 image resampler the NaFlex u8
+# `pixon` supplies the byte-exact PIL-parity q8 image resampler the NaFlex u8
 # resize path delegates to, retiring the former hand-rolled fixed-point kernel.
-# `default-features = false` with EXACTLY `["std", "rgb"]`: `std` gates colconv's
+# `default-features = false` with EXACTLY `["std", "rgb"]`: `std` gates pixon's
 # `Convert` / `resample` tiers (the `Convert::from(Rgb24Frame).resize_with(
 # Triangle, …).rgb(…).run()` path this crate drives), and `rgb` gates the
 # packed-RGB24 source frame — the `frame` umbrella (every YUV/bayer/xyz format)
 # is NOT needed for the RGB→RGB resize, so it stays off. Transitive deps are
 # pure-Rust and ort-free (`mediaframe`, `derive_more`, `half`, `thiserror`).
-# Rev-pinned to the reviewed colconv HEAD (the asry/diaric/windit convention).
-# CO-DEV against a LOCAL colconv checkout: add an UNCOMMITTED patch to the
+# A published crates.io range, no longer a rev pin: `pixon` is the renamed
+# `colconv`, and `pixon` 0.1.0 carries the API `colconv` 0.2.1 shipped, so the
+# resampler bytes are the ones the goldens were taken against.
+# CO-DEV against a LOCAL pixon checkout: add an UNCOMMITTED patch to the
 # WORKSPACE ROOT Cargo.toml (never commit it):
 #
-#   [patch."https://github.com/findit-studio/colconv"]
-#   colconv = { path = "../colconv" }
+#   [patch.crates-io]
+#   pixon = { path = "../pixon" }
 #
-# LICENSE: colconv is GPL-3.0-or-later today; its owner-gated relicense to
+# LICENSE: pixon is GPL-3.0-or-later today; its owner-gated relicense to
 # MIT OR Apache-2.0 is a merge blocker for this branch (see the `siglip` feature
 # comment above).
-colconv = { git = "https://github.com/findit-studio/colconv", rev = "0e2cef95498bbcbb6f500ce14f2137c38ed66470", default-features = false, features = ["std", "rgb"], optional = true }
+pixon = { version = "0.1", default-features = false, features = ["std", "rgb"], optional = true }
 
 [dev-dependencies]
 # Integration tests / benches / examples are external consumers: they link the

--- a/crates/coremlit/conversion/siglip/scripts/_siglip_common.py
+++ b/crates/coremlit/conversion/siglip/scripts/_siglip_common.py
@@ -108,7 +108,7 @@ def load_model(attn_implementation="sdpa"):
 def load_slow_image_processor():
     """The SLOW ``Siglip2ImageProcessor`` (explicit class, NOT AutoProcessor / the
     declared Fast one): its uint8 PIL resize (pillow BILINEAR) is what the Rust
-    colconv q8 path is bit-exact against. use_fast is irrelevant for an explicit
+    pixon q8 path is bit-exact against. use_fast is irrelevant for an explicit
     slow class."""
     return Siglip2ImageProcessor.from_pretrained(src_dir())
 

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/mod.rs
@@ -11,7 +11,7 @@
 //!    fits `P`.
 //! 2. [`resize_bilinear_antialias_u8`] — the PIL-parity antialiased-bilinear
 //!    image resize in the **uint8 domain** (Pillow `Resample.c` fixed-point:
-//!    22-bit coefficients, per-pass u8 rounding), delegated to [`colconv`]'s
+//!    22-bit coefficients, per-pass u8 rounding), delegated to [`pixon`]'s
 //!    byte-exact q8 resampler and matching the SigLIP2 processor (resize on u8,
 //!    THEN rescale+normalize). Its sibling f64 [`resize_bilinear_antialias`] is
 //!    the position-embedding lift's kernel (stage 5), which the reference
@@ -63,14 +63,14 @@ pub const PATCH_DIM: usize = CHANNELS * PATCH_SIZE * PATCH_SIZE;
 ///   `precompute_coeffs(int inSize, float in0, float in1, …)` computes
 ///   `scale = (double)(in1 - in0) / outSize`), so the source extent is rounded
 ///   to `f32` before the `f64` coefficient math. Every integer extent `≤ 2²⁴`
-///   is exactly `f32`-representable, keeping both colconv's q8 image resampler
+///   is exactly `f32`-representable, keeping both pixon's q8 image resampler
 ///   and the native `f64` `precompute_coeffs` (the pos-emb lift) bit-identical
 ///   to Pillow's; from `2²⁴ + 1` upward Pillow computes with a different extent
 ///   (`16 777 219 → 16 777 220.0f32`) and the u8 resize's bit-exact contract
 ///   would silently break. The cap keeps every accepted extent 16× inside the
 ///   envelope.
 /// * **Bounded working memory.** The resize output (`dst_h · dst_w · 3` bytes)
-///   and colconv's streaming working set both grow with the accepted axis — a
+///   and pixon's streaming working set both grow with the accepted axis — a
 ///   degenerate strip the budget solver otherwise accepts could demand
 ///   hundreds of MB. Under the cap the whole resize working set stays modest
 ///   even at the boundary.
@@ -172,7 +172,7 @@ fn triangle(t: f64) -> f64 {
 /// The sole live caller is the position-embedding lift
 /// ([`lift_position_embeddings`], via [`resize_bilinear_antialias`]), whose
 /// source is the fixed `16×16` base grid ([`POS_GRID_SIDE`]) — the image
-/// resize path uses colconv's `u8` resampler instead
+/// resize path uses pixon's `u8` resampler instead
 /// ([`resize_bilinear_antialias_u8`]). `16 ≪ 2²⁴`, so this pure-`f64` extent
 /// math trivially coincides bit-for-bit with Pillow's `float box[4]` semantics
 /// (see [`MAX_IMAGE_AXIS`]'s doc for the threshold).
@@ -313,31 +313,31 @@ pub(crate) fn resize_bilinear_antialias(
 
 /// PIL-parity antialiased-bilinear resize of a packed RGB8 image
 /// (`(src_h, src_w, 3)` row-major, RGB-interleaved) to `(dst_h, dst_w, 3)`,
-/// delegated to [`colconv`]'s fixed-point q8 resampler.
+/// delegated to [`pixon`]'s fixed-point q8 resampler.
 ///
-/// colconv's `Triangle` (PIL BILINEAR) u8 path reproduces Pillow's 8bpc
+/// pixon's `Triangle` (PIL BILINEAR) u8 path reproduces Pillow's 8bpc
 /// `Resample.c` pipeline byte-for-byte — 22-bit coefficients, per-pass `u8`
 /// rounding of the horizontal intermediate — which is exactly the SigLIP2
 /// processor's image-resize semantics (resize on `u8`, THEN rescale+normalize;
 /// the per-pass rounding is part of the reference and is what a pure-`f64`
-/// resize cannot emulate). The byte-exactness is enforced upstream by colconv's
+/// resize cannot emulate). The byte-exactness is enforced upstream by pixon's
 /// tolerance-0 Pillow golden suite and downstream by this module's committed E3
 /// oracles (`tests.rs`).
 ///
 /// The only caller, [`preprocess_image`], bounds `src_h`/`src_w` by
 /// [`MAX_IMAGE_AXIS`], which keeps every accepted extent exactly
-/// `f32`-representable — inside Pillow's `float box[4]` envelope, so colconv's
+/// `f32`-representable — inside Pillow's `float box[4]` envelope, so pixon's
 /// coefficient math matches Pillow's (see [`MAX_IMAGE_AXIS`]) — and keeps
-/// colconv's streaming working set small.
+/// pixon's streaming working set small.
 ///
 /// # Errors
 /// [`Error::PreprocessAllocation`] if the output buffer cannot be reserved, a
-/// dimension does not fit colconv's `u32` frame geometry, or colconv rejects the
-/// resize plan — returned instead of aborting the process (`colconv` reserves
-/// fallibly and [`Rgb24Frame::try_new`](colconv::frame::Rgb24Frame::try_new)
+/// dimension does not fit pixon's `u32` frame geometry, or pixon rejects the
+/// resize plan — returned instead of aborting the process (`pixon` reserves
+/// fallibly and [`Rgb24Frame::try_new`](pixon::frame::Rgb24Frame::try_new)
 /// validates the geometry rather than panicking). `bytes` is the `dst_h · dst_w
 /// · 3` output-buffer size — representable even when its reservation or
-/// colconv's own resize plan is what actually failed — or [`usize::MAX`] for a
+/// pixon's own resize plan is what actually failed — or [`usize::MAX`] for a
 /// geometry that could never be represented.
 pub(crate) fn resize_bilinear_antialias_u8(
   src: &[u8],
@@ -346,9 +346,9 @@ pub(crate) fn resize_bilinear_antialias_u8(
   dst_h: usize,
   dst_w: usize,
 ) -> Result<Vec<u8>, Error> {
-  use colconv::{Convert, frame::Rgb24Frame, resample::Triangle};
+  use pixon::{Convert, frame::Rgb24Frame, resample::Triangle};
 
-  // colconv's frame geometry is `u32`; a source extent that does not fit could
+  // pixon's frame geometry is `u32`; a source extent that does not fit could
   // never be represented, let alone allocated. Only reachable through a direct
   // pathological-geometry call — `preprocess_image` caps both axes by
   // `MAX_IMAGE_AXIS`, far inside `u32`.
@@ -382,7 +382,7 @@ pub(crate) fn resize_bilinear_antialias_u8(
   // Filtered (windowed-triangle = PIL BILINEAR) resample, any ratio; the sole
   // fallible call assembles the sink and walks the frame into `out`. `out` is
   // already sized to `dst_len` (a representable value) at this point, so a
-  // colconv-side plan rejection or internal reservation failure here is
+  // pixon-side plan rejection or internal reservation failure here is
   // reported at that real size — not aliased onto the `usize::MAX` sentinel,
   // which is reserved for a geometry that could not be represented at all.
   Convert::from(&frame)
@@ -563,10 +563,10 @@ pub(crate) fn preprocess_image(
 
   let (grid_h, grid_w) = fit_to_patch_budget(height, width, PATCH_SIZE, budget);
 
-  // Resize in the u8 domain (colconv's PIL-parity q8 resampler), then
+  // Resize in the u8 domain (pixon's PIL-parity q8 resampler), then
   // rescale+normalize to f32 — the SigLIP2 processor's order AND dtype (it
   // resizes the u8 image, rounding each pass to u8, then casts to f32). No
-  // whole-image f32 buffer is materialized; colconv streams the resize and the
+  // whole-image f32 buffer is materialized; pixon streams the resize and the
   // only owned buffer is its fallibly-reserved u8 output.
   let dst_h = grid_h * PATCH_SIZE;
   let dst_w = grid_w * PATCH_SIZE;

--- a/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
+++ b/crates/coremlit/src/embeddings/siglip/image/preprocess/tests.rs
@@ -213,9 +213,9 @@ fn resize_preserves_vertical_constancy() {
   assert!((out[1] - out[3]).abs() <= 1e-6, "column 1 not constant");
 }
 
-// ── E3: uint8 PIL-parity resize oracles (colconv q8 engine) ───────────────────
+// ── E3: uint8 PIL-parity resize oracles (pixon q8 engine) ───────────────────
 //
-// The u8 resize is delegated to colconv's byte-exact PIL-parity q8 resampler,
+// The u8 resize is delegated to pixon's byte-exact PIL-parity q8 resampler,
 // whose source frame is packed RGB8 (3-channel). The kernel is
 // channel-independent, so most of these oracles drive a single-channel Pillow
 // grid by replicating it across the three RGB channels and asserting the same
@@ -241,7 +241,7 @@ fn channel(rgb: &[u8], c: usize) -> Vec<u8> {
 }
 
 /// Identity dims (`src == dst`) pass the input bytes through byte-exactly on
-/// every channel — colconv plans a direct copy. 27 distinct bytes (no value
+/// every channel — pixon plans a direct copy. 27 distinct bytes (no value
 /// repeated, unlike a mono-replicated `R=G=B` pattern) so a channel-order
 /// permutation on the direct-copy plan would move a value to the wrong slot
 /// and fail this exact comparison.
@@ -348,7 +348,7 @@ fn rgb_from_channels(r: &[u8], g: &[u8], b: &[u8]) -> Vec<u8> {
 /// with its own independently hand-derived PIL fixed-point expectation. Every
 /// other E3 oracle replicates one pattern across all three channels
 /// (`mono_to_rgb`), so a channel-order permutation (RGB↔BGR) in a future
-/// colconv bump would pass them all unchanged; asserting each output channel
+/// pixon bump would pass them all unchanged; asserting each output channel
 /// against its OWN grid here makes that regression visible — swapping any two
 /// output channels below fails at least one of the three assertions.
 #[test]
@@ -369,7 +369,7 @@ fn resize_u8_distinct_channels_match_independent_pil_grids() {
     255, 191,  64,   0,
   ];
   // G: the mirror grid's own surface, derived by the same per-tap fixed-point
-  // method as R (not read back from colconv's output). The mirror source is
+  // method as R (not read back from pixon's output). The mirror source is
   // the checker source's bytewise complement (`255 − v`), and every quantized
   // weight pair in this 2→4 upscale sums to exactly 2²² with no output
   // landing on a half-integer tie, so the complement carries through both
@@ -409,7 +409,7 @@ fn resize_u8_distinct_channels_match_independent_pil_grids() {
   );
 }
 
-/// An over-tall source height that overflows colconv's `u32` frame geometry
+/// An over-tall source height that overflows pixon's `u32` frame geometry
 /// returns a typed [`Error::PreprocessAllocation`] `{ bytes: usize::MAX }` — no
 /// panic, no abort — before any resize work. (`preprocess_image` caps both axes
 /// far inside `u32`; this exercises the wrapper's own backstop via a direct
@@ -422,7 +422,7 @@ fn resize_u8_rejects_overflowing_geometry() {
   }
 }
 
-/// The over-wide twin: a source width that overflows colconv's `u32` frame
+/// The over-wide twin: a source width that overflows pixon's `u32` frame
 /// geometry is rejected with the same typed [`Error::PreprocessAllocation`]
 /// `{ bytes: usize::MAX }`, before any tap is indexed — no panic, no abort. The
 /// tiny `src` is never read.

--- a/crates/coremlit/tests/feature_map.rs
+++ b/crates/coremlit/tests/feature_map.rs
@@ -81,7 +81,7 @@ fn expected_features() -> Vec<(&'static str, Vec<&'static str>)> {
       "ced",
       vec!["dep:rustfft", "dep:soundevents-dataset", "dep:windit"],
     ),
-    ("siglip", vec!["dep:tokenizers", "dep:colconv"]),
+    ("siglip", vec!["dep:tokenizers", "dep:pixon"]),
   ]
 }
 

--- a/crates/coremlit/tests/siglip/parity_embed.rs
+++ b/crates/coremlit/tests/siglip/parity_embed.rs
@@ -6,7 +6,7 @@
 //! `#[ignore]`d until the owner stages the conversion (`SIGLIP_TEST_MODELS`) and
 //! the committed goldens (Wave B). The `CpuAndGpu` arm is THE GATE (floor never
 //! below 0.99917; measured worst here ≈ 0.99999 both towers — the vision path
-//! preprocesses via colconv and the text path feeds the golden ids). The ANE /
+//! preprocesses via pixon and the text path feeds the golden ids). The ANE /
 //! CpuOnly arms are CHARACTERIZED in `placement.rs`, not floor-gated. Non-vacuity:
 //! zeroed `position_embeddings` collapses vision parity far below the floor.
 

--- a/crates/coremlit/tests/siglip/preprocess.rs
+++ b/crates/coremlit/tests/siglip/preprocess.rs
@@ -353,7 +353,7 @@ fn load_npy<T: npyz::Deserialize>(path: &std::path::Path) -> Vec<T> {
 /// Full-tensor parity of the Rust NaFlex tensors against the staged per-image
 /// `.npy` fixtures (the slow processor + the official lift). `pixel_values` and
 /// the mask must be BITWISE equal (the pillow-fixed-point contract, delegated to
-/// colconv). For `position_embeddings`, the lifted REAL rows match within the
+/// pixon). For `position_embeddings`, the lifted REAL rows match within the
 /// pinned tolerance while the Rust pad rows are asserted bitwise ZERO — the
 /// reference fills pad rows with `resized[0]` (masked, output-invariant), so the
 /// pad rows are canonicalized, not compared to the raw dump.


### PR DESCRIPTION
## Summary

Moves coremlit's `colconv` dependency onto the published **`pixon 0.1.0`**. Phase 2 of the rename; Phase 1 (the crate itself) merged as colconv#402.

This also completes a re-pin the manifest had been anticipating in prose — the old comment read *"Rev-pinned to the reviewed colconv HEAD … RE-PIN in the same follow-up wave"*. This is that wave.

```toml
- colconv = { git = "…/colconv", rev = "0e2cef95…", default-features = false, features = ["std","rgb"], optional = true }
+ pixon   = { version = "0.1",                      default-features = false, features = ["std","rgb"], optional = true }
```

The feature list is **unchanged and exact**, and `default-features = false` is preserved — the surrounding comment explains why those two and nothing else. `siglip = ["dep:tokenizers", "dep:pixon"]`.

## Two things that needed more than a rename

**The `[patch]` block needed a real fix, not a find-and-replace.** A registry dependency cannot be patched by git URL, so `[patch."https://github.com/findit-studio/colconv"]` became `[patch.crates-io]`. The documented co-development workflow — an uncommitted local-path patch for working against a checkout — is otherwise intact.

**`tests/feature_map.rs:84` was load-bearing.** It asserts the exact dependency set against the manifest, so it would have gone red without `dep:pixon`. That is the test doing its job.

Files touched: `crates/coremlit/Cargo.toml`, `conversion/siglip/scripts/_siglip_common.py` (a Python script — an `*.rs`-only sweep would have missed it), `src/embeddings/siglip/image/preprocess/{mod.rs,tests.rs}`, `tests/feature_map.rs`, `tests/siglip/{parity_embed.rs,preprocess.rs}`.

## The check that matters

`pixon` supplies the **byte-exact PIL-parity q8 resampler** the SigLIP2 NaFlex u8 path depends on, so a silent version or feature drift would surface as a preprocessing divergence rather than a build error.

That contract is **not** model-gated — it lives in eight committed E3 oracles in `src/embeddings/siglip/image/preprocess/tests.rs`, hand-derived Pillow fixed-point grids. **All passed**, including the two that exist specifically to catch a resampler swap:

- `resize_u8_per_pass_rounding_discriminates_from_float` — proves q8 per-pass `u8` rounding rather than a float resize
- `resize_u8_distinct_channels_match_independent_pil_grids` — catches an RGB↔BGR permutation that mono-replicated oracles would miss

Every pixon-sensitive path is byte-identical.

The CoreML siglip *inference* tests stay `ignored`: the `.mlmodelc` bundles are not staged on this machine (only the HF PyTorch source snapshot, which is the conversion input), so they require an owner-run local conversion. A dependency rename cannot affect CoreML inference, and the preprocessing contract that *is* affected is fully covered above.

## Verification

**6/6 green**, each exit code captured separately: `fmt=0 · clippy=0 · test=0 · doc=0 · deftest=0 · clippy_default=0`.

- clippy is `-p coremlit --all-features --all-targets -- -D warnings` (`--all-targets` covers the `harness = false` benches)
- `test --all-features` — **1193 passed, 0 failed**
- `doc` with `RUSTDOCFLAGS=-D warnings` — this is what proves the renamed intra-doc links resolve
- plus a default-features `cargo test --no-run` and a default-features clippy row

The three `extract_serde_bypassed_*` tests are `ignored` (gated on `SPEAKERKIT_TEST_MODELS`), not failing.

`cargo tree`: `pixon v0.1.0` from the registry, one entry, sole consumer coremlit; **zero** `colconv` entries. Same checksum as desktop's resolution. `Cargo.lock` is gitignored here, so nothing to commit.

## Related

- colconv#402 — Phase 1, the crate rename itself (merged)
- findit-studio/desktop#169 — the other consumer, where the same change **repairs a broken `main`**
- colconv#403 — pre-existing rustdoc failures with no CI job, found during Phase 1
