### PR TITLE
ci(coremlit/granite): run the real granite model gates, pinned and checksum-verified (#44 finding 7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           path: |
             Models/whisperkit-coreml/openai_whisper-tiny
             Models/tokenizers/whisper-tiny
+            Models/embedkit-granite/granite-97m-multilingual-r2
           key: models-${{ hashFiles('MODELS_LOCK') }}
       - name: Download models (cache miss)
         if: steps.models.outputs.cache-hit != 'true'
@@ -82,12 +83,14 @@ jobs:
           set -euo pipefail
 
           # MODELS_LOCK is the source of truth for what gets downloaded, not
-          # just a cache-busting key: it has a fixed two-table shape (the
-          # whisperkit-coreml model repo, selector field `include`; then the
-          # tokenizer repo, selector field `files`), each with its own
-          # `revision`. Pull repo/selector/revision out by hand instead of
-          # hardcoding them here, so a MODELS_LOCK edit is what changes what
-          # this job downloads — no TOML crate needed for two fixed tables.
+          # just a cache-busting key: it has a fixed three-table shape (the
+          # whisperkit-coreml model repo, selector field `include`; the
+          # tokenizer repo, selector field `files`; the embedkit-coreml granite
+          # repo, selector field `include`), each with its own `revision`. Pull
+          # repo/selector/revision out by hand instead of hardcoding them here,
+          # so a MODELS_LOCK edit is what changes what this job downloads — no
+          # TOML crate needed for three fixed tables. Tables are selected by
+          # INDEX, so appending is safe but reordering MODELS_LOCK is not.
           lock=MODELS_LOCK
 
           table_header() { # Nth `["..."]` header line, unquoted.
@@ -113,15 +116,20 @@ jobs:
           tokenizer_files=$(table_field 2 files)
           tokenizer_revision=$(table_field 2 revision)
           read -ra tokenizer_files_arr <<< "$tokenizer_files"
+          granite_repo=$(table_header 3)
+          granite_include=$(table_field 3 include)
+          granite_revision=$(table_field 3 revision)
 
           echo "MODELS_LOCK: model=$model_repo@$model_revision include=$model_include"
           echo "MODELS_LOCK: tokenizer=$tokenizer_repo@$tokenizer_revision files=$tokenizer_files"
+          echo "MODELS_LOCK: granite=$granite_repo@$granite_revision include=$granite_include"
 
           # Fail LOUD on any empty extraction: `hf download repo` with no
           # selector silently fetches the WHOLE repository, so a future
           # MODELS_LOCK format drift must stop the job here, not download
           # different content than the lock intends.
-          for v in model_repo model_include model_revision tokenizer_repo tokenizer_files tokenizer_revision; do
+          for v in model_repo model_include model_revision tokenizer_repo tokenizer_files tokenizer_revision \
+                   granite_repo granite_include granite_revision; do
             if [ -z "${!v}" ]; then
               echo "::error::MODELS_LOCK parse produced empty '$v' — format drift? fix the lock or the parser" >&2
               exit 1
@@ -133,18 +141,42 @@ jobs:
             --local-dir Models/whisperkit-coreml
           hf download "$tokenizer_repo" "${tokenizer_files_arr[@]}" --revision "$tokenizer_revision" \
             --local-dir Models/tokenizers/whisper-tiny
+          # `include` keeps the bundle's own directory, so this lands at
+          # Models/embedkit-granite/granite-97m-multilingual-r2/ — the layout
+          # tests/granite/common/mod.rs resolves without EMBEDKIT_TEST_MODELS.
+          hf download "$granite_repo" --include "$granite_include" --revision "$granite_revision" \
+            --local-dir Models/embedkit-granite
+      # Runs on EVERY run, not just cache misses, so a truncated download AND a
+      # tampered or partially-restored cache entry both fail here rather than
+      # surfacing later as a confusing parity or model_io failure. The bundle
+      # ships its own CHECKSUMS.sha256 (paths relative to the bundle root);
+      # `shasum -c` is fail-closed in all three degenerate directions — a listed
+      # file that is missing, a hash mismatch, and a checksum file with no valid
+      # lines each exit non-zero.
+      - name: Verify granite artifact checksums
+        run: |
+          set -euo pipefail
+          bundle_root=Models/embedkit-granite/granite-97m-multilingual-r2
+          if [ ! -d "$bundle_root" ]; then
+            echo "::error::$bundle_root is absent after download/cache-restore — the granite model gates would have nothing to run against" >&2
+            exit 1
+          fi
+          cd "$bundle_root"
+          shasum -a 256 -c CHECKSUMS.sha256
       # build.rs UN-ignores the fp16 graph sweep
       # (`every_shipped_model_graph_survives_fp16`) when Models/ is present, so
       # the `-- --ignored` (ignored-ONLY) runs below EXCLUDE it exactly when the
       # models are here — and the modelless `check` job skips it too (ignored
       # there). Run the coremlit sweep binary's ordinary suite here so a newly
       # vanishing fp16 guard cannot merge green. This runner downloads WHISPER
-      # ONLY (per MODELS_LOCK), so COREMLIT_FP16_SWEEP_VENDORS narrows the
-      # vendor manifest to the vendor actually present (fail-closed: unset would
-      # demand EVERY pinned vendor). fp16_guards is a core test — no feature
-      # needed. See the coverage-boundary note in
-      # crates/coremlit/tests/fp16_guards.rs.
-      - run: COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml cargo test -p coremlit --test fp16_guards
+      # and GRANITE ONLY (per MODELS_LOCK), so COREMLIT_FP16_SWEEP_VENDORS
+      # narrows the vendor manifest to exactly the vendors staged here
+      # (fail-closed: unset would demand EVERY pinned vendor). Naming BOTH is
+      # what makes a vanished vendor tree a failure instead of a quiet drop in
+      # coverage; the absent speakerkit/alignkit/argmax vendors stay the
+      # documented escape. fp16_guards is a core test — no feature needed. See
+      # the coverage-boundary note in crates/coremlit/tests/fp16_guards.rs.
+      - run: COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite cargo test -p coremlit --test fp16_guards
       - run: crates/coremlit/tests/fp16_sweep_inventory.sh
       # Core model-gated suite (tiny_model etc., whisper-tiny via
       # WHISPERKIT_TEST_MODELS); then the whisper pipeline's model-gated suite.
@@ -152,3 +184,34 @@ jobs:
       # download and stay local/dev gates, exactly as before the restructure.
       - run: cargo test -p coremlit -- --ignored
       - run: cargo test -p coremlit --features whisper -- --ignored
+      # The granite model gates. They are plain `#[ignore]` (not the sweep's
+      # build.rs cfg), so nothing un-ignores them implicitly: CI has to ask for
+      # them by name, per test target, under `--features granite`. Two ways they
+      # could pass while proving nothing, both closed here:
+      #   - artifact absent: the gates would still be selected but every one
+      #     would fail on a missing bundle. Checked FIRST so the job reports the
+      #     real cause once instead of a wall of load failures.
+      #   - target emptied: `-- --ignored` over a suite whose model gates were
+      #     deleted, renamed, or un-ignored runs 0 tests and exits 0. The
+      #     ignored-only `--list` count refuses that vacuum, and a target that
+      #     failed to BUILD lists nothing either, so it trips the same guard
+      #     (the fp16_sweep_inventory.sh idiom).
+      # The hermetic granite suites (tokenizer identity, in-lib) are the
+      # `features` job's, not this one's.
+      - name: Granite model gates
+        run: |
+          set -euo pipefail
+          bundle=Models/embedkit-granite/granite-97m-multilingual-r2/granite_97m_512.mlmodelc
+          if [ ! -d "$bundle" ]; then
+            echo "::error::granite bundle $bundle is absent — the model gates below must FAIL here, never skip" >&2
+            exit 1
+          fi
+          for target in granite_model_io granite_parity_embed granite_placement granite_embed_long; do
+            listed=$(cargo test -p coremlit --features granite --test "$target" -- --list --ignored 2>/dev/null | grep -c ': test$' || true)
+            if [ "$listed" -eq 0 ]; then
+              echo "::error::$target lists 0 ignored tests — it failed to build, or its model gates were deleted, renamed, or un-ignored, so an ignored-only run would pass vacuously" >&2
+              exit 1
+            fi
+            echo "== $target: $listed model gate(s) =="
+            cargo test -p coremlit --features granite --test "$target" -- --ignored
+          done

--- a/MODELS_LOCK
+++ b/MODELS_LOCK
@@ -3,20 +3,25 @@
 # different revisions) to force a re-download.
 #
 # This file is CONSUMED, not decorative: ci.yml's "Download models (cache
-# miss)" step hand-parses the two tables below (small sed/awk block, no
-# TOML crate — see the comment there) to build both `hf download`
+# miss)" step hand-parses the three tables below (small sed/awk block, no
+# TOML crate — see the comment there) to build all three `hf download`
 # commands, including `--revision`. Editing a repo name, selector, or
 # revision here changes what CI actually downloads next run, exactly like
-# editing any other lock file.
+# editing any other lock file. Table ORDER is load-bearing: that parser
+# selects a table by INDEX (1 = whisper model, 2 = whisper tokenizer,
+# 3 = granite), so tables may be appended but never reordered without
+# editing ci.yml to match.
 #
-# LOUD FOLLOW-UP: `revision = "main"` below is a MOVING target, not a real
-# lock — CI can still download different upstream bytes on two runs of an
-# unchanged MODELS_LOCK if `main` moves between them. Pinning immutable,
-# content-addressed commit hashes for both repos is a deliberate user
-# follow-up: it requires live network access (`hf api ...` or the HF web
-# UI) to look up each repo's current commit SHA, which this environment
-# does not have. Until that lands, treat `cache-epoch` bumps as the only
-# reliable way to force a fresh, verified download.
+# LOUD FOLLOW-UP: `revision = "main"` on the two whisper tables is a MOVING
+# target, not a real lock — CI can still download different upstream bytes
+# on two runs of an unchanged MODELS_LOCK if `main` moves between them.
+# Pinning immutable, content-addressed commit hashes for those two repos is
+# a deliberate user follow-up: it requires live network access (`hf api ...`
+# or the HF web UI) to look up each repo's current commit SHA. Until that
+# lands, treat `cache-epoch` bumps as the only reliable way to force a
+# fresh, verified download of them. The granite table is NOT in that state:
+# it pins an immutable commit SHA, and ci.yml verifies the downloaded bytes
+# against the `CHECKSUMS.sha256` that artifact ships.
 cache-epoch = 1
 
 ["argmaxinc/whisperkit-coreml"]
@@ -26,3 +31,12 @@ revision = "main"
 ["openai/whisper-tiny"]
 files    = "tokenizer.json tokenizer_config.json config.json"
 revision = "main"
+
+# The granite embeddings artifact (`embeddings::granite`), staged under
+# Models/embedkit-granite/ — the layout tests/granite/common/mod.rs resolves
+# by default (overridable via EMBEDKIT_TEST_MODELS). `include` pulls the whole
+# bundle directory: the `.mlmodelc` the gates load, the `.mlpackage`, and the
+# `CHECKSUMS.sha256` ci.yml checks every one of them against.
+["FinDIT-Studio/embedkit-coreml"]
+include  = "granite-97m-multilingual-r2/*"
+revision = "81852f707848407a4f3059f47a34e2bad71f1c6d"

--- a/crates/coremlit/tests/fp16_guards.rs
+++ b/crates/coremlit/tests/fp16_guards.rs
@@ -48,16 +48,17 @@
 //! # Coverage boundary (`COREMLIT_FP16_SWEEP_VENDORS`)
 //!
 //! By default the sweep requires EVERY vendor named by a [`KNOWN_DEFECTS`] pin to
-//! be present. CI's model job, however, downloads WHISPER ONLY (per MODELS_LOCK),
-//! so it sets `COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml` to narrow the
+//! be present. CI's model job, however, downloads WHISPER and GRANITE only (per
+//! MODELS_LOCK), so it sets
+//! `COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite` to narrow the
 //! manifest EXPLICITLY: there the sweep proves it runs and that the whisper mel
-//! control is clean, but it CANNOT verify the speakerkit / alignkit / argmax
-//! defect pins — those models are not downloaded. Full pin verification (all ten
-//! defect pins) is a local/dev gate that needs the complete `Models/` tree. The
-//! override is fail-closed — absence of it requires ALL pinned vendors — so
-//! narrowing coverage is always an explicit, reviewable act in ci.yml, never the
-//! silent side effect of a deleted directory, which is the whole point of the
-//! manifest.
+//! and granite norm controls are clean, but it CANNOT verify the speakerkit /
+//! alignkit / argmax defect pins — those models are not downloaded. Full pin
+//! verification (all ten defect pins) is a local/dev gate that needs the complete
+//! `Models/` tree. The override is fail-closed — absence of it requires ALL
+//! pinned vendors — so narrowing coverage is always an explicit, reviewable act
+//! in ci.yml, never the silent side effect of a deleted directory, which is the
+//! whole point of the manifest.
 //!
 //! When `Models/` is absent the sweep is `ignored`, never a green `ok`
 //! over zero models (see `build.rs`). The parser tests below are hermetic
@@ -1738,9 +1739,10 @@ fn vendor_of(path: &str) -> &str {
 /// absence of the override is the strictest setting.
 ///
 /// `COREMLIT_FP16_SWEEP_VENDORS` (comma-separated) OVERRIDES the manifest for a
-/// deliberately-partial tree: CI's model job downloads WHISPER ONLY (per
-/// MODELS_LOCK) and sets `COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml`, so there
-/// the sweep requires the whisper vendor and audits its graphs while the absent
+/// deliberately-partial tree: CI's model job downloads WHISPER and GRANITE only
+/// (per MODELS_LOCK) and sets
+/// `COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite`, so there the
+/// sweep requires both staged vendors and audits their graphs while the absent
 /// speakerkit/alignkit/argmax vendors are the DOCUMENTED escape, not a silent
 /// skip. Narrowing coverage is thus an explicit, reviewable act; the full pin
 /// verification remains a local/dev gate (see the module docs' coverage boundary).
@@ -1932,7 +1934,7 @@ fn sweep_tree(root: &Path, expected_vendors: &BTreeSet<String>) -> io::Result<Sw
   // went missing, test went green" mode one level up from a single missing model.
   // A tree carrying only the clean whisper vendor used to sweep green with every
   // speakerkit/alignkit/argmax pin skipped. `expected_vendors` is narrowed
-  // explicitly for CI's whisper-only tree; unset, it demands every pinned vendor.
+  // explicitly for CI's partial tree; unset, it demands every pinned vendor.
   for vendor in expected_vendors {
     if !root.join(vendor).is_dir() {
       failures.push(format!(
@@ -2074,34 +2076,46 @@ fn a_missing_pinned_vendor_fails_the_sweep_not_silently_skips() {
   );
 }
 
-/// F3/F1 reconciliation: the CI whisper-only scope sweeps CLEAN. With
-/// `expected_vendors = {whisperkit-coreml}` — what CI's model job sets via
-/// `COREMLIT_FP16_SWEEP_VENDORS` — a tree containing only the clean whisper mel
-/// sweeps green: the whisper vendor is present and its graph is clean, and the
+/// F3/F1 reconciliation: the CI model job's scope sweeps CLEAN. With
+/// `expected_vendors = {whisperkit-coreml, embedkit-granite}` — what that job sets
+/// via `COREMLIT_FP16_SWEEP_VENDORS`, matching the two vendors MODELS_LOCK stages
+/// — a tree containing the clean whisper mel and the clean granite norms sweeps
+/// green: both staged vendors are present and their graphs are clean, and the
 /// absent speakerkit/alignkit/argmax pins are the DOCUMENTED escape (verified by
 /// the full local/dev gate, not here). This is the exact scenario the model job
 /// runs; proving it here keeps the ci.yml wiring honest even though Actions cannot
 /// run in-repo. It also proves the narrowed manifest does NOT demand the pinned
 /// vendors — the fail-closed default does that only when the override is unset.
 #[test]
-fn the_ci_whisper_only_scope_sweeps_clean() {
-  let tree = TempTree::new("whisper_only");
+fn the_ci_model_job_scope_sweeps_clean() {
+  let tree = TempTree::new("ci_model_job_scope");
   write_model(
     tree.path(),
     "whisperkit-coreml/openai_whisper-tiny/MelSpectrogram.mlmodelc",
     WHISPER_MEL,
   );
-  let expected = BTreeSet::from(["whisperkit-coreml".to_string()]);
+  write_model(
+    tree.path(),
+    "embedkit-granite/granite-97m-multilingual-r2/granite_97m_512.mlmodelc",
+    GRANITE_NORMS_CLEAN,
+  );
+  let expected = BTreeSet::from([
+    "whisperkit-coreml".to_string(),
+    "embedkit-granite".to_string(),
+  ]);
 
   let outcome = sweep_tree(tree.path(), &expected).expect("walk the temp tree");
   assert!(
     outcome.failures.is_empty(),
-    "the whisper-only CI scope must sweep clean (whisper present + clean; the pins are the \
-     documented escape) — got {:?}",
+    "the CI model job's scope must sweep clean (both staged vendors present + clean; the pins \
+     are the documented escape) — got {:?}",
     outcome.failures
   );
-  assert_eq!(outcome.models_len, 1, "one synthetic model");
-  assert!(outcome.audited_sites >= 1, "the mel log site was audited");
+  assert_eq!(outcome.models_len, 2, "both synthetic models");
+  assert!(
+    outcome.audited_sites >= 2,
+    "the mel log site and a granite norm site were audited"
+  );
 }
 
 /// codex r7 F3: a present-but-EMPTY `COREMLIT_FP16_SWEEP_VENDORS` must HARD-ERROR,

--- a/crates/coremlit/tests/vad/common/mod.rs
+++ b/crates/coremlit/tests/vad/common/mod.rs
@@ -14,8 +14,8 @@ use sha2::{Digest, Sha256};
 /// §5; the v6.2.1 artifact ships pre-compiled, so this loads directly with no
 /// `coremlcompiler` step). Its HF revision + per-file SHA-256 are pinned in
 /// `tests/model_io.rs` — the alignkit/speakerkit convention for adopted models,
-/// NOT `MODELS_LOCK` (which a whisperkit hermetic gate holds to exactly the two
-/// CI-downloaded whisper tables).
+/// NOT `MODELS_LOCK` (which a whisperkit hermetic gate holds to exactly the
+/// tables CI actually downloads; vad is not among them).
 pub const ARTIFACT: &str = "silero-vad-unified-256ms-v6.2.1.mlmodelc";
 
 /// Directory containing the downloaded vadkit model artifact.

--- a/crates/coremlit/tests/vad/model_io.rs
+++ b/crates/coremlit/tests/vad/model_io.rs
@@ -64,8 +64,8 @@
 //!    `coremlcompiler` step is needed or possible.
 //! 4. Spec §5 / plan T2 called for the revision to be "revision-pinned in
 //!    `MODELS_LOCK`". Reality: `MODELS_LOCK` is held by a whisperkit hermetic
-//!    gate (`crates/coremlit/tests/whisper/models_lock.rs`) to EXACTLY the two
-//!    whisper tables CI actually downloads, and the established convention for
+//!    gate (`crates/coremlit/tests/whisper/models_lock.rs`) to EXACTLY the
+//!    tables CI actually downloads (vad is not among them), and the convention for
 //!    an adopted, CI-untested model (alignkit, speakerkit) is to pin its
 //!    revision + per-file SHA-256 in the crate's own `model_io.rs` — which is
 //!    where this record lives. Following that gated convention, not the plan's

--- a/crates/coremlit/tests/whisper/models_lock.rs
+++ b/crates/coremlit/tests/whisper/models_lock.rs
@@ -5,7 +5,7 @@
 //! rot: the lock stops parsing, or the workflow stops actually reading it.
 //!
 //! No TOML crate: this is a deliberately tiny hand-rolled reader over the
-//! lock's fixed two-table shape (`["repo/name"]` headers, single-line
+//! lock's fixed three-table shape (`["repo/name"]` headers, single-line
 //! `key = "value"` fields), mirroring the sed/awk parsing `ci.yml` itself
 //! performs at CI time — not a general TOML parser.
 
@@ -96,8 +96,8 @@ fn lock_parses_and_every_table_has_a_selector_and_a_revision() {
 
   assert_eq!(
     tables.len(),
-    2,
-    "MODELS_LOCK: expected exactly two tables, found {}",
+    3,
+    "MODELS_LOCK: expected exactly three tables, found {}",
     tables.len()
   );
   for table in &tables {
@@ -124,11 +124,18 @@ fn ci_workflow_derives_downloads_from_the_lock_instead_of_hardcoding_them() {
   let tables = parse_lock(&lock_contents);
   let ci_contents = fs::read_to_string(workflow_path).expect(".github/workflows/ci.yml reads");
 
+  // ORDER matters as much as membership: ci.yml's parser selects a table by
+  // INDEX, so a reordered lock silently re-points every `hf download` at the
+  // wrong repo's selector and revision. `assert_eq!` on the Vec pins both.
   let repo_names: Vec<&str> = tables.iter().map(|t| t.name.as_str()).collect();
   assert_eq!(
     repo_names,
-    vec!["argmaxinc/whisperkit-coreml", "openai/whisper-tiny"],
-    "MODELS_LOCK's table names changed — update this test alongside it"
+    vec![
+      "argmaxinc/whisperkit-coreml",
+      "openai/whisper-tiny",
+      "FinDIT-Studio/embedkit-coreml"
+    ],
+    "MODELS_LOCK's table names or their order changed — update this test alongside it"
   );
 
   // The literal repo strings belong to MODELS_LOCK alone. If ci.yml also
@@ -158,11 +165,29 @@ fn ci_workflow_derives_downloads_from_the_lock_instead_of_hardcoding_them() {
     "download step doesn't invoke hf with a lock-derived $tokenizer_repo"
   );
   assert!(
+    ci_contents.contains("hf download \"$granite_repo\""),
+    "download step doesn't invoke hf with a lock-derived $granite_repo"
+  );
+  assert!(
     ci_contents.contains("--revision \"$model_revision\""),
     "download step doesn't pass a lock-derived --revision for the model repo"
   );
   assert!(
     ci_contents.contains("--revision \"$tokenizer_revision\""),
     "download step doesn't pass a lock-derived --revision for the tokenizer repo"
+  );
+  assert!(
+    ci_contents.contains("--revision \"$granite_revision\""),
+    "download step doesn't pass a lock-derived --revision for the granite repo"
+  );
+
+  // MODELS_LOCK's header states that the granite bytes are checked against the
+  // `CHECKSUMS.sha256` the artifact ships. A lock file that documents an
+  // integrity check ci.yml no longer performs is a lock file lying about what
+  // CI does — the same rot this test exists to catch one level down.
+  assert!(
+    ci_contents.contains("shasum -a 256 -c CHECKSUMS.sha256"),
+    "ci.yml no longer verifies the granite bundle against its shipped CHECKSUMS.sha256, which \
+     MODELS_LOCK's header claims it does"
   );
 }


### PR DESCRIPTION
Closes the CI half of #44 (finding 7). The conversion-provenance half (finding 8) is #68.

## The defect

`model-tests` downloads **whisper only**. `MODELS_LOCK` had exactly two tables — `argmaxinc/whisperkit-coreml` and `openai/whisper-tiny` — with no granite entry.

So **18 granite model gates have never run in CI**: `embed_long` 8, `parity_embed` 5, `model_io` 4, `placement` 1. A green run proved nothing about compiled model I/O, FP32 parity, placement behaviour, or real-model `embed_long`.

(`tokenizer_identity` is **not** among them — it is genuinely hermetic, 0 ignores, and is deliberately excluded from the new loop so it cannot pad the count.)

## What changed

- **`MODELS_LOCK`** — a third table, `FinDIT-Studio/embedkit-coreml` pinned to `81852f707848407a4f3059f47a34e2bad71f1c6d`.
- **`ci.yml`** — table-3 extraction feeding a third `hf download`; the fail-loud-on-empty loop extended to all nine variables; granite added to the cache path; a checksum-verification step that runs on **every** run, not just cache miss; a granite model-gate step; `COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite`.
- **Four tests that hardcoded the old shape.** `whisper/models_lock.rs` asserted `tables.len() == 2` ("expected exactly two tables") and would have failed the `features` job. `fp16_guards.rs` and two vad tests asserted MODELS_LOCK holds "EXACTLY the two whisper tables". Those tests were doing their job.

The vendor key `embedkit-granite` was derived from `fp16_guards.rs:910`, not guessed.

## The requirement that matters

#44's fourth point: **fail when the model directory is missing rather than silently skipping.** A gate that skips when models are absent is indistinguishable from one that passes — which is how 18 gates sat unrun in a green CI.

Verified: no `Models/` → checksum step exits **1**, gate step exits **1**. Partial download (1 of 9 files) → exits **1** with 8 `FAILED open or read`.

## Verification

The `MODELS_LOCK` parser is hand-rolled `sed`/`awk` selecting the **Nth table by index**, so it was exercised directly — helpers extracted verbatim, not retyped:

- 9/9 expected-value assertions across all three tables
- fail-loud on all five drift shapes: granite table deleted, `include` renamed to `files`, revision emptied, **tables reordered**, and the real lock passing

Table order is load-bearing, so it is now pinned as an ordered `Vec`.

Also verified: the pinned revision and 10-file set exist on HF; the real `model.mil` SHA `b00d8da3…` matches **both** the published `CHECKSUMS.sha256` and the in-repo `ARTIFACT_SHA256`; the fp16 sweep over the **real granite graph** passes (25 `layer_norm`s at `0x1.5p-17`, zero `log`/`sqrt`/`rsqrt`/`real_div`); and the comma-split works — with whisper absent it exits 101 naming the missing vendor, proving granite's directory *was* found.

Only the 1.9 MB `model.mil` was downloaded to prove the graph audit, not the 394 MB bundle.

## Not claimed

**That the gates now run in CI** — that cannot be observed from here. What is verified is the wiring, the lock parse, the fail-closed paths and the gate selection, all locally. The `shasum -c` all-nine happy path needs the full bundle. And macos-15 runners have no ANE, so `placement.rs`/`parity_embed.rs` passing there is reasoning — both assert cross-placement numerical agreement and never residency — not observation.

## Deliberately untouched

`MODELS_LOCK` pins `revision = "main"` for the whisper tables — a moving target flagged by a LOUD FOLLOW-UP comment in the file itself, with no checksum verification. **That is a real defect and an open owner decision**, so both revisions are unchanged here. The comment's *scope* wording was corrected (it said "both repos" and claimed no network access, which a third pinned table contradicts); the decision is not.

Worth stating: the cache key is `hashFiles('MODELS_LOCK')`, so with a moving revision the same commit can test different model bytes depending on invisible cache state. Granite is pinned; whisper is not, yet.

Related: #44.