### PR TITLE
fix(coremlit/speaker): retire the int8 embedder for the fp16-safe fp32 wespeaker — the coherent palettization bias behind the clip-09 collapse (#15)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -101,8 +101,14 @@ CoreML and feeds dia's community-1 PLDA clustering. Attribution obligations:
   - pyannote/segmentation-3.0 (both sources' segmenters derive from it): MIT.
   - WeSpeaker embedder (wenet-e2e/wespeaker): see its model license
     (https://github.com/wenet-e2e/wespeaker).
-  - FluidInference/speaker-diarization-coreml (the default source's CoreML
-    conversion): SDK Apache-2.0; parent pyannote model cc-by-4.0.
+  - FinDIT-Studio/speakerkit-coreml (the SEGMENTATION artifact only,
+    pyannote_segmentation.mlmodelc): HF license "other"/mixed-upstream. A
+    re-conversion of the same segmentation-3.0 weights with an fp16-survivable
+    log-softmax tail, so the upstream term above (MIT) still governs.
+  - FluidInference/speaker-diarization-coreml (the CoreML conversion this crate
+    was built against, and still the source of every other speakerkit artifact
+    including the shipping WeSpeaker embedder): SDK Apache-2.0; parent pyannote
+    model cc-by-4.0.
   - argmaxinc/speakerkit-coreml (the optional argmax source's conversion):
     NO declared license on the HF repo — undeclared defaults to all rights
     reserved on the converted artifact; argmax's Swift code

--- a/NOTICE
+++ b/NOTICE
@@ -101,14 +101,16 @@ CoreML and feeds dia's community-1 PLDA clustering. Attribution obligations:
   - pyannote/segmentation-3.0 (both sources' segmenters derive from it): MIT.
   - WeSpeaker embedder (wenet-e2e/wespeaker): see its model license
     (https://github.com/wenet-e2e/wespeaker).
-  - FinDIT-Studio/speakerkit-coreml (the SEGMENTATION artifact only,
-    pyannote_segmentation.mlmodelc): HF license "other"/mixed-upstream. A
-    re-conversion of the same segmentation-3.0 weights with an fp16-survivable
-    log-softmax tail, so the upstream term above (MIT) still governs.
+  - FinDIT-Studio/speakerkit-coreml (the TWO SHIPPING artifacts,
+    pyannote_segmentation.mlmodelc and the fp32 wespeaker.mlmodelc): HF license
+    "other"/mixed-upstream. Re-conversions of the same upstream weights with
+    fp16-survivable guards (a fused log-softmax tail; pooling epsilons at the
+    fp16 floor), so the upstream terms above (segmentation-3.0 MIT; WeSpeaker
+    its model license) still govern.
   - FluidInference/speaker-diarization-coreml (the CoreML conversion this crate
     was built against, and still the source of every other speakerkit artifact
-    including the shipping WeSpeaker embedder): SDK Apache-2.0; parent pyannote
-    model cc-by-4.0.
+    including the retired int8 WeSpeaker embedder kept for tests): SDK
+    Apache-2.0; parent pyannote model cc-by-4.0.
   - argmaxinc/speakerkit-coreml (the optional argmax source's conversion):
     NO declared license on the HF repo — undeclared defaults to all rights
     reserved on the converted artifact; argmax's Swift code

--- a/crates/coremlit/Cargo.toml
+++ b/crates/coremlit/Cargo.toml
@@ -543,6 +543,14 @@ name = "speaker_parity_shipping_der"
 path = "tests/speaker/parity_shipping_der.rs"
 required-features = ["speaker-oracle"]
 
+# The segmentation-vs-embedding backend cross-product at the SHIPPING
+# configuration: mixes both CoreML conversions with dia's ONNX pair in one
+# process, so it needs the oracle linked alongside the CoreML models.
+[[test]]
+name = "speaker_backend_factorial"
+path = "tests/speaker/backend_factorial.rs"
+required-features = ["speaker-oracle"]
+
 [[test]]
 name = "speaker_generate_goldens"
 path = "tests/speaker/generate_goldens.rs"

--- a/crates/coremlit/src/audio/speaker/embed/mod.rs
+++ b/crates/coremlit/src/audio/speaker/embed/mod.rs
@@ -1,4 +1,7 @@
-//! CoreML wrapper for `wespeaker_v2.mlmodelc` (spec §4): raw waveform +
+//! CoreML wrapper for the WeSpeaker embedder family (spec §4) — the shipping
+//! fp32 `wespeaker.mlmodelc` and its contract-equal int8 siblings
+//! `wespeaker_v2`/`wespeaker_int8` (which artifact ships is
+//! `source::FluidAudioArtifacts`'s decision, issue #15): raw waveform +
 //! per-frame speaker-activity mask in, raw (un-normalized) 256-d WeSpeaker
 //! embeddings out, batched across all 3 pyannote speaker slots per call.
 //!

--- a/crates/coremlit/src/audio/speaker/embed/tests.rs
+++ b/crates/coremlit/src/audio/speaker/embed/tests.rs
@@ -448,7 +448,7 @@ fn from_file_loads_and_reports_mask_frame_count_v2() {
 fn from_file_loads_and_reports_mask_frame_count_fp32() {
   let model = load_embed_model(embed_fp32_path());
   // Ground truth pinned by
-  // `tests/model_io.rs::wespeaker_fp32_io_contract_equal_but_not_targeted`.
+  // `tests/model_io.rs::wespeaker_fp32_io_matches_spec`.
   assert_eq!(model.num_mask_frames(), 589);
 }
 

--- a/crates/coremlit/src/audio/speaker/mod.rs
+++ b/crates/coremlit/src/audio/speaker/mod.rs
@@ -60,7 +60,11 @@
 //! (argmax bakes preprocessing/decoding into its graph; FluidAudio does host-
 //! side powerset/mask/window decode), not interchangeable weight swaps:
 //!
-//! - **FluidAudio** (`Source::FluidAudio`, default; `FluidInference/speaker-diarization-coreml`):
+//! - **FluidAudio** (`Source::FluidAudio`, default;
+//!   `FluidInference/speaker-diarization-coreml`, except the segmentation
+//!   graph, which is the fp16-safe re-conversion published as
+//!   `FinDIT-Studio/speakerkit-coreml` — see `tests/speaker/model_io.rs` for
+//!   the pinned revision and per-file SHA-256):
 //!   powerset log-probs `[1,589,7]`, host-side decode; seg 99.97% / embed
 //!   cosine 0.99999989 vs fp32 dia-ort. **Validated** default.
 //! - **argmax** (`Source::Argmax`, optional; `argmaxinc/speakerkit-coreml`):

--- a/crates/coremlit/src/audio/speaker/segment/mod.rs
+++ b/crates/coremlit/src/audio/speaker/segment/mod.rs
@@ -67,29 +67,27 @@
 //!   both formats), so building the lookup table directly in `f64` here is
 //!   bit-identical to dia's f32-then-cast.
 //!
-//! # `segments` is `log(softmax(·))`, NOT raw logits
+//! # `segments` is `log_softmax(·)`, NOT raw logits
 //!
 //! This module's docs asserted "raw powerset logits" until someone read
 //! the graph. They are not. `pyannote_segmentation.mlmodelc/model.mil`
-//! ends (lines 137-139, immediately before its `-> (segments)` return):
+//! ends (immediately before its `-> (segments)` return):
 //!
 //! ```text
-//! var_231_softmax_cast_fp16 = softmax(axis = var_230, x = linear_2_cast_fp16)
-//! var_231_epsilon_0_to_fp16 = const()[..., val = tensor<fp16, []>(0x0p+0)]
-//! var_231_cast_fp16         = log(epsilon = var_231_epsilon_0_to_fp16,
-//!                                 x = var_231_softmax_cast_fp16)
-//! segments                  = cast(dtype = fp32, x = var_231_cast_fp16)
+//! var_247_cast_fp16 = reduce_log_sum_exp(axes = [-1], keep_dims = true,
+//!                                        x = linear_2_cast_fp16)
+//! var_249_cast_fp16 = sub(x = linear_2_cast_fp16, y = var_247_cast_fp16)
+//! segments          = cast(dtype = fp32, x = var_249_cast_fp16)
 //! ```
 //!
-//! `segments` is that `log`'s output. The tensor holds per-frame
-//! **log-probabilities** — a `log_softmax` the converter decomposed into
-//! `softmax` → `log`. The fp32 `Segmentation.mlmodelc` variant has the
-//! identical tail and names its output `log_probs`, which is the honest
-//! name.
+//! `segments` holds per-frame **log-probabilities**: `z − logsumexp(z)`, the
+//! fused form of `log_softmax`. The fp32 `Segmentation.mlmodelc` variant
+//! computes the same quantity and names its output `log_probs`, which is the
+//! honest name.
 //!
-//! That mistake was not cosmetic: it is precisely why nobody went looking
-//! for a `log` op — and there is one, carrying an `epsilon` of literally
-//! `0x0p+0`. See "fp16 hazard" below.
+//! The "raw logits" mistake was not cosmetic: believing there was no `log` in
+//! the graph is exactly why nobody looked at the `log`'s guard epsilon for a
+//! full review cycle. See "fp16 safety" below.
 //!
 //! # Why argmaxing it without a softmax is still correct
 //!
@@ -130,27 +128,42 @@
 //! never reads a magnitude, which is what keeps the decode correct in
 //! spite of the next section.
 //!
-//! # fp16 hazard in the shipped graph (a KNOWN, pinned defect)
+//! # fp16 safety of the shipped graph (a REPAIRED defect)
 //!
-//! That in-graph `log`'s guard epsilon is `0x0p+0` — zero. Its fp32 and
-//! argmax-vendored siblings carry `0x1p-149`, which is fp32's smallest
-//! subnormal and rounds to zero in fp16 all the same. Every epsilon below
-//! fp16's smallest subnormal (`2^-24` ≈ 5.96e-8) is inert on any ANE/GPU
-//! path — i.e. on the default [`crate::ComputeUnits::All`] — so a
-//! softmax output that underflows to 0 reaches `log(0)`, which saturates
-//! (≈ -45440 on the ANE) instead of being guarded.
+//! The artifact this module loaded until 2026-07-26 reached the same
+//! log-probabilities through `softmax` → `log(epsilon = 0x0p+0)`. Every
+//! epsilon below fp16's smallest subnormal (`2^-24` ≈ 5.96e-8) is inert
+//! wherever the graph actually computes in fp16 — i.e. on the default
+//! [`crate::ComputeUnits::All`] — so a softmax output that underflowed to 0
+//! reached an unguarded `log(0)` and saturated instead of being clamped.
+//! Measured over 1033 chunks of a real 17-minute recording, the minimum
+//! `segments` value was **−45440** on `All` against **−32.31** on `CpuOnly`
+//! (issue #15).
 //!
-//! `coremlit`'s `tests/fp16_guards.rs` pins this graph, and every other
-//! shipped graph, against that floor. Two consequences for callers:
+//! The shipped graph now has **no `log` op at all**. `reduce_log_sum_exp` →
+//! `sub` computes `z − logsumexp(z)` directly, and for finite `z` its output
+//! is bounded below by `min(z) − logsumexp(z)` — there is no value it can
+//! saturate on, at any precision, on any placement. The same measurement
+//! gives −31.80 on `All`. `tests/fp16_guards.rs` holds this graph and every
+//! other shipped graph to the `2^-24` floor in BOTH directions, and
+//! `tests/speaker/model_io.rs` asserts the fused tail structurally and pins
+//! the artifact's bytes, so neither a regression nor a silent repair can land
+//! unseen.
 //!
-//! - The argmax decode survives it. Classes that underflow all saturate to
-//!   the same floor, so they tie at the BOTTOM of the row; with seven
-//!   classes the winner's softmax is at least `1/7`, so the winning class
-//!   can never underflow and can never be displaced.
-//! - The magnitudes do NOT survive it. On any fp16 path these values are
-//!   saturated, not calibrated log-probabilities. Do not consume
-//!   `segments` as a confidence, a threshold input, or a log-likelihood.
-//!   Only its per-row ordering is trustworthy.
+//! **What this did NOT cause, despite the coincidence in timing.** The
+//! 8-speaker clip on which the CoreML path returns 5 speakers at 16.6 % DER
+//! (`tests/speaker/parity_shipping_der.rs`'s clip-09 pin) is a segmentation
+//! defect, but not THIS one: swapping in the repaired artifact and changing
+//! nothing else leaves every gated DER number on that corpus bit-identical.
+//! The clip-09 divergence is this graph's ordinary fp16-vs-fp32 precision in
+//! the log-probability tail — enough to flip 0.18 % of powerset argmax frames
+//! against dia-ort — and both conversions are fp16, so both carry it.
+//!
+//! What callers get: [`multilabel`] consumes per-row ORDERING only, and that
+//! was never at risk. Magnitudes are now unsaturated on every placement, but
+//! they are still computed in fp16 on the ANE/GPU (`All` can return a value a
+//! few thousandths above 0 where one class dominates), so read them as
+//! fp16-precise log-probabilities, not as an fp32-accurate log-likelihood.
 //!
 //! # Tie handling
 //!
@@ -265,7 +278,7 @@ fn describe(shape: &[usize], dtype: Option<DataType>) -> String {
 /// CoreML wrapper over `pyannote_segmentation.mlmodelc`: one
 /// [`SEG_CHUNK_SAMPLES`]-sample chunk in, flattened `[num_frames *
 /// POWERSET_CLASSES]` powerset **log-probabilities** out (the graph's tail
-/// is `softmax` → `log`; see the module doc) — layout-identical to dia's
+/// is `reduce_log_sum_exp` → `sub`; see the module doc) — layout-identical to dia's
 /// `SegmentModel::infer` (`diarization/src/segment/model.rs:280-357`; see
 /// the module doc's "dia contract match" section).
 #[derive(Debug)]

--- a/crates/coremlit/src/audio/speaker/segment/mod.rs
+++ b/crates/coremlit/src/audio/speaker/segment/mod.rs
@@ -182,8 +182,11 @@
 //! its own reproduces the 5-of-8 collapse exactly (16.5904 %). An earlier
 //! cross-product run with the fp32 embedder on `CpuOnly` attributed the whole
 //! thing here; it does not survive re-measurement at the configuration this
-//! crate ships. See `tests/speaker/model_io.rs`'s "Clip 09" section for both
-//! tables side by side.
+//! crate ships. Within that embedding path the responsibility splits further —
+//! the int8 palettization costs 2 speakers and the `All` placement 1, while the
+//! embedding CONVERSION on its own is frame-perfect against dia-ort. See
+//! `tests/speaker/model_io.rs`'s "Clip 09" section for all three tables side by
+//! side.
 //!
 //! Which PART of this graph produces its own overcount is a further step, and
 //! it is NOT established: `segments` is the only tensor either graph exposes,

--- a/crates/coremlit/src/audio/speaker/segment/mod.rs
+++ b/crates/coremlit/src/audio/speaker/segment/mod.rs
@@ -128,7 +128,7 @@
 //! never reads a magnitude, which is what keeps the decode correct in
 //! spite of the next section.
 //!
-//! # fp16 safety of the shipped graph (a REPAIRED defect)
+//! # fp16 safety of the shipped graph (one mechanism removed, not a proof)
 //!
 //! The artifact this module loaded until 2026-07-26 reached the same
 //! log-probabilities through `softmax` → `log(epsilon = 0x0p+0)`. Every
@@ -136,34 +136,69 @@
 //! wherever the graph actually computes in fp16 — i.e. on the default
 //! [`crate::ComputeUnits::All`] — so a softmax output that underflowed to 0
 //! reached an unguarded `log(0)` and saturated instead of being clamped.
-//! Measured over 1033 chunks of a real 17-minute recording, the minimum
-//! `segments` value was **−45440** on `All` against **−32.31** on `CpuOnly`
-//! (issue #15).
+//! Measured over 1033 chunks of a real 17-minute recording
+//! (`09_mrbeast_dollar_date`), the minimum `segments` value was **−45440** on
+//! `All` against **−32.31** on `CpuOnly` (issue #15).
 //!
-//! The shipped graph now has **no `log` op at all**. `reduce_log_sum_exp` →
-//! `sub` computes `z − logsumexp(z)` directly, and for finite `z` its output
-//! is bounded below by `min(z) − logsumexp(z)` — there is no value it can
-//! saturate on, at any precision, on any placement. The same measurement
-//! gives −31.80 on `All`. `tests/fp16_guards.rs` holds this graph and every
-//! other shipped graph to the `2^-24` floor in BOTH directions, and
-//! `tests/speaker/model_io.rs` asserts the fused tail structurally and pins
-//! the artifact's bytes, so neither a regression nor a silent repair can land
-//! unseen.
+//! The shipped graph has **no `log` op at all**: `reduce_log_sum_exp` → `sub`
+//! computes `z − logsumexp(z)` directly. **That removes the mechanism above,
+//! and removing that mechanism is the whole claim.** No `log` means no guard
+//! epsilon, so the measured "underflowed softmax reaches `log(0)`" path cannot
+//! occur.
 //!
-//! **What this did NOT cause, despite the coincidence in timing.** The
-//! 8-speaker clip on which the CoreML path returns 5 speakers at 16.6 % DER
-//! (`tests/speaker/parity_shipping_der.rs`'s clip-09 pin) is a segmentation
-//! defect, but not THIS one: swapping in the repaired artifact and changing
-//! nothing else leaves every gated DER number on that corpus bit-identical.
-//! The clip-09 divergence is this graph's ordinary fp16-vs-fp32 precision in
-//! the log-probability tail — enough to flip 0.18 % of powerset argmax frames
-//! against dia-ort — and both conversions are fp16, so both carry it.
+//! It is NOT a proof that no value can saturate at any precision on any
+//! placement, and the wording that said so was reasoning one step past its
+//! evidence. `sub` is not immune on its own terms: two finite fp16 operands
+//! near the format's ±65504 maximum subtract to ≈ ∓131008, outside fp16's
+//! range — and nothing here bounds the intermediates the trunk feeds it.
+//! What the repo's gates actually bound is narrower than the old claim
+//! sounded: `tests/fp16_guards.rs` bounds guard CONSTANTS against the `2^-24`
+//! floor, and `tests/speaker/model_io.rs` bounds the artifact's BYTES (sha256)
+//! and the tail's STRUCTURE (no `log` op, `reduce_log_sum_exp` present). None
+//! of the three bounds a runtime value.
+//!
+//! - *Established*: the decomposed-softmax `log(0)` mechanism is gone, and on
+//!   the same 1033-chunk measurement the minimum `segments` value on `All` is
+//!   **−31.80** rather than −45440.
+//! - *Not established*: any bound on `segments` for other inputs, other
+//!   placements, or other hosts. An observed range on one recording is not a
+//!   range guarantee.
+//! - *What would settle it*: explicit finite/range testing — drive the graph
+//!   at each placement with inputs chosen to push the trunk toward the fp16
+//!   extremes and assert a bound on the output. This crate has no such test.
+//!
+//! **What this repair did NOT fix, and what this graph is NOT responsible
+//! for.** The 8-speaker clip on which the shipping CoreML path returns 5
+//! speakers at 16.6 % DER (`tests/speaker/parity_shipping_der.rs`'s clip-09
+//! pin) is not repaired by the swap: re-running that suite's four gated clips
+//! with only the artifact changed reproduced every gated number, clip 09
+//! included.
+//!
+//! It is also **not this stage's collapse**. Measured at the shipping
+//! configuration by `tests/speaker/backend_factorial.rs` — int8 embedder, both
+//! CoreML models on [`crate::ComputeUnits::All`], dia's ONNX as the reference
+//! for whichever stage is not swapped — this graph on its own OVERcounts by
+//! one speaker (9 of 8, 1.3011 % DER), while the CoreML *embedding* path on
+//! its own reproduces the 5-of-8 collapse exactly (16.5904 %). An earlier
+//! cross-product run with the fp32 embedder on `CpuOnly` attributed the whole
+//! thing here; it does not survive re-measurement at the configuration this
+//! crate ships. See `tests/speaker/model_io.rs`'s "Clip 09" section for both
+//! tables side by side.
+//!
+//! Which PART of this graph produces its own overcount is a further step, and
+//! it is NOT established: `segments` is the only tensor either graph exposes,
+//! so a divergence in it cannot be attributed to this tail rather than to the
+//! trunk that feeds it. `backend_factorial`'s `seg_divergence` doc carries the
+//! one decomposition the observable outputs do support (a monotone per-row
+//! shift can only collapse an ordering into a tie, never invert one) and what
+//! would settle the rest.
 //!
 //! What callers get: [`multilabel`] consumes per-row ORDERING only, and that
-//! was never at risk. Magnitudes are now unsaturated on every placement, but
-//! they are still computed in fp16 on the ANE/GPU (`All` can return a value a
-//! few thousandths above 0 where one class dominates), so read them as
-//! fp16-precise log-probabilities, not as an fp32-accurate log-likelihood.
+//! was never at risk from the epsilon. Magnitudes are unsaturated in the
+//! measurements above, but they are still computed in fp16 on the ANE/GPU
+//! (`All` can return a value a few thousandths above 0 where one class
+//! dominates), so read them as fp16-precise log-probabilities — not as an
+//! fp32-accurate log-likelihood, and not as a quantity this crate bounds.
 //!
 //! # Tie handling
 //!
@@ -369,11 +404,13 @@ impl SegmentModel {
   /// `[frame][class]` — layout-identical to dia's `SegmentModel::infer`
   /// (`diarization/src/segment/model.rs:280-357`).
   ///
-  /// These are `log(softmax(z))`, not the raw logits `z`: the graph's tail
-  /// is a decomposed `log_softmax` (module doc, "`segments` is
-  /// `log(softmax(·))`"). Consume the per-row ORDERING — which is
-  /// identical to the logits' — and not the magnitudes, which the graph's
-  /// inert fp16 `log` epsilon saturates on ANE/GPU paths.
+  /// These are `log(softmax(z))`, not the raw logits `z`: the shipped
+  /// graph's tail is the FUSED `reduce_log_sum_exp` → `sub` (module doc,
+  /// "`segments` is `log_softmax(·)`"). Consume the per-row ORDERING — the
+  /// property [`multilabel`] needs, and the one a per-row constant shift
+  /// preserves — rather than the magnitudes, which are computed in fp16 on
+  /// ANE/GPU placements and are not bounded by anything this crate tests
+  /// (module doc, "fp16 safety of the shipped graph").
   ///
   /// # Errors
   /// [`InferError::InputLength`] unless `samples.len() == SEG_CHUNK_SAMPLES`

--- a/crates/coremlit/src/audio/speaker/source/mod.rs
+++ b/crates/coremlit/src/audio/speaker/source/mod.rs
@@ -91,7 +91,7 @@ pub trait ModelSource {
 }
 
 /// The FluidAudio model source: `pyannote_segmentation.mlmodelc` +
-/// `wespeaker_v2.mlmodelc` via [`SegmentModel`]/[`EmbedModel`], decoded
+/// `wespeaker.mlmodelc` via [`SegmentModel`]/[`EmbedModel`], decoded
 /// host-side by [`Extractor::extract`] — this crate's original (and,
 /// until the multi-source split, only) pipeline. See the module doc's
 /// "`FluidAudioSource`: the existing pipeline, unchanged" section.
@@ -167,13 +167,21 @@ impl Default for Source {
 ///
 /// [`AnySource::load`] resolves the FluidAudio paths through this and nothing
 /// else, so a gate can assert the shipping selection at its source of truth
-/// instead of re-encoding it. [`Self::embedder`] is the int8-palettized
-/// `wespeaker_v2.mlmodelc` (the shipping default; byte-identical to
-/// `wespeaker_int8.mlmodelc`, `tests/model_io.rs`). Repointing it at the fp32
-/// `wespeaker.mlmodelc` — the fp32-tested/int8-shipped hazard — then moves
-/// production AND the test that pins it together, so the two cannot silently
-/// diverge (a test that loaded its OWN `wespeaker_v2` path while production
-/// loaded something else is exactly how that hazard hides).
+/// instead of re-encoding it. [`Self::embedder`] is the fp32
+/// `wespeaker.mlmodelc` (issue #15): the previously shipped int8-palettized
+/// `wespeaker_v2.mlmodelc` silently collapses 8-speaker audio (5 of 8
+/// speakers, 16.59 % DER on the measured clip) because its per-tensor
+/// palettization error is a COHERENT shared displacement that compresses
+/// between-speaker margins in the frozen community-1 PLDA space — while
+/// holding no stable extraction-speed edge over fp32 on any placement
+/// (≤ ~15 % apart with the sign varying run to run; the measured trade is in
+/// `tests/speaker/model_io.rs`'s DECISION). The mechanism, the factorial
+/// that isolated
+/// it, and the retirement rationale live in `tests/speaker/model_io.rs` (the
+/// DECISION section) and `tests/speaker/backend_factorial.rs`
+/// (`quantization_error_structure`). Repointing this resolver moves
+/// production AND every gate that pins the selection through it, so the two
+/// cannot silently diverge.
 ///
 /// **Pure**: path selection only — no filesystem access, no model load — so a
 /// hermetic unit test can pin the selection with no models present.
@@ -191,7 +199,7 @@ impl FluidAudioArtifacts {
     let root = models_root.as_ref();
     Self {
       segmenter: root.join("pyannote_segmentation.mlmodelc"),
-      embedder: root.join("wespeaker_v2.mlmodelc"),
+      embedder: root.join("wespeaker.mlmodelc"),
     }
   }
 
@@ -202,8 +210,8 @@ impl FluidAudioArtifacts {
     &self.segmenter
   }
 
-  /// The embedder artifact path (`<root>/wespeaker_v2.mlmodelc`, the int8
-  /// shipping default).
+  /// The embedder artifact path (`<root>/wespeaker.mlmodelc`, the fp32
+  /// shipping default — issue #15).
   #[inline]
   #[must_use]
   pub fn embedder(&self) -> &Path {
@@ -234,7 +242,7 @@ impl AnySource {
   /// both:
   ///
   /// - [`Source::FluidAudio`]: a directory holding
-  ///   `pyannote_segmentation.mlmodelc` and `wespeaker_v2.mlmodelc`
+  ///   `pyannote_segmentation.mlmodelc` and `wespeaker.mlmodelc`
   ///   (this crate's `Models/speakerkit`).
   /// - [`Source::Argmax`]: the `speakerkit-coreml` root holding
   ///   `speaker_segmenter/` and `speaker_embedder/` (this crate's

--- a/crates/coremlit/src/audio/speaker/source/tests.rs
+++ b/crates/coremlit/src/audio/speaker/source/tests.rs
@@ -88,17 +88,19 @@ fn any_source_argmax_does_not_fall_back_to_fluid_audio() {
 }
 
 /// Finding 3, hermetic: the shipping FluidAudio selection is a pure function of
-/// the models root, pinned to the int8 `wespeaker_v2.mlmodelc`. This is the same
-/// resolver [`AnySource::load`] uses, so the pin sits on production's own
-/// selection. Repointing [`FluidAudioArtifacts::resolve`] at the fp32
-/// `wespeaker.mlmodelc` (the fp32-tested/int8-shipped hazard) fails this
-/// immediately — no models needed, because the resolver does no I/O.
+/// the models root, pinned to the fp32 `wespeaker.mlmodelc` (issue #15 — the
+/// int8 `wespeaker_v2.mlmodelc` is retired from shipping; its palettization
+/// collapses 8-speaker audio, see `tests/speaker/model_io.rs`'s DECISION).
+/// This is the same resolver [`AnySource::load`] uses, so the pin sits on
+/// production's own selection. Repointing [`FluidAudioArtifacts::resolve`]
+/// back at `wespeaker_v2.mlmodelc` fails this immediately — no models needed,
+/// because the resolver does no I/O.
 #[test]
-fn fluid_audio_artifacts_resolve_to_the_int8_shipping_embedder() {
+fn fluid_audio_artifacts_resolve_to_the_fp32_shipping_embedder() {
   let artifacts = FluidAudioArtifacts::resolve("some/models/root");
   assert!(
-    artifacts.embedder().ends_with("wespeaker_v2.mlmodelc"),
-    "the shipping FluidAudio embedder must be the int8 wespeaker_v2.mlmodelc, got {}",
+    artifacts.embedder().ends_with("wespeaker.mlmodelc"),
+    "the shipping FluidAudio embedder must be the fp32 wespeaker.mlmodelc, got {}",
     artifacts.embedder().display()
   );
   assert!(
@@ -112,7 +114,7 @@ fn fluid_audio_artifacts_resolve_to_the_int8_shipping_embedder() {
   // to the join logic — not just the filename — also fails).
   assert_eq!(
     artifacts.embedder(),
-    std::path::Path::new("some/models/root/wespeaker_v2.mlmodelc")
+    std::path::Path::new("some/models/root/wespeaker.mlmodelc")
   );
   assert_eq!(
     artifacts.segmenter(),

--- a/crates/coremlit/tests/fp16_guards.rs
+++ b/crates/coremlit/tests/fp16_guards.rs
@@ -13,10 +13,11 @@
 //! which is every path by default, because
 //! [`ComputeUnits::default()`][coremlit::ComputeUnits] is
 //! `All`. A model's *declared* MIL dtype is therefore **not** protection:
-//! `speakerkit/wespeaker.mlmodelc` is fp32 end-to-end in its MIL and still
-//! collapses to a cosine of 0.035 when the same fp32 artifact is loaded
-//! `CpuOnly → All`. This gate consequently holds **every** graph to the
-//! fp16 floor, whatever dtype it declares.
+//! the pre-repair FluidInference `wespeaker.mlmodelc` was fp32 end-to-end in
+//! its MIL and still collapsed to a cosine of 0.035 when the same fp32
+//! artifact was loaded `CpuOnly → All` (issue #15; the shipping artifact now
+//! carries the repaired `0x1p-24` guards). This gate consequently holds
+//! **every** graph to the fp16 floor, whatever dtype it declares.
 //!
 //! # Why a graph gate and not an output check
 //!
@@ -709,13 +710,14 @@ struct KnownDefect {
 /// Every fp16-vanishing guard in the tree. Each entry is a defect, not an
 /// exemption.
 ///
-/// The sweep that created this gate found ten sites across nine models. ONE of
-/// those models — `speakerkit/pyannote_segmentation` — has since been replaced
-/// by a guard-repaired re-conversion (issue #15) and its pin is gone: that
-/// graph no longer contains a `log` op at all, so there is no epsilon left to
-/// vanish. Every other pin below still stands, including the ones whose
-/// re-conversions exist but are NOT adopted (see the `wespeaker` note, and
-/// `alignkit/base960h_aligner`).
+/// The sweep that created this gate found ten sites across nine models. TWO of
+/// those models — the two the speakerkit pipeline SHIPS — have since been
+/// replaced by guard-repaired re-conversions (issue #15) and their pins are
+/// gone: `speakerkit/pyannote_segmentation` no longer contains a `log` op at
+/// all, and `speakerkit/wespeaker` (the fp32 shipping embedder) carries its
+/// three pooling divisor guards at `0x1p-24`, the fp16 floor. Every other pin
+/// below still stands, including the ones whose re-conversions exist but are
+/// NOT adopted (see the `wespeaker_v2` note, and `alignkit/base960h_aligner`).
 const KNOWN_DEFECTS: &[KnownDefect] = &[
   KnownDefect {
     path: "alignkit/base960h_aligner.mlmodelc",
@@ -734,7 +736,7 @@ const KNOWN_DEFECTS: &[KnownDefect] = &[
            its fp16 sibling.",
   },
   KnownDefect {
-    path: "speakerkit/wespeaker.mlmodelc",
+    path: "speakerkit/wespeaker_v2.mlmodelc",
     // THREE identical divisor guards, one per attentive-stat pooling division
     // (the weighted mean and the two divisions feeding the weighted variance /
     // `std`). Listed thrice, not deduped: the multiplicity is the blast radius
@@ -746,22 +748,14 @@ const KNOWN_DEFECTS: &[KnownDefect] = &[
     ],
     note: "Attentive-stat pooling divides by `count + 1e-8` at THREE sites (the weighted mean \
            and the two divisions behind the weighted variance/std). 1e-8 is 0.168x fp16's \
-           smallest subnormal, so on the ANE all three divisor guards are zero. Same fp32 \
-           artifact, same input, only CpuOnly -> All: cosine collapses to 0.035. A guard-repaired \
-           re-conversion is published (FinDIT-Studio/speakerkit-coreml) but is NOT adopted: for \
-           the int8 sibling it is also a RE-PALETTIZATION, and that moves clip 14's shipping \
-           ANE arm from 0.8178 % to 1.4860 % DER — past `parity_shipping_der`'s +-1 pp bound. \
-           Adopting it is an owner call, measured in issue #15, not a silent swap.",
-  },
-  KnownDefect {
-    path: "speakerkit/wespeaker_v2.mlmodelc",
-    sites: &[
-      "real_div/fp32 guard=denom:add(+9.99999993922529e-9) eff=9.99999993922529e-9",
-      "real_div/fp32 guard=denom:add(+9.99999993922529e-9) eff=9.99999993922529e-9",
-      "real_div/fp32 guard=denom:add(+9.99999993922529e-9) eff=9.99999993922529e-9",
-    ],
-    note: "Same three-site pooling epsilon as wespeaker.mlmodelc — and this is the SHIPPING \
-           embedder, so this is the one that matters.",
+           smallest subnormal, so on the ANE all three divisor guards are zero. This is the int8 \
+           embedder issue #15 RETIRED from shipping (its per-tensor palettization silently \
+           collapses 8-speaker audio — tests/speaker/model_io.rs's DECISION); it stays on disk \
+           as the tested sibling the factorial record runs on, guards unrepaired. The published \
+           re-conversion is NOT adopted for it: that artifact is also a RE-PALETTIZATION \
+           (different LUTs), and it moves clip 14's int8 ANE arm from 0.8178 % to 1.4860 % DER. \
+           The fp32 `wespeaker.mlmodelc` the pipeline ships instead carries these SAME pooling \
+           guards repaired to 0x1p-24 — which is why the shipping embedder has no entry here.",
   },
   KnownDefect {
     path: "speakerkit/wespeaker_int8.mlmodelc",
@@ -770,7 +764,7 @@ const KNOWN_DEFECTS: &[KnownDefect] = &[
       "real_div/fp32 guard=denom:add(+9.99999993922529e-9) eff=9.99999993922529e-9",
       "real_div/fp32 guard=denom:add(+9.99999993922529e-9) eff=9.99999993922529e-9",
     ],
-    note: "Same three-site pooling epsilon as wespeaker.mlmodelc.",
+    note: "Same three-site pooling epsilon as wespeaker_v2.mlmodelc (byte-identical artifact).",
   },
   KnownDefect {
     path: "speakerkit/PLDA.mlmodelc",
@@ -834,19 +828,27 @@ const ALIGNKIT_LOG_SOFTMAX: &str = r#"
 /// `speakerkit/pyannote_segmentation.mlmodelc/model.mil` lines 137-139 **as
 /// shipped before the issue-#15 re-conversion** — the shipped graph now ends
 /// `reduce_log_sum_exp` → `sub` and carries no `log` at all. Retained verbatim:
-/// this is the exact text that produced the 8-speaker collapse, and the parser
-/// must keep catching it if it ever reappears from a re-conversion.
+/// this is the exact pre-repair tail whose inert `log(epsilon = 0)` saturated
+/// `segments` to −45440 on the ANE, and the parser must keep catching it if it
+/// ever reappears from a re-conversion. It did NOT cause the 8-speaker
+/// clip-09 collapse — the factorial attributes that to the int8 EMBEDDER
+/// (swapping only the segmentation conversion left the collapse unchanged;
+/// `tests/speaker/model_io.rs`, "Clip 09"). Conflating the two defects is the
+/// attribution error the factorial exists to prevent.
 const SPEAKERKIT_SEG_FP16: &str = r#"
             tensor<fp16, [1, 589, 7]> var_231_softmax_cast_fp16 = softmax(axis = var_230, x = linear_2_cast_fp16)[name = tensor<string, []>("op_231_softmax_cast_fp16")];
             tensor<fp16, []> var_231_epsilon_0_to_fp16 = const()[name = tensor<string, []>("op_231_epsilon_0_to_fp16"), val = tensor<fp16, []>(0x0p+0)];
             tensor<fp16, [1, 589, 7]> var_231_cast_fp16 = log(epsilon = var_231_epsilon_0_to_fp16, x = var_231_softmax_cast_fp16)[name = tensor<string, []>("op_231_cast_fp16")];
 "#;
 
-/// `Models/speakerkit/wespeaker.mlmodelc/model.mil`, lines 4444-4450 — still
-/// what ships. The published re-conversion raises this constant (and its
-/// `op_5807` twin) from `0x1.5798eep-27` (1e-8) to `0x1p-24` and leaves every
-/// other byte of the graph and all weights identical, but it is not adopted;
-/// see this model's [`KNOWN_DEFECTS`] note.
+/// The pre-repair FluidInference `wespeaker.mlmodelc/model.mil`, lines
+/// 4444-4450 — the exact text that shipped until issue #15. The adopted
+/// FinDIT-Studio re-conversion raises this constant (and its `op_5807` twin)
+/// from `0x1.5798eep-27` (1e-8) to `0x1p-24` and leaves every other byte of
+/// the graph and all weights identical; the retired int8 siblings
+/// (`wespeaker_v2`/`wespeaker_int8`) still carry it — see their
+/// [`KNOWN_DEFECTS`] notes. Kept verbatim so the parser keeps catching this
+/// pattern if a re-conversion ever reintroduces it.
 const WESPEAKER_POOLING: &str = r#"
             tensor<fp32, []> var_5790 = const()[name = tensor<string, []>("op_5790"), val = tensor<fp32, []>(0x1.5798eep-27)];
             tensor<fp32, [3, 1]> v1 = add(x = var_5789, y = var_5790)[name = tensor<string, []>("v1")];
@@ -992,8 +994,9 @@ const TWO_HALF_SUBNORMAL_GUARDS: &str = r#"
 
 /// Two INDEPENDENT decomposed-`log_softmax` sites, distinct vars but an
 /// identical vanishing signature — the multiset shape finding 5 is about, and
-/// the exact one the live wespeaker/PLDA graphs carry (3 and 2 same-signature
-/// sites). Both render to `log/fp16 guard=softmax->log eff=0e0`, so a `dedup` or
+/// the exact one the live wespeaker_v2/PLDA graphs carry (3 and 2
+/// same-signature sites; the shipping fp32 wespeaker's three were repaired,
+/// issue #15). Both render to `log/fp16 guard=softmax->log eff=0e0`, so a `dedup` or
 /// set would collapse them into one and hide the second defect under a green
 /// pin. Synthesized from two copies of the real `SPEAKERKIT_SEG_FP16` shape.
 const TWO_SITE_LOG_SOFTMAX: &str = r#"

--- a/crates/coremlit/tests/fp16_guards.rs
+++ b/crates/coremlit/tests/fp16_guards.rs
@@ -54,11 +54,11 @@
 //! manifest EXPLICITLY: there the sweep proves it runs and that the whisper mel
 //! and granite norm controls are clean, but it CANNOT verify the speakerkit /
 //! alignkit / argmax defect pins — those models are not downloaded. Full pin
-//! verification (all ten defect pins) is a local/dev gate that needs the complete
-//! `Models/` tree. The override is fail-closed — absence of it requires ALL
-//! pinned vendors — so narrowing coverage is always an explicit, reviewable act
-//! in ci.yml, never the silent side effect of a deleted directory, which is the
-//! whole point of the manifest.
+//! verification (every [`KNOWN_DEFECTS`] entry) is a local/dev gate that needs
+//! the complete `Models/` tree. The override is fail-closed — absence of it
+//! requires ALL pinned vendors — so narrowing coverage is always an explicit,
+//! reviewable act in ci.yml, never the silent side effect of a deleted
+//! directory, which is the whole point of the manifest.
 //!
 //! When `Models/` is absent the sweep is `ignored`, never a green `ok`
 //! over zero models (see `build.rs`). The parser tests below are hermetic
@@ -706,8 +706,16 @@ struct KnownDefect {
   note: &'static str,
 }
 
-/// Every fp16-vanishing guard in the tree, as of the sweep that created
-/// this gate. Each entry is a defect, not an exemption.
+/// Every fp16-vanishing guard in the tree. Each entry is a defect, not an
+/// exemption.
+///
+/// The sweep that created this gate found ten sites across nine models. ONE of
+/// those models — `speakerkit/pyannote_segmentation` — has since been replaced
+/// by a guard-repaired re-conversion (issue #15) and its pin is gone: that
+/// graph no longer contains a `log` op at all, so there is no epsilon left to
+/// vanish. Every other pin below still stands, including the ones whose
+/// re-conversions exist but are NOT adopted (see the `wespeaker` note, and
+/// `alignkit/base960h_aligner`).
 const KNOWN_DEFECTS: &[KnownDefect] = &[
   KnownDefect {
     path: "alignkit/base960h_aligner.mlmodelc",
@@ -715,14 +723,6 @@ const KNOWN_DEFECTS: &[KnownDefect] = &[
     note: "Decomposed log-softmax; eps 0x1p-149 rounds to 0 in fp16. `emissions` IS the log \
            output, so ANE log(0) -> ~-45440 lands directly in the shipped tensor: 16.7% of \
            output cells corrupted, word timings shifted up to 881 ms.",
-  },
-  KnownDefect {
-    path: "speakerkit/pyannote_segmentation.mlmodelc",
-    sites: &["log/fp16 guard=softmax->log eff=0e0"],
-    note: "The fp16 sibling of Segmentation.mlmodelc: coremltools already folded the epsilon to \
-           a literal 0x0p+0 at conversion. `segments` IS the log output. Worst logit delta \
-           45,422; the shipping diarizer returns 5 of 8 speakers at 16.6% DER where the ONNX \
-           reference is frame-perfect.",
   },
   KnownDefect {
     path: "speakerkit/Segmentation.mlmodelc",
@@ -747,7 +747,11 @@ const KNOWN_DEFECTS: &[KnownDefect] = &[
     note: "Attentive-stat pooling divides by `count + 1e-8` at THREE sites (the weighted mean \
            and the two divisions behind the weighted variance/std). 1e-8 is 0.168x fp16's \
            smallest subnormal, so on the ANE all three divisor guards are zero. Same fp32 \
-           artifact, same input, only CpuOnly -> All: cosine collapses to 0.035.",
+           artifact, same input, only CpuOnly -> All: cosine collapses to 0.035. A guard-repaired \
+           re-conversion is published (FinDIT-Studio/speakerkit-coreml) but is NOT adopted: for \
+           the int8 sibling it is also a RE-PALETTIZATION, and that moves clip 14's shipping \
+           ANE arm from 0.8178 % to 1.4860 % DER — past `parity_shipping_der`'s +-1 pp bound. \
+           Adopting it is an owner call, measured in issue #15, not a silent swap.",
   },
   KnownDefect {
     path: "speakerkit/wespeaker_v2.mlmodelc",
@@ -756,7 +760,8 @@ const KNOWN_DEFECTS: &[KnownDefect] = &[
       "real_div/fp32 guard=denom:add(+9.99999993922529e-9) eff=9.99999993922529e-9",
       "real_div/fp32 guard=denom:add(+9.99999993922529e-9) eff=9.99999993922529e-9",
     ],
-    note: "Same three-site pooling epsilon as wespeaker.mlmodelc.",
+    note: "Same three-site pooling epsilon as wespeaker.mlmodelc — and this is the SHIPPING \
+           embedder, so this is the one that matters.",
   },
   KnownDefect {
     path: "speakerkit/wespeaker_int8.mlmodelc",
@@ -826,14 +831,22 @@ const ALIGNKIT_LOG_SOFTMAX: &str = r#"
             tensor<fp16, [1, 2999, 29]> var_849_cast_fp16 = log(epsilon = var_849_epsilon_0, x = var_849_softmax_cast_fp16)[name = tensor<string, []>("op_849_cast_fp16")];
 "#;
 
-/// `Models/speakerkit/pyannote_segmentation.mlmodelc/model.mil`, lines 137-139.
+/// `speakerkit/pyannote_segmentation.mlmodelc/model.mil` lines 137-139 **as
+/// shipped before the issue-#15 re-conversion** — the shipped graph now ends
+/// `reduce_log_sum_exp` → `sub` and carries no `log` at all. Retained verbatim:
+/// this is the exact text that produced the 8-speaker collapse, and the parser
+/// must keep catching it if it ever reappears from a re-conversion.
 const SPEAKERKIT_SEG_FP16: &str = r#"
             tensor<fp16, [1, 589, 7]> var_231_softmax_cast_fp16 = softmax(axis = var_230, x = linear_2_cast_fp16)[name = tensor<string, []>("op_231_softmax_cast_fp16")];
             tensor<fp16, []> var_231_epsilon_0_to_fp16 = const()[name = tensor<string, []>("op_231_epsilon_0_to_fp16"), val = tensor<fp16, []>(0x0p+0)];
             tensor<fp16, [1, 589, 7]> var_231_cast_fp16 = log(epsilon = var_231_epsilon_0_to_fp16, x = var_231_softmax_cast_fp16)[name = tensor<string, []>("op_231_cast_fp16")];
 "#;
 
-/// `Models/speakerkit/wespeaker.mlmodelc/model.mil`, lines 4444-4450.
+/// `Models/speakerkit/wespeaker.mlmodelc/model.mil`, lines 4444-4450 — still
+/// what ships. The published re-conversion raises this constant (and its
+/// `op_5807` twin) from `0x1.5798eep-27` (1e-8) to `0x1p-24` and leaves every
+/// other byte of the graph and all weights identical, but it is not adopted;
+/// see this model's [`KNOWN_DEFECTS`] note.
 const WESPEAKER_POOLING: &str = r#"
             tensor<fp32, []> var_5790 = const()[name = tensor<string, []>("op_5790"), val = tensor<fp32, []>(0x1.5798eep-27)];
             tensor<fp32, [3, 1]> v1 = add(x = var_5789, y = var_5790)[name = tensor<string, []>("v1")];

--- a/crates/coremlit/tests/speaker/backend_factorial.rs
+++ b/crates/coremlit/tests/speaker/backend_factorial.rs
@@ -1,0 +1,1116 @@
+//! **Where does the clip-09 collapse come from — the segmentation conversion,
+//! the embedding conversion, or both — AT THE CONFIGURATION WE SHIP?**
+//!
+//! `parity_shipping_der.rs` measures the shipping default end to end and pins
+//! its known-bad clip-09 state (int8 `wespeaker_v2.mlmodelc` on
+//! [`ComputeUnits::All`]: 5 of 8 speakers, 16.5904 % DER, 100 % confusion). It
+//! cannot say WHICH of the two CoreML conversions produces that, because it
+//! never varies them independently: every one of its speakerkit arms runs
+//! CoreML segmentation AND CoreML embedding.
+//!
+//! This suite varies them independently — the 2x2 cross-product of
+//! `{ONNX, CoreML}` segmentation x `{ONNX, CoreML}` embedding — with every
+//! other factor held constant, and it does so **at the shipping
+//! configuration**: the int8 embedder, both CoreML models on
+//! [`ComputeUnits::All`].
+//!
+//! # Why this is a distinct experiment from the one already on record
+//!
+//! An earlier cross-product (issue #15, recorded in `model_io.rs`'s module doc)
+//! ran the **fp32** embedder on **`CpuOnly`**. That configuration has a
+//! different symptom — dia's clustering returns
+//! `Err(AmbiguousAliveCluster { .. })`, i.e. NO diarization at all — from the
+//! one this crate ships, which silently returns 5 of 8 speakers. A result
+//! measured on the erroring configuration cannot exonerate the answering one:
+//! they differ in both the embedder artifact (fp32 vs int8-palettized) and the
+//! placement (`CpuOnly`'s IEEE CPU kernels vs `All`'s fp16 ANE/GPU kernels),
+//! and the failure they exhibit is not even the same kind of failure. Hence
+//! this suite, which runs the identical design where the defect actually lives.
+//!
+//! # The design (one variable at a time)
+//!
+//! Held constant across all four cells, so the ONLY difference between any two
+//! is which conversion computed a stage:
+//!
+//! - **one audio buffer** — FNV-1a fingerprinted before and after every cell
+//!   and asserted unchanged (a divergence caused by different input is a
+//!   harness bug, not a finding);
+//! - **the chunk grid** — speakerkit's production
+//!   [`chunk_starts`]/[`chunk_sliding_window`]/[`frame_sliding_window`]
+//!   geometry, from the production [`Options`] defaults;
+//! - **the powerset decode** — speakerkit's shipping [`multilabel`] (direct
+//!   argmax over the log-probabilities) on BOTH segmentation backends. Holding
+//!   it fixed is what makes the seg factor a *backend* factor and not a
+//!   backend-plus-decode factor; see [`assemble`]'s doc for the consequence
+//!   this has for the all-ONNX cell;
+//! - **the overlap-exclusion mask rule** — `common::derive_expected_slot_masks`,
+//!   the same port of `owned.rs:507-591` that speakerkit's private
+//!   `extract::derive_slot_plans` and `generate_goldens.rs`'s
+//!   `derive_slot_masks` implement;
+//! - **the clustering** — `diaric::offline::diarize_offline` over the measured
+//!   side's community-1 PLDA, for every cell including the all-ONNX one.
+//!
+//! # Harness validity: the two corners are checked against pinned numbers
+//!
+//! The cells are assembled by this file, not by `Extractor::extract`
+//! ([`Extraction::from_parts`] is crate-private, so a mixed-backend
+//! `Extraction` cannot be built from outside the crate). A hand-assembled
+//! pipeline is only worth as much as its agreement with the real one, so
+//! [`assert_factorial_verdict`] checks both corners against numbers that were
+//! pinned elsewhere by the real pipelines:
+//!
+//! - the all-CoreML corner must reproduce `parity_shipping_der`'s pinned
+//!   `int8/All` clip-09 state (5 speakers, 16.5904 % DER) — same artifacts,
+//!   same placement, same decode, so this is an EXACT reproduction and any
+//!   drift means the assembly diverged from `Extractor::extract`;
+//! - the all-ONNX corner must reproduce dia-ort's pinned clip-09 speaker count
+//!   (8) at 0.0000 % DER against `reference.rttm`.
+//!
+//! Both hold on the measured run, which is what licenses reading the hybrids.
+//!
+//! # What it found: the two configurations do NOT agree
+//!
+//! The recorded fp32/`CpuOnly` cross-product concluded "the segmentation
+//! conversion is guilty; the embedder is exonerated". At the shipping
+//! configuration that is **not** what happens (full table and per-cell
+//! rationale in [`assert_factorial_verdict`]): swapping only the EMBEDDING
+//! conversion reproduces the collapse exactly (5 of 8 speakers, 16.5904 %,
+//! the all-CoreML corner's own number), while swapping only the SEGMENTATION
+//! conversion produces a different and much smaller defect — one spurious
+//! speaker, 1.3011 %. A conclusion measured on the fp32/`CpuOnly`
+//! configuration did not transfer to the one this crate ships, which is
+//! precisely why it had to be re-measured here.
+//!
+//! # What this suite does NOT establish
+//!
+//! It localizes the collapse to a STAGE, on ONE clip, at ONE configuration, on
+//! ONE host. Three limits, all load-bearing:
+//!
+//! - **It does not separate int8 from `All` from the conversion itself.** The
+//!   factor varied is the BACKEND; the CoreML embedding arm is the shipping
+//!   bundle (int8-palettized artifact + `All` placement + that conversion) as
+//!   one unit. See [`assert_factorial_verdict`]'s "What it does NOT pin".
+//! - **It does not say which op inside a stage is responsible, and it cannot.**
+//!   Both segmentation graphs expose only their post-tail output
+//!   (`z - logsumexp(z)`), never the pre-tail logits `z`, so no measurement
+//!   here separates a divergence created in the graph's trunk from one created
+//!   in its log-softmax tail. [`seg_divergence`] reports the one decomposition
+//!   the observable outputs DO support, and names what would settle the rest.
+//! - **It is one clip.** Clip 09 is the clip with the defect; nothing here
+//!   extends to the rest of the corpus.
+//!
+//! `#[ignore]`d and `speaker-oracle`-gated (needs the gitignored
+//! `Models/speakerkit`, the sibling `diarization` ONNX + parity fixtures, and
+//! `ort`). Run with:
+//!
+//! ```text
+//! cargo test -p coremlit --features speaker-oracle --test speaker_backend_factorial -- --ignored --nocapture
+//! ```
+#![cfg(feature = "speaker-oracle")]
+
+mod common;
+mod der_calc;
+
+use std::path::PathBuf;
+
+use coremlit::{
+  ComputeUnits,
+  audio::speaker::{
+    embed::{EMBED_SLOTS, EMBEDDING_DIM, EmbedModel, EmbedModelOptions},
+    extract::Options,
+    segment::{
+      POWERSET_CLASSES, SEG_CHUNK_SAMPLES, SEG_NUM_SLOTS, SegmentModel, SegmentModelOptions,
+      multilabel,
+    },
+    window::{
+      WindowOptions, chunk_sliding_window, chunk_starts, count_from_segmentations,
+      frame_sliding_window,
+    },
+  },
+};
+use der_calc::{Der, Seg, der_std, distinct_speakers, fmt_der, parse_rttm};
+
+// ══════════════════════════════════════════════════════════════════════
+// The clip, the pinned corners, and the fixture/model resolution
+// ══════════════════════════════════════════════════════════════════════
+
+/// The clip this experiment runs on: dia's 8-speaker parity fixture, the one
+/// whose shipping-configuration collapse `parity_shipping_der`'s
+/// `shipping_int8_der_09_mrbeast_dollar_date_8spk_known_defect` pins.
+const CLIP: &str = "09_mrbeast_dollar_date";
+
+/// Decoded 16 kHz-mono sample count of `09_mrbeast_dollar_date/clip_16k.wav`,
+/// and [`common::fnv1a_f32`] of those samples — the same two-part content pin
+/// `parity_shipping_der::MULTI_SPEAKER_CLIPS` carries, repeated here so a
+/// same-name audio swap fails before any cell is measured rather than
+/// producing a comparison across different audio.
+const CLIP_SAMPLES: usize = 16_671_744;
+const CLIP_AUDIO_FNV: u64 = 8_657_240_795_675_234_981;
+
+/// `reference.rttm`'s distinct-speaker count for [`CLIP`] (pyannote 4.0.4's own
+/// output, not human labels — see `parity_shipping_der`'s module doc).
+const CLIP_REF_SPK: usize = 8;
+
+/// The all-CoreML corner's expected state: `parity_shipping_der`'s pinned
+/// `int8/All` clip-09 numbers. Same artifacts, same placement, same decode as
+/// that suite's shipping arm, so this corner reproduces them exactly or the
+/// hand-assembly in [`assemble`] has diverged from `Extractor::extract`.
+const SHIPPING_CORNER_SPK: usize = 5;
+const SHIPPING_CORNER_DER: f64 = 0.165_904;
+
+/// The all-ONNX corner's expected speaker count: dia-ort's pinned clip-09
+/// oracle count. Its DER against `reference.rttm` is 0.0000 % (dia-ort is
+/// frame-perfect against pyannote here), asserted as
+/// `<= `[`CORNER_DER_TOL`].
+const REFERENCE_CORNER_SPK: usize = 8;
+
+/// `ONNX-seg + COREML-emb` — the measured speaker count when ONLY the
+/// embedding conversion is swapped, over dia's own reference segmentation.
+/// It equals [`SHIPPING_CORNER_SPK`], at [`SHIPPING_CORNER_DER`]: the shipping
+/// collapse, reproduced by the embedder alone. See
+/// [`assert_factorial_verdict`].
+const EMBED_ONLY_SPK: usize = 5;
+
+/// `COREML-seg + ONNX-emb` — the measured speaker count and standard DER when
+/// ONLY the segmentation conversion is swapped. An OVERcount by one, an order
+/// of magnitude smaller than the collapse: a separate defect, not this one.
+const SEG_ONLY_SPK: usize = 9;
+const SEG_ONLY_DER: f64 = 0.013_011;
+
+/// Two-sided band on the corner DER reproductions — `parity_shipping_der`'s own
+/// `DER_PIN_TOL`, for the same reason: the pipeline is deterministic and these
+/// values reproduced exactly across runs, so the band absorbs a stray flipped
+/// frame on a different CoreML build, not real movement. The distances this
+/// experiment resolves are ~16 pp, ~330x this band.
+const CORNER_DER_TOL: f64 = 0.000_5;
+
+/// dia's parity-fixture root (override with `DIA_PARITY_FIXTURES`) — the same
+/// convention `parity_e2e.rs` / `parity_shipping_der.rs` use.
+fn fixtures_root() -> PathBuf {
+  std::env::var_os("DIA_PARITY_FIXTURES").map_or_else(
+    || PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../diarization/tests/parity/fixtures"),
+    PathBuf::from,
+  )
+}
+
+/// dia's fp32 WeSpeaker ONNX (override with `DIA_EMBED_MODEL_PATH`) — the same
+/// convention `parity_e2e.rs` / `generate_goldens.rs` use.
+fn dia_wespeaker_onnx() -> PathBuf {
+  std::env::var_os("DIA_EMBED_MODEL_PATH").map_or_else(
+    || {
+      PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../diarization/models/wespeaker_resnet34_lm.onnx")
+    },
+    PathBuf::from,
+  )
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// The two factors
+// ══════════════════════════════════════════════════════════════════════
+
+/// Which conversion computes a stage. The whole experiment is this value,
+/// chosen independently for segmentation and for embedding.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Backend {
+  /// dia's ONNX graph on `ort`'s CPU EP — the reference implementation.
+  Onnx,
+  /// speakerkit's CoreML conversion at the placement under test.
+  CoreMl,
+}
+
+impl Backend {
+  const fn tag(self) -> &'static str {
+    match self {
+      Self::Onnx => "ONNX",
+      Self::CoreMl => "COREML",
+    }
+  }
+}
+
+/// The compute placement both CoreML models run on. `All` IS the shipping
+/// default ([`coremlit::audio::speaker::segment::DEFAULT_SEGMENT_COMPUTE`] and
+/// its embed twin), which is the entire point of running the factorial here:
+/// the recorded prior cross-product used `CpuOnly`.
+const PLACEMENT: ComputeUnits = ComputeUnits::All;
+
+/// The one embedding artifact this experiment's CoreML side uses:
+/// `wespeaker_v2.mlmodelc`, i.e. the **int8-palettized** model `ModelSource`
+/// actually loads (`common::embed_path`). The prior cross-product used the
+/// fp32 `wespeaker.mlmodelc` instead.
+fn coreml_embed_path() -> PathBuf {
+  common::embed_path()
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Stage 1 — segmentation log-probabilities, one backend at a time
+// ══════════════════════════════════════════════════════════════════════
+
+/// Every chunk's flattened `[num_frames * POWERSET_CLASSES]` powerset
+/// log-probabilities from ONE segmentation backend, plus the frame count both
+/// backends must agree on.
+struct SegRun {
+  slabs: Vec<Vec<f32>>,
+  num_frames: usize,
+  elapsed_s: f64,
+}
+
+/// Fills `padded` with the chunk starting at `start`, zero-padding any overhang
+/// past the end of `samples`. Byte-identical to speakerkit's private
+/// `extract::fill_padded_chunk` (`extract/mod.rs`), itself a port of
+/// `owned.rs:469-475`: the two models are contracted to exactly
+/// [`SEG_CHUNK_SAMPLES`] samples and neither pads internally.
+fn fill_padded_chunk(padded: &mut [f32], samples: &[f32], start: usize) {
+  padded.fill(0.0);
+  let end = (start + SEG_CHUNK_SAMPLES).min(samples.len());
+  let lo = start.min(samples.len());
+  let n = end - lo;
+  if n > 0 {
+    padded[..n].copy_from_slice(&samples[lo..end]);
+  }
+}
+
+/// Runs one segmentation backend over the whole chunk grid.
+///
+/// Both backends emit the same quantity — per-frame powerset
+/// log-probabilities, `z - logsumexp(z)` (dia's ONNX through `softmax` ->
+/// `log`, the CoreML conversion through the fused `reduce_log_sum_exp` ->
+/// `sub`; see `coremlit::audio::speaker::segment`'s module doc) — which is what
+/// makes them comparable element-for-element in [`seg_divergence`] and
+/// substitutable for each other here.
+fn run_seg(backend: Backend, samples: &[f32], starts: &[usize]) -> SegRun {
+  let mut padded = vec![0.0f32; SEG_CHUNK_SAMPLES];
+  let mut slabs: Vec<Vec<f32>> = Vec::with_capacity(starts.len());
+  let t0 = std::time::Instant::now();
+
+  let num_frames = match backend {
+    Backend::CoreMl => {
+      let seg = SegmentModel::from_file_with(
+        common::seg_path(),
+        SegmentModelOptions::new().with_compute(PLACEMENT),
+      )
+      .expect("load pyannote_segmentation.mlmodelc");
+      for &start in starts {
+        fill_padded_chunk(&mut padded, samples, start);
+        slabs.push(seg.infer(&padded).expect("CoreML segmentation infer"));
+      }
+      seg.num_frames()
+    }
+    Backend::Onnx => {
+      let mut seg = dia::segment::SegmentModel::bundled().expect("dia bundled segmentation-3.0");
+      for &start in starts {
+        fill_padded_chunk(&mut padded, samples, start);
+        slabs.push(seg.infer(&padded).expect("dia-ort segmentation infer"));
+      }
+      slabs[0].len() / POWERSET_CLASSES
+    }
+  };
+
+  for (c, slab) in slabs.iter().enumerate() {
+    assert_eq!(
+      slab.len(),
+      num_frames * POWERSET_CLASSES,
+      "{}-seg chunk {c}: {} values, expected {num_frames} frames x {POWERSET_CLASSES} classes",
+      backend.tag(),
+      slab.len()
+    );
+  }
+  SegRun {
+    slabs,
+    num_frames,
+    elapsed_s: t0.elapsed().as_secs_f64(),
+  }
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Stage 2 — assembly: seg slabs + an embedding backend -> clustered spans
+// ══════════════════════════════════════════════════════════════════════
+
+/// dia's minimum pre-PLDA embedding norm (`owned.rs:619-630`; speakerkit's
+/// private `extract::PLDA_MIN_NORM`): a slot whose raw embedding is shorter
+/// than this is dropped, its segmentation column zeroed, exactly as if it had
+/// never been active.
+const PLDA_MIN_NORM: f64 = 0.01;
+
+/// The embedding backend for one cell, holding its loaded model. dia's is
+/// `&mut self` per call; speakerkit's is `&self` and batches all three slots.
+enum EmbedSide {
+  CoreMl(EmbedModel),
+  Onnx(Box<dia::embed::EmbedModel>),
+}
+
+impl EmbedSide {
+  fn load(backend: Backend) -> Self {
+    match backend {
+      Backend::CoreMl => Self::CoreMl(
+        EmbedModel::from_file_with(
+          coreml_embed_path(),
+          EmbedModelOptions::new().with_compute(PLACEMENT),
+        )
+        .expect("load wespeaker_v2.mlmodelc (int8, shipping)"),
+      ),
+      Backend::Onnx => {
+        let onnx = dia_wespeaker_onnx();
+        assert!(
+          onnx.exists(),
+          "dia WeSpeaker ONNX not found at {}; set DIA_EMBED_MODEL_PATH",
+          onnx.display()
+        );
+        Self::Onnx(Box::new(
+          dia::embed::EmbedModel::from_file(&onnx).expect("dia WeSpeaker fp32 ONNX"),
+        ))
+      }
+    }
+  }
+
+  /// This chunk's raw 256-d embedding for every PLANNED slot, in slot order.
+  /// `None` entries are slots the mask rule skipped — no embed call is made for
+  /// them on either backend.
+  ///
+  /// The two arms mirror how each pipeline actually calls its model: dia's
+  /// offline pipeline makes one `embed_chunk_with_frame_mask` call per planned
+  /// slot (`owned.rs:593-617`), speakerkit's `Extractor` makes ONE batched
+  /// `embed_chunk` call whose skipped rows borrow a planned slot's mask as a
+  /// non-degenerate placeholder and are discarded (design spec §4). Calling
+  /// each backend the way its own pipeline does is what lets the corners
+  /// reproduce the pinned numbers.
+  fn embed_chunk(
+    &mut self,
+    padded: &[f32],
+    plans: &[Option<Vec<bool>>; SEG_NUM_SLOTS],
+  ) -> [Option<[f32; EMBEDDING_DIM]>; SEG_NUM_SLOTS] {
+    let Some(placeholder) = plans.iter().flatten().next() else {
+      return [const { None }; SEG_NUM_SLOTS];
+    };
+    match self {
+      Self::CoreMl(model) => {
+        let masks: [&[bool]; EMBED_SLOTS] =
+          core::array::from_fn(|s| plans[s].as_deref().unwrap_or(placeholder.as_slice()));
+        let rows = model
+          .embed_chunk(padded, &masks)
+          .expect("CoreML embed_chunk");
+        core::array::from_fn(|s| plans[s].as_ref().map(|_| rows[s]))
+      }
+      Self::Onnx(model) => core::array::from_fn(|s| {
+        plans[s].as_ref().map(|mask| {
+          model
+            .embed_chunk_with_frame_mask(padded, mask)
+            .expect("dia-ort embed_chunk_with_frame_mask")
+        })
+      }),
+    }
+  }
+}
+
+/// One cell's assembled diaric offline-input tensors.
+struct Cell {
+  segmentations: Vec<f64>,
+  raw_embeddings: Vec<f32>,
+  num_chunks: usize,
+  num_frames: usize,
+  embed_s: f64,
+}
+
+/// Assembles one cell: a fixed set of segmentation slabs + a chosen embedding
+/// backend -> the `segmentations` / `raw_embeddings` tensor pair
+/// `diaric::offline::OfflineInput` consumes.
+///
+/// This is `Extractor::extract`'s stage 8 (`extract/mod.rs`) with the two model
+/// calls made pluggable, and it must stay a faithful copy of it — the
+/// all-CoreML corner assertion in [`shipping_config_backend_factorial`] is what
+/// enforces that. Reproduced in order: the shipping [`multilabel`] decode, the
+/// overlap-exclusion mask rule, the Skip-slot column zeroing, and the
+/// [`PLDA_MIN_NORM`] drop (which also zeroes the slot's column).
+///
+/// **The decode is speakerkit's on BOTH segmentation backends.** dia's own
+/// pipeline decodes `softmax`-then-argmax instead; the two agree over the reals
+/// (a per-row constant shift) and on every committed golden row
+/// (`parity_seg::golden_direct_and_dia_decode_agree`) but can differ on an f32
+/// near-tie. Holding the decode fixed is required for the factorial to isolate
+/// the BACKEND — the cost is that the all-ONNX cell is this crate's decode over
+/// dia's logits, not a byte-for-byte rerun of dia's pipeline, which is why that
+/// corner is checked against dia-ort's pinned speaker count rather than
+/// asserted identical to it.
+fn assemble(seg: &SegRun, embed: &mut EmbedSide, samples: &[f32], starts: &[usize]) -> Cell {
+  let num_frames = seg.num_frames;
+  let num_chunks = starts.len();
+  let mut segmentations = vec![0.0f64; num_chunks * num_frames * SEG_NUM_SLOTS];
+  let mut raw_embeddings = vec![0.0f32; num_chunks * SEG_NUM_SLOTS * EMBEDDING_DIM];
+  let mut padded = vec![0.0f32; SEG_CHUNK_SAMPLES];
+  let t0 = std::time::Instant::now();
+
+  for (c, &start) in starts.iter().enumerate() {
+    fill_padded_chunk(&mut padded, samples, start);
+    let lo = c * num_frames * SEG_NUM_SLOTS;
+    let hi = lo + num_frames * SEG_NUM_SLOTS;
+    let slab = multilabel(&seg.slabs[c], num_frames);
+    segmentations[lo..hi].copy_from_slice(&slab);
+
+    // The overlap-exclusion rule, over the PRE-zeroing values, exactly as
+    // `derive_slot_plans` runs it. `None` = Skip.
+    let plans = common::derive_expected_slot_masks(&seg.slabs[c], num_frames);
+    for (s, plan) in plans.iter().enumerate() {
+      if plan.is_none() {
+        zero_slot_column(&mut segmentations[lo..hi], num_frames, s);
+      }
+    }
+
+    let rows = embed.embed_chunk(&padded, &plans);
+    for (s, row) in rows.iter().enumerate() {
+      let Some(row) = row else { continue };
+      // dia's f64 norm pre-check (`owned.rs:619-630`): a degenerate embedding
+      // is dropped and its column zeroed rather than fed to PLDA.
+      let norm_sq: f64 = row.iter().map(|v| f64::from(*v) * f64::from(*v)).sum();
+      if norm_sq.sqrt() < PLDA_MIN_NORM {
+        zero_slot_column(&mut segmentations[lo..hi], num_frames, s);
+      } else {
+        let e = (c * SEG_NUM_SLOTS + s) * EMBEDDING_DIM;
+        raw_embeddings[e..e + EMBEDDING_DIM].copy_from_slice(row);
+      }
+    }
+  }
+
+  Cell {
+    segmentations,
+    raw_embeddings,
+    num_chunks,
+    num_frames,
+    embed_s: t0.elapsed().as_secs_f64(),
+  }
+}
+
+/// Zeroes exactly slot `s`'s column across one chunk's `[f][s]` slab — dia's
+/// column-zero on a dropped `(chunk, slot)` (`owned.rs:567-569,626-628`).
+fn zero_slot_column(chunk_segs: &mut [f64], num_frames: usize, s: usize) {
+  for f in 0..num_frames {
+    chunk_segs[f * SEG_NUM_SLOTS + s] = 0.0;
+  }
+}
+
+/// Clusters one assembled cell through the SAME `diaric::offline::diarize_offline`
+/// every measured arm in this repo runs, returning diaric's TYPED error rather
+/// than unwrapping: whether a cell can cluster AT ALL is a first-class result
+/// here (the prior cross-product's every CoreML-seg cell could not).
+fn cluster(
+  cell: &Cell,
+  window: &WindowOptions,
+  plda: &diaric::plda::PldaTransform,
+) -> Result<Vec<Seg>, diaric::offline::Error> {
+  let count = count_from_segmentations(
+    &cell.segmentations,
+    cell.num_chunks,
+    cell.num_frames,
+    SEG_NUM_SLOTS,
+    window.onset(),
+    chunk_sliding_window(window),
+    frame_sliding_window(),
+  );
+  let input = diaric::offline::OfflineInput::new(
+    &cell.raw_embeddings,
+    cell.num_chunks,
+    SEG_NUM_SLOTS,
+    &cell.segmentations,
+    cell.num_frames,
+    &count,
+    count.len(),
+    chunk_sliding_window(window).into(),
+    frame_sliding_window().into(),
+    plda,
+  );
+  diaric::offline::diarize_offline(&input).map(|out| {
+    out
+      .spans_slice()
+      .iter()
+      .map(|s| Seg {
+        start: s.start(),
+        end: s.start() + s.duration(),
+        spk: s.cluster(),
+      })
+      .collect()
+  })
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// The segmentation-divergence decomposition
+// ══════════════════════════════════════════════════════════════════════
+
+/// What the two segmentation backends' outputs differ by, and how much of that
+/// difference the log-softmax TAIL could account for.
+struct SegDivergence {
+  /// Worst per-element `|CoreML - ONNX|` over every `(chunk, frame, class)`.
+  worst_abs: f64,
+  /// Total frames compared.
+  frames: usize,
+  /// Frames whose shipping [`multilabel`] argmax class differs.
+  flips: usize,
+  /// Of [`Self::flips`], those where the CoreML row has more than one element
+  /// EQUAL to its maximum. See this struct's doc for why that is the only
+  /// subset of flips the tail can be responsible for.
+  flips_with_coreml_tie: usize,
+  /// Minimum and maximum log-probability observed on each side — the observed
+  /// value range Finding 3 asks for in place of a universal no-saturation claim.
+  coreml_min: f64,
+  coreml_max: f64,
+  onnx_min: f64,
+  onnx_max: f64,
+  /// Non-finite cells on the CoreML side (the `ort` CoreML-EP corruption mode
+  /// this crate exists to replace).
+  coreml_nonfinite: usize,
+}
+
+/// Compares the two backends' log-probability slabs element for element and
+/// splits the argmax flips into the two populations the observable outputs can
+/// distinguish.
+///
+/// # What this can and cannot attribute
+///
+/// Neither graph exposes its PRE-TAIL logits `z`: both emit only
+/// `z - logsumexp(z)`. So no measurement here can say whether a given
+/// divergence was created in the graph's trunk (the convolutional/LSTM/linear
+/// stack producing `z` in fp16) or in its log-softmax tail. What the outputs
+/// DO support is a bound in one direction, for ARGMAX flips specifically:
+///
+/// - the tail subtracts ONE per-row scalar from every element of that row;
+/// - correctly-rounded IEEE arithmetic is monotone, so for a common `L`,
+///   `z_i >= z_j` implies `fl(z_i - L) >= fl(z_j - L)`;
+/// - therefore the tail can never INVERT two elements' order. The only argmax
+///   change it can produce is collapsing a strict inequality into an exact tie,
+///   which [`multilabel`]'s lowest-index rule then breaks toward the lower
+///   class.
+///
+/// So a flipped frame whose CoreML row has NO tie at its maximum cannot have
+/// been flipped by the tail; its ordering already differed upstream.
+/// [`Self::flips_with_coreml_tie`] is the entire population of flips the tail
+/// could be responsible for.
+///
+/// Two caveats, both load-bearing: monotonicity is a property of
+/// correctly-rounded operations, which CoreML does not contract for its ANE/GPU
+/// kernels, so on [`ComputeUnits::All`] this is an argument about IEEE
+/// semantics rather than a guarantee about the silicon; and it bounds only
+/// argmax flips, not [`Self::worst_abs`] — the tail can contribute freely to
+/// magnitude divergence. **Settling the trunk-vs-tail question needs a
+/// re-conversion that emits the pre-tail activation as a second output**, on
+/// both sides, compared on identical input; nothing short of that isolates it.
+fn seg_divergence(coreml: &SegRun, onnx: &SegRun) -> SegDivergence {
+  assert_eq!(
+    coreml.num_frames, onnx.num_frames,
+    "backends disagree on the per-chunk frame count ({} vs {})",
+    coreml.num_frames, onnx.num_frames
+  );
+  assert_eq!(
+    coreml.slabs.len(),
+    onnx.slabs.len(),
+    "backends ran a different number of chunks"
+  );
+
+  let mut d = SegDivergence {
+    worst_abs: 0.0,
+    frames: 0,
+    flips: 0,
+    flips_with_coreml_tie: 0,
+    coreml_min: f64::INFINITY,
+    coreml_max: f64::NEG_INFINITY,
+    onnx_min: f64::INFINITY,
+    onnx_max: f64::NEG_INFINITY,
+    coreml_nonfinite: 0,
+  };
+
+  for (a, b) in coreml.slabs.iter().zip(&onnx.slabs) {
+    for (ra, rb) in a
+      .as_chunks::<POWERSET_CLASSES>()
+      .0
+      .iter()
+      .zip(b.as_chunks::<POWERSET_CLASSES>().0)
+    {
+      d.frames += 1;
+      for (&x, &y) in ra.iter().zip(rb) {
+        if x.is_finite() {
+          d.coreml_min = d.coreml_min.min(f64::from(x));
+          d.coreml_max = d.coreml_max.max(f64::from(x));
+        } else {
+          d.coreml_nonfinite += 1;
+        }
+        d.onnx_min = d.onnx_min.min(f64::from(y));
+        d.onnx_max = d.onnx_max.max(f64::from(y));
+        d.worst_abs = d.worst_abs.max((f64::from(x) - f64::from(y)).abs());
+      }
+      if common::powerset_argmax(ra) != common::powerset_argmax(rb) {
+        d.flips += 1;
+        let max = ra.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        if ra.iter().filter(|v| **v == max).count() > 1 {
+          d.flips_with_coreml_tie += 1;
+        }
+      }
+    }
+  }
+  d
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// The experiment
+// ══════════════════════════════════════════════════════════════════════
+
+/// One cell's result, for the printed table.
+struct CellResult {
+  seg: Backend,
+  embed: Backend,
+  outcome: Result<Vec<Seg>, diaric::offline::Error>,
+  embed_s: f64,
+}
+
+impl CellResult {
+  fn spk(&self) -> Option<usize> {
+    self
+      .outcome
+      .as_ref()
+      .ok()
+      .map(|s| distinct_speakers(s).len())
+  }
+  fn der(&self, reference: &[Seg]) -> Option<Der> {
+    self.outcome.as_ref().ok().map(|s| der_std(reference, s))
+  }
+}
+
+/// **The shipping-configuration backend cross-product on clip 09.**
+///
+/// Runs all four `{ONNX, CoreML}` x `{ONNX, CoreML}` cells with the int8
+/// embedder on [`ComputeUnits::All`] — the literal shipping default — prints
+/// the full table with each cell's speaker count, standard-collar DER against
+/// `reference.rttm` and clustering outcome, then asserts only:
+///
+/// 1. the audio and grid are the ones every cell was supposed to share;
+/// 2. the two CORNERS reproduce the numbers the real pipelines pinned
+///    elsewhere (harness validity — see the module doc);
+/// 3. the localization VERDICT the table supports, pinned two-sided so that a
+///    change in which stage is implicated fails here rather than silently
+///    rewriting the record.
+///
+/// The report prints in full BEFORE any assertion fires, so a failure never
+/// hides the numbers that explain it.
+#[test]
+#[ignore = "requires speakerkit models, dia parity fixtures + WeSpeaker ONNX (17 min of audio, 6 model passes)"]
+fn shipping_config_backend_factorial() {
+  let audio = fixtures_root().join(CLIP).join("clip_16k.wav");
+  assert!(
+    audio.exists(),
+    "clip audio not found at {} (set DIA_PARITY_FIXTURES)",
+    audio.display()
+  );
+  assert!(
+    common::seg_path().exists() && coreml_embed_path().exists(),
+    "need pyannote_segmentation.mlmodelc + wespeaker_v2.mlmodelc under {} (set \
+     SPEAKERKIT_TEST_MODELS)",
+    common::models_dir().display()
+  );
+
+  let samples = common::load_wav_16k_mono(&audio);
+  let audio_fnv = common::fnv1a_f32(&samples);
+  assert_eq!(
+    samples.len(),
+    CLIP_SAMPLES,
+    "{CLIP}: decoded {} samples, pinned {CLIP_SAMPLES} — the audio identity changed",
+    samples.len()
+  );
+  assert_eq!(
+    audio_fnv, CLIP_AUDIO_FNV,
+    "{CLIP}: audio content hash {audio_fnv} != pinned {CLIP_AUDIO_FNV}"
+  );
+
+  let reference = parse_rttm(&fixtures_root().join(CLIP).join("reference.rttm"));
+  let ref_spk = distinct_speakers(&reference).len();
+  assert_eq!(
+    ref_spk, CLIP_REF_SPK,
+    "{CLIP}: reference.rttm has {ref_spk} speakers, expected {CLIP_REF_SPK}"
+  );
+
+  let window = Options::new().window();
+  let starts = chunk_starts(samples.len(), &window);
+  let plda = diaric::plda::PldaTransform::new().expect("load community-1 PldaTransform (diaric)");
+
+  println!(
+    "\n╔══ backend factorial @ SHIPPING CONFIG — {CLIP} ══\n║ {:.2} s, {} samples, fnv1a={}\n║ \
+     embedder: wespeaker_v2.mlmodelc (int8) | placement: {PLACEMENT:?} | {} chunks",
+    samples.len() as f64 / 16_000.0,
+    samples.len(),
+    common::fnv_hex(audio_fnv),
+    starts.len()
+  );
+
+  // ── Stage 1: each segmentation backend once, cached, so the four cells
+  // differ ONLY in which conversion produced the tensors they consume.
+  let seg_coreml = run_seg(Backend::CoreMl, &samples, &starts);
+  let seg_onnx = run_seg(Backend::Onnx, &samples, &starts);
+  assert_eq!(
+    common::fnv1a_f32(&samples),
+    audio_fnv,
+    "the audio buffer changed under segmentation — comparison invalid"
+  );
+  println!(
+    "║ seg: COREML/{PLACEMENT:?} {:.1} s, ONNX {:.1} s, {} frames/chunk",
+    seg_coreml.elapsed_s, seg_onnx.elapsed_s, seg_coreml.num_frames
+  );
+
+  let div = seg_divergence(&seg_coreml, &seg_onnx);
+  println!(
+    "║\n║ segmentation divergence (COREML/{PLACEMENT:?} vs ONNX), {} frames:\n║   worst \
+     |Δlog-prob| {:.4} | argmax flips {} ({:.4} %)\n║   of those flips, with an exact tie at the \
+     CoreML max: {} — the ONLY ones the log-softmax tail could have caused\n║   observed range: \
+     CoreML [{:.4}, {:.4}] ({} non-finite) | ONNX [{:.4}, {:.4}]",
+    div.frames,
+    div.worst_abs,
+    div.flips,
+    100.0 * div.flips as f64 / div.frames as f64,
+    div.flips_with_coreml_tie,
+    div.coreml_min,
+    div.coreml_max,
+    div.coreml_nonfinite,
+    div.onnx_min,
+    div.onnx_max,
+  );
+
+  // ── Stage 2: the four cells.
+  let mut cells: Vec<CellResult> = Vec::with_capacity(4);
+  for (seg_backend, seg_run) in [(Backend::Onnx, &seg_onnx), (Backend::CoreMl, &seg_coreml)] {
+    for embed_backend in [Backend::Onnx, Backend::CoreMl] {
+      let mut embed = EmbedSide::load(embed_backend);
+      let cell = assemble(seg_run, &mut embed, &samples, &starts);
+      assert_eq!(
+        common::fnv1a_f32(&samples),
+        audio_fnv,
+        "{}-seg + {}-emb: the audio buffer changed under the cell — comparison invalid",
+        seg_backend.tag(),
+        embed_backend.tag()
+      );
+      assert_eq!(
+        cell.num_chunks,
+        starts.len(),
+        "{}-seg + {}-emb: chunk grid diverged",
+        seg_backend.tag(),
+        embed_backend.tag()
+      );
+      let outcome = cluster(&cell, &window, &plda);
+      println!(
+        "║ ran {:>6}-seg + {:>6}-emb ({:.1} s embed): {}",
+        seg_backend.tag(),
+        embed_backend.tag(),
+        cell.embed_s,
+        match &outcome {
+          Ok(s) => format!("{} speakers", distinct_speakers(s).len()),
+          Err(e) => format!("CLUSTERING FAILED — {e}"),
+        }
+      );
+      cells.push(CellResult {
+        seg: seg_backend,
+        embed: embed_backend,
+        outcome,
+        embed_s: cell.embed_s,
+      });
+    }
+  }
+
+  // ── The table.
+  println!(
+    "║\n║ {:>11} | {:>11} | {:>4} | {:>9} | {:>9} | {:>9} | outcome",
+    "segmentation", "embedding", "spk", "DER", "miss", "conf"
+  );
+  println!(
+    "║ {:-<11}-+-{:-<11}-+-{:-<4}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+--------",
+    "", "", "", "", "", ""
+  );
+  for c in &cells {
+    match (c.spk(), c.der(&reference)) {
+      (Some(spk), Some(d)) => println!(
+        "║ {:>11} | {:>11} | {spk:>4} | {:>8.4}% | {:>8.4}% | {:>8.4}% | clustered ({:.1} s embed)",
+        c.seg.tag(),
+        c.embed.tag(),
+        d.der * 100.0,
+        d.miss * 100.0,
+        d.confusion * 100.0,
+        c.embed_s,
+      ),
+      _ => println!(
+        "║ {:>11} | {:>11} | {:>4} | {:>9} | {:>9} | {:>9} | Err: {}",
+        c.seg.tag(),
+        c.embed.tag(),
+        "ERR",
+        "-",
+        "-",
+        "-",
+        c.outcome
+          .as_ref()
+          .expect_err("no speaker count implies Err"),
+      ),
+    }
+  }
+  for c in &cells {
+    if let Some(d) = c.der(&reference) {
+      println!(
+        "║   {}",
+        fmt_der(&format!("{}-seg + {}-emb", c.seg.tag(), c.embed.tag()), &d)
+      );
+    }
+  }
+  println!("╚══ reference (pyannote 4.0.4): {ref_spk} speakers\n");
+
+  let corner = |seg: Backend, embed: Backend| -> &CellResult {
+    cells
+      .iter()
+      .find(|c| c.seg == seg && c.embed == embed)
+      .expect("every cell ran")
+  };
+  let cell = |seg: Backend, embed: Backend| -> Option<(usize, f64)> {
+    let c = corner(seg, embed);
+    Some((c.spk()?, c.der(&reference)?.der))
+  };
+
+  assert_factorial_verdict(&FactorialObserved {
+    onnx_onnx: cell(Backend::Onnx, Backend::Onnx),
+    coreml_onnx: cell(Backend::CoreMl, Backend::Onnx),
+    onnx_coreml: cell(Backend::Onnx, Backend::CoreMl),
+    coreml_coreml: cell(Backend::CoreMl, Backend::CoreMl),
+  });
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// The verdict, as a pure function + its hermetic falsifiability guard
+// ══════════════════════════════════════════════════════════════════════
+
+/// The four cells' decision-relevant outcomes — `(speaker count, standard
+/// DER)`, or `None` when that cell's clustering refused to answer. Extracted
+/// from the measurement (or synthesized by
+/// [`factorial_verdict_pins_every_cell`]) so [`assert_factorial_verdict`] is a
+/// pure function both can call, exactly as `parity_shipping_der`'s
+/// `Clip09Observed` is.
+#[derive(Clone, Copy, Debug)]
+struct FactorialObserved {
+  onnx_onnx: Option<(usize, f64)>,
+  coreml_onnx: Option<(usize, f64)>,
+  onnx_coreml: Option<(usize, f64)>,
+  coreml_coreml: Option<(usize, f64)>,
+}
+
+/// The MEASURED shipping-configuration cross-product on clip 09, pinned cell by
+/// cell (Apple M1 Max, macOS 26.5 build 25F71, arm64; int8 `wespeaker_v2` and
+/// the fp16-safe `pyannote_segmentation` re-conversion, both on
+/// [`ComputeUnits::All`]):
+///
+/// ```text
+/// segmentation | embedding | spk |      DER | conf
+/// -------------+-----------+-----+----------+---------
+///         ONNX |      ONNX |   8 |  0.0000% |  0.0000%   the dia-ort reference, reproduced
+///         ONNX |    COREML |   5 | 16.5904% | 16.5904%   the shipping collapse, from the EMBEDDER alone
+///       COREML |      ONNX |   9 |  1.3011% |  1.3011%   a DIFFERENT defect: one spurious speaker
+///       COREML |    COREML |   5 | 16.5904% | 16.5904%   the shipping default
+/// ```
+///
+/// # What this pins, and why each direction matters
+///
+/// - **Both corners** are harness-validity checks against numbers the REAL
+///   pipelines pinned elsewhere: all-ONNX must reproduce dia-ort's 8 speakers
+///   at 0.0000 %, and all-CoreML must reproduce `parity_shipping_der`'s
+///   `int8/All` clip-09 pin (5 speakers, 16.5904 %). The all-CoreML corner
+///   lands on that pin to the printed precision — same DER, same 11 999
+///   confusion units — which is what licenses reading the two hybrid cells at
+///   all.
+/// - **`ONNX-seg + COREML-emb` is the finding.** Swapping ONLY the embedding
+///   conversion, over dia's own reference segmentation, reproduces the
+///   shipping failure exactly: 5 of 8 speakers at 16.5904 %, identical to the
+///   all-CoreML corner. The recorded fp32/`CpuOnly` cross-product concluded
+///   the embedder was *exonerated*; at the configuration this crate ships it
+///   is sufficient on its own. Pinned so that conclusion cannot silently
+///   revert.
+/// - **`COREML-seg + ONNX-emb` is a different defect, not this one.** The
+///   segmentation conversion alone OVERcounts by one (9 speakers, 1.3011 %) —
+///   the same "spurious extra cluster" signature that, with the fp32 embedder
+///   on `CpuOnly`, tripped diaric's `AmbiguousAliveCluster` bail-out. It is
+///   real, it is an order of magnitude smaller, and it is masked in the
+///   shipping arm. Pinned so it is not conflated with the collapse again.
+///
+/// # What it does NOT pin
+///
+/// The factor varied here is the BACKEND (dia's ONNX vs this crate's CoreML),
+/// not precision and not placement. `ONNX-seg + COREML-emb` therefore
+/// implicates "the CoreML embedding path as shipped" — int8-palettized
+/// artifact, `All` placement, that conversion — as one bundle. Which of those
+/// three properties carries the failure is NOT isolated here; separating them
+/// needs the same hybrid harness run with the fp32 CoreML embedder on `All`
+/// and with the int8 CoreML embedder on `CpuOnly`, reference segmentation held
+/// fixed.
+///
+/// # Panics
+/// On any divergence from the pinned record, naming the cell and what the
+/// divergence means for the attribution recorded in `model_io.rs`.
+fn assert_factorial_verdict(o: &FactorialObserved) {
+  // ── Corner 1: the harness reproduces the dia-ort reference.
+  let (onnx_spk, onnx_der) = o.onnx_onnx.unwrap_or_else(|| {
+    panic!(
+      "ONNX-seg + ONNX-emb did not cluster. The reference corner must reproduce dia-ort; that is \
+       a harness failure, not a finding about the CoreML path — no other cell can be trusted."
+    )
+  });
+  assert_eq!(
+    onnx_spk, REFERENCE_CORNER_SPK,
+    "ONNX-seg + ONNX-emb found {onnx_spk} speakers, not dia-ort's pinned {REFERENCE_CORNER_SPK} — \
+     the harness does not reproduce the reference, so no cell it produced can be trusted"
+  );
+  assert!(
+    onnx_der <= CORNER_DER_TOL,
+    "ONNX-seg + ONNX-emb scored {:.4} % DER against reference.rttm; dia-ort is frame-perfect on \
+     this clip (0.0000 %), so the harness has diverged from the reference pipeline",
+    onnx_der * 100.0
+  );
+
+  // ── Corner 2: the harness reproduces `Extractor::extract` at the shipping
+  // configuration, to `parity_shipping_der`'s own pinned numbers.
+  let (ship_spk, ship_der) = o.coreml_coreml.unwrap_or_else(|| {
+    panic!(
+      "COREML-seg + COREML-emb did not cluster. `parity_shipping_der` pins this exact \
+       configuration as ANSWERING with {SHIPPING_CORNER_SPK} of 8 speakers; either the shipping \
+       path regressed to 'cannot answer at all' or this harness diverged from `Extractor::extract`."
+    )
+  });
+  assert_eq!(
+    ship_spk, SHIPPING_CORNER_SPK,
+    "COREML-seg + COREML-emb found {ship_spk} speakers; `parity_shipping_der` pins the identical \
+     artifacts/placement/decode at {SHIPPING_CORNER_SPK}. This corner is the harness's \
+     equivalence proof against `Extractor::extract` — investigate before reading any other cell."
+  );
+  assert!(
+    (ship_der - SHIPPING_CORNER_DER).abs() <= CORNER_DER_TOL,
+    "COREML-seg + COREML-emb scored {:.4} % DER; `parity_shipping_der` pins the identical \
+     configuration at {:.4} % (±{:.4} %)",
+    ship_der * 100.0,
+    SHIPPING_CORNER_DER * 100.0,
+    CORNER_DER_TOL * 100.0
+  );
+
+  // ── THE FINDING: the embedding conversion alone reproduces the collapse.
+  let (emb_spk, emb_der) = o.onnx_coreml.unwrap_or_else(|| {
+    panic!(
+      "ONNX-seg + COREML-emb did not cluster. It is pinned as REPRODUCING the shipping collapse \
+       (an answer of {EMBED_ONLY_SPK} of 8 speakers), not as failing to answer — a change of \
+       failure MODE is a new finding; re-measure before rewriting `model_io.rs`."
+    )
+  });
+  assert_eq!(
+    emb_spk, EMBED_ONLY_SPK,
+    "ONNX-seg + COREML-emb found {emb_spk} speakers, not the pinned {EMBED_ONLY_SPK}. This cell \
+     is the whole reason `model_io.rs` attributes the clip-09 collapse at the SHIPPING \
+     configuration to the embedding conversion rather than the segmentation one. If it now \
+     recovers all {REFERENCE_CORNER_SPK}, that attribution is stale and must be rewritten — do \
+     NOT delete this assertion."
+  );
+  assert!(
+    (emb_der - SHIPPING_CORNER_DER).abs() <= CORNER_DER_TOL,
+    "ONNX-seg + COREML-emb scored {:.4} % DER, off the pinned {:.4} % (±{:.4} %). Its landing on \
+     the SAME DER as the all-CoreML corner is what says the embedding conversion accounts for the \
+     shipping collapse rather than merely contributing to it.",
+    emb_der * 100.0,
+    SHIPPING_CORNER_DER * 100.0,
+    CORNER_DER_TOL * 100.0
+  );
+
+  // ── The segmentation conversion's own, DIFFERENT defect.
+  let (seg_spk, seg_der) = o.coreml_onnx.unwrap_or_else(|| {
+    panic!(
+      "COREML-seg + ONNX-emb did not cluster. It is pinned as ANSWERING with {SEG_ONLY_SPK} \
+       speakers (one spurious cluster); a refusal to answer is the fp32/`CpuOnly` symptom \
+       appearing at a placement where it was not seen before — a new finding, not a flake."
+    )
+  });
+  assert_eq!(
+    seg_spk, SEG_ONLY_SPK,
+    "COREML-seg + ONNX-emb found {seg_spk} speakers, not the pinned {SEG_ONLY_SPK}. The \
+     segmentation conversion's own defect on this clip is an OVERcount by one, an order of \
+     magnitude smaller than the collapse; if that changed, `model_io.rs`'s two-defect account is \
+     stale."
+  );
+  assert!(
+    (seg_der - SEG_ONLY_DER).abs() <= CORNER_DER_TOL,
+    "COREML-seg + ONNX-emb scored {:.4} % DER, off the pinned {:.4} % (±{:.4} %)",
+    seg_der * 100.0,
+    SEG_ONLY_DER * 100.0,
+    CORNER_DER_TOL * 100.0
+  );
+}
+
+/// [`assert_factorial_verdict`] pins EVERY cell, in BOTH directions — proven
+/// here hermetically (no models, no fixtures, no audio): the measured record
+/// passes, and every single-cell perturbation fails. Without this, a cell could
+/// silently go unpinned and a real change in the localization would pass green
+/// — the same falsifiability contract `parity_shipping_der`'s
+/// `clip09_known_defect_pins_every_field` carries.
+#[test]
+fn factorial_verdict_pins_every_cell() {
+  let good = FactorialObserved {
+    onnx_onnx: Some((REFERENCE_CORNER_SPK, 0.0)),
+    coreml_onnx: Some((SEG_ONLY_SPK, SEG_ONLY_DER)),
+    onnx_coreml: Some((EMBED_ONLY_SPK, SHIPPING_CORNER_DER)),
+    coreml_coreml: Some((SHIPPING_CORNER_SPK, SHIPPING_CORNER_DER)),
+  };
+  assert_factorial_verdict(&good);
+
+  let fails = |o: FactorialObserved, what: &str| {
+    assert!(
+      std::panic::catch_unwind(move || assert_factorial_verdict(&o)).is_err(),
+      "assert_factorial_verdict accepted a record with {what} — that cell is NOT pinned"
+    );
+  };
+
+  // Every cell must be pinned on BOTH axes (count and DER) and against a
+  // refusal to cluster.
+  for (mutate, what) in [
+    (
+      (|o: &mut FactorialObserved| o.onnx_onnx = Some((9, 0.0))) as fn(&mut FactorialObserved),
+      "a moved all-ONNX speaker count",
+    ),
+    (
+      |o: &mut FactorialObserved| o.onnx_onnx = Some((REFERENCE_CORNER_SPK, 0.05)),
+      "a moved all-ONNX DER",
+    ),
+    (
+      |o: &mut FactorialObserved| o.onnx_onnx = None,
+      "an all-ONNX clustering refusal",
+    ),
+    (
+      |o: &mut FactorialObserved| o.coreml_coreml = Some((6, SHIPPING_CORNER_DER)),
+      "a moved all-CoreML speaker count",
+    ),
+    (
+      |o: &mut FactorialObserved| o.coreml_coreml = Some((SHIPPING_CORNER_SPK, 0.17)),
+      "a moved all-CoreML DER",
+    ),
+    (
+      |o: &mut FactorialObserved| o.coreml_coreml = None,
+      "an all-CoreML clustering refusal",
+    ),
+    (
+      |o: &mut FactorialObserved| o.onnx_coreml = Some((REFERENCE_CORNER_SPK, 0.0)),
+      "an embedder-only cell that recovers every speaker",
+    ),
+    (
+      |o: &mut FactorialObserved| o.onnx_coreml = Some((EMBED_ONLY_SPK, 0.17)),
+      "a moved embedder-only DER",
+    ),
+    (
+      |o: &mut FactorialObserved| o.onnx_coreml = None,
+      "an embedder-only clustering refusal",
+    ),
+    (
+      |o: &mut FactorialObserved| o.coreml_onnx = Some((REFERENCE_CORNER_SPK, SEG_ONLY_DER)),
+      "a moved segmenter-only speaker count",
+    ),
+    (
+      |o: &mut FactorialObserved| o.coreml_onnx = Some((SEG_ONLY_SPK, 0.05)),
+      "a moved segmenter-only DER",
+    ),
+    (
+      |o: &mut FactorialObserved| o.coreml_onnx = None,
+      "a segmenter-only clustering refusal",
+    ),
+  ] {
+    let mut o = good;
+    mutate(&mut o);
+    fails(o, what);
+  }
+}

--- a/crates/coremlit/tests/speaker/backend_factorial.rs
+++ b/crates/coremlit/tests/speaker/backend_factorial.rs
@@ -81,6 +81,18 @@
 //! configuration did not transfer to the one this crate ships, which is
 //! precisely why it had to be re-measured here.
 //!
+//! # The follow-up this file also carries
+//!
+//! The cross-product above varies the whole BACKEND, so its finding implicates
+//! the CoreML embedding path as shipped — int8-palettized artifact **plus**
+//! `All` placement **plus** that conversion — as one bundle.
+//! [`embedding_precision_x_placement`] separates the three: same harness, same
+//! clip, dia's reference segmentation held fixed for every arm, and the
+//! embedding arm run across precision x placement. Its verdict
+//! ([`assert_precision_placement_verdict`]) carries the measured table; in
+//! short, the conversion alone is frame-perfect, the int8 palettization costs 2
+//! speakers at either placement, and `All` costs 1 at either precision.
+//!
 //! # What this suite does NOT establish
 //!
 //! It localizes the collapse to a STAGE, on ONE clip, at ONE configuration, on
@@ -89,7 +101,9 @@
 //! - **It does not separate int8 from `All` from the conversion itself.** The
 //!   factor varied is the BACKEND; the CoreML embedding arm is the shipping
 //!   bundle (int8-palettized artifact + `All` placement + that conversion) as
-//!   one unit. See [`assert_factorial_verdict`]'s "What it does NOT pin".
+//!   one unit. See [`assert_factorial_verdict`]'s "What it does NOT pin" — and
+//!   [`embedding_precision_x_placement`], which is the experiment that does
+//!   separate them.
 //! - **It does not say which op inside a stage is responsible, and it cannot.**
 //!   Both segmentation graphs expose only their post-tail output
 //!   (`z - logsumexp(z)`), never the pre-tail logits `z`, so no measurement
@@ -106,6 +120,17 @@
 //! ```text
 //! cargo test -p coremlit --features speaker-oracle --test speaker_backend_factorial -- --ignored --nocapture
 //! ```
+//!
+//! **`--features speaker-oracle`, never `--all-features`.** Under
+//! `--all-features` this binary HANGS instead of running: `align-oracle` pulls
+//! `asry`, which enables `ort/load-dynamic`, and Cargo unifies that onto the
+//! single `ort` in the build — so `dia`'s first `Session` tries to `dlopen` an
+//! ONNX Runtime dylib that is not there, and `ort`'s failure path re-enters the
+//! same `OnceLock` it is initializing (`setup_api` -> error construction ->
+//! `ort::api()` -> `Once::wait`) and deadlocks forever. A plain
+//! `cargo test -p coremlit --all-features` does not notice, because without
+//! `--ignored` it never opens an `ort` session. The same applies to every
+//! `speaker-oracle` DER binary.
 #![cfg(feature = "speaker-oracle")]
 
 mod common;
@@ -242,6 +267,92 @@ fn coreml_embed_path() -> PathBuf {
   common::embed_path()
 }
 
+/// The CoreML embedding artifact's **weight precision** — the quantization
+/// axis of [`embedding_precision_x_placement`].
+///
+/// Both artifacts are contract-equal (`model_io`'s
+/// `wespeaker_fp32_io_contract_equal_but_not_targeted`), so they are
+/// substitutable for each other in [`EmbedSide`] and differ only in whether the
+/// weights were palettized.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Precision {
+  /// `wespeaker.mlmodelc` — 27 MB of unquantized float32 weights.
+  Fp32,
+  /// `wespeaker_v2.mlmodelc` — the int8-palettized artifact `ModelSource`
+  /// ships.
+  Int8,
+}
+
+impl Precision {
+  fn path(self) -> PathBuf {
+    match self {
+      Self::Fp32 => common::embed_fp32_path(),
+      Self::Int8 => coreml_embed_path(),
+    }
+  }
+  const fn artifact(self) -> &'static str {
+    match self {
+      Self::Fp32 => "wespeaker.mlmodelc",
+      Self::Int8 => "wespeaker_v2.mlmodelc",
+    }
+  }
+  const fn tag(self) -> &'static str {
+    match self {
+      Self::Fp32 => "fp32",
+      Self::Int8 => "int8",
+    }
+  }
+}
+
+/// **One embedding arm**: which conversion computes the embeddings and, for the
+/// CoreML conversion, at which precision and on which compute placement.
+///
+/// [`shipping_config_backend_factorial`] only ever needs the two ends of the
+/// [`Backend`] axis, so it uses [`Self::SHIPPING`] for its CoreML cells and
+/// nothing else. [`embedding_precision_x_placement`] is the suite that opens
+/// the other two dimensions up.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum EmbedArm {
+  /// dia's fp32 `wespeaker_resnet34_lm.onnx` on `ort`'s CPU EP — the reference
+  /// implementation, and the only arm that is not a CoreML conversion.
+  Onnx,
+  /// speakerkit's CoreML conversion at a chosen precision and placement.
+  CoreMl {
+    precision: Precision,
+    placement: ComputeUnits,
+  },
+}
+
+impl EmbedArm {
+  /// The literal shipping embedding path: the int8-palettized artifact on
+  /// [`ComputeUnits::All`]. This is the bundle
+  /// [`shipping_config_backend_factorial`] varies as a single unit.
+  const SHIPPING: Self = Self::CoreMl {
+    precision: Precision::Int8,
+    placement: PLACEMENT,
+  };
+
+  /// The [`Backend`] this arm belongs to — the coarse factor the 2x2
+  /// cross-product varies.
+  const fn backend(self) -> Backend {
+    match self {
+      Self::Onnx => Backend::Onnx,
+      Self::CoreMl { .. } => Backend::CoreMl,
+    }
+  }
+
+  /// `"ONNX (fp32) / CPU"`-style label for the report tables.
+  fn label(self) -> String {
+    match self {
+      Self::Onnx => "ONNX fp32 / ort CPU EP".to_string(),
+      Self::CoreMl {
+        precision,
+        placement,
+      } => format!("CoreML {} / {placement:?}", precision.tag()),
+    }
+  }
+}
+
 // ══════════════════════════════════════════════════════════════════════
 // Stage 1 — segmentation log-probabilities, one backend at a time
 // ══════════════════════════════════════════════════════════════════════
@@ -340,16 +451,25 @@ enum EmbedSide {
 }
 
 impl EmbedSide {
-  fn load(backend: Backend) -> Self {
-    match backend {
-      Backend::CoreMl => Self::CoreMl(
+  fn load(arm: EmbedArm) -> Self {
+    match arm {
+      EmbedArm::CoreMl {
+        precision,
+        placement,
+      } => Self::CoreMl(
         EmbedModel::from_file_with(
-          coreml_embed_path(),
-          EmbedModelOptions::new().with_compute(PLACEMENT),
+          precision.path(),
+          EmbedModelOptions::new().with_compute(placement),
         )
-        .expect("load wespeaker_v2.mlmodelc (int8, shipping)"),
+        .unwrap_or_else(|e| {
+          panic!(
+            "load {} ({}) on {placement:?}: {e}",
+            precision.artifact(),
+            precision.tag()
+          )
+        }),
       ),
-      Backend::Onnx => {
+      EmbedArm::Onnx => {
         let onnx = dia_wespeaker_onnx();
         assert!(
           onnx.exists(),
@@ -771,8 +891,9 @@ fn shipping_config_backend_factorial() {
   // ── Stage 2: the four cells.
   let mut cells: Vec<CellResult> = Vec::with_capacity(4);
   for (seg_backend, seg_run) in [(Backend::Onnx, &seg_onnx), (Backend::CoreMl, &seg_coreml)] {
-    for embed_backend in [Backend::Onnx, Backend::CoreMl] {
-      let mut embed = EmbedSide::load(embed_backend);
+    for embed_arm in [EmbedArm::Onnx, EmbedArm::SHIPPING] {
+      let embed_backend = embed_arm.backend();
+      let mut embed = EmbedSide::load(embed_arm);
       let cell = assemble(seg_run, &mut embed, &samples, &starts);
       assert_eq!(
         common::fnv1a_f32(&samples),
@@ -932,10 +1053,14 @@ struct FactorialObserved {
 /// not precision and not placement. `ONNX-seg + COREML-emb` therefore
 /// implicates "the CoreML embedding path as shipped" — int8-palettized
 /// artifact, `All` placement, that conversion — as one bundle. Which of those
-/// three properties carries the failure is NOT isolated here; separating them
-/// needs the same hybrid harness run with the fp32 CoreML embedder on `All`
-/// and with the int8 CoreML embedder on `CpuOnly`, reference segmentation held
-/// fixed.
+/// three properties carries the failure is NOT isolated here.
+///
+/// [`embedding_precision_x_placement`] is the experiment that isolates them,
+/// and it re-measures this very cell as its own cell B. Its finding, in one
+/// line: the conversion carries none of it (fp32 on `CpuOnly` is frame-perfect
+/// against dia-ort), the palettization carries 2 of the 3 lost speakers, and
+/// the `All` placement carries 1 — so this cell's "the CoreML embedding path"
+/// must not be read as "the CoreML embedding conversion".
 ///
 /// # Panics
 /// On any divergence from the pinned record, naming the cell and what the
@@ -1107,6 +1232,787 @@ fn factorial_verdict_pins_every_cell() {
     (
       |o: &mut FactorialObserved| o.coreml_onnx = None,
       "a segmenter-only clustering refusal",
+    ),
+  ] {
+    let mut o = good;
+    mutate(&mut o);
+    fails(o, what);
+  }
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// The disambiguating experiment: precision x placement, reference
+// segmentation held fixed
+// ══════════════════════════════════════════════════════════════════════
+
+/// The five embedding arms, in report order. Reference segmentation is held
+/// fixed for all of them, so the ONLY thing that varies down this list is a
+/// property of the embedding path.
+///
+/// | cell | arm | what its outcome establishes |
+/// |---|---|---|
+/// | A | ONNX fp32 on `ort`'s CPU EP | the reference; harness validity |
+/// | B | CoreML int8 on `All` | the shipping bundle; reproduces `shipping_config_backend_factorial`'s `ONNX-seg + COREML-emb` cell |
+/// | C | CoreML **fp32** on `All` | placement + conversion, quantization removed |
+/// | D | CoreML int8 on **`CpuOnly`** | quantization + conversion, placement removed |
+/// | E | CoreML fp32 on `CpuOnly` | the conversion alone, both other factors removed |
+const PRECISION_PLACEMENT_ARMS: [EmbedArm; 5] = [
+  EmbedArm::Onnx,
+  EmbedArm::SHIPPING,
+  EmbedArm::CoreMl {
+    precision: Precision::Fp32,
+    placement: ComputeUnits::All,
+  },
+  EmbedArm::CoreMl {
+    precision: Precision::Int8,
+    placement: ComputeUnits::CpuOnly,
+  },
+  EmbedArm::CoreMl {
+    precision: Precision::Fp32,
+    placement: ComputeUnits::CpuOnly,
+  },
+];
+
+/// One embedding arm's measured result over the fixed reference segmentation.
+struct ArmResult {
+  cell: char,
+  arm: EmbedArm,
+  outcome: Result<Vec<Seg>, diaric::offline::Error>,
+  embed_s: f64,
+  /// The arm's `[num_chunks * SEG_NUM_SLOTS * EMBEDDING_DIM]` raw embeddings,
+  /// kept so [`embed_agreement`] can report how far each arm's embedding SPACE
+  /// moved — the intermediate the DER table's outcomes are downstream of.
+  embeddings: Vec<f32>,
+}
+
+impl ArmResult {
+  fn spk(&self) -> Option<usize> {
+    self
+      .outcome
+      .as_ref()
+      .ok()
+      .map(|s| distinct_speakers(s).len())
+  }
+  fn der(&self, reference: &[Seg]) -> Option<Der> {
+    self.outcome.as_ref().ok().map(|s| der_std(reference, s))
+  }
+}
+
+/// How far one arm's embeddings sit from the ONNX reference arm's, over the
+/// `(chunk, slot)` rows both arms actually produced.
+///
+/// Reported, not asserted: it is the mechanism-side companion to the DER table,
+/// and its job is to say whether two arms that land on the same DER got there
+/// through the same size of embedding perturbation. The DER outcomes are what
+/// the verdict is pinned on.
+struct EmbedAgreement {
+  /// Rows non-zero on BOTH sides — the ones a cosine is defined on.
+  rows: usize,
+  mean_cos: f64,
+  min_cos: f64,
+  /// Rows non-zero on exactly one side: dia's [`PLDA_MIN_NORM`] pre-check
+  /// dropped the `(chunk, slot)` on one arm and kept it on the other. A cosine
+  /// is undefined against a zeroed row, so these are counted rather than
+  /// folded in — and they are themselves a divergence, since a dropped slot
+  /// also zeroes that slot's segmentation column.
+  drop_disagreements: usize,
+}
+
+/// Compares one arm's `raw_embeddings` against the reference arm's, row by row.
+///
+/// An all-zero row means the slot was never embedded: either the
+/// overlap-exclusion rule skipped it (identical across arms — the plans derive
+/// from the ONE fixed reference segmentation) or [`PLDA_MIN_NORM`] dropped it
+/// (which CAN differ per arm). Rows zero on both sides carry no information.
+fn embed_agreement(arm: &[f32], reference: &[f32]) -> EmbedAgreement {
+  assert_eq!(
+    arm.len(),
+    reference.len(),
+    "embedding tensors have different lengths ({} vs {})",
+    arm.len(),
+    reference.len()
+  );
+  let mut d = EmbedAgreement {
+    rows: 0,
+    mean_cos: 0.0,
+    min_cos: f64::INFINITY,
+    drop_disagreements: 0,
+  };
+  let mut total = 0.0f64;
+  for (a, r) in arm
+    .as_chunks::<EMBEDDING_DIM>()
+    .0
+    .iter()
+    .zip(reference.as_chunks::<EMBEDDING_DIM>().0)
+  {
+    let a_live = a.iter().any(|v| *v != 0.0);
+    let r_live = r.iter().any(|v| *v != 0.0);
+    match (a_live, r_live) {
+      (true, true) => {
+        let c = common::cosine(a, r);
+        d.rows += 1;
+        total += c;
+        d.min_cos = d.min_cos.min(c);
+      }
+      (false, false) => {}
+      _ => d.drop_disagreements += 1,
+    }
+  }
+  if d.rows > 0 {
+    d.mean_cos = total / d.rows as f64;
+  } else {
+    d.min_cos = f64::NAN;
+  }
+  d
+}
+
+/// **Which property of the CoreML embedding path carries the clip-09 collapse:
+/// the int8 palettization, the `ComputeUnits::All` placement, or the conversion
+/// itself?**
+///
+/// [`shipping_config_backend_factorial`] established that swapping ONLY the
+/// embedding conversion, over dia's own reference segmentation, reproduces the
+/// shipping collapse exactly (5 of 8 speakers, 16.5904 %). But the factor it
+/// varied is the whole BACKEND, so three properties were implicated as one
+/// bundle. This suite separates them: same harness, same clip, same reference
+/// segmentation slabs, five embedding arms.
+///
+/// The DER verdict is [`assert_precision_placement_verdict`]. The report also
+/// prints an unpinned embedding-space companion ([`embed_agreement`]), and it
+/// is worth reading against the verdict because the two disagree about which
+/// factor is "bigger". Measured on the same run as the pinned table, mean and
+/// minimum cosine against cell A over all 2 114 `(chunk, slot)` rows, with zero
+/// [`PLDA_MIN_NORM`] drop disagreements on any arm:
+///
+/// ```text
+/// B  CoreML int8 / All        mean 0.985777 | min 0.042112
+/// C  CoreML fp32 / All        mean 0.987201 | min 0.035367
+/// D  CoreML int8 / CpuOnly    mean 0.998545 | min 0.963721
+/// E  CoreML fp32 / CpuOnly    mean 1.000000 | min 1.000000
+/// ```
+///
+/// Two things to take from it. First, cell E is not merely "clean at the DER
+/// level": the CoreML embedding conversion on `CpuOnly` agrees with dia's fp32
+/// ONNX to 1.000000 on EVERY row, minimum included — the conversion is
+/// numerically the same function, which is the strongest form the exoneration
+/// could take.
+///
+/// Second, **the embedding perturbation is anti-correlated with the clustering
+/// damage here.** The `All` placement moves the embeddings roughly 9x further
+/// in mean cosine distance than the palettization does (~0.013 vs ~0.0015) and
+/// drags some rows to near-orthogonality (min cosine 0.035), yet it costs 1
+/// speaker and 1 839 error units; int8's much smaller, much more uniform
+/// perturbation costs 2 speakers and 11 835. So the size of the embedding
+/// perturbation does not predict the clustering outcome — consistent with
+/// `parity_shipping_der`'s module doc, which already argues that the KIND of
+/// perturbation matters rather than its magnitude, but pointing the opposite
+/// way from that doc's specific rationale: there, quantization was expected to
+/// be the benign, roughly isotropic one. On this clip it is the harmful one.
+/// What structure in the palettization error the frozen community-1 LDA/PLDA
+/// basis is sensitive to is NOT established here; it would need the
+/// perturbation decomposed against that basis, which nothing in this repo
+/// currently does.
+///
+/// **The `embed_s` column is not a latency measurement.** It is wall time for
+/// one un-warmed pass, so it carries each arm's cold CoreML/ANE specialization,
+/// and it is not stable: across two runs of this suite the identical int8/`All`
+/// arm measured 31.7 s and 51.9 s, and fp32/`CpuOnly` 61.1 s and 100.3 s. It is
+/// printed to show an arm ran and roughly how long to expect, nothing else. The
+/// int8-vs-fp32 cost question is answered by
+/// `parity_shipping_der::shipping_embedder_cost_int8_vs_fp32`, which warms up
+/// first and times the whole extract.
+///
+/// The report prints in full BEFORE any assertion fires.
+#[test]
+#[ignore = "requires speakerkit models, dia parity fixtures + WeSpeaker ONNX (17 min of audio, 1 seg + 5 embed passes)"]
+fn embedding_precision_x_placement() {
+  let audio = fixtures_root().join(CLIP).join("clip_16k.wav");
+  assert!(
+    audio.exists(),
+    "clip audio not found at {} (set DIA_PARITY_FIXTURES)",
+    audio.display()
+  );
+  assert!(
+    common::embed_path().exists() && common::embed_fp32_path().exists(),
+    "need BOTH wespeaker_v2.mlmodelc (int8) and wespeaker.mlmodelc (fp32) under {} (set \
+     SPEAKERKIT_TEST_MODELS) — this experiment's whole point is varying the precision, so a \
+     missing artifact must fail loudly rather than be substituted",
+    common::models_dir().display()
+  );
+
+  let samples = common::load_wav_16k_mono(&audio);
+  let audio_fnv = common::fnv1a_f32(&samples);
+  assert_eq!(
+    samples.len(),
+    CLIP_SAMPLES,
+    "{CLIP}: decoded {} samples, pinned {CLIP_SAMPLES} — the audio identity changed",
+    samples.len()
+  );
+  assert_eq!(
+    audio_fnv, CLIP_AUDIO_FNV,
+    "{CLIP}: audio content hash {audio_fnv} != pinned {CLIP_AUDIO_FNV}"
+  );
+
+  let reference = parse_rttm(&fixtures_root().join(CLIP).join("reference.rttm"));
+  let ref_spk = distinct_speakers(&reference).len();
+  assert_eq!(
+    ref_spk, CLIP_REF_SPK,
+    "{CLIP}: reference.rttm has {ref_spk} speakers, expected {CLIP_REF_SPK}"
+  );
+
+  let window = Options::new().window();
+  let starts = chunk_starts(samples.len(), &window);
+  let plda = diaric::plda::PldaTransform::new().expect("load community-1 PldaTransform (diaric)");
+
+  println!(
+    "\n╔══ embedding precision x placement — {CLIP} ══\n║ {:.2} s, {} samples, fnv1a={}\n║ \
+     segmentation: dia ONNX (the REFERENCE), held fixed for every arm | {} chunks",
+    samples.len() as f64 / 16_000.0,
+    samples.len(),
+    common::fnv_hex(audio_fnv),
+    starts.len()
+  );
+
+  // ── The reference segmentation, computed ONCE. Every arm consumes these
+  // exact slabs, so nothing downstream of the embedder can differ for a
+  // segmentation reason.
+  let seg = run_seg(Backend::Onnx, &samples, &starts);
+  assert_eq!(
+    common::fnv1a_f32(&samples),
+    audio_fnv,
+    "the audio buffer changed under segmentation — comparison invalid"
+  );
+  println!(
+    "║ seg: ONNX {:.1} s, {} frames/chunk\n║",
+    seg.elapsed_s, seg.num_frames
+  );
+
+  let mut arms: Vec<ArmResult> = Vec::with_capacity(PRECISION_PLACEMENT_ARMS.len());
+  for (i, arm) in PRECISION_PLACEMENT_ARMS.into_iter().enumerate() {
+    let cell = char::from(b'A' + u8::try_from(i).expect("five arms"));
+    let mut embed = EmbedSide::load(arm);
+    let assembled = assemble(&seg, &mut embed, &samples, &starts);
+    assert_eq!(
+      common::fnv1a_f32(&samples),
+      audio_fnv,
+      "cell {cell} ({}): the audio buffer changed under the arm — comparison invalid",
+      arm.label()
+    );
+    assert_eq!(
+      assembled.num_chunks,
+      starts.len(),
+      "cell {cell} ({}): chunk grid diverged",
+      arm.label()
+    );
+    let outcome = cluster(&assembled, &window, &plda);
+    println!(
+      "║ ran {cell}: {:<24} ({:>5.1} s embed): {}",
+      arm.label(),
+      assembled.embed_s,
+      match &outcome {
+        Ok(s) => format!("{} speakers", distinct_speakers(s).len()),
+        Err(e) => format!("CLUSTERING FAILED — {e}"),
+      }
+    );
+    arms.push(ArmResult {
+      cell,
+      arm,
+      outcome,
+      embed_s: assembled.embed_s,
+      embeddings: assembled.raw_embeddings,
+    });
+  }
+
+  // ── The table.
+  println!(
+    "║\n║ {:>4} | {:>24} | {:>4} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} | outcome",
+    "cell", "embedding arm", "spk", "DER", "miss", "fa", "conf", "err units"
+  );
+  println!(
+    "║ {:-<4}-+-{:-<24}-+-{:-<4}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+--------",
+    "", "", "", "", "", "", "", ""
+  );
+  for a in &arms {
+    match (a.spk(), a.der(&reference)) {
+      (Some(spk), Some(d)) => println!(
+        "║ {:>4} | {:>24} | {spk:>4} | {:>8.4}% | {:>8.4}% | {:>8.4}% | {:>8.4}% | {:>9} | \
+         clustered ({:.1} s embed)",
+        a.cell,
+        a.arm.label(),
+        d.der * 100.0,
+        d.miss * 100.0,
+        d.fa * 100.0,
+        d.confusion * 100.0,
+        d.err_units(),
+        a.embed_s,
+      ),
+      _ => println!(
+        "║ {:>4} | {:>24} | {:>4} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} | Err: {}",
+        a.cell,
+        a.arm.label(),
+        "ERR",
+        "-",
+        "-",
+        "-",
+        "-",
+        "-",
+        a.outcome
+          .as_ref()
+          .expect_err("no speaker count implies Err"),
+      ),
+    }
+  }
+  for a in &arms {
+    if let Some(d) = a.der(&reference) {
+      println!(
+        "║   {}",
+        fmt_der(&format!("{} {}", a.cell, a.arm.label()), &d)
+      );
+    }
+  }
+
+  // ── The embedding space each arm handed to clustering, against cell A's.
+  // Reported, not pinned: it says whether arms that land on the same DER got
+  // there through the same size of perturbation.
+  let reference_embeddings: &[f32] = &arms
+    .iter()
+    .find(|a| a.arm == EmbedArm::Onnx)
+    .expect("cell A ran")
+    .embeddings;
+  println!("║\n║ embedding agreement vs cell A (ONNX fp32), per (chunk, slot) row:");
+  for a in arms.iter().filter(|a| a.arm != EmbedArm::Onnx) {
+    let g = embed_agreement(&a.embeddings, reference_embeddings);
+    println!(
+      "║   {} {:<24} mean cos {:.6} | min cos {:.6} | {} rows | {} PLDA_MIN_NORM drop \
+       disagreements",
+      a.cell,
+      a.arm.label(),
+      g.mean_cos,
+      g.min_cos,
+      g.rows,
+      g.drop_disagreements,
+    );
+  }
+  println!("╚══ reference (pyannote 4.0.4): {ref_spk} speakers\n");
+
+  let at = |arm: EmbedArm| -> Option<CellOutcome> {
+    let a = arms
+      .iter()
+      .find(|a| a.arm == arm)
+      .unwrap_or_else(|| panic!("every arm ran ({})", arm.label()));
+    let d = a.der(&reference)?;
+    Some(CellOutcome {
+      spk: a.spk()?,
+      der: d.der,
+      err_units: d.err_units(),
+    })
+  };
+
+  assert_precision_placement_verdict(&PrecisionPlacementObserved {
+    onnx_cpu: at(EmbedArm::Onnx),
+    int8_all: at(EmbedArm::SHIPPING),
+    fp32_all: at(EmbedArm::CoreMl {
+      precision: Precision::Fp32,
+      placement: ComputeUnits::All,
+    }),
+    int8_cpu: at(EmbedArm::CoreMl {
+      precision: Precision::Int8,
+      placement: ComputeUnits::CpuOnly,
+    }),
+    fp32_cpu: at(EmbedArm::CoreMl {
+      precision: Precision::Fp32,
+      placement: ComputeUnits::CpuOnly,
+    }),
+  });
+}
+
+/// One arm's decision-relevant outcome. `err_units` is the DER numerator in raw
+/// speaker-frames — the axis on which "0" means *not one scored frame differs*
+/// rather than "rounds to 0.0000 %", which is the whole strength of cells A
+/// and E.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct CellOutcome {
+  spk: usize,
+  der: f64,
+  err_units: u64,
+}
+
+/// The five arms' outcomes, or `None` where an arm's clustering refused to
+/// answer. Extracted from the measurement (or synthesized by
+/// [`precision_placement_verdict_pins_every_cell`]) so
+/// [`assert_precision_placement_verdict`] is a pure function both can call.
+#[derive(Clone, Copy, Debug)]
+struct PrecisionPlacementObserved {
+  onnx_cpu: Option<CellOutcome>,
+  int8_all: Option<CellOutcome>,
+  fp32_all: Option<CellOutcome>,
+  int8_cpu: Option<CellOutcome>,
+  fp32_cpu: Option<CellOutcome>,
+}
+
+/// `CoreML fp32 / All` (cell C) — the placement + conversion, quantization
+/// removed.
+const CELL_C_SPK: usize = 7;
+const CELL_C_DER: f64 = 0.025_427;
+
+/// `CoreML int8 / CpuOnly` (cell D) — the quantization + conversion, placement
+/// removed.
+const CELL_D_SPK: usize = 6;
+const CELL_D_DER: f64 = 0.163_636;
+
+/// `CoreML fp32 / CpuOnly` (cell E) — the conversion ALONE. It reproduces the
+/// dia-ort reference exactly, which is why its pin is `err_units == 0` rather
+/// than a DER band.
+const CELL_E_SPK: usize = 8;
+
+/// **The measured precision x placement record on clip 09**, reference
+/// segmentation held fixed (Apple M1 Max, macOS 26.5 build 25F71, arm64):
+///
+/// ```text
+/// cell | embedding arm            | spk |      DER |     conf | err units
+/// -----+--------------------------+-----+----------+----------+----------
+///    A | ONNX fp32 / ort CPU EP   |   8 |  0.0000% |  0.0000% |         0
+///    B | CoreML int8 / All        |   5 | 16.5904% | 16.5904% |     11999
+///    C | CoreML fp32 / All        |   7 |  2.5427% |  2.5427% |      1839
+///    D | CoreML int8 / CpuOnly    |   6 | 16.3636% | 16.3636% |     11835
+///    E | CoreML fp32 / CpuOnly    |   8 |  0.0000% |  0.0000% |         0
+/// ```
+///
+/// Laid out as the 2x2 it is, speakers / err units:
+///
+/// ```text
+///          | CpuOnly        | All
+/// ---------+----------------+---------------
+///     fp32 | 8 /      0 (E) | 7 /  1 839 (C)
+///     int8 | 6 / 11 835 (D) | 5 / 11 999 (B)
+/// ```
+///
+/// # What this establishes
+///
+/// - **The conversion itself is exonerated.** Cell E — the CoreML embedding
+///   conversion with BOTH other factors removed — reproduces dia-ort's answer
+///   frame-perfectly: 8 of 8 speakers and `err_units == 0`, not one
+///   collar-scored speaker-frame different from the ONNX reference. Whatever
+///   the clip-09 embedding defect is, it is not "speakerkit converted this
+///   graph wrong".
+/// - **Quantization is the dominant term, and it is placement-independent.**
+///   Holding placement fixed, int8 costs exactly 2 speakers at BOTH
+///   placements (E 8 -> D 6 on `CpuOnly`; C 7 -> B 5 on `All`) and it moves
+///   11 835 of cell B's 11 999 error units — 98.6 % of the shipping arm's
+///   entire error mass — on `CpuOnly` alone.
+/// - **Placement is a real but minority term, and it too is
+///   precision-independent.** Holding precision fixed, `All` costs exactly 1
+///   speaker at BOTH precisions (E 8 -> C 7 on fp32; D 6 -> B 5 on int8). Its
+///   error-unit cost is 1 839 in the fp32 arm (E 0 -> C 1 839) and 164 in the
+///   int8 arm (D 11 835 -> B 11 999) — the latter 1.4 % of the shipping arm's
+///   total, against quantization's 98.6 %.
+/// - **Neither factor alone reproduces the shipping collapse.** Cell B is 5
+///   speakers at 16.5904 %; the best either single factor manages is D's 6
+///   speakers at 16.3636 % (nearly all the DER, one speaker short) or C's 7
+///   speakers at 2.5427 % (one speaker short of the reference, and 6.5x
+///   smaller in DER). On speaker count the two factors are cleanly ADDITIVE:
+///   -2 for quantization, -1 for placement, at every level of the other.
+///
+/// # What it does NOT establish
+///
+/// - **It is one clip, one host, one segmentation backend.** Every arm here
+///   runs over dia's ONNX reference segmentation, which is NOT what this crate
+///   ships; `parity_shipping_der`'s arms run CoreML segmentation and land
+///   nearby but not identically (its int8/`CpuOnly` clip-09 arm is 6 speakers
+///   at 16.4590 %, against cell D's 16.3636 %).
+/// - **It does not price the remedy.** That fp32 recovers speakers HERE says
+///   nothing about what fp32 does to the other corpus clips, and no fp32/`All`
+///   DER arm exists for the gated clips (06 / 14 / 10) — `parity_shipping_der`
+///   measures fp32 only on `CpuOnly`. Deciding to ship fp32 needs that arm
+///   measured, clip 14 especially.
+/// - **It does not say WHY int8 costs two speakers.** Palettization changes the
+///   weights, not the graph: the two artifacts' op histograms are identical
+///   apart from 38 `constexpr_lut_to_dense` decompressions replacing 36 `const`
+///   weight tensors (and one dropped no-op `identity`). Which layer's
+///   perturbation the frozen LDA/PLDA basis is sensitive to is unmeasured.
+///
+/// # Panics
+/// On any divergence from the pinned record, naming the cell and what the
+/// divergence means for the attribution recorded in `model_io.rs`.
+fn assert_precision_placement_verdict(o: &PrecisionPlacementObserved) {
+  // ── Cell A: the harness reproduces the dia-ort reference.
+  let a = o.onnx_cpu.unwrap_or_else(|| {
+    panic!(
+      "cell A (ONNX fp32 / ort CPU EP) did not cluster. The reference arm must reproduce dia-ort; \
+       that is a harness failure, not a finding about the CoreML path — no other cell can be \
+       trusted."
+    )
+  });
+  assert_eq!(
+    a.spk, REFERENCE_CORNER_SPK,
+    "cell A found {} speakers, not dia-ort's pinned {REFERENCE_CORNER_SPK} — the harness does not \
+     reproduce the reference, so no cell it produced can be trusted",
+    a.spk
+  );
+  assert_eq!(
+    a.err_units, 0,
+    "cell A scored {} error units against reference.rttm; dia-ort is frame-perfect on this clip, \
+     so the harness has diverged from the reference pipeline",
+    a.err_units
+  );
+
+  // ── Cell B: this suite's arm B is `shipping_config_backend_factorial`'s
+  // `ONNX-seg + COREML-emb` cell, re-measured. Same segmentation backend, same
+  // artifact, same placement — so it lands on that suite's pin or the two
+  // suites are not measuring the same thing.
+  let b = o.int8_all.unwrap_or_else(|| {
+    panic!(
+      "cell B (CoreML int8 / All) did not cluster. It is pinned as REPRODUCING the shipping \
+       collapse (an answer of {EMBED_ONLY_SPK} of 8 speakers), which is also \
+       `shipping_config_backend_factorial`'s pinned `ONNX-seg + COREML-emb` cell — a change of \
+       failure MODE is a new finding, not a flake."
+    )
+  });
+  assert_eq!(
+    b.spk, EMBED_ONLY_SPK,
+    "cell B found {} speakers, not the {EMBED_ONLY_SPK} that \
+     `shipping_config_backend_factorial` pins for the identical arm. These two suites share a \
+     cell on purpose; if it moved, they are no longer measuring the same configuration and this \
+     experiment's baseline is gone.",
+    b.spk
+  );
+  assert!(
+    (b.der - SHIPPING_CORNER_DER).abs() <= CORNER_DER_TOL,
+    "cell B scored {:.4} % DER; the identical arm is pinned at {:.4} % (±{:.4} %) by \
+     `shipping_config_backend_factorial` and by `parity_shipping_der`'s int8/All clip-09 pin",
+    b.der * 100.0,
+    SHIPPING_CORNER_DER * 100.0,
+    CORNER_DER_TOL * 100.0
+  );
+
+  // ── THE FINDING, part 1: the conversion alone is CLEAN.
+  let e = o.fp32_cpu.unwrap_or_else(|| {
+    panic!(
+      "cell E (CoreML fp32 / CpuOnly) did not cluster. It is pinned as reproducing the reference \
+       EXACTLY; a refusal to answer would mean the CoreML embedding conversion is defective on \
+       its own, overturning this suite's central result."
+    )
+  });
+  assert_eq!(
+    e.spk, CELL_E_SPK,
+    "cell E found {} speakers, not the pinned {CELL_E_SPK}. This cell is the whole reason \
+     `model_io.rs` records the CoreML embedding CONVERSION as exonerated and attributes clip 09 \
+     to the int8 palettization plus the `All` placement instead. If it moved, that attribution is \
+     stale and must be rewritten — do NOT delete this assertion.",
+    e.spk
+  );
+  assert_eq!(
+    e.err_units, 0,
+    "cell E scored {} error units. The pinned claim is not 'small DER' but frame-perfect identity \
+     with the dia-ort reference — with quantization and the `All` placement both removed, the \
+     CoreML embedding conversion does not move one collar-scored speaker-frame. A non-zero value \
+     here weakens that to 'nearly clean', which is a different finding.",
+    e.err_units
+  );
+
+  // ── THE FINDING, part 2: quantization, placement held at CpuOnly.
+  let d = o.int8_cpu.unwrap_or_else(|| {
+    panic!(
+      "cell D (CoreML int8 / CpuOnly) did not cluster. It is pinned as ANSWERING with \
+       {CELL_D_SPK} speakers; a refusal is a new failure mode, not a flake."
+    )
+  });
+  assert_eq!(
+    d.spk, CELL_D_SPK,
+    "cell D found {} speakers, not the pinned {CELL_D_SPK}. Against cell E's {CELL_E_SPK}, this \
+     cell is what prices the int8 palettization on its own: 2 speakers, with the placement held \
+     at `CpuOnly`.",
+    d.spk
+  );
+  assert!(
+    (d.der - CELL_D_DER).abs() <= CORNER_DER_TOL,
+    "cell D scored {:.4} % DER, off the pinned {:.4} % (±{:.4} %). Its landing within 0.23 pp of \
+     the shipping arm's 16.5904 % is what says quantization carries almost the whole error mass.",
+    d.der * 100.0,
+    CELL_D_DER * 100.0,
+    CORNER_DER_TOL * 100.0
+  );
+
+  // ── THE FINDING, part 3: placement, precision held at fp32.
+  let c = o.fp32_all.unwrap_or_else(|| {
+    panic!(
+      "cell C (CoreML fp32 / All) did not cluster. It is pinned as ANSWERING with {CELL_C_SPK} \
+       speakers; a refusal is a new failure mode, not a flake."
+    )
+  });
+  assert_eq!(
+    c.spk, CELL_C_SPK,
+    "cell C found {} speakers, not the pinned {CELL_C_SPK}. Against cell E's {CELL_E_SPK}, this \
+     cell is what prices the `All` placement on its own: 1 speaker, with the precision held at \
+     fp32. If it now recovers all {CELL_E_SPK}, the placement is no longer implicated at all and \
+     the record must say so.",
+    c.spk
+  );
+  assert!(
+    (c.der - CELL_C_DER).abs() <= CORNER_DER_TOL,
+    "cell C scored {:.4} % DER, off the pinned {:.4} % (±{:.4} %). Its being 6.5x SMALLER than \
+     the shipping arm's 16.5904 % is what says the placement is the minority term.",
+    c.der * 100.0,
+    CELL_C_DER * 100.0,
+    CORNER_DER_TOL * 100.0
+  );
+}
+
+/// [`assert_precision_placement_verdict`] pins EVERY cell, in BOTH directions —
+/// proven here hermetically (no models, no fixtures, no audio): the measured
+/// record passes, and every single-cell perturbation fails. Same falsifiability
+/// contract as [`factorial_verdict_pins_every_cell`]; without it a cell could
+/// silently go unpinned and a real change in which factor carries the collapse
+/// would pass green.
+#[test]
+fn precision_placement_verdict_pins_every_cell() {
+  /// A frame-perfect outcome: `spk` speakers and not one differing scored
+  /// speaker-frame. Free-standing rather than a closure so the mutation table
+  /// below can still coerce to `fn(&mut _)`.
+  const fn clean(spk: usize) -> CellOutcome {
+    CellOutcome {
+      spk,
+      der: 0.0,
+      err_units: 0,
+    }
+  }
+  let good = PrecisionPlacementObserved {
+    onnx_cpu: Some(clean(REFERENCE_CORNER_SPK)),
+    int8_all: Some(CellOutcome {
+      spk: EMBED_ONLY_SPK,
+      der: SHIPPING_CORNER_DER,
+      err_units: 11_999,
+    }),
+    fp32_all: Some(CellOutcome {
+      spk: CELL_C_SPK,
+      der: CELL_C_DER,
+      err_units: 1_839,
+    }),
+    int8_cpu: Some(CellOutcome {
+      spk: CELL_D_SPK,
+      der: CELL_D_DER,
+      err_units: 11_835,
+    }),
+    fp32_cpu: Some(clean(CELL_E_SPK)),
+  };
+  assert_precision_placement_verdict(&good);
+
+  let fails = |o: PrecisionPlacementObserved, what: &str| {
+    assert!(
+      std::panic::catch_unwind(move || assert_precision_placement_verdict(&o)).is_err(),
+      "assert_precision_placement_verdict accepted a record with {what} — that cell is NOT pinned"
+    );
+  };
+
+  for (mutate, what) in [
+    (
+      (|o: &mut PrecisionPlacementObserved| o.onnx_cpu = Some(clean(9)))
+        as fn(&mut PrecisionPlacementObserved),
+      "a moved cell-A speaker count",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.onnx_cpu = Some(CellOutcome {
+          spk: REFERENCE_CORNER_SPK,
+          der: 0.0,
+          err_units: 1,
+        });
+      },
+      "a cell A that is no longer frame-perfect",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| o.onnx_cpu = None,
+      "a cell-A clustering refusal",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.int8_all = Some(CellOutcome {
+          spk: 6,
+          der: SHIPPING_CORNER_DER,
+          err_units: 11_999,
+        });
+      },
+      "a moved cell-B speaker count",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.int8_all = Some(CellOutcome {
+          spk: EMBED_ONLY_SPK,
+          der: 0.17,
+          err_units: 11_999,
+        });
+      },
+      "a moved cell-B DER",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| o.int8_all = None,
+      "a cell-B clustering refusal",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.fp32_all = Some(CellOutcome {
+          spk: CELL_E_SPK,
+          der: CELL_C_DER,
+          err_units: 1_839,
+        });
+      },
+      "a cell C that recovers every speaker (the placement no longer implicated)",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.fp32_all = Some(CellOutcome {
+          spk: CELL_C_SPK,
+          der: SHIPPING_CORNER_DER,
+          err_units: 11_999,
+        });
+      },
+      "a cell-C DER that moved to the shipping arm's",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| o.fp32_all = None,
+      "a cell-C clustering refusal",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.int8_cpu = Some(CellOutcome {
+          spk: CELL_E_SPK,
+          der: CELL_D_DER,
+          err_units: 11_835,
+        });
+      },
+      "a cell D that recovers every speaker (quantization no longer implicated)",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.int8_cpu = Some(CellOutcome {
+          spk: CELL_D_SPK,
+          der: 0.0,
+          err_units: 0,
+        });
+      },
+      "a moved cell-D DER",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| o.int8_cpu = None,
+      "a cell-D clustering refusal",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| o.fp32_cpu = Some(clean(CELL_C_SPK)),
+      "a cell E that loses a speaker (the conversion no longer exonerated)",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.fp32_cpu = Some(CellOutcome {
+          spk: CELL_E_SPK,
+          der: 0.0,
+          err_units: 1,
+        });
+      },
+      "a cell E that is no longer frame-perfect",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| o.fp32_cpu = None,
+      "a cell-E clustering refusal",
     ),
   ] {
     let mut o = good;

--- a/crates/coremlit/tests/speaker/backend_factorial.rs
+++ b/crates/coremlit/tests/speaker/backend_factorial.rs
@@ -1,18 +1,23 @@
 //! **Where does the clip-09 collapse come from — the segmentation conversion,
-//! the embedding conversion, or both — AT THE CONFIGURATION WE SHIP?**
+//! the embedding conversion, or both — AT THE CONFIGURATION THAT SHIPPED?**
 //!
-//! `parity_shipping_der.rs` measures the shipping default end to end and pins
-//! its known-bad clip-09 state (int8 `wespeaker_v2.mlmodelc` on
-//! [`ComputeUnits::All`]: 5 of 8 speakers, 16.5904 % DER, 100 % confusion). It
-//! cannot say WHICH of the two CoreML conversions produces that, because it
+//! This file is the ATTRIBUTION RECORD for issue #15. The configuration it
+//! dissects — the int8 `wespeaker_v2.mlmodelc` on [`ComputeUnits::All`] —
+//! shipped until that issue retired it for the collapse pinned here (5 of 8
+//! speakers, 16.5904 % DER, 100 % confusion on clip 09), and the retirement
+//! decision (`model_io.rs`'s DECISION, `parity_shipping_der.rs`'s gates)
+//! cites these experiments as its evidence. The int8 artifact stays on disk,
+//! byte-pinned (`model_io.rs`), exactly so this record keeps reproducing.
+//!
+//! `parity_shipping_der.rs` measured that default end to end; it could not
+//! say WHICH of the two CoreML conversions produced the collapse, because it
 //! never varies them independently: every one of its speakerkit arms runs
 //! CoreML segmentation AND CoreML embedding.
 //!
 //! This suite varies them independently — the 2x2 cross-product of
 //! `{ONNX, CoreML}` segmentation x `{ONNX, CoreML}` embedding — with every
-//! other factor held constant, and it does so **at the shipping
-//! configuration**: the int8 embedder, both CoreML models on
-//! [`ComputeUnits::All`].
+//! other factor held constant, and it does so **at that configuration**: the
+//! int8 embedder, both CoreML models on [`ComputeUnits::All`].
 //!
 //! # Why this is a distinct experiment from the one already on record
 //!
@@ -50,21 +55,27 @@
 //! - **the clustering** — `diaric::offline::diarize_offline` over the measured
 //!   side's community-1 PLDA, for every cell including the all-ONNX one.
 //!
-//! # Harness validity: the two corners are checked against pinned numbers
+//! # Harness validity: both corners are anchored to the REAL pipelines
 //!
 //! The cells are assembled by this file, not by `Extractor::extract`
 //! ([`Extraction::from_parts`] is crate-private, so a mixed-backend
 //! `Extraction` cannot be built from outside the crate). A hand-assembled
-//! pipeline is only worth as much as its agreement with the real one, so
-//! [`assert_factorial_verdict`] checks both corners against numbers that were
-//! pinned elsewhere by the real pipelines:
+//! pipeline is only worth as much as its agreement with the real one:
 //!
-//! - the all-CoreML corner must reproduce `parity_shipping_der`'s pinned
-//!   `int8/All` clip-09 state (5 speakers, 16.5904 % DER) — same artifacts,
-//!   same placement, same decode, so this is an EXACT reproduction and any
-//!   drift means the assembly diverged from `Extractor::extract`;
-//! - the all-ONNX corner must reproduce dia-ort's pinned clip-09 speaker count
-//!   (8) at 0.0000 % DER against `reference.rttm`.
+//! - the all-ONNX corner must reproduce dia-ort's pinned clip-09 speaker
+//!   count (8) at 0.0000 % DER against `reference.rttm`
+//!   ([`assert_factorial_verdict`]);
+//! - the all-CoreML corner is checked against an IN-SUITE control:
+//!   [`shipping_config_backend_factorial`] also runs the identical
+//!   configuration through the PRODUCTION path — `FluidAudioSource::extract`
+//!   (the real `Extractor::extract`) + the public `Extraction::diarize` —
+//!   and asserts the production run and the hand-assembled corner agree on
+//!   the count and to ±[`CORNER_DER_TOL`] / ±[`ERR_UNITS_TOL`] on the
+//!   error mass, both landing on the retired shipping record (5 speakers,
+//!   16.5904 %). This control used to live in `parity_shipping_der` as its
+//!   int8/All pin; that suite's arms moved to the fp32 shipping
+//!   configuration with issue #15, so the anchor now runs here, where the
+//!   retired artifact still has its record to hold.
 //!
 //! Both hold on the measured run, which is what licenses reading the hybrids.
 //!
@@ -147,6 +158,7 @@ use coremlit::{
       POWERSET_CLASSES, SEG_CHUNK_SAMPLES, SEG_NUM_SLOTS, SegmentModel, SegmentModelOptions,
       multilabel,
     },
+    source::{FluidAudioSource, ModelSource},
     window::{
       WindowOptions, chunk_sliding_window, chunk_starts, count_from_segmentations,
       frame_sliding_window,
@@ -159,9 +171,10 @@ use der_calc::{Der, Seg, der_std, distinct_speakers, fmt_der, parse_rttm};
 // The clip, the pinned corners, and the fixture/model resolution
 // ══════════════════════════════════════════════════════════════════════
 
-/// The clip this experiment runs on: dia's 8-speaker parity fixture, the one
-/// whose shipping-configuration collapse `parity_shipping_der`'s
-/// `shipping_int8_der_09_mrbeast_dollar_date_8spk_known_defect` pins.
+/// The clip this experiment runs on: dia's 8-speaker parity fixture — the
+/// clip whose int8-era shipping collapse this suite dissects and whose
+/// post-fix record `parity_shipping_der`'s
+/// `shipping_der_09_mrbeast_dollar_date_8spk` now gates.
 const CLIP: &str = "09_mrbeast_dollar_date";
 
 /// Decoded 16 kHz-mono sample count of `09_mrbeast_dollar_date/clip_16k.wav`,
@@ -176,10 +189,13 @@ const CLIP_AUDIO_FNV: u64 = 8_657_240_795_675_234_981;
 /// output, not human labels — see `parity_shipping_der`'s module doc).
 const CLIP_REF_SPK: usize = 8;
 
-/// The all-CoreML corner's expected state: `parity_shipping_der`'s pinned
-/// `int8/All` clip-09 numbers. Same artifacts, same placement, same decode as
-/// that suite's shipping arm, so this corner reproduces them exactly or the
-/// hand-assembly in [`assemble`] has diverged from `Extractor::extract`.
+/// The all-CoreML corner's expected state: the retired int8/All shipping
+/// record (formerly `parity_shipping_der`'s clip-09 pin, retired there with
+/// the artifact). [`shipping_config_backend_factorial`]'s in-suite production
+/// control re-measures the same configuration through the real
+/// `FluidAudioSource::extract` + `Extraction::diarize` path, so this corner
+/// reproduces these numbers or the hand-assembly in [`assemble`] has
+/// diverged from `Extractor::extract`.
 const SHIPPING_CORNER_SPK: usize = 5;
 const SHIPPING_CORNER_DER: f64 = 0.165_904;
 
@@ -253,7 +269,7 @@ impl Backend {
   }
 }
 
-/// The compute placement both CoreML models run on. `All` IS the shipping
+/// The compute placement both CoreML models run on. `All` is the shipping
 /// default ([`coremlit::audio::speaker::segment::DEFAULT_SEGMENT_COMPUTE`] and
 /// its embed twin), which is the entire point of running the factorial here:
 /// the recorded prior cross-product used `CpuOnly`.
@@ -271,7 +287,7 @@ fn coreml_embed_path() -> PathBuf {
 /// axis of [`embedding_precision_x_placement`].
 ///
 /// Both artifacts are contract-equal (`model_io`'s
-/// `wespeaker_fp32_io_contract_equal_but_not_targeted`), so they are
+/// `wespeaker_fp32_io_matches_spec`), so they are
 /// substitutable for each other in [`EmbedSide`] and differ only in whether the
 /// weights were palettized.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -324,8 +340,8 @@ enum EmbedArm {
 }
 
 impl EmbedArm {
-  /// The literal shipping embedding path: the int8-palettized artifact on
-  /// [`ComputeUnits::All`]. This is the bundle
+  /// The int8-palettized artifact on [`ComputeUnits::All`] — the embedding
+  /// path that SHIPPED until issue #15 retired it. This is the bundle
   /// [`shipping_config_backend_factorial`] varies as a single unit.
   const SHIPPING: Self = Self::CoreMl {
     precision: Precision::Int8,
@@ -984,6 +1000,98 @@ fn shipping_config_backend_factorial() {
     Some((c.spk()?, c.der(&reference)?.der))
   };
 
+  // ── The in-suite PRODUCTION control (module doc, "Harness validity"): the
+  // identical retired-int8 configuration through the real
+  // `FluidAudioSource::extract` (`Extractor::extract`) + public
+  // `Extraction::diarize` path. The all-CoreML corner above is a hand
+  // assembly; this run is what anchors it to the production pipeline now
+  // that `parity_shipping_der`'s int8 arms are retired.
+  let control_seg = SegmentModel::from_file_with(
+    common::seg_path(),
+    SegmentModelOptions::new().with_compute(PLACEMENT),
+  )
+  .expect("load pyannote_segmentation.mlmodelc (production control)");
+  let control_embed = EmbedModel::from_file_with(
+    coreml_embed_path(),
+    EmbedModelOptions::new().with_compute(PLACEMENT),
+  )
+  .expect("load wespeaker_v2.mlmodelc (production control)");
+  let control_ext = FluidAudioSource::with_options(control_seg, control_embed, Options::new())
+    .extract(&samples)
+    .expect("production-control extract");
+  assert_eq!(
+    common::fnv1a_f32(&samples),
+    audio_fnv,
+    "the audio buffer changed under the production control — comparison invalid"
+  );
+  let control_segs: Vec<Seg> = control_ext
+    .diarize(&plda)
+    .map(|out| {
+      out
+        .spans_slice()
+        .iter()
+        .map(|s| Seg {
+          start: s.start(),
+          end: s.start() + s.duration(),
+          spk: s.cluster(),
+        })
+        .collect()
+    })
+    .expect(
+      "the production control (FluidAudioSource, retired int8/All) must cluster — its record \
+       ANSWERS with 5 of 8 speakers",
+    );
+  let control_spk = distinct_speakers(&control_segs).len();
+  let control_der = der_std(&reference, &control_segs);
+  println!(
+    "║ production control (FluidAudioSource + Extraction::diarize, int8/All): {control_spk} \
+     speakers, {:.4} % DER, {} err units",
+    control_der.der * 100.0,
+    control_der.err_units()
+  );
+  assert_eq!(
+    control_spk, SHIPPING_CORNER_SPK,
+    "the production control found {control_spk} speakers, not the retired shipping record's \
+     {SHIPPING_CORNER_SPK} — the real pipeline no longer reproduces the record every corner and \
+     hybrid here is read against"
+  );
+  assert!(
+    (control_der.der - SHIPPING_CORNER_DER).abs() <= CORNER_DER_TOL,
+    "the production control scored {:.4} % DER, off the retired shipping record's {:.4} % \
+     (±{:.4} %)",
+    control_der.der * 100.0,
+    SHIPPING_CORNER_DER * 100.0,
+    CORNER_DER_TOL * 100.0
+  );
+  // The equivalence gate: the hand assembly and the production pipeline must
+  // agree — count exactly, DER and error mass to the stray-frame bands.
+  let corner_cell = corner(Backend::CoreMl, Backend::CoreMl);
+  let corner_der = corner_cell
+    .der(&reference)
+    .expect("the all-CoreML corner clustered (checked above)");
+  assert_eq!(
+    control_spk,
+    corner_cell.spk().expect("corner clustered"),
+    "the production control and the hand-assembled all-CoreML corner disagree on the speaker \
+     count — `assemble` has diverged from `Extractor::extract`, and no hybrid cell can be read \
+     until that is fixed"
+  );
+  assert!(
+    (control_der.der - corner_der.der).abs() <= CORNER_DER_TOL,
+    "production control at {:.4} % DER vs the hand-assembled corner's {:.4} % — beyond the \
+     ±{:.4} % stray-frame band; `assemble` has diverged from `Extractor::extract`",
+    control_der.der * 100.0,
+    corner_der.der * 100.0,
+    CORNER_DER_TOL * 100.0
+  );
+  assert!(
+    control_der.err_units().abs_diff(corner_der.err_units()) <= ERR_UNITS_TOL,
+    "production control at {} err units vs the hand-assembled corner's {} — beyond \
+     ±{ERR_UNITS_TOL}; `assemble` has diverged from `Extractor::extract` at unit precision",
+    control_der.err_units(),
+    corner_der.err_units()
+  );
+
   assert_factorial_verdict(&FactorialObserved {
     onnx_onnx: cell(Backend::Onnx, Backend::Onnx),
     coreml_onnx: cell(Backend::CoreMl, Backend::Onnx),
@@ -1026,13 +1134,14 @@ struct FactorialObserved {
 ///
 /// # What this pins, and why each direction matters
 ///
-/// - **Both corners** are harness-validity checks against numbers the REAL
-///   pipelines pinned elsewhere: all-ONNX must reproduce dia-ort's 8 speakers
-///   at 0.0000 %, and all-CoreML must reproduce `parity_shipping_der`'s
-///   `int8/All` clip-09 pin (5 speakers, 16.5904 %). The all-CoreML corner
-///   lands on that pin to the printed precision — same DER, same 11 999
-///   confusion units — which is what licenses reading the two hybrid cells at
-///   all.
+/// - **Both corners** are harness-validity checks against the REAL pipelines:
+///   all-ONNX must reproduce dia-ort's 8 speakers at 0.0000 %, and all-CoreML
+///   must reproduce the retired int8/All shipping record (5 speakers,
+///   16.5904 %, 11 999 confusion units) that
+///   [`shipping_config_backend_factorial`]'s in-suite production control
+///   re-measures through `FluidAudioSource::extract` + `Extraction::diarize`
+///   on every run. The corner lands on that record to the printed precision,
+///   which is what licenses reading the two hybrid cells at all.
 /// - **`ONNX-seg + COREML-emb` is the finding.** Swapping ONLY the embedding
 ///   conversion, over dia's own reference segmentation, reproduces the
 ///   shipping failure exactly: 5 of 8 speakers at 16.5904 %, identical to the
@@ -1085,25 +1194,26 @@ fn assert_factorial_verdict(o: &FactorialObserved) {
     onnx_der * 100.0
   );
 
-  // ── Corner 2: the harness reproduces `Extractor::extract` at the shipping
-  // configuration, to `parity_shipping_der`'s own pinned numbers.
+  // ── Corner 2: the harness reproduces `Extractor::extract` at the retired
+  // int8/All configuration, to the record the in-suite production control
+  // re-measures.
   let (ship_spk, ship_der) = o.coreml_coreml.unwrap_or_else(|| {
     panic!(
-      "COREML-seg + COREML-emb did not cluster. `parity_shipping_der` pins this exact \
-       configuration as ANSWERING with {SHIPPING_CORNER_SPK} of 8 speakers; either the shipping \
-       path regressed to 'cannot answer at all' or this harness diverged from `Extractor::extract`."
+      "COREML-seg + COREML-emb did not cluster. The in-suite production control pins this exact \
+       configuration as ANSWERING with {SHIPPING_CORNER_SPK} of 8 speakers; either that path \
+       regressed to 'cannot answer at all' or this harness diverged from `Extractor::extract`."
     )
   });
   assert_eq!(
     ship_spk, SHIPPING_CORNER_SPK,
-    "COREML-seg + COREML-emb found {ship_spk} speakers; `parity_shipping_der` pins the identical \
-     artifacts/placement/decode at {SHIPPING_CORNER_SPK}. This corner is the harness's \
+    "COREML-seg + COREML-emb found {ship_spk} speakers; the in-suite production control pins the \
+     identical artifacts/placement/decode at {SHIPPING_CORNER_SPK}. This corner is the harness's \
      equivalence proof against `Extractor::extract` — investigate before reading any other cell."
   );
   assert!(
     (ship_der - SHIPPING_CORNER_DER).abs() <= CORNER_DER_TOL,
-    "COREML-seg + COREML-emb scored {:.4} % DER; `parity_shipping_der` pins the identical \
-     configuration at {:.4} % (±{:.4} %)",
+    "COREML-seg + COREML-emb scored {:.4} % DER; the in-suite production control pins the \
+     identical configuration at {:.4} % (±{:.4} %)",
     ship_der * 100.0,
     SHIPPING_CORNER_DER * 100.0,
     CORNER_DER_TOL * 100.0
@@ -1403,15 +1513,15 @@ fn embed_agreement(arm: &[f32], reference: &[f32]) -> EmbedAgreement {
 /// drags some rows to near-orthogonality (min cosine 0.035), yet it costs 1
 /// speaker and 1 839 error units; int8's much smaller, much more uniform
 /// perturbation costs 2 speakers and 11 835. So the size of the embedding
-/// perturbation does not predict the clustering outcome — consistent with
-/// `parity_shipping_der`'s module doc, which already argues that the KIND of
-/// perturbation matters rather than its magnitude, but pointing the opposite
-/// way from that doc's specific rationale: there, quantization was expected to
-/// be the benign, roughly isotropic one. On this clip it is the harmful one.
-/// What structure in the palettization error the frozen community-1 LDA/PLDA
-/// basis is sensitive to is NOT established here; it would need the
-/// perturbation decomposed against that basis, which nothing in this repo
-/// currently does.
+/// perturbation does not predict the clustering outcome. The KIND of
+/// perturbation is what matters — the int8-era `parity_shipping_der` module
+/// doc argued that shape too, but with the roles reversed (quantization was
+/// expected to be the benign, roughly isotropic one; on this clip it is the
+/// harmful one), and that rationale was retired with the artifact. WHAT
+/// structure the frozen community-1 LDA/PLDA basis is sensitive to is
+/// established by [`quantization_error_structure`]: the palettization delta
+/// is a coherent shared displacement that compresses between-cluster margins
+/// in that basis, while the placement scatter averages out.
 ///
 /// **The `embed_s` column is not a latency measurement.** It is wall time for
 /// one un-warmed pass, so it carries each arm's cold CoreML/ANE specialization,
@@ -1654,11 +1764,32 @@ struct PrecisionPlacementObserved {
 /// removed.
 const CELL_C_SPK: usize = 7;
 const CELL_C_DER: f64 = 0.025_427;
+const CELL_C_ERR_UNITS: u64 = 1_839;
 
 /// `CoreML int8 / CpuOnly` (cell D) — the quantization + conversion, placement
 /// removed.
 const CELL_D_SPK: usize = 6;
 const CELL_D_DER: f64 = 0.163_636;
+const CELL_D_ERR_UNITS: u64 = 11_835;
+
+/// Cell B's pinned error units — `parity_shipping_der`'s retired int8/All
+/// record in raw speaker-frames.
+const CELL_B_ERR_UNITS: u64 = 11_999;
+
+/// Band on the B/C/D error-unit pins. Each unit is one 10 ms scored frame; a
+/// cross-CoreML-build stray flip moves a boundary by a few frames, so ±10
+/// absorbs strays at far finer precision than the DER bands alone hold
+/// (±[`CORNER_DER_TOL`] admits ±36 units at this clip's 72 325 reference
+/// units).
+///
+/// What is GUARDED is each CELL's unit count. Derived cross-cell figures —
+/// the 11 999 − 11 835 = 164-unit placement contribution, the 98.6 %
+/// quantization share — are REPORTED measurements of the pinned run, not
+/// separately asserted invariants: within these cell bands the difference
+/// can drift by up to ±20 units and the share by ~±0.15 pp, and pinning the
+/// relations too would only push the same gap one level up. Every place this
+/// record cites 164 or 98.6 % labels them as measured values of that run.
+const ERR_UNITS_TOL: u64 = 10;
 
 /// `CoreML fp32 / CpuOnly` (cell E) — the conversion ALONE. It reproduces the
 /// dia-ort reference exactly, which is why its pin is `err_units == 0` rather
@@ -1697,15 +1828,17 @@ const CELL_E_SPK: usize = 8;
 ///   graph wrong".
 /// - **Quantization is the dominant term, and it is placement-independent.**
 ///   Holding placement fixed, int8 costs exactly 2 speakers at BOTH
-///   placements (E 8 -> D 6 on `CpuOnly`; C 7 -> B 5 on `All`) and it moves
-///   11 835 of cell B's 11 999 error units — 98.6 % of the shipping arm's
-///   entire error mass — on `CpuOnly` alone.
+///   placements (E 8 -> D 6 on `CpuOnly`; C 7 -> B 5 on `All`); the measured
+///   run's cell values put 11 835 of cell B's 11 999 error units — 98.6 % —
+///   on `CpuOnly` alone (derived figures REPORTED from the pinned run;
+///   [`ERR_UNITS_TOL`]'s doc states what is guarded vs reported).
 /// - **Placement is a real but minority term, and it too is
 ///   precision-independent.** Holding precision fixed, `All` costs exactly 1
-///   speaker at BOTH precisions (E 8 -> C 7 on fp32; D 6 -> B 5 on int8). Its
-///   error-unit cost is 1 839 in the fp32 arm (E 0 -> C 1 839) and 164 in the
-///   int8 arm (D 11 835 -> B 11 999) — the latter 1.4 % of the shipping arm's
-///   total, against quantization's 98.6 %.
+///   speaker at BOTH precisions (E 8 -> C 7 on fp32; D 6 -> B 5 on int8);
+///   the measured run's error-unit cost is 1 839 in the fp32 arm (E 0 ->
+///   C 1 839) and 164 in the int8 arm (D 11 835 -> B 11 999) — the latter
+///   1.4 % of the shipping arm's total, against quantization's 98.6 %
+///   (same reported-not-asserted status).
 /// - **Neither factor alone reproduces the shipping collapse.** Cell B is 5
 ///   speakers at 16.5904 %; the best either single factor manages is D's 6
 ///   speakers at 16.3636 % (nearly all the DER, one speaker short) or C's 7
@@ -1716,20 +1849,27 @@ const CELL_E_SPK: usize = 8;
 /// # What it does NOT establish
 ///
 /// - **It is one clip, one host, one segmentation backend.** Every arm here
-///   runs over dia's ONNX reference segmentation, which is NOT what this crate
-///   ships; `parity_shipping_der`'s arms run CoreML segmentation and land
-///   nearby but not identically (its int8/`CpuOnly` clip-09 arm is 6 speakers
-///   at 16.4590 %, against cell D's 16.3636 %).
-/// - **It does not price the remedy.** That fp32 recovers speakers HERE says
-///   nothing about what fp32 does to the other corpus clips, and no fp32/`All`
-///   DER arm exists for the gated clips (06 / 14 / 10) — `parity_shipping_der`
-///   measures fp32 only on `CpuOnly`. Deciding to ship fp32 needs that arm
-///   measured, clip 14 especially.
-/// - **It does not say WHY int8 costs two speakers.** Palettization changes the
+///   runs over dia's ONNX reference segmentation, which is NOT what this
+///   crate ships. Real-pipeline numbers (CoreML segmentation) land nearby
+///   but not identically — the retired int8-era record had the CoreML-seg
+///   int8/`CpuOnly` composition at 6 speakers / 16.4590 % against cell D's
+///   16.3636 % here — so no cell in this table doubles as a real-pipeline
+///   number.
+/// - **It does not price the remedy; `parity_shipping_der` does.** That fp32
+///   recovers speakers over the REFERENCE segmentation says nothing by
+///   itself about the shipped composition. The remedy's real-pipeline
+///   pricing is that suite's job today: it resolves the production fp32
+///   embedder and gates `seg@All + fp32@All` (with both CPU placement
+///   controls) on all four clips — 06 / 14 / 10 under [`gate`], clip 09
+///   under its pinned record.
+/// - **It does not say WHY int8 costs two speakers** —
+///   [`quantization_error_structure`] does. Palettization changes the
 ///   weights, not the graph: the two artifacts' op histograms are identical
-///   apart from 38 `constexpr_lut_to_dense` decompressions replacing 36 `const`
-///   weight tensors (and one dropped no-op `identity`). Which layer's
-///   perturbation the frozen LDA/PLDA basis is sensitive to is unmeasured.
+///   apart from 38 `constexpr_lut_to_dense` decompressions replacing 36
+///   `const` weight tensors (and one dropped no-op `identity`). Which LAYER's
+///   perturbation the frozen LDA/PLDA basis is sensitive to is still
+///   unmeasured; the probe pins the embedding-space mechanism, not a
+///   per-layer attribution.
 ///
 /// # Panics
 /// On any divergence from the pinned record, naming the cell and what the
@@ -1755,6 +1895,12 @@ fn assert_precision_placement_verdict(o: &PrecisionPlacementObserved) {
      so the harness has diverged from the reference pipeline",
     a.err_units
   );
+  assert!(
+    a.der == 0.0,
+    "cell A carries a DER of {:.4} % alongside zero error units — in a real measurement the two \
+     derive from one scoring pass and cannot disagree; this record is internally inconsistent",
+    a.der * 100.0
+  );
 
   // ── Cell B: this suite's arm B is `shipping_config_backend_factorial`'s
   // `ONNX-seg + COREML-emb` cell, re-measured. Same segmentation backend, same
@@ -1779,10 +1925,17 @@ fn assert_precision_placement_verdict(o: &PrecisionPlacementObserved) {
   assert!(
     (b.der - SHIPPING_CORNER_DER).abs() <= CORNER_DER_TOL,
     "cell B scored {:.4} % DER; the identical arm is pinned at {:.4} % (±{:.4} %) by \
-     `shipping_config_backend_factorial` and by `parity_shipping_der`'s int8/All clip-09 pin",
+     `shipping_config_backend_factorial`'s corner and its retired-int8 production control",
     b.der * 100.0,
     SHIPPING_CORNER_DER * 100.0,
     CORNER_DER_TOL * 100.0
+  );
+  assert!(
+    b.err_units.abs_diff(CELL_B_ERR_UNITS) <= ERR_UNITS_TOL,
+    "cell B scored {} error units, off the pinned {CELL_B_ERR_UNITS} (±{ERR_UNITS_TOL}) — the \
+     collapse's error mass moved at unit precision; the reported figures derived from it \
+     (see ERR_UNITS_TOL's doc) need re-deriving from the new run",
+    b.err_units
   );
 
   // ── THE FINDING, part 1: the conversion alone is CLEAN.
@@ -1809,6 +1962,12 @@ fn assert_precision_placement_verdict(o: &PrecisionPlacementObserved) {
      here weakens that to 'nearly clean', which is a different finding.",
     e.err_units
   );
+  assert!(
+    e.der == 0.0,
+    "cell E carries a DER of {:.4} % alongside zero error units — in a real measurement the two \
+     derive from one scoring pass and cannot disagree; this record is internally inconsistent",
+    e.der * 100.0
+  );
 
   // ── THE FINDING, part 2: quantization, placement held at CpuOnly.
   let d = o.int8_cpu.unwrap_or_else(|| {
@@ -1831,6 +1990,13 @@ fn assert_precision_placement_verdict(o: &PrecisionPlacementObserved) {
     d.der * 100.0,
     CELL_D_DER * 100.0,
     CORNER_DER_TOL * 100.0
+  );
+  assert!(
+    d.err_units.abs_diff(CELL_D_ERR_UNITS) <= ERR_UNITS_TOL,
+    "cell D scored {} error units, off the pinned {CELL_D_ERR_UNITS} (±{ERR_UNITS_TOL}) — the \
+     quantization arm's error mass moved at unit precision; the reported '98.6 %' share derived \
+     from it (see ERR_UNITS_TOL's doc) needs re-deriving from the new run",
+    d.err_units
   );
 
   // ── THE FINDING, part 3: placement, precision held at fp32.
@@ -1855,6 +2021,13 @@ fn assert_precision_placement_verdict(o: &PrecisionPlacementObserved) {
     c.der * 100.0,
     CELL_C_DER * 100.0,
     CORNER_DER_TOL * 100.0
+  );
+  assert!(
+    c.err_units.abs_diff(CELL_C_ERR_UNITS) <= ERR_UNITS_TOL,
+    "cell C scored {} error units, off the pinned {CELL_C_ERR_UNITS} (±{ERR_UNITS_TOL}) — the \
+     placement arm's error mass moved at unit precision; the reported figures derived from it \
+     (see ERR_UNITS_TOL's doc) need re-deriving from the new run",
+    c.err_units
   );
 }
 
@@ -1926,6 +2099,16 @@ fn precision_placement_verdict_pins_every_cell() {
     ),
     (
       |o: &mut PrecisionPlacementObserved| {
+        o.onnx_cpu = Some(CellOutcome {
+          spk: REFERENCE_CORNER_SPK,
+          der: 0.05,
+          err_units: 0,
+        });
+      },
+      "a cell-A DER that disagrees with its own zero error units",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
         o.int8_all = Some(CellOutcome {
           spk: 6,
           der: SHIPPING_CORNER_DER,
@@ -1943,6 +2126,16 @@ fn precision_placement_verdict_pins_every_cell() {
         });
       },
       "a moved cell-B DER",
+    ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.int8_all = Some(CellOutcome {
+          spk: EMBED_ONLY_SPK,
+          der: SHIPPING_CORNER_DER,
+          err_units: 12_035,
+        });
+      },
+      "a cell-B error mass drifted 36 units inside the DER band",
     ),
     (
       |o: &mut PrecisionPlacementObserved| o.int8_all = None,
@@ -1969,6 +2162,16 @@ fn precision_placement_verdict_pins_every_cell() {
       "a cell-C DER that moved to the shipping arm's",
     ),
     (
+      |o: &mut PrecisionPlacementObserved| {
+        o.fp32_all = Some(CellOutcome {
+          spk: CELL_C_SPK,
+          der: CELL_C_DER,
+          err_units: 1_875,
+        });
+      },
+      "a cell-C error mass drifted 36 units inside the DER band",
+    ),
+    (
       |o: &mut PrecisionPlacementObserved| o.fp32_all = None,
       "a cell-C clustering refusal",
     ),
@@ -1993,6 +2196,17 @@ fn precision_placement_verdict_pins_every_cell() {
       "a moved cell-D DER",
     ),
     (
+      |o: &mut PrecisionPlacementObserved| {
+        o.int8_cpu = Some(CellOutcome {
+          spk: CELL_D_SPK,
+          der: CELL_D_DER,
+          err_units: 11_799,
+        });
+      },
+      "a cell-D error mass drifted 36 units inside the DER band (the 98.6 % share silently \
+       becoming 98.0 %)",
+    ),
+    (
       |o: &mut PrecisionPlacementObserved| o.int8_cpu = None,
       "a cell-D clustering refusal",
     ),
@@ -2014,9 +2228,898 @@ fn precision_placement_verdict_pins_every_cell() {
       |o: &mut PrecisionPlacementObserved| o.fp32_cpu = None,
       "a cell-E clustering refusal",
     ),
+    (
+      |o: &mut PrecisionPlacementObserved| {
+        o.fp32_cpu = Some(CellOutcome {
+          spk: CELL_E_SPK,
+          der: 0.05,
+          err_units: 0,
+        });
+      },
+      "a cell-E DER that disagrees with its own zero error units",
+    ),
   ] {
     let mut o = good;
     mutate(&mut o);
     fails(o, what);
   }
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// The mechanism probe: WHAT KIND of perturbation each factor applies
+// ══════════════════════════════════════════════════════════════════════
+
+/// One arm's per-row 256-d f64 embeddings, `None` for dead rows.
+type ArmRows = Vec<Option<[f64; EMBEDDING_DIM]>>;
+
+/// Per-row 256-d f64 copy of one arm's raw embeddings, `None` for dead rows.
+fn arm_rows(raw: &[f32]) -> ArmRows {
+  raw
+    .as_chunks::<EMBEDDING_DIM>()
+    .0
+    .iter()
+    .map(|r| {
+      if r.iter().any(|v| *v != 0.0) {
+        Some(core::array::from_fn(|d| f64::from(r[d])))
+      } else {
+        None
+      }
+    })
+    .collect()
+}
+
+fn norm(v: &[f64]) -> f64 {
+  v.iter().map(|x| x * x).sum::<f64>().sqrt()
+}
+
+fn cos64(a: &[f64], b: &[f64]) -> f64 {
+  let (na, nb) = (norm(a), norm(b));
+  if na == 0.0 || nb == 0.0 {
+    return f64::NAN;
+  }
+  a.iter().zip(b).map(|(x, y)| x * y).sum::<f64>() / (na * nb)
+}
+
+/// How one arm's per-row perturbation against the fp32/`CpuOnly` base is
+/// SHAPED, in the raw 256-d space: its size, and how much of it is one shared
+/// direction versus independent per-row scatter.
+struct DeltaShape {
+  rows: usize,
+  /// Mean per-row `‖Δ‖`.
+  mean_norm: f64,
+  /// `‖mean(Δ)‖` — the shared (coherent) component's size.
+  bias_norm: f64,
+  /// `mean(Δ)` itself — the shared component's DIRECTION, kept so the verdict
+  /// can compare arms' bias directions rather than only their sizes.
+  bias: [f64; EMBEDDING_DIM],
+  /// `‖mean(Δ)‖ / mean(‖Δ‖)`. Independent zero-mean scatter drives this
+  /// toward `1/sqrt(rows)` (~0.02 at 2 114 rows); a shared bias holds it up.
+  coherence: f64,
+  /// Mean `cos(Δ_i, mean(Δ))` — how aligned individual rows' perturbations
+  /// are with the shared direction.
+  mean_cos_to_bias: f64,
+  /// Fraction of rows with `cos(Δ_i, mean(Δ)) > 0`.
+  frac_pos: f64,
+  /// Rows whose delta is exactly zero — bit-identical in both arms. Excluded
+  /// from the two alignment stats above (no direction to compare).
+  zero_deltas: usize,
+}
+
+fn delta_shape(
+  arm: &[Option<[f64; EMBEDDING_DIM]>],
+  base: &[Option<[f64; EMBEDDING_DIM]>],
+) -> DeltaShape {
+  let deltas: Vec<[f64; EMBEDDING_DIM]> = arm
+    .iter()
+    .zip(base)
+    .filter_map(|(a, b)| match (a, b) {
+      (Some(a), Some(b)) => Some(core::array::from_fn(|d| a[d] - b[d])),
+      _ => None,
+    })
+    .collect();
+  let rows = deltas.len();
+  let mut bias = [0.0f64; EMBEDDING_DIM];
+  for d in &deltas {
+    for (m, v) in bias.iter_mut().zip(d) {
+      *m += v;
+    }
+  }
+  for m in &mut bias {
+    *m /= rows as f64;
+  }
+  let mean_norm = deltas.iter().map(|d| norm(d)).sum::<f64>() / rows as f64;
+  let bias_norm = norm(&bias);
+  // A zero delta (a row identical in both arms) has no direction, so a cosine
+  // against the bias is undefined for it; such rows are excluded from the
+  // alignment stats rather than poisoning the mean with NaN. They still count
+  // toward `rows`/`mean_norm`/`coherence` — an exactly-agreeing row is real
+  // agreement data.
+  let cosines: Vec<f64> = deltas
+    .iter()
+    .filter(|d| d.iter().any(|v| *v != 0.0))
+    .map(|d| cos64(d, &bias))
+    .collect();
+  let directed = cosines.len().max(1);
+  DeltaShape {
+    rows,
+    mean_norm,
+    bias_norm,
+    bias,
+    coherence: bias_norm / mean_norm,
+    mean_cos_to_bias: cosines.iter().sum::<f64>() / directed as f64,
+    frac_pos: cosines.iter().filter(|c| **c > 0.0).count() as f64 / directed as f64,
+    zero_deltas: rows - cosines.len(),
+  }
+}
+
+/// Clusters one cell keeping diaric's full output (hard per-(chunk, slot)
+/// assignments included), unlike [`cluster`] which keeps only the spans.
+fn cluster_full(
+  cell: &Cell,
+  window: &WindowOptions,
+  plda: &diaric::plda::PldaTransform,
+) -> Result<diaric::offline::OfflineOutput, diaric::offline::Error> {
+  let count = count_from_segmentations(
+    &cell.segmentations,
+    cell.num_chunks,
+    cell.num_frames,
+    SEG_NUM_SLOTS,
+    window.onset(),
+    chunk_sliding_window(window),
+    frame_sliding_window(),
+  );
+  let input = diaric::offline::OfflineInput::new(
+    &cell.raw_embeddings,
+    cell.num_chunks,
+    SEG_NUM_SLOTS,
+    &cell.segmentations,
+    cell.num_frames,
+    &count,
+    count.len(),
+    chunk_sliding_window(window).into(),
+    frame_sliding_window().into(),
+    plda,
+  );
+  diaric::offline::diarize_offline(&input)
+}
+
+/// The decision-relevant shape statistics of one arm's perturbation and its
+/// effect in the clustering space, extracted from the measurement (or
+/// synthesized by [`mechanism_verdict_pins_every_field`]) so
+/// [`assert_mechanism_verdict`] is a pure function both can call.
+#[derive(Clone, Copy, Debug)]
+struct ArmMechanism {
+  /// `‖mean(Δ)‖ / mean(‖Δ‖)` vs cell E ([`DeltaShape::coherence`]).
+  coherence: f64,
+  /// Fraction of rows whose delta has positive projection on the shared bias.
+  frac_pos: f64,
+  /// Mean per-row `‖Δ‖` vs cell E ([`DeltaShape::mean_norm`]) — the arm's
+  /// per-row perturbation SIZE.
+  mean_norm: f64,
+  /// `mean(Δ)` vs cell E ([`DeltaShape::bias`]) — the shared (coherent)
+  /// component, direction AND size. A scalar norm alone admits a bias
+  /// pointing anywhere; the vector is what lets the verdict hold two arms to
+  /// the SAME direction.
+  bias: [f64; EMBEDDING_DIM],
+  /// Rows paired live in both this arm and cell E ([`DeltaShape::rows`]).
+  rows: usize,
+  /// Rows whose delta is exactly zero ([`DeltaShape::zero_deltas`]). A
+  /// summary over mostly-zero deltas can reproduce every ratio above from a
+  /// single moved embedding; this counter is what forbids that record.
+  zero_deltas: usize,
+  /// Mean cos-to-own-centroid of the arm's PLDA-projected rows, grouped by
+  /// cell E's labels — within-cluster tightness.
+  within: f64,
+  /// The LARGEST positive between-E-cluster centroid-cosine movement vs cell
+  /// E's own geometry — margin compression toward an AHC merge.
+  max_pair_gain: f64,
+}
+
+/// The mechanism record: cells D (quantization isolated), C (placement
+/// isolated) and B (the int8-era shipping bundle) against base E, plus E's
+/// own within-cluster tightness and mean raw embedding norm.
+#[derive(Clone, Copy, Debug)]
+struct MechanismObserved {
+  base_within: f64,
+  /// Mean raw `‖x‖` of cell E's live rows — the scale the bias sizes are
+  /// read against.
+  base_mean_norm: f64,
+  d: ArmMechanism,
+  c: ArmMechanism,
+  b: ArmMechanism,
+}
+
+/// **The measured mechanism, pinned** (clip 09, dia reference segmentation
+/// fixed, Apple M1 Max, macOS 26.5 build 25F71, arm64; the independent-scatter
+/// null for `coherence` is `1/sqrt(2114)` ≈ 0.022; cell E's mean raw `‖x‖` is
+/// 2.5182):
+///
+/// ```text
+/// cell |            arm | rows |  Δ=0 | coherence | frac>0 | mean|Δ| |  |bias| | within (E 0.6813) | max pair Δcos
+/// -----+----------------+------+------+-----------+--------+---------+--------+-------------------+--------------
+///    D | int8 / CpuOnly | 2114 |    9 |    0.5039 | 0.9868 | 0.12223 | 0.0616 |            0.6812 |       +0.0504
+///    C | fp32 / All     | 2114 |    4 |    0.0624 | 0.6026 | 0.18897 | 0.0118 |            0.6811 |       +0.0196
+///    B | int8 / All     | 2114 |    4 |    0.2473 | 0.9669 | 0.25264 | 0.0625 |            0.6809 |       +0.0524
+/// ```
+///
+/// Every causal claim the record documents is guarded below — a claim this
+/// gate cannot catch is a claim this gate does not support:
+///
+/// - **The statistics summarize the whole population, not an outlier.** Every
+///   arm pairs all 2 114 live rows against cell E, and at most a handful are
+///   bit-identical (measured 4-9). Without these two guards a single moved
+///   embedding among zero deltas reproduces every ratio below. Guards:
+///   `rows == 2114` and `zero_deltas <= 20`, per arm.
+/// - **Quantization error is COHERENT** (D: half the perturbation mass is one
+///   shared direction, 23x the independent-scatter null; 98.7 % of rows
+///   aligned with it). The palettization applies a near-constant displacement
+///   to every embedding — NOT the "roughly isotropic, unbiased noise" the
+///   int8 DECISION's original rationale assumed. Guards: `d.coherence`,
+///   `d.frac_pos`.
+/// - **The int8-era shipping bundle B carries D's displacement — the same
+///   DIRECTION, not merely a same-sized one** (B keeps 96.7 % alignment
+///   against its own bias, and its bias vector must lie in D's half-space
+///   cone). Guards: `b.coherence`, `b.frac_pos`, and
+///   `cos(bias_B, bias_D) >= 0.70` — the floor separates the shared-direction
+///   mechanism from the orthogonal/opposite counterexample class, the way
+///   `NULL_COHERENCE` separates coherence from scatter. B's per-row
+///   magnitude carries no causal claim of its own, but its table row is part
+///   of this pinned record, so it is held to the record band
+///   `b.mean_norm ∈ [0.20, 0.31]` around the measured 0.25264 — the bundle
+///   keeps its stacked-perturbation scale (a collapse to D's ~0.12 would
+///   mean the placement scatter vanished from the bundle).
+/// - **Placement error is NEAR-ISOTROPIC and LARGER per row** (C: coherence
+///   within ~3x of the null, alignment near chance, per-row magnitude 1.5x
+///   D's — the anti-correlation of perturbation size with clustering
+///   damage). Guards: `c.coherence`, `c.frac_pos`, and the two-sided ratio
+///   `c.mean_norm / d.mean_norm ∈ [1.25, 1.85]` around the measured 1.55.
+/// - **The coherent component is what distinguishes the arms**: D's shared
+///   bias is ~2.4 % of the mean embedding norm and ~5x C's. Guards:
+///   `‖bias_D‖ / base_mean_norm ∈ [0.015, 0.035]` and
+///   `‖bias_D‖ / ‖bias_C‖ ∈ [4.0, 7.0]` around the measured 5.2.
+/// - **The damage is between-class compression, not added scatter**: every
+///   arm's within-cluster tightness equals E's to three decimals — guarded at
+///   that stated precision (±0.0005) — while D and B move their worst
+///   between-centroid pair by at least +0.03 cosine (measured +0.05) toward
+///   AHC's merge region and C stays below that. Which specific clusters then
+///   lose their identity is the printed merge contingency's report, not an
+///   asserted claim. Guards: `within` per arm, `max_pair_gain` per arm.
+///
+/// # Panics
+/// On any divergence from the pinned mechanism, naming what changed and what
+/// record it invalidates.
+fn assert_mechanism_verdict(o: &MechanismObserved) {
+  /// The independent-scatter null for the coherence statistic at 2 114 rows,
+  /// named in the panic messages.
+  const NULL_COHERENCE: f64 = 0.022;
+  /// Every arm pairs this many live `(chunk, slot)` rows against cell E —
+  /// the probe's full population, with zero `PLDA_MIN_NORM` drop
+  /// disagreements.
+  const MECHANISM_ROWS: usize = 2_114;
+  /// Ceiling on bit-identical rows per arm (measured 4-9). A mostly-zero
+  /// delta field is the degenerate record in which one moved embedding
+  /// reproduces every summary ratio.
+  const MAX_ZERO_DELTAS: usize = 20;
+
+  for (name, arm) in [("D", &o.d), ("C", &o.c), ("B", &o.b)] {
+    assert_eq!(
+      arm.rows, MECHANISM_ROWS,
+      "cell {name}: {} rows paired against cell E, not the probe's full {MECHANISM_ROWS} — the \
+       population these statistics summarize changed; nothing below can be read until the \
+       coverage is re-established",
+      arm.rows
+    );
+    assert!(
+      arm.zero_deltas <= MAX_ZERO_DELTAS,
+      "cell {name}: {} of {MECHANISM_ROWS} rows have an exactly-zero delta (measured 4-9). A \
+       mostly-zero delta field lets a handful of moved embeddings reproduce every summary ratio \
+       this verdict checks; the statistics no longer describe the population",
+      arm.zero_deltas
+    );
+  }
+
+  assert!(
+    o.d.coherence >= 0.35,
+    "int8/CpuOnly delta coherence {:.4} is no longer far above the isotropic null \
+     ({NULL_COHERENCE}) — the 'palettization error is a coherent shared displacement' mechanism \
+     (model_io.rs) is stale; re-derive it before trusting any conclusion built on it",
+    o.d.coherence
+  );
+  assert!(
+    o.d.frac_pos >= 0.95,
+    "int8/CpuOnly bias alignment {:.4} dropped below 0.95 — the shared-direction claim weakened",
+    o.d.frac_pos
+  );
+  assert!(
+    o.c.coherence <= 0.15,
+    "fp32/All delta coherence {:.4} is no longer near-isotropic — the placement axis developed a \
+     systematic component; the C-vs-D mechanism contrast is stale",
+    o.c.coherence
+  );
+  assert!(
+    o.c.frac_pos <= 0.75,
+    "fp32/All bias alignment {:.4} rose above 0.75 — placement error is no longer directionless",
+    o.c.frac_pos
+  );
+  assert!(
+    o.b.coherence >= 0.20,
+    "int8/All delta coherence {:.4} lost the quantization bias component (0.2473 measured for \
+     the int8-era shipping bundle) — B no longer carries D's coherent displacement",
+    o.b.coherence
+  );
+  assert!(
+    o.b.frac_pos >= 0.90,
+    "int8/All bias alignment {:.4} dropped below 0.90 (0.9669 measured) — the shipping bundle no \
+     longer shares the quantization arm's one-signed displacement; the mechanism's claim that B \
+     carries D's bias is stale",
+    o.b.frac_pos
+  );
+  assert!(
+    (0.20..=0.31).contains(&o.b.mean_norm),
+    "int8/All per-row perturbation {:.5} left the record band [0.20, 0.31] around the measured \
+     0.25264 — the bundle no longer carries its stacked quantization-plus-placement scale; \
+     re-derive the record",
+    o.b.mean_norm
+  );
+  let bd_alignment = cos64(&o.b.bias, &o.d.bias);
+  assert!(
+    bd_alignment >= 0.70,
+    "cos(bias_B, bias_D) = {bd_alignment:.4}: the int8/All bundle's shared displacement no \
+     longer points where int8/CpuOnly's does. Equal-sized biases in different directions are a \
+     DIFFERENT mechanism; the record's 'B carries D's displacement' claim is stale"
+  );
+  let size_ratio = o.c.mean_norm / o.d.mean_norm;
+  assert!(
+    (1.25..=1.85).contains(&size_ratio),
+    "fp32/All per-row perturbation is {size_ratio:.3}x int8/CpuOnly's ({:.5} / {:.5}), outside \
+     the pinned [1.25, 1.85] band around the measured 1.55 — the anti-correlation record (the \
+     LARGER perturbation does LESS damage) no longer matches its measurement; re-derive before \
+     citing it",
+    o.c.mean_norm,
+    o.d.mean_norm
+  );
+  let bias_ratio = norm(&o.d.bias) / norm(&o.c.bias);
+  assert!(
+    (4.0..=7.0).contains(&bias_ratio),
+    "int8/CpuOnly shared bias is {bias_ratio:.2}x fp32/All's ({:.4} / {:.4}), outside the pinned \
+     [4.0, 7.0] band around the measured 5.2 — the '|bias| ~5x' record no longer matches its \
+     measurement; re-derive before citing it",
+    norm(&o.d.bias),
+    norm(&o.c.bias)
+  );
+  let bias_frac = norm(&o.d.bias) / o.base_mean_norm;
+  assert!(
+    (0.015..=0.035).contains(&bias_frac),
+    "int8/CpuOnly shared bias is {:.4} of the mean embedding norm ({:.4} / {:.4}), outside the \
+     pinned [0.015, 0.035] band around the measured 0.024 — the bias magnitude story changed in \
+     one direction or the other; re-derive before citing '~2.4 % of norm'",
+    bias_frac,
+    norm(&o.d.bias),
+    o.base_mean_norm
+  );
+  for (name, arm) in [("D", &o.d), ("C", &o.c), ("B", &o.b)] {
+    assert!(
+      (arm.within - o.base_within).abs() <= 0.000_5,
+      "cell {name}: within-cluster tightness {:.4} moved from E's {:.4} beyond ±0.0005 — the \
+       'unchanged to three decimals' record no longer holds; the damage may have stopped being \
+       pure between-class compression",
+      arm.within,
+      o.base_within
+    );
+  }
+  for (name, arm) in [("D", &o.d), ("B", &o.b)] {
+    assert!(
+      arm.max_pair_gain >= 0.03,
+      "cell {name}: worst between-centroid margin compression {:+.4} fell below +0.03 — int8 no \
+       longer visibly compresses a speaker-pair margin, so the collapse must have another cause; \
+       re-derive the mechanism",
+      arm.max_pair_gain
+    );
+  }
+  assert!(
+    o.c.max_pair_gain <= 0.03,
+    "cell C: worst between-centroid margin compression {:+.4} exceeds +0.03 — the placement now \
+     compresses margins as much as quantization does; the minority-factor record is stale",
+    o.c.max_pair_gain
+  );
+}
+
+/// [`assert_mechanism_verdict`] pins EVERY field in the direction that
+/// invalidates the recorded mechanism — proven hermetically: the measured
+/// record passes, and each single-field perturbation fails, including the
+/// degenerate-record classes (a bias pointing elsewhere, a mostly-zero delta
+/// field, lost or phantom row coverage) and values just inside the former,
+/// looser bounds. Same falsifiability contract as
+/// [`precision_placement_verdict_pins_every_cell`].
+#[test]
+fn mechanism_verdict_pins_every_field() {
+  /// A vector with `v` at index `i`, zero elsewhere — the synthetic bias
+  /// directions the hermetic record is built from.
+  fn axis(i: usize, v: f64) -> [f64; EMBEDDING_DIM] {
+    let mut a = [0.0; EMBEDDING_DIM];
+    a[i] = v;
+    a
+  }
+  /// The measured record (bias directions synthesized: D and B share one
+  /// axis, as the live probe's B·D alignment guard demands; C on another).
+  fn good() -> MechanismObserved {
+    MechanismObserved {
+      base_within: 0.6813,
+      base_mean_norm: 2.5182,
+      d: ArmMechanism {
+        coherence: 0.5039,
+        frac_pos: 0.9868,
+        mean_norm: 0.12223,
+        bias: axis(0, 0.0616),
+        rows: 2_114,
+        zero_deltas: 9,
+        within: 0.6812,
+        max_pair_gain: 0.0504,
+      },
+      c: ArmMechanism {
+        coherence: 0.0624,
+        frac_pos: 0.6026,
+        mean_norm: 0.18897,
+        bias: axis(1, 0.0118),
+        rows: 2_114,
+        zero_deltas: 4,
+        within: 0.6811,
+        max_pair_gain: 0.0196,
+      },
+      b: ArmMechanism {
+        coherence: 0.2473,
+        frac_pos: 0.9669,
+        mean_norm: 0.25264,
+        bias: axis(0, 0.0625),
+        rows: 2_114,
+        zero_deltas: 4,
+        within: 0.6809,
+        max_pair_gain: 0.0524,
+      },
+    }
+  }
+  assert_mechanism_verdict(&good());
+
+  let fails = |mutate: fn(&mut MechanismObserved), what: &str| {
+    let mut o = good();
+    mutate(&mut o);
+    assert!(
+      std::panic::catch_unwind(move || assert_mechanism_verdict(&o)).is_err(),
+      "assert_mechanism_verdict accepted a record with {what} — that field is NOT pinned"
+    );
+  };
+  fails(
+    |o| o.d.coherence = 0.05,
+    "an isotropic int8 delta (the coherence claim gone)",
+  );
+  fails(|o| o.d.frac_pos = 0.6, "an unaligned int8 delta");
+  fails(
+    |o| o.c.coherence = 0.4,
+    "a systematic placement delta (the isotropy contrast gone)",
+  );
+  fails(|o| o.c.frac_pos = 0.95, "a directional placement delta");
+  fails(
+    |o| o.b.coherence = 0.05,
+    "a shipping bundle without the bias",
+  );
+  fails(
+    |o| o.b.frac_pos = 0.5,
+    "a shipping bundle whose rows no longer align with the shared bias",
+  );
+  fails(
+    |o| o.b.mean_norm = f64::NAN,
+    "a NaN shipping-bundle magnitude",
+  );
+  fails(
+    |o| o.b.mean_norm = 0.13,
+    "a shipping bundle collapsed to the quantization arm's scale (placement scatter gone)",
+  );
+  fails(
+    |o| o.b.mean_norm = 0.40,
+    "a shipping bundle far above its recorded scale",
+  );
+  // The direction class: equal-sized biases pointing elsewhere.
+  fails(
+    |o| o.b.bias = axis(1, 0.0625),
+    "a shipping-bundle bias orthogonal to quantization's",
+  );
+  fails(
+    |o| o.b.bias = axis(0, -0.0625),
+    "a shipping-bundle bias opposite to quantization's",
+  );
+  // The coverage class: statistics no longer describing the population.
+  fails(
+    |o| o.d.zero_deltas = 2_113,
+    "a mostly-zero delta field (one moved embedding faking every ratio)",
+  );
+  fails(|o| o.d.rows = 2_113, "a probe that lost a row of coverage");
+  fails(|o| o.b.rows = 2_115, "a probe that grew phantom coverage");
+  // The size-ordering band, wild and just inside the former ordering-only
+  // guard.
+  fails(
+    |o| o.c.mean_norm = 0.05,
+    "an inverted size ordering (placement no longer perturbs more per row)",
+  );
+  fails(
+    |o| o.c.mean_norm = 0.1234,
+    "a size ratio of 1.01x — ordered, but far off the measured 1.55x",
+  );
+  fails(
+    |o| o.c.mean_norm = 0.245,
+    "a size ratio of 2.0x, past the pinned band",
+  );
+  // The bias-ratio band, floor and ceiling.
+  fails(
+    |o| o.c.bias = axis(1, 0.02),
+    "a placement bias grown to within 4x of quantization's",
+  );
+  fails(
+    |o| o.c.bias = axis(1, 0.001),
+    "a placement bias so small the coherence contrast reads 61.6x — far off its measurement",
+  );
+  // The fraction-of-norm band, both sides.
+  fails(
+    |o| o.d.bias = axis(0, 0.09),
+    "a quantization bias above the pinned fraction-of-norm band",
+  );
+  fails(
+    |o| o.base_mean_norm = 5.0,
+    "a quantization bias below the pinned fraction-of-norm band",
+  );
+  // Within-cluster tightness, wild and just inside the former tolerance.
+  fails(
+    |o| o.d.within = 0.60,
+    "a within-cluster collapse under quantization",
+  );
+  fails(
+    |o| o.d.within = 0.6773,
+    "a within-cluster drift of 0.004 — outside the stated three-decimals equality",
+  );
+  fails(
+    |o| o.c.within = 0.75,
+    "a within-cluster change under placement",
+  );
+  fails(
+    |o| o.b.within = 0.60,
+    "a within-cluster collapse under the shipping bundle",
+  );
+  fails(
+    |o| o.d.max_pair_gain = 0.001,
+    "an int8 arm that no longer compresses any margin",
+  );
+  fails(
+    |o| o.b.max_pair_gain = 0.001,
+    "a shipping bundle that no longer compresses any margin",
+  );
+  fails(
+    |o| o.c.max_pair_gain = 0.06,
+    "a placement arm compressing margins like quantization",
+  );
+}
+
+/// **WHY does the int8 palettization cost speakers when its per-row
+/// perturbation is ~9x SMALLER than the `All` placement's?** The DER factorial
+/// ([`embedding_precision_x_placement`]) pinned the outcome; this probe pins
+/// the mechanism, on the same clip, same host, same fixed reference
+/// segmentation.
+///
+/// Three measurements per arm, each against cell E (fp32/`CpuOnly`, the
+/// frame-perfect conversion base):
+///
+/// 1. **Raw-space delta SHAPE** ([`DeltaShape`]): how much of the arm's
+///    perturbation is ONE shared direction (a bias all rows move along)
+///    versus independent per-row scatter.
+/// 2. **Clustering-space between-speaker margins**: every live row projected
+///    through diaric's own frozen community-1 transform
+///    (`PldaTransform::project` — center on the FROZEN mean, L2-normalize,
+///    LDA, re-center, re-normalize, PLDA-whiten), grouped by cell E's own
+///    hard-cluster labels, and the pairwise centroid cosines compared arm
+///    vs E. AHC merges at cosine distance `1 - max(0, cos) < 0.6`, so a
+///    between-centroid cosine climbing toward and past 0.4 is the margin
+///    that decides a merge.
+/// 3. **Merge contingency**: which of E's 8 clusters land in the same
+///    cluster of the arm's own diarization — naming the speakers that
+///    collapse rather than inferring them from a count.
+///
+/// The report prints in full before any assertion fires.
+#[test]
+#[ignore = "requires speakerkit models, dia parity fixtures + WeSpeaker ONNX (17 min of audio, 1 seg + 5 embed passes)"]
+fn quantization_error_structure() {
+  let audio = fixtures_root().join(CLIP).join("clip_16k.wav");
+  assert!(
+    audio.exists(),
+    "clip audio not found (set DIA_PARITY_FIXTURES)"
+  );
+  assert!(
+    common::embed_path().exists() && common::embed_fp32_path().exists(),
+    "need BOTH wespeaker_v2.mlmodelc and wespeaker.mlmodelc (set SPEAKERKIT_TEST_MODELS)"
+  );
+  let samples = common::load_wav_16k_mono(&audio);
+  assert_eq!(
+    samples.len(),
+    CLIP_SAMPLES,
+    "{CLIP}: audio identity changed"
+  );
+  assert_eq!(common::fnv1a_f32(&samples), CLIP_AUDIO_FNV);
+
+  let window = Options::new().window();
+  let starts = chunk_starts(samples.len(), &window);
+  let plda = diaric::plda::PldaTransform::new().expect("load community-1 PldaTransform (diaric)");
+  let seg = run_seg(Backend::Onnx, &samples, &starts);
+
+  println!(
+    "\n╔══ quantization error structure — {CLIP} ══\n║ reference segmentation: dia ONNX, fixed | \
+     {} chunks x {SEG_NUM_SLOTS} slots",
+    starts.len()
+  );
+
+  // ── The five arms' raw embeddings + full clustering outputs.
+  let mut rows_by_cell: Vec<(char, EmbedArm, ArmRows)> = Vec::new();
+  let mut outs_by_cell: Vec<(
+    char,
+    Result<diaric::offline::OfflineOutput, diaric::offline::Error>,
+  )> = Vec::new();
+  for (i, arm) in PRECISION_PLACEMENT_ARMS.into_iter().enumerate() {
+    let cell_tag = char::from(b'A' + u8::try_from(i).expect("five arms"));
+    let mut embed = EmbedSide::load(arm);
+    let assembled = assemble(&seg, &mut embed, &samples, &starts);
+    let out = cluster_full(&assembled, &window, &plda);
+    println!(
+      "║ ran {cell_tag}: {:<24} -> {}",
+      arm.label(),
+      match &out {
+        Ok(o) => format!(
+          "{} speakers",
+          distinct_speakers(
+            &o.spans_slice()
+              .iter()
+              .map(|s| Seg {
+                start: s.start(),
+                end: s.start() + s.duration(),
+                spk: s.cluster(),
+              })
+              .collect::<Vec<_>>()
+          )
+          .len()
+        ),
+        Err(e) => format!("CLUSTERING FAILED — {e}"),
+      }
+    );
+    rows_by_cell.push((cell_tag, arm, arm_rows(&assembled.raw_embeddings)));
+    outs_by_cell.push((cell_tag, out));
+  }
+
+  let rows_of = |tag: char| -> &ArmRows {
+    &rows_by_cell
+      .iter()
+      .find(|(c, ..)| *c == tag)
+      .expect("cell ran")
+      .2
+  };
+  let out_of = |tag: char| -> &diaric::offline::OfflineOutput {
+    match &outs_by_cell
+      .iter()
+      .find(|(c, _)| *c == tag)
+      .expect("cell ran")
+      .1
+    {
+      Ok(o) => o,
+      Err(e) => panic!("cell {tag} failed to cluster ({e}); the probe needs its labels"),
+    }
+  };
+
+  // ── 1. Delta shape vs cell E, raw 256-d space.
+  println!(
+    "║\n║ raw-space perturbation vs cell E (fp32/CpuOnly):\n║ {:>4} | {:>24} | {:>5} | {:>5} | \
+     {:>9} | {:>9} | {:>9} | {:>11} | {:>8}",
+    "cell", "arm", "rows", "Δ=0", "mean|Δ|", "|bias|", "coherence", "cos(Δ,bias)", "frac>0"
+  );
+  let base = rows_of('E');
+  let mut shapes: std::collections::BTreeMap<char, DeltaShape> = std::collections::BTreeMap::new();
+  for (tag, arm, rows) in rows_by_cell.iter().filter(|(c, ..)| *c != 'E') {
+    let s = delta_shape(rows, base);
+    println!(
+      "║ {tag:>4} | {:>24} | {:>5} | {:>5} | {:>9.5} | {:>9.5} | {:>9.4} | {:>11.4} | {:>8.4}",
+      arm.label(),
+      s.rows,
+      s.zero_deltas,
+      s.mean_norm,
+      s.bias_norm,
+      s.coherence,
+      s.mean_cos_to_bias,
+      s.frac_pos,
+    );
+    shapes.insert(*tag, s);
+  }
+  let mean_norm_of = |tag: char| -> f64 {
+    let rows = rows_of(tag);
+    let live: Vec<f64> = rows.iter().flatten().map(|r| norm(r)).collect();
+    live.iter().sum::<f64>() / live.len() as f64
+  };
+  println!(
+    "║ mean raw ‖x‖: A {:.4} | B {:.4} | C {:.4} | D {:.4} | E {:.4}",
+    mean_norm_of('A'),
+    mean_norm_of('B'),
+    mean_norm_of('C'),
+    mean_norm_of('D'),
+    mean_norm_of('E'),
+  );
+  println!(
+    "║ bias-direction alignment: cos(bias_B, bias_D) {:.4} | cos(bias_C, bias_D) {:.4}",
+    cos64(&shapes[&'B'].bias, &shapes[&'D'].bias),
+    cos64(&shapes[&'C'].bias, &shapes[&'D'].bias),
+  );
+
+  // ── 2. Between-speaker margins in diaric's own clustering space, grouped
+  // by cell E's hard labels (E reproduces dia-ort frame-perfectly, so its
+  // labels are the reference partition).
+  let e_hard = out_of('E').hard_clusters();
+  let e_label = |row: usize| -> i32 { e_hard[row / SEG_NUM_SLOTS][row % SEG_NUM_SLOTS] };
+  let n_clusters = 1
+    + e_hard
+      .iter()
+      .flatten()
+      .copied()
+      .max()
+      .expect("nonempty hard clusters");
+  assert!(
+    n_clusters >= 2,
+    "need at least two E-clusters to measure margins"
+  );
+
+  // Per arm: per-E-cluster centroid of the PLDA-projected live rows.
+  let projected_centroids = |tag: char| -> (Vec<Vec<f64>>, usize, f64) {
+    let rows = rows_of(tag);
+    let mut sums = vec![vec![0.0f64; 128]; usize::try_from(n_clusters).expect("cluster count")];
+    let mut counts = vec![0usize; sums.len()];
+    let mut proj_fail = 0usize;
+    let mut projected: Vec<(usize, Vec<f64>)> = Vec::new();
+    for (row, x) in rows.iter().enumerate() {
+      let Some(x) = x else { continue };
+      let label = e_label(row);
+      let Ok(k) = usize::try_from(label) else {
+        continue;
+      };
+      let arr: [f32; 256] = core::array::from_fn(|d| x[d] as f32);
+      let Ok(raw) = diaric::plda::RawEmbedding::from_wespeaker(arr) else {
+        proj_fail += 1;
+        continue;
+      };
+      let Ok(p) = plda.project(&raw) else {
+        proj_fail += 1;
+        continue;
+      };
+      for (sum, v) in sums[k].iter_mut().zip(p.iter()) {
+        *sum += v;
+      }
+      counts[k] += 1;
+      projected.push((k, p.to_vec()));
+    }
+    for (sum, n) in sums.iter_mut().zip(&counts) {
+      for v in sum.iter_mut() {
+        *v /= *n as f64;
+      }
+    }
+    // Within-cluster tightness: mean cos of a row's projection to its own
+    // centroid.
+    let within: f64 = projected
+      .iter()
+      .map(|(k, p)| cos64(p, &sums[*k]))
+      .sum::<f64>()
+      / projected.len() as f64;
+    (sums, proj_fail, within)
+  };
+
+  println!(
+    "║\n║ between-E-cluster centroid cosines in the PLDA clustering space (AHC merges when \
+     pairwise cosine distance 1-max(0,cos) < 0.6):"
+  );
+  let (base_cent, base_fail, base_within) = projected_centroids('E');
+  println!(
+    "║   E within-cluster mean cos-to-centroid {base_within:.4} ({base_fail} projection failures)"
+  );
+  let mut margins: std::collections::BTreeMap<char, (f64, f64)> = std::collections::BTreeMap::new();
+  for tag in ['D', 'C', 'B'] {
+    let (cent, fail, within) = projected_centroids(tag);
+    let mut pair_cos_e: Vec<f64> = Vec::new();
+    let mut pair_cos_x: Vec<f64> = Vec::new();
+    for i in 0..cent.len() {
+      for j in (i + 1)..cent.len() {
+        pair_cos_e.push(cos64(&base_cent[i], &base_cent[j]));
+        pair_cos_x.push(cos64(&cent[i], &cent[j]));
+      }
+    }
+    let mean = |v: &[f64]| v.iter().sum::<f64>() / v.len() as f64;
+    let max = |v: &[f64]| v.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    println!(
+      "║   {tag}: between-centroid cos mean {:.4} (E {:.4}) | max {:.4} (E {:.4}) | \
+       within-cluster {within:.4} | {fail} projection failures",
+      mean(&pair_cos_x),
+      mean(&pair_cos_e),
+      max(&pair_cos_x),
+      max(&pair_cos_e),
+    );
+    // The per-pair movement, worst five wideners toward a merge.
+    let mut moved: Vec<(usize, f64, f64)> = pair_cos_e
+      .iter()
+      .zip(&pair_cos_x)
+      .enumerate()
+      .map(|(idx, (e, x))| (idx, *e, *x))
+      .collect();
+    moved.sort_by(|a, b| (b.2 - b.1).total_cmp(&(a.2 - a.1)));
+    for (idx, e, x) in moved.iter().take(5) {
+      // Recover (i, j) from the flattened upper-triangle index.
+      let mut k = *idx;
+      let mut i = 0usize;
+      let n = cent.len();
+      while k >= n - 1 - i {
+        k -= n - 1 - i;
+        i += 1;
+      }
+      let j = i + 1 + k;
+      println!(
+        "║      pair ({i},{j}): cos {e:+.4} -> {x:+.4}  (Δ {:+.4})",
+        x - e
+      );
+    }
+    let max_pair_gain = pair_cos_e
+      .iter()
+      .zip(&pair_cos_x)
+      .map(|(e, x)| x - e)
+      .fold(f64::NEG_INFINITY, f64::max);
+    margins.insert(tag, (within, max_pair_gain));
+  }
+
+  // ── 3. Merge contingency: which E-clusters share an arm cluster.
+  for tag in ['D', 'B', 'C'] {
+    let hard = out_of(tag).hard_clusters();
+    let x_label = |row: usize| -> i32 { hard[row / SEG_NUM_SLOTS][row % SEG_NUM_SLOTS] };
+    let rows = rows_of(tag);
+    let mut table: std::collections::BTreeMap<(i32, i32), usize> =
+      std::collections::BTreeMap::new();
+    for (row, x) in rows.iter().enumerate() {
+      if x.is_none() {
+        continue;
+      }
+      let (e, l) = (e_label(row), x_label(row));
+      if e >= 0 && l >= 0 {
+        *table.entry((e, l)).or_default() += 1;
+      }
+    }
+    println!("║\n║ E-cluster -> {tag}-cluster contingency (live rows):");
+    let mut by_e: std::collections::BTreeMap<i32, Vec<(i32, usize)>> =
+      std::collections::BTreeMap::new();
+    for ((e, l), n) in table {
+      by_e.entry(e).or_default().push((l, n));
+    }
+    for (e, mut ls) in by_e {
+      ls.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+      let s: Vec<String> = ls.iter().map(|(l, n)| format!("{tag}{l}:{n}")).collect();
+      println!("║   E{e} -> {}", s.join(" "));
+    }
+  }
+  println!("╚══");
+
+  // ── The verdict, after the full report has printed.
+  let mech = |tag: char| -> ArmMechanism {
+    let s = &shapes[&tag];
+    let (within, max_pair_gain) = margins[&tag];
+    ArmMechanism {
+      coherence: s.coherence,
+      frac_pos: s.frac_pos,
+      mean_norm: s.mean_norm,
+      bias: s.bias,
+      rows: s.rows,
+      zero_deltas: s.zero_deltas,
+      within,
+      max_pair_gain,
+    }
+  };
+  assert_mechanism_verdict(&MechanismObserved {
+    base_within,
+    base_mean_norm: mean_norm_of('E'),
+    d: mech('D'),
+    c: mech('C'),
+    b: mech('B'),
+  });
 }

--- a/crates/coremlit/tests/speaker/common/mod.rs
+++ b/crates/coremlit/tests/speaker/common/mod.rs
@@ -67,22 +67,22 @@ pub fn argmax_models_dir() -> PathBuf {
   )
 }
 
-/// Path to the decided embedding artifact: the raw-waveform, in-graph-fbank
-/// WeSpeaker v2 model (spec §2.4 — no separate fbank stage needed).
+/// Path to the RETIRED int8 embedding artifact (`wespeaker_v2.mlmodelc`, the
+/// raw-waveform, in-graph-fbank WeSpeaker model).
 ///
-/// See `tests/model_io.rs`'s `// DECISION:` comment for why this is
-/// `wespeaker_v2.mlmodelc` and not `wespeaker.mlmodelc`/`wespeaker_int8.mlmodelc`.
-/// This is the **int8-palettized** shipping artifact; Gate 2's
-/// conversion-fidelity comparison uses [`embed_fp32_path`] instead (matched
-/// against dia-ort's fp32 ONNX — see `tests/parity_embed.rs`).
+/// This was the shipping artifact until issue #15 measured its palettization
+/// silently collapsing 8-speaker audio; the shipping embedder is now the fp32
+/// [`embed_fp32_path`] (see `tests/model_io.rs`'s DECISION). The int8 bytes
+/// stay on disk and byte-pinned because the factorial and mechanism records
+/// (`tests/speaker/backend_factorial.rs`) run on them.
 pub fn embed_path() -> PathBuf {
   models_dir().join("wespeaker_v2.mlmodelc")
 }
 
-/// Path to the **true fp32** embedding artifact, `wespeaker.mlmodelc`
+/// Path to the **fp32 SHIPPING** embedding artifact, `wespeaker.mlmodelc`
 /// (27 MB uncompressed float32 weights — `tests/model_io.rs`'s
-/// `wespeaker_fp32_io_contract_equal_but_not_targeted`). Contract-equal to
-/// the shipping int8 `wespeaker_v2.mlmodelc` but not quantized.
+/// `wespeaker_fp32_io_matches_spec`; the shipping selection since issue #15).
+/// Contract-equal to the retired int8 `wespeaker_v2.mlmodelc`.
 ///
 /// Gate 2 (embedding conversion fidelity, cosine ≥ 0.9999) is only
 /// meaningful at MATCHED precision: dia-ort runs the fp32

--- a/crates/coremlit/tests/speaker/common/mod.rs
+++ b/crates/coremlit/tests/speaker/common/mod.rs
@@ -139,10 +139,11 @@ pub const FIXTURES: &[Fixture] = &[
 /// documents for the golden's `seg_logits` field name: renaming it would churn
 /// every committed golden (each ~270 KB) for zero behavioral gain, since no
 /// gate reads this string. The values are in fact powerset **log-probabilities**
-/// (`pyannote_segmentation.mlmodelc`'s MIL ends `softmax` → `log`, see
-/// `coremlit::audio::speaker::segment`'s module doc; the committed ORT golden agrees — every
-/// value `<= 0`, every 7-class row `sum(exp(row)) == 1`). Read the string as a
-/// provenance tag, not a claim about the tensor's calibration.
+/// (`pyannote_segmentation.mlmodelc`'s MIL ends `reduce_log_sum_exp` → `sub`,
+/// see `coremlit::audio::speaker::segment`'s module doc; the committed ORT
+/// golden agrees — every value `<= 0`, every 7-class row
+/// `sum(exp(row)) == 1`). Read the string as a provenance tag, not a claim
+/// about the tensor's calibration.
 pub const SEG_MODEL_LABEL: &str =
   "segmentation-3.0.onnx (dia bundled, ort CPU EP, raw powerset logits)";
 
@@ -357,8 +358,9 @@ pub const SEG_ROW_SUM_EXP_TOL: f64 = 1e-4;
 /// each [`POWERSET_CLASSES`]-wide row normalized so `Σ exp = 1` (within
 /// [`SEG_ROW_SUM_EXP_TOL`]).
 ///
-/// dia-ort's segmentation MIL ends `softmax → log` and the CoreML side matches;
-/// the committed goldens store that quantity under the legacy `seg_logits` name.
+/// dia-ort's segmentation graph ends `softmax → log` and the CoreML side emits
+/// the same quantity through the fused `reduce_log_sum_exp → sub` tail; the
+/// committed goldens store it under the legacy `seg_logits` name.
 /// A future model emitting RAW logits (positive values, rows that do not sum-exp
 /// to 1) with the argmax ORDERING preserved would decode to the same speakers yet
 /// break this invariant — which `generate_goldens.rs`'s prose used to only

--- a/crates/coremlit/tests/speaker/der_gate_inventory.sh
+++ b/crates/coremlit/tests/speaker/der_gate_inventory.sh
@@ -172,29 +172,29 @@ check_bin parity_e2e \
   stress_12_mrbeast_schools_15_speakers \
   stress_14_mrbeast_strongman_robot_4_speakers || fail=1
 
-# parity_shipping_der.rs — ALL FOUR shipping-int8 DER clips (06, 14, 10, 09),
-# plus the shipping-default resolver gate, the corpus-selection gate, and the
-# clip-09 audio-content pin. Clip 14 and the resolver/corpus/content-pin gates
-# were previously unlisted.
+# parity_shipping_der.rs — ALL FOUR shipping DER clips (06, 14, 10, 09; the
+# fp32 shipping configuration + placement controls since issue #15), plus the
+# shipping-default resolver gate, the corpus-selection gate, and the clip-09
+# audio-content pin.
 check_bin parity_shipping_der \
-  shipping_int8_der_06_long_recording_3spk \
-  shipping_int8_der_14_mrbeast_strongman_robot_4spk \
-  shipping_int8_der_10_mrbeast_clean_water_7spk \
-  shipping_int8_der_09_mrbeast_dollar_date_8spk_known_defect \
-  shipping_default_is_the_int8_embedder \
+  shipping_der_06_long_recording_3spk \
+  shipping_der_14_mrbeast_strongman_robot_4spk \
+  shipping_der_10_mrbeast_clean_water_7spk \
+  shipping_der_09_mrbeast_dollar_date_8spk \
+  shipping_default_is_the_fp32_embedder \
   shipping_clip_selection_is_the_documented_subset \
   clip09_content_pin_catches_an_audio_swap || fail=1
 
-# backend_factorial.rs — the seg-vs-embed cross-product at the SHIPPING
-# configuration, plus the precision x placement experiment that disambiguates
-# what that cross-product could only implicate as a bundle. The first localizes
-# the clip-09 collapse to a STAGE where the defect actually lives (int8 embedder,
-# ComputeUnits::All); the second says WHICH property of that stage carries it.
-# `model_io.rs`'s recorded attribution cites both, so neither must be deletable
-# without a red build.
+# backend_factorial.rs — the seg-vs-embed cross-product at the int8-era
+# shipping configuration, the precision x placement experiment that
+# disambiguates what that cross-product could only implicate as a bundle, and
+# the mechanism probe that says WHAT KIND of perturbation each factor applies.
+# `model_io.rs`'s recorded attribution (and the issue-#15 embedder retirement)
+# cites all three, so none must be deletable without a red build.
 check_bin backend_factorial \
   shipping_config_backend_factorial \
-  embedding_precision_x_placement || fail=1
+  embedding_precision_x_placement \
+  quantization_error_structure || fail=1
 
 # ── Require each binary's load-bearing ORDINARY (hermetic) gates by NAME, then
 #    execute the ordinary suite (codex r7 F2 + r6 F4). The name manifest runs
@@ -205,10 +205,11 @@ check_ordinary parity_e2e \
   equal_delta_der_hides_disjoint_placement_errors \
   stress_gate_roster_is_consistent || fail=1
 check_ordinary parity_shipping_der \
-  clip09_known_defect_pins_every_field || fail=1
+  clip09_record_pins_every_field || fail=1
 check_ordinary backend_factorial \
   factorial_verdict_pins_every_cell \
-  precision_placement_verdict_pins_every_cell || fail=1
+  precision_placement_verdict_pins_every_cell \
+  mechanism_verdict_pins_every_field || fail=1
 
 run_ordinary parity_e2e || fail=1
 run_ordinary parity_shipping_der || fail=1

--- a/crates/coremlit/tests/speaker/der_gate_inventory.sh
+++ b/crates/coremlit/tests/speaker/der_gate_inventory.sh
@@ -11,6 +11,16 @@
 # the gitignored `Models/` tree plus the sibling `diarization` fixtures), and
 # the README drives them with `cargo test ... -- --ignored`.
 #
+# `--features speaker-oracle` is also the ONLY workable feature set for actually
+# RUNNING these gates — `--all-features` hangs them. `align-oracle` pulls `asry`,
+# which turns on `ort/load-dynamic`; Cargo unifies that onto the single `ort` in
+# the build, dia's first Session then fails to `dlopen` an ONNX Runtime dylib
+# that is not installed, and ort's error path re-enters the `OnceLock` it is
+# initializing (setup_api -> Error::new_internal -> ort::api() -> Once::wait)
+# and blocks forever. `cargo test -p coremlit --all-features` stays green only
+# because, without `--ignored`, it never opens an ort session. So every cargo
+# invocation below names `--features speaker-oracle` deliberately.
+#
 # Two failure modes this must catch, which a plain `--list` cannot:
 #   * a gate DELETED (or renamed) — e.g. dropping `stress_10...`, the central
 #     argmax multi-speaker regression — leaves the sweep green with the gate
@@ -176,12 +186,15 @@ check_bin parity_shipping_der \
   clip09_content_pin_catches_an_audio_swap || fail=1
 
 # backend_factorial.rs — the seg-vs-embed cross-product at the SHIPPING
-# configuration. It is the only gate that localizes the clip-09 collapse to a
-# STAGE where the defect actually lives (int8 embedder, ComputeUnits::All), and
-# `model_io.rs`'s recorded attribution cites it, so it must not be deletable
+# configuration, plus the precision x placement experiment that disambiguates
+# what that cross-product could only implicate as a bundle. The first localizes
+# the clip-09 collapse to a STAGE where the defect actually lives (int8 embedder,
+# ComputeUnits::All); the second says WHICH property of that stage carries it.
+# `model_io.rs`'s recorded attribution cites both, so neither must be deletable
 # without a red build.
 check_bin backend_factorial \
-  shipping_config_backend_factorial || fail=1
+  shipping_config_backend_factorial \
+  embedding_precision_x_placement || fail=1
 
 # ── Require each binary's load-bearing ORDINARY (hermetic) gates by NAME, then
 #    execute the ordinary suite (codex r7 F2 + r6 F4). The name manifest runs
@@ -194,7 +207,8 @@ check_ordinary parity_e2e \
 check_ordinary parity_shipping_der \
   clip09_known_defect_pins_every_field || fail=1
 check_ordinary backend_factorial \
-  factorial_verdict_pins_every_cell || fail=1
+  factorial_verdict_pins_every_cell \
+  precision_placement_verdict_pins_every_cell || fail=1
 
 run_ordinary parity_e2e || fail=1
 run_ordinary parity_shipping_der || fail=1

--- a/crates/coremlit/tests/speaker/der_gate_inventory.sh
+++ b/crates/coremlit/tests/speaker/der_gate_inventory.sh
@@ -2,7 +2,8 @@
 # F1 gate-inventory check: prove the end-to-end DER gates are actually COMPILED
 # and still #[ignore]d — not silently feature-gated out, deleted, or un-ignored.
 #
-# The DER binaries (`tests/speaker/parity_e2e.rs`, `tests/speaker/parity_shipping_der.rs`) are
+# The DER binaries (`tests/speaker/parity_e2e.rs`, `tests/speaker/parity_shipping_der.rs`,
+# `tests/speaker/backend_factorial.rs`) are
 # `#![cfg(feature = "speaker-oracle")]` — they need dia's own ort inference path as
 # the parity oracle. Without `--features speaker-oracle` they compile to nothing, so
 # `cargo test -p coremlit --features speaker -- --ignored` reports a green sweep containing
@@ -174,6 +175,14 @@ check_bin parity_shipping_der \
   shipping_clip_selection_is_the_documented_subset \
   clip09_content_pin_catches_an_audio_swap || fail=1
 
+# backend_factorial.rs — the seg-vs-embed cross-product at the SHIPPING
+# configuration. It is the only gate that localizes the clip-09 collapse to a
+# STAGE where the defect actually lives (int8 embedder, ComputeUnits::All), and
+# `model_io.rs`'s recorded attribution cites it, so it must not be deletable
+# without a red build.
+check_bin backend_factorial \
+  shipping_config_backend_factorial || fail=1
+
 # ── Require each binary's load-bearing ORDINARY (hermetic) gates by NAME, then
 #    execute the ordinary suite (codex r7 F2 + r6 F4). The name manifest runs
 #    FIRST so a deleted/`#[ignore]`d pin-falsifiability guard fails even though
@@ -184,9 +193,12 @@ check_ordinary parity_e2e \
   stress_gate_roster_is_consistent || fail=1
 check_ordinary parity_shipping_der \
   clip09_known_defect_pins_every_field || fail=1
+check_ordinary backend_factorial \
+  factorial_verdict_pins_every_cell || fail=1
 
 run_ordinary parity_e2e || fail=1
 run_ordinary parity_shipping_der || fail=1
+run_ordinary backend_factorial || fail=1
 
 if [ "${fail}" -ne 0 ]; then
   echo "DER gate inventory FAILED — the gates above are not all compiled, present, and #[ignore]d." >&2

--- a/crates/coremlit/tests/speaker/generate_goldens.rs
+++ b/crates/coremlit/tests/speaker/generate_goldens.rs
@@ -196,8 +196,9 @@ fn generate_goldens() {
 
     for (c, chunk) in chunks.iter().enumerate() {
       // dia-ort segmentation: [num_frames * POWERSET_CLASSES] powerset
-      // LOG-PROBABILITIES (the CoreML side matches: its MIL ends `softmax` ->
-      // `log`, so `parity_seg.rs` compares like with like). The `logits` /
+      // LOG-PROBABILITIES (the CoreML side emits the same quantity through its
+      // fused `reduce_log_sum_exp` -> `sub` tail, so `parity_seg.rs` compares
+      // like with like). The `logits` /
       // `seg_logits` names are legacy, kept to avoid churning every committed
       // golden. That these ARE log-probs — every element <= 0 and each row
       // normalized so sum(exp) == 1 — is ENFORCED by `common::check_seg_log_probs`

--- a/crates/coremlit/tests/speaker/model_io.rs
+++ b/crates/coremlit/tests/speaker/model_io.rs
@@ -13,9 +13,9 @@
 //! |---|---|---|
 //! | `pyannote_segmentation.mlmodelc` | segmentation | **yes** — see DECISION |
 //! | `Segmentation.mlmodelc` | segmentation, alt conversion | no |
-//! | `wespeaker_v2.mlmodelc` | embedding | **yes** — see DECISION |
+//! | `wespeaker.mlmodelc` | embedding, fp32 | **yes** — see DECISION (issue #15) |
+//! | `wespeaker_v2.mlmodelc` | embedding, int8 — RETIRED from shipping | no (tested sibling) |
 //! | `wespeaker_int8.mlmodelc` | embedding, byte-identical to `wespeaker_v2` | no (same file) |
-//! | `wespeaker.mlmodelc` | embedding, fp32, contract-equal | no |
 //! | `FBank.mlmodelc` | embedding frontend, split-pipeline alt | no |
 //! | `Embedding.mlmodelc` | embedding backend, split-pipeline alt | no |
 //!
@@ -59,69 +59,88 @@
 //!   above; they are spelled out here so the restoration needs no `git log`
 //!   archaeology.
 //!
-//! # Segmentation provenance (the fp16-safe re-conversion, issue #15)
+//! # Artifact provenance (issue #15)
 //!
-//! `pyannote_segmentation.mlmodelc` — and ONLY that artifact — comes from
+//! Two artifacts — the two the shipping pipeline loads — come from
 //! <https://huggingface.co/FinDIT-Studio/speakerkit-coreml>, revision (commit
-//! SHA) `3db69988bf2de12bab250614d6ac2b03d35132a2`. Every one of its files is
-//! byte-pinned by [`fp16_safe_segmentation_matches_pinned_sha256`]. Every other
-//! artifact in `Models/speakerkit/` is still FluidInference's
-//! `speaker-diarization-coreml` conversion.
+//! SHA) `3db69988bf2de12bab250614d6ac2b03d35132a2`, and every file of each is
+//! byte-pinned in this suite:
+//!
+//! - `pyannote_segmentation.mlmodelc`
+//!   ([`fp16_safe_segmentation_matches_pinned_sha256`]);
+//! - `wespeaker.mlmodelc` ([`fp16_safe_wespeaker_fp32_matches_pinned_sha256`]).
 //!
 //! ```text
 //! hf download FinDIT-Studio/speakerkit-coreml \
 //!   --revision 3db69988bf2de12bab250614d6ac2b03d35132a2 \
-//!   --include 'pyannote_segmentation.mlmodelc/*' --local-dir Models/speakerkit
+//!   --include 'pyannote_segmentation.mlmodelc/*' 'wespeaker.mlmodelc/*' \
+//!   --local-dir Models/speakerkit
 //! ```
 //!
-//! It is a **re-conversion of the same upstream weights**, not a different
-//! model. FluidInference's fp16 conversion ended `softmax` →
-//! `log(epsilon = 0x0p+0)`; `0` is below fp16's smallest subnormal (`2^-24`),
-//! so wherever the graph computes in fp16 the guard is inert and an underflowed
-//! softmax reaches an unguarded `log(0)`. Measured on `09_mrbeast_dollar_date`,
-//! 1033 chunks, the shipping `ComputeUnits::All` placement: minimum `segments`
-//! value **−45440.0** against **−32.31** on `CpuOnly`. The re-conversion emits
-//! the fused `reduce_log_sum_exp` → `sub` form — no `log` op at all, nothing to
-//! saturate — and the same measurement gives **−31.80** on `All`.
+//! Every other artifact in `Models/speakerkit/` is FluidInference's
+//! `speaker-diarization-coreml` conversion at revision
+//! `1ed7a662fdc7109e36d822db793ee6eebdaf8594`, verified 2026-07-27 against the
+//! HuggingFace API (LFS sha256 for `weights/weight.bin`, git blob SHA-1 for
+//! `model.mil`) and byte-pinned for the tested int8 sibling by
+//! [`int8_wespeaker_matches_fluidinference_pinned_sha256`]:
 //!
-//! **What this swap does NOT do — an OBSERVATION, not an enforced property.**
-//! Re-running `parity_shipping_der`'s four gated clips (06 / 14 / 10 / 09)
-//! with only this artifact changed reproduced every gated number, clip 09's
-//! 5-of-8-speaker collapse included (its known-defect pin still passes
-//! unchanged). Environment: Apple M1 Max, macOS 26.5 (build 25F71), arm64;
-//! CoreML through this crate at each arm's own placement (`CpuOnly` for the
-//! fp32 control, `CpuOnly` and `All` for the int8 arms); the reference side is
-//! dia's ONNX on `ort`'s CPU EP.
+//! ```text
+//! hf download FluidInference/speaker-diarization-coreml \
+//!   --revision 1ed7a662fdc7109e36d822db793ee6eebdaf8594 \
+//!   --local-dir Models/speakerkit
+//! ```
 //!
-//! No test turns that into a guarantee, and the wording must not pretend
-//! otherwise. Nothing compares a pre-swap number against a post-swap number:
-//! the gates that run afterwards bound reference-agreement within ±1 pp on the
-//! gated clips (`SHIPPING_ABS_DELTA_MAX`) and ±0.05 pp on clip 09's pins
-//! (`DER_PIN_TOL`), so a swap that moved a number by anything short of those
-//! bounds would still pass every one of them.
+//! (Fetch FluidInference first, then overlay the two FinDIT-Studio artifacts —
+//! the second download replaces `pyannote_segmentation.mlmodelc` and
+//! `wespeaker.mlmodelc` in place. A tree that skips the overlay fails the two
+//! byte-pin tests with re-download instructions rather than silently running
+//! the pre-repair artifacts.)
 //!
-//! - *Established*: on those FOUR clips — four of the eight ≥ 3-speaker clips
-//!   in dia's parity corpus, not the whole multi-speaker corpus — on this
-//!   host, the two artifacts produced the same gated numbers.
-//! - *Not established*: inertness on the other four ≥ 3-speaker clips
-//!   (08 / 11 / 12 / 13), on any other host or macOS build, or at exact bit
-//!   level anywhere.
-//! - *What would settle it*: a differential gate storing each clip's pre-swap
-//!   speaker count and DER and asserting EXACT equality against the post-swap
-//!   run, across all eight ≥ 3-speaker clips. That gate does not exist; this
-//!   paragraph is its honest substitute.
+//! Both FinDIT-Studio artifacts are **re-conversions of the same upstream
+//! weights**, not different models:
 //!
-//! The swap removes a real, silent, four-orders-of-magnitude corruption on the
-//! default placement (see the measurement above); it does not repair clip 09.
-//! For what does and does not cause clip 09, see "Clip 09" below — the
-//! attribution belongs to a cross-product run at the SHIPPING configuration,
-//! not to this swap.
+//! - `pyannote_segmentation.mlmodelc`: FluidInference's fp16 conversion ended
+//!   `softmax` → `log(epsilon = 0x0p+0)`; `0` is below fp16's smallest
+//!   subnormal (`2^-24`), so wherever the graph computes in fp16 the guard is
+//!   inert and an underflowed softmax reaches an unguarded `log(0)`. Measured
+//!   on `09_mrbeast_dollar_date`, 1033 chunks, the shipping
+//!   `ComputeUnits::All` placement: minimum `segments` value **−45440.0**
+//!   against **−32.31** on `CpuOnly`. The re-conversion emits the fused
+//!   `reduce_log_sum_exp` → `sub` form — no `log` op at all, nothing to
+//!   saturate — and the same measurement gives **−31.80** on `All`.
+//! - `wespeaker.mlmodelc`: byte-identical weights (`weights/weight.bin`
+//!   sha256 `680837ec…` on both sides — the Phase-A repair was MIL-only) and a
+//!   `model.mil` differing ONLY in the two attentive-stat pooling guard
+//!   constants (`1e-8` → `0x1p-24`, the fp16 floor) plus coremlc buildInfo
+//!   strings. On this host the two MILs measured EQUAL to the last DER error
+//!   unit on every clip-09 remedy-matrix arm — the guard sites add their
+//!   epsilon to mask sums that are never near zero — so the repair is a
+//!   static fp16-floor guarantee (`tests/fp16_guards.rs`'s defect class), not
+//!   a measured quality change. Adopting it removes the shipping embedder
+//!   from the sub-fp16-guard defect roster.
 //!
-//! The published re-conversions of `wespeaker`/`wespeaker_int8` are
-//! deliberately NOT adopted: the int8 one is also a re-palettization, and it
-//! moves clip 14's shipping ANE arm from 0.8178 % to 1.4860 % DER, past
-//! `parity_shipping_der`'s ±1 pp bound (isolated by swapping one artifact at a
-//! time; see issue #15). Their `fp16_guards` pins therefore stand.
+//! **What the SEGMENTATION swap did NOT do — an OBSERVATION from the int8
+//! era, kept for attribution.** Re-running the then-current four gated clips
+//! (06 / 14 / 10 / 09, int8 shipping arms) with only the segmentation
+//! artifact changed reproduced every gated number, clip 09's 5-of-8-speaker
+//! collapse included. Environment: Apple M1 Max, macOS 26.5 (build 25F71),
+//! arm64; the reference side dia's ONNX on `ort`'s CPU EP. That measurement
+//! is why the collapse was never the segmentation tail's to fix: it removed a
+//! real, silent, four-orders-of-magnitude corruption on the default placement
+//! and moved no gated DER. The collapse belonged to the embedder — see
+//! "Clip 09" below — and its repair is the EMBEDDING decision, not this
+//! swap.
+//!
+//! The published `wespeaker_int8` re-conversion stays NOT adopted: it is also
+//! a RE-PALETTIZATION (different LUTs), and it moves clip 14's int8 ANE arm
+//! from 0.8178 % to 1.4860 % DER (isolated by swapping one artifact at a
+//! time; see issue #15). Its `fp16_guards` pin therefore stands, and the
+//! retired-but-tested int8 sibling keeps FluidInference's original bytes
+//! ([`int8_wespeaker_matches_fluidinference_pinned_sha256`]). The published
+//! fp32 `wespeaker` re-conversion IS adopted — the clip-14 regression
+//! belongs to the re-palettized LUTs, which the fp32 artifact does not have,
+//! and its remedy-matrix arms are measured DER-equal to FluidInference's
+//! fp32 on this host (see "Artifact provenance" above).
 //!
 //! # Clip 09: what the cross-products establish, and at WHICH configuration
 //!
@@ -146,12 +165,12 @@
 //! - *Not established by (a)*: anything about the int8 embedder or about
 //!   `ComputeUnits::All` — a different artifact, different kernels, and not
 //!   even the same failure (a refusal to cluster, versus the silent 5-of-8
-//!   undercount this crate ships). The sentence this doc carried until
+//!   undercount this crate shipped). The sentence this doc carried until
 //!   2026-07-26, "the embedder is exonerated", generalized (a) to a
 //!   configuration it never touched.
 //!
 //! **(b) int8 embedder (`wespeaker_v2.mlmodelc`) on `ComputeUnits::All` — the
-//! SHIPPING configuration.** `tests/speaker/backend_factorial.rs` runs the
+//! configuration that SHIPPED until issue #15 retired it.** `tests/speaker/backend_factorial.rs` runs the
 //! identical design where the defect actually lives, same clip, same host:
 //!
 //! ```text
@@ -174,7 +193,7 @@
 //!   5 / 16.5904 %), which is what makes the hybrid cells readable at all.
 //! - *Not established by (b)*: WHICH property of the CoreML embedding path
 //!   carries it. The factor varied is the BACKEND, so the implicated object is
-//!   the shipping bundle — int8 palettization **plus** `All` placement **plus**
+//!   the then-shipping bundle — int8 palettization **plus** `All` placement **plus**
 //!   that conversion — as one unit. That is what (c) separates.
 //!
 //! **(c) The embedding path's three properties, separated.**
@@ -201,20 +220,36 @@
 //!   embedding conversion".
 //! - *Established*: the two remaining factors are separable, additive on
 //!   speaker count, and very unequal on error mass. **int8 palettization costs
-//!   2 speakers at BOTH placements** (E 8 -> D 6; C 7 -> B 5) and 11 835 of the
-//!   shipping arm's 11 999 error units — 98.6 % of it. **The `All` placement
-//!   costs 1 speaker at BOTH precisions** (E 8 -> C 7; D 6 -> B 5) and 1 839 /
-//!   164 error units respectively. Neither factor alone reproduces the shipping
-//!   5-of-8 collapse.
-//! - *Not established*: anything about the REMEDY's cost. Every arm here runs
-//!   over ONNX segmentation, which is not what this crate ships, and no
-//!   fp32/`All` DER arm exists for the gated clips (06 / 14 / 10) —
-//!   `parity_shipping_der` measures fp32 only on `CpuOnly`. Nor does any of it
-//!   extend beyond clip 09 or this host.
-//! - *What would settle the remainder*: an fp32/`All` arm added to
-//!   `parity_shipping_der`'s per-clip measurement, so the speakers cell C
-//!   recovers on clip 09 can be priced against what fp32 does to clip 14 — the
-//!   clip that already sits nearest a clustering decision boundary.
+//!   2 speakers at BOTH placements** (E 8 -> D 6; C 7 -> B 5), moving 11 835
+//!   of the shipping arm's 11 999 error units — 98.6 % — in the measured run.
+//!   **The `All` placement costs 1 speaker at BOTH precisions** (E 8 -> C 7;
+//!   D 6 -> B 5), 1 839 / 164 error units respectively in that run. The
+//!   speaker counts and per-cell units are guarded
+//!   (`backend_factorial`'s verdicts, cells to ±10 units); the derived
+//!   splits (164, 98.6 %) are REPORTED measurements of that run. Neither
+//!   factor alone reproduces the shipping 5-of-8 collapse.
+//! - *Not established by (c) alone*: the arms run over ONNX segmentation,
+//!   which is not what this crate ships, and nothing here extends beyond clip
+//!   09 or this host. (d) below is the real-pipeline pricing that settled the
+//!   remedy.
+//!
+//! **(d) The mechanism, and the remedy priced in the REAL pipeline.**
+//! `backend_factorial.rs`'s `quantization_error_structure` decomposes each
+//! arm's embedding perturbation against cell E and projects it through
+//! diaric's own frozen community-1 transform: the int8 delta is a COHERENT
+//! shared displacement (coherence 0.50 vs the 0.022 isotropic null, 98.7 % of
+//! rows aligned) that compresses between-speaker centroid margins by up to
+//! +0.05 cosine, concentrated on pairs involving the clusters that then lose
+//! their identity (the probe's printed contingency names them), with
+//! within-cluster tightness unchanged; the `All` placement's delta is 1.5x
+//! larger per row
+//! but near-isotropic (coherence 0.06). Perturbation SIZE anti-correlates
+//! with damage; the coherent component predicts it. The full DECISION section
+//! carries the artifact-level cause (38 per-tensor 256-entry LUTs) and the
+//! remedy-matrix table (real pipeline: `seg@All + fp32@All` = 8/8 at
+//! 2.9810 %; the CPU-embedder arms sit on the segmentation knife edge — 9
+//! speakers / `Err(AmbiguousAliveCluster)`); `parity_shipping_der.rs` gates
+//! the adopted configuration per clip and pins the clip-09 record.
 //!
 //! The mechanism INSIDE the segmentation graph is a further step again, and it
 //! is not established either: `segments` is the only tensor either graph
@@ -225,7 +260,12 @@
 //! of those flips only 50 carry an exact tie at the CoreML row maximum, and a
 //! tie is the ONLY argmax change a monotone per-row shift can produce — so at
 //! least 515 of them originate upstream of the tail. `backend_factorial`'s
-//! `seg_divergence` carries the full argument and its caveats.
+//! `seg_divergence` carries the full argument and its caveats. On clip 09
+//! that trunk divergence surfaces as the shipping suite's three
+//! separately-pinned placement outcomes (9 spk / `Err` / 8-with-confusion);
+//! reading them as one near-threshold cluster whose state flips with
+//! placement is the interpretation the pattern supports — the pinned record
+//! (`assert_clip09_record`) states the distinction.
 //!
 //! # Licenses (`Models/speakerkit/README.md`)
 //!
@@ -259,94 +299,93 @@
 //!   spec's pinned contract (§4 table) and the `SegmentModel::infer`
 //!   single-chunk API (§5) exactly, and it is FluidAudio's shipping name —
 //!   the brief's fallback tiebreaker.
-//! - **Embedding: `wespeaker_v2.mlmodelc`.** Verified byte-identical
-//!   (`diff -rq`, sha256 of `model.mil` and `weights/weight.bin`, at plan
-//!   time) to `wespeaker_int8.mlmodelc` — "v2" is an alias for the
-//!   int8-palettized model, not a distinct fp32 architecture; see
-//!   `wespeaker_v2_and_wespeaker_int8_are_byte_identical` below.
-//!   `wespeaker.mlmodelc` is contract-equal but ships uncompressed fp32
-//!   weights (27 MB vs 6.9 MB, `du -sh */weights`).
+//! - **Embedding: `wespeaker.mlmodelc` (fp32, the FinDIT-Studio fp16-safe
+//!   MIL) — issue #15.** The original DECISION here was the int8-palettized
+//!   `wespeaker_v2.mlmodelc` (byte-identical to `wespeaker_int8.mlmodelc`;
+//!   see `wespeaker_v2_and_wespeaker_int8_are_byte_identical` below). It was
+//!   retired on measurement:
 //!
-//!   **The rationale recorded here until 2026-07-26 was false.** It read
-//!   "the smaller int8 footprint better serves the issue's ANE uplift
-//!   targets". There is no uplift, and `parity_shipping_der.rs`'s
-//!   `shipping_embedder_cost_int8_vs_fp32` measures it directly. On 120 s of
-//!   `10_mrbeast_clean_water`, warm, one config at a time: on the shipping
-//!   `All` placement int8 EXTRACTS SLOWER than fp32 (4.92 s vs 4.41 s,
-//!   24.4× vs 27.2× realtime); on `CpuOnly` it is faster (25.03 s vs
-//!   28.89 s). No consistent speed advantage in either direction, and the
-//!   sign is negative on the placement we ship. Palettization buys 21.5 MB of
-//!   on-disk footprint (8.0 MB vs 29.4 MB, 3.7×) and nothing else. Reasoning
-//!   from "smaller ⇒ faster on the ANE" without measuring is what produced
-//!   the wrong claim.
+//!   *The collapse.* On 8-speaker audio the int8 embedder silently loses
+//!   speakers: `09_mrbeast_dollar_date`, 5 of 8 speakers at 16.5904 % DER
+//!   (100 % confusion) at the then-shipping `int8/All`, where dia-ort is
+//!   frame-perfect. `backend_factorial.rs` isolated the factors over dia's
+//!   reference segmentation: the CoreML embedding CONVERSION is exonerated
+//!   (fp32/`CpuOnly` reproduces dia-ort frame-perfectly, mean AND minimum
+//!   cosine 1.000000 over all 2 114 rows), the int8 palettization costs 2
+//!   speakers at either placement (98.6 % of the shipping arm's error mass —
+//!   a reported figure of the measured run, cells guarded to ±10 units),
+//!   and the `All` placement costs 1 more at either precision.
 //!
-//!   The DECISION still stands, on different evidence: int8 **preserves the
-//!   measured speaker count and stays inside the DER bounds this suite
-//!   selected**. It is not accuracy-free, and the replacement rationale must
-//!   not repeat the original's mistake of claiming more than was measured.
+//!   *The mechanism* (`backend_factorial.rs`'s
+//!   `quantization_error_structure`, same clip/host): the palettization
+//!   error is NOT isotropic noise — it is a COHERENT shared displacement.
+//!   Against the fp32/`CpuOnly` base, the int8 arm's per-row delta carries
+//!   half its mass in ONE shared direction (coherence 0.50 vs the 0.022
+//!   independent-scatter null; 98.7 % of rows aligned), producing a
+//!   near-constant ~2.4 %-of-norm shift on every embedding. Through diaric's
+//!   frozen community-1 projection (center on a FROZEN mean → L2-normalize →
+//!   LDA → re-center → re-normalize → PLDA-whiten) that shared shift
+//!   compresses BETWEEN-speaker centroid margins by up to +0.05 cosine,
+//!   concentrated on pairs involving the clusters that then lose their
+//!   identity (the probe's printed contingency names them), while
+//!   within-cluster tightness is unchanged to three decimals. The `All` placement's fp16 scatter is the
+//!   opposite shape — 1.5× LARGER per row but near-isotropic (coherence
+//!   0.06) — which is why the perturbation SIZE anti-correlates with the
+//!   damage. The earlier "quantization is roughly isotropic and survives the
+//!   frozen basis" rationale in `parity_shipping_der` was refuted by this
+//!   measurement: palettization is the coherent, basis-hostile perturbation;
+//!   the placement is the noisy benign one. The structural reason is in the
+//!   artifact: 38 `constexpr_lut_to_dense` sites, each ONE flat 256-entry
+//!   fp32 codebook for the WHOLE tensor (~0.8-1.0 % rel-RMS weight error per
+//!   ResNet conv, compounding over 34 layers), covering even the
+//!   deterministic DSP constants (STFT cos/sin bases, mel filterbank) and
+//!   the 5120→256 embedding head — the same ΔW applied to every input's
+//!   shared activation statistics is a constant output-space bias. A
+//!   repaired quantization must break that coherence (per-channel/grouped
+//!   LUTs, higher bits, exempting the head and DSP constants) and re-enter
+//!   the full DER validation; the one published re-palettization
+//!   (`wespeaker_int8` at the FinDIT revision) is measured to REGRESS clip
+//!   14's ANE arm from 0.8178 % to 1.4860 % and stays rejected.
 //!
-//!   *Established* — `parity_shipping_der.rs`, four gated clips
-//!   (06 / 14 / 10 / 09), Apple M1 Max, macOS 26.5 (build 25F71), arm64:
-//!   int8 and fp32 agree on the speaker count on every clip whose fp32
-//!   control clusters at all, and on `10_mrbeast_clean_water` — the clip
-//!   that exposed the argmax source's spurious 8th speaker — the
-//!   precision-isolated `int8/CpuOnly` arm clusters so that not one
-//!   collar-scored frame differs from the fp32 control
-//!   (`der_std(fp32, int8).err_units() == 0`, asserted, not narrated), while
-//!   carrying a *worse* embedding cosine (~0.90-0.92) than argmax's ~0.94.
-//!   That is the noise-vs-warp distinction: quantization scatter is roughly
-//!   isotropic and survives the frozen community-1 LDA+PLDA basis, whereas
-//!   argmax's front-end change is a systematic rotation that does not.
+//!   *The remedy pricing* (issue #15 remedy matrix, real pipeline — CoreML
+//!   fp16-safe segmentation + each embedder arm, Apple M1 Max, macOS 26.5
+//!   build 25F71, arm64, release harness): on clip 09, `seg@All +
+//!   fp32@All` = **8 of 8 speakers at 2.9810 %** (the only composition with
+//!   the right count); `seg@All + fp32@CpuOnly` = 9 speakers at 1.3011 %
+//!   (a spurious cluster survives against a bit-near-ONNX embedder — the
+//!   segmentation conversion's overcount class); `seg@CpuOnly +
+//!   fp32@CpuOnly` = `Err(AmbiguousAliveCluster)` (an alive-band refusal;
+//!   one shared near-threshold cluster is the supported interpretation, not
+//!   an asserted identity — the pinned record states the distinction); the
+//!   retired `seg@All + int8@All` = 5 at 16.5904 %. Speed does not
+//!   adjudicate the artifact choice: two warm runs of THIS bench
+//!   (`shipping_embedder_cost_int8_vs_fp32`, 120 s of clip 10, one config at
+//!   a time, this host, post-swap artifacts) put the int8-vs-fp32 extraction
+//!   difference ≤ ~15 % on every placement WITH THE SIGN FLIPPING BETWEEN
+//!   RUNS (`All`: fp32 4.33 s vs int8 4.95 s in the first run, then int8
+//!   4.13 s vs fp32 4.65 s in the second; the CPU rows flipped likewise) —
+//!   inside warm-run scheduler variability, so neither artifact holds a
+//!   stable edge and the bench prints rather than asserts a winner. The
+//!   stable cost axis is PLACEMENT (CPU-embedder configs run ~2x slower than
+//!   `All`, both artifacts, both runs). Palettization's remaining edge is
+//!   ~21 MB of footprint (8.0 MB vs 29.4 MB) — retired as the price of not
+//!   silently losing 3 speakers.
 //!
-//!   *The accuracy cost int8 does carry*, from that same suite: against the
-//!   independent pyannote reference, int8 agrees worse than the fp32 control
-//!   by up to +0.2209 pp (`int8/CpuOnly`) and +0.4217 pp (`int8/All`, the
-//!   literal shipping config) — inside `SHIPPING_ABS_DELTA_MAX`'s ±1 pp
-//!   bound, but not zero. On `14_mrbeast_strongman_robot` int8 moves
-//!   0.7832 % of collar-scored speech to a different speaker than the fp32
-//!   control put it under — on a clip whose fp32 CoreML control already
-//!   carries ~0.39 % confusion against dia-ort with no quantization involved
-//!   (`SHIPPING_CONFUSION_TRIPWIRE`'s doc), so the increment is of the same
-//!   order as the conversion's own. "Within the selected bound" is the
-//!   claim; "free" is not.
+//!   *The artifact choice within fp32*: the FinDIT-Studio fp16-safe MIL
+//!   (pooling eps `1e-8` → `0x1p-24`) over FluidInference's original —
+//!   measured EQUAL to the last DER error unit on every clip-09 arm on this
+//!   host, adopted for the static fp16-floor guarantee (see "Artifact
+//!   provenance" above and `tests/fp16_guards.rs`).
 //!
-//!   *Refuted on 8-speaker audio, and this is the open question against the
-//!   DECISION.* This paragraph used to say clip 09 "cannot adjudicate the
-//!   precision axis at all", because `parity_shipping_der`'s fp32 control
-//!   there returns `Err(AmbiguousAliveCluster)` and produces nothing to
-//!   compare against. That control is confounded: it runs CoreML
-//!   segmentation, and the segmentation conversion has its own clip-09
-//!   defect. With dia's reference segmentation held fixed instead, the fp32
-//!   control clusters fine and the precision axis IS measurable —
-//!   `backend_factorial.rs`'s `embedding_precision_x_placement`, "Clip 09"
-//!   table (c) above. It costs **2 speakers at both placements** (8 -> 6 on
-//!   `CpuOnly`, 7 -> 5 on `All`) and 11 835 of the shipping arm's 11 999
-//!   error units. On this clip int8 is not accuracy-neutral by a wide margin;
-//!   it is the dominant term in the collapse.
-//!
-//!   That does not overturn the DECISION, which rests on the clips whose fp32
-//!   control clusters and where the count is preserved — but it converts "the
-//!   open question against it" from a suspicion into a measurement. Nothing
-//!   here extends past these four clips, this host, or these two placements.
-//!
-//!   *What would settle it*: an fp32/`All` arm in `parity_shipping_der`'s
-//!   per-clip measurement, so the two speakers fp32 recovers on clip 09 can be
-//!   priced against what fp32 does to clip 14 (the clip nearest a clustering
-//!   decision boundary) — plus the four remaining ≥ 3-speaker corpus clips
-//!   (08 / 11 / 12 / 13) measured on the same precision axis. Note the
-//!   candidate remedy here is the ALREADY-STAGED fp32 `wespeaker.mlmodelc`,
-//!   not the published re-palettized `wespeaker_int8` re-conversion whose
-//!   clip-14 regression is recorded above; they are different artifacts and
-//!   only the latter has been measured to cost clip 14.
-//!
-//!   The evidence lives in `parity_shipping_der.rs`; a parity gate
-//!   (spec §6.2) separately confirms quantization doesn't reintroduce the
-//!   NaN/Inf corruption dia already routes around `ort`'s CoreML EP for
+//!   The remaining gate evidence lives in `parity_shipping_der.rs` (per-clip
+//!   placement matrix + clip-09 record); a parity gate (spec §6.2)
+//!   separately confirms the fp32 conversion carries no NaN/Inf corruption
 //!   (spec §1).
 //!
 //!   `FBank.mlmodelc` + `Embedding.mlmodelc` (the split fbank-then-embed
-//!   pipeline) are NOT targeted per spec §2.4: wespeaker_v2 computes fbank
-//!   in-graph from raw waveform, so the split frontend is unnecessary.
+//!   pipeline) are NOT targeted per spec §2.4: the wespeaker artifacts
+//!   compute fbank in-graph from raw waveform, so the split frontend is
+//!   unnecessary.
 //!
 //! # Spec-vs-reality deltas
 //!
@@ -546,7 +585,9 @@ fn wespeaker_v2_io_matches_spec() {
   let model = Model::load(common::embed_path(), ComputeUnits::CpuOnly).unwrap();
   let description = model.description();
 
-  // DECISION: this is the Task 2 embedding target — see the module doc.
+  // The RETIRED int8 sibling (issue #15) — kept introspected because the
+  // factorial and mechanism records run on it; the shipping target is
+  // `wespeaker.mlmodelc`, see the module doc's DECISION.
   let waveform = description.input("waveform").expect("waveform input");
   assert_eq!(waveform.shape(), &[3, 160000]);
   assert_eq!(waveform.data_type(), Some(DataType::F32));
@@ -580,7 +621,7 @@ fn wespeaker_v2_and_wespeaker_int8_are_byte_identical() {
   // byte-compares them file-for-file: equal relative path sets, and equal bytes
   // for every file. A divergence breaks the DECISION's premise and is a finding
   // to surface, NOT a test to relax.
-  let v2 = common::embed_path(); // wespeaker_v2.mlmodelc (the shipping int8 alias)
+  let v2 = common::embed_path(); // wespeaker_v2.mlmodelc (the retired int8 alias)
   let int8 = common::models_dir().join("wespeaker_int8.mlmodelc");
 
   let mut v2_tree = BTreeSet::new();
@@ -677,6 +718,112 @@ fn fp16_safe_segmentation_matches_pinned_sha256() {
   }
 }
 
+/// Byte-pins every file of the fp16-safe fp32 embedder against the published
+/// `FinDIT-Studio/speakerkit-coreml` revision (module doc, "Artifact
+/// provenance") — the shipping-embedder twin of
+/// [`fp16_safe_segmentation_matches_pinned_sha256`], and the issue-#15 gate
+/// that makes the int8 retirement non-reversible by accident.
+///
+/// The whole difference between this artifact and FluidInference's original
+/// fp32 conversion lives inside `model.mil` (two pooling guard constants and
+/// buildInfo strings; the weights are byte-identical), and the two are
+/// measured DER-equal on this host — so nothing but a byte pin can tell them
+/// apart, and only these bytes carry the static fp16-floor repair that keeps
+/// `tests/fp16_guards.rs`'s roster clean for the shipping embedder.
+#[test]
+#[ignore = "requires local speakerkit models (SPEAKERKIT_TEST_MODELS)"]
+fn fp16_safe_wespeaker_fp32_matches_pinned_sha256() {
+  const FILES: &[(&str, &str)] = &[
+    (
+      "metadata.json",
+      "330d8018e32a2c056ace110b3079aafacaaef37f70eae6cdad7296e85e9687c1",
+    ),
+    (
+      "model.mil",
+      "cff0cfe914078e9336754a9b38a68c2cdd88ca7b6bf97568ad551ab03ae1b666",
+    ),
+    (
+      "weights/weight.bin",
+      "680837ec172d67c3197bba93800e1623eebfd35c3b17011802f5f98b8026a0aa",
+    ),
+    (
+      "coremldata.bin",
+      "4a2840e7abc9aafa02ca23f6a3cb37fd8c8d9a95887336dae3d1e09f6ba7f9f6",
+    ),
+    (
+      "analytics/coremldata.bin",
+      "30528b97b29e0f0221b99c1c3456484f3123a68214b777f324a8b85ef5634c9a",
+    ),
+  ];
+
+  let root = common::embed_fp32_path();
+  for (relative, expected) in FILES {
+    let path = root.join(relative);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    assert_eq!(
+      common::sha256_hex(&bytes),
+      *expected,
+      "sha256 drift on wespeaker.mlmodelc/{relative}. These bytes ARE the shipping fp32 embedder \
+       (issue #15): the pre-repair FluidInference artifact is contract-identical, DER-equal on \
+       this host, and would pass every other gate while re-introducing the sub-fp16 pooling \
+       guards. Re-download from FinDIT-Studio/speakerkit-coreml at the pinned revision (module \
+       doc), or re-baseline this pin deliberately."
+    );
+  }
+}
+
+/// Byte-pins the retired int8 sibling (`wespeaker_v2.mlmodelc`) against
+/// FluidInference's `speaker-diarization-coreml` at the pinned revision
+/// (module doc, "Artifact provenance").
+///
+/// The artifact no longer ships, but the issue-#15 record RUNS on it:
+/// `backend_factorial.rs`'s B/D cells and the `quantization_error_structure`
+/// mechanism probe reproduce the collapse from exactly these bytes. A silent
+/// swap (for instance to the published re-palettization, whose different LUTs
+/// regress clip 14) would quietly re-baseline that whole record, so the bytes
+/// are pinned like the shipping artifacts'.
+#[test]
+#[ignore = "requires local speakerkit models (SPEAKERKIT_TEST_MODELS)"]
+fn int8_wespeaker_matches_fluidinference_pinned_sha256() {
+  const FILES: &[(&str, &str)] = &[
+    (
+      "metadata.json",
+      "ddc4858b4051254098015cd0b97080149839d697faf7b036f933190e70b26758",
+    ),
+    (
+      "model.mil",
+      "2850f775d6ba659f01f616fed77ce6a45a25de3eb7e4bf3a4b07b658be4e13dd",
+    ),
+    (
+      "weights/weight.bin",
+      "34004f6798d35cad7071e2fdc67e63faaa782f53697e1cb49bcb452cf81ae151",
+    ),
+    (
+      "coremldata.bin",
+      "6feb2472a71fa9d8a84020c85206138a4f6261c565c9884bf518d59dd5838da7",
+    ),
+    (
+      "analytics/coremldata.bin",
+      "d2b1fcde6121aea3ff0e14c1dc50d09dacb0314a2e89156353c31804230a422f",
+    ),
+  ];
+
+  let root = common::embed_path();
+  for (relative, expected) in FILES {
+    let path = root.join(relative);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    assert_eq!(
+      common::sha256_hex(&bytes),
+      *expected,
+      "sha256 drift on wespeaker_v2.mlmodelc/{relative}. This is the RETIRED int8 artifact the \
+       issue-#15 factorial and mechanism records were measured on (FluidInference revision in \
+       the module doc); a different int8 conversion here silently re-baselines those records. \
+       Re-download from FluidInference/speaker-diarization-coreml at the pinned revision, or \
+       re-baseline this pin deliberately."
+    );
+  }
+}
+
 /// The shipped segmentation graph reaches its powerset log-probabilities through
 /// the FUSED `reduce_log_sum_exp` → `sub` tail, and contains no `log` op that a
 /// vanishing epsilon could leave unguarded. Reading the MIL is what the whole
@@ -706,14 +853,13 @@ fn segmentation_graph_has_no_log_op() {
 
 #[test]
 #[ignore = "requires local speakerkit models (SPEAKERKIT_TEST_MODELS)"]
-fn wespeaker_fp32_io_contract_equal_but_not_targeted() {
-  // `wespeaker.mlmodelc` shares the identical I/O contract with
-  // `wespeaker_v2`/`wespeaker_int8` (same names/shapes/dtypes below) but is
-  // a DIFFERENT, non-palettized artifact: 27 MB of weights vs 6.9 MB
-  // (`du -sh */weights`, recorded at plan time) — full float32 storage
-  // precision instead of 8-bit palettized. Not targeted (see DECISION in
-  // the module doc), but contract equality means Task 2 could fall back to
-  // it without any shape-handling changes.
+fn wespeaker_fp32_io_matches_spec() {
+  // DECISION (issue #15): this is the SHIPPING embedding target. It shares
+  // the identical I/O contract with the retired `wespeaker_v2`/
+  // `wespeaker_int8` siblings (same names/shapes/dtypes below) but carries
+  // full float32 weights instead of per-tensor 8-bit palettization
+  // (27 MB vs 6.9 MB of weights) — the contract equality is what made the
+  // retirement a pure artifact swap with no shape-handling changes.
   let path = common::models_dir().join("wespeaker.mlmodelc");
   let model = Model::load(path, ComputeUnits::CpuOnly).unwrap();
   let description = model.description();

--- a/crates/coremlit/tests/speaker/model_io.rs
+++ b/crates/coremlit/tests/speaker/model_io.rs
@@ -59,6 +59,50 @@
 //!   above; they are spelled out here so the restoration needs no `git log`
 //!   archaeology.
 //!
+//! # Segmentation provenance (the fp16-safe re-conversion, issue #15)
+//!
+//! `pyannote_segmentation.mlmodelc` — and ONLY that artifact — comes from
+//! <https://huggingface.co/FinDIT-Studio/speakerkit-coreml>, revision (commit
+//! SHA) `3db69988bf2de12bab250614d6ac2b03d35132a2`. Every one of its files is
+//! byte-pinned by [`fp16_safe_segmentation_matches_pinned_sha256`]. Every other
+//! artifact in `Models/speakerkit/` is still FluidInference's
+//! `speaker-diarization-coreml` conversion.
+//!
+//! ```text
+//! hf download FinDIT-Studio/speakerkit-coreml \
+//!   --revision 3db69988bf2de12bab250614d6ac2b03d35132a2 \
+//!   --include 'pyannote_segmentation.mlmodelc/*' --local-dir Models/speakerkit
+//! ```
+//!
+//! It is a **re-conversion of the same upstream weights**, not a different
+//! model. FluidInference's fp16 conversion ended `softmax` →
+//! `log(epsilon = 0x0p+0)`; `0` is below fp16's smallest subnormal (`2^-24`),
+//! so wherever the graph computes in fp16 the guard is inert and an underflowed
+//! softmax reaches an unguarded `log(0)`. Measured on `09_mrbeast_dollar_date`,
+//! 1033 chunks, the shipping `ComputeUnits::All` placement: minimum `segments`
+//! value **−45440.0** against **−32.31** on `CpuOnly`. The re-conversion emits
+//! the fused `reduce_log_sum_exp` → `sub` form — no `log` op at all, nothing to
+//! saturate — and the same measurement gives **−31.80** on `All`.
+//!
+//! **What this swap does NOT do.** It is end-to-end inert on the whole
+//! multi-speaker DER corpus: with only this artifact changed, every gated
+//! number on clips 06 / 09 / 10 / 14 is bit-identical to the pre-swap
+//! measurement, including clip 09's 5-of-8-speaker collapse
+//! (`parity_shipping_der`'s known-defect pin, unchanged). The clip-09 defect is
+//! a segmentation-conversion defect — the model cross-product attributes it
+//! there, and the embedder is exonerated at cosine 1.000000 — but its mechanism
+//! is the fp16 conversion's ordinary tail precision (1091 of 608 437 powerset
+//! argmax frames flip against dia-ort's fp32 ONNX), not the vanished epsilon,
+//! and the re-conversion is still fp16, so it does not move it. The swap
+//! removes a real, silent, four-orders-of-magnitude corruption on the default
+//! placement; it does not repair clip 09.
+//!
+//! The published re-conversions of `wespeaker`/`wespeaker_int8` are
+//! deliberately NOT adopted: the int8 one is also a re-palettization, and it
+//! moves clip 14's shipping ANE arm from 0.8178 % to 1.4860 % DER, past
+//! `parity_shipping_der`'s ±1 pp bound (isolated by swapping one artifact at a
+//! time; see issue #15). Their `fp16_guards` pins therefore stand.
+//!
 //! # Licenses (`Models/speakerkit/README.md`)
 //!
 //! The repo's HuggingFace frontmatter declares `license: cc-by-4.0` for the
@@ -87,7 +131,7 @@
 //!   hold, see `segmentation_alt_io_recorded_not_targeted` below. It is
 //!   chosen anyway because its single-chunk, fixed-shape `segments` output
 //!   (per-frame powerset **log-probabilities** — the graph's tail is
-//!   `softmax` → `log`, see `crate::segment`'s module doc) matches both the
+//!   `reduce_log_sum_exp` → `sub`, see `crate::segment`'s module doc) matches both the
 //!   spec's pinned contract (§4 table) and the `SegmentModel::infer`
 //!   single-chunk API (§5) exactly, and it is FluidAudio's shipping name —
 //!   the brief's fallback tiebreaker.
@@ -97,14 +141,40 @@
 //!   int8-palettized model, not a distinct fp32 architecture; see
 //!   `wespeaker_v2_and_wespeaker_int8_are_byte_identical` below.
 //!   `wespeaker.mlmodelc` is contract-equal but ships uncompressed fp32
-//!   weights (27 MB vs 6.9 MB, `du -sh */weights`); not targeted, since the
-//!   smaller int8 footprint better serves the issue's ANE uplift targets —
-//!   a parity gate (spec §6.2) confirms quantization doesn't reintroduce
-//!   the NaN/Inf corruption dia already routes around `ort`'s CoreML EP
-//!   for (spec §1). `FBank.mlmodelc` + `Embedding.mlmodelc` (the split
-//!   fbank-then-embed pipeline) are NOT targeted per spec §2.4: wespeaker_v2
-//!   computes fbank in-graph from raw waveform, so the split frontend is
-//!   unnecessary.
+//!   weights (27 MB vs 6.9 MB, `du -sh */weights`).
+//!
+//!   **The rationale recorded here until 2026-07-26 was false.** It read
+//!   "the smaller int8 footprint better serves the issue's ANE uplift
+//!   targets". There is no uplift, and `parity_shipping_der.rs`'s
+//!   `shipping_embedder_cost_int8_vs_fp32` measures it directly. On 120 s of
+//!   `10_mrbeast_clean_water`, warm, one config at a time: on the shipping
+//!   `All` placement int8 EXTRACTS SLOWER than fp32 (4.92 s vs 4.41 s,
+//!   24.4× vs 27.2× realtime); on `CpuOnly` it is faster (25.03 s vs
+//!   28.89 s). No consistent speed advantage in either direction, and the
+//!   sign is negative on the placement we ship. Palettization buys 21.5 MB of
+//!   on-disk footprint (8.0 MB vs 29.4 MB, 3.7×) and nothing else. Reasoning
+//!   from "smaller ⇒ faster on the ANE" without measuring is what produced
+//!   the wrong claim.
+//!
+//!   The DECISION is still correct, for a different reason: int8 does not
+//!   move the CLUSTERING decision. On `10_mrbeast_clean_water` — the clip
+//!   that exposed the argmax source's spurious 8th speaker — the
+//!   precision-isolated int8 arm clusters identically to fp32 (0.0000 %
+//!   standard-collar DER, zero confusion) while carrying a *worse*
+//!   embedding cosine (~0.90-0.92) than argmax's ~0.94, and no clip in the
+//!   gated set has ever shown int8 and fp32 disagreeing on the speaker
+//!   count. That is the noise-vs-warp distinction: quantization scatter is
+//!   roughly isotropic and survives the frozen community-1 LDA+PLDA basis,
+//!   whereas argmax's front-end change is a systematic rotation that does
+//!   not. So int8 is chosen because it is free in accuracy terms and cheap
+//!   in footprint — NOT because it is faster. The evidence lives in
+//!   `parity_shipping_der.rs`; a parity gate (spec §6.2) separately confirms
+//!   quantization doesn't reintroduce the NaN/Inf corruption dia already
+//!   routes around `ort`'s CoreML EP for (spec §1).
+//!
+//!   `FBank.mlmodelc` + `Embedding.mlmodelc` (the split fbank-then-embed
+//!   pipeline) are NOT targeted per spec §2.4: wespeaker_v2 computes fbank
+//!   in-graph from raw waveform, so the split frontend is unnecessary.
 //!
 //! # Spec-vs-reality deltas
 //!
@@ -380,6 +450,86 @@ fn wespeaker_v2_and_wespeaker_int8_are_byte_identical() {
   assert_eq!(description.input("waveform").unwrap().shape(), &[3, 160000]);
   assert_eq!(description.input("mask").unwrap().shape(), &[3, 589]);
   assert_eq!(description.output("embedding").unwrap().shape(), &[3, 256]);
+}
+
+/// Byte-pins every file of the fp16-safe segmentation artifact against the
+/// published `FinDIT-Studio/speakerkit-coreml` revision (module doc,
+/// "Segmentation provenance").
+///
+/// This is the gate that makes the issue-#15 swap non-reversible by accident.
+/// The whole difference between the two conversions lives inside `model.mil`:
+/// the pre-swap FluidInference artifact has the identical filename, the
+/// identical `audio [1,1,160000]` → `segments [1,589,7]` contract, and passes
+/// every other test in this file — while restoring a `segments` minimum of
+/// −45440 on the shipping `ComputeUnits::All` placement. Only these bytes carry
+/// the repair, so only a byte pin can defend it.
+#[test]
+#[ignore = "requires local speakerkit models (SPEAKERKIT_TEST_MODELS)"]
+fn fp16_safe_segmentation_matches_pinned_sha256() {
+  const FILES: &[(&str, &str)] = &[
+    (
+      "metadata.json",
+      "2926b811344e40ab6ce5406354bf5aaac35a297d0e67e3c0d3f6dd766e9f5f8f",
+    ),
+    (
+      "model.mil",
+      "ded0d1ee11d77976b5c706ce667d0c8cb49977d3fe4367cccbd7b582bdb86dec",
+    ),
+    (
+      "weights/weight.bin",
+      "0266f4ad4d843ecf31ef9220ad6b80616b3ec64a4404b64f3ea0371554e236ec",
+    ),
+    (
+      "coremldata.bin",
+      "e75fc0ac9641de87e3514369455c8c8a65b00aae339817b20642f115d5d8861e",
+    ),
+    (
+      "analytics/coremldata.bin",
+      "f283c01fa863188733c33c6fddac4c5dca42ca7cb22580918e1bc55877897e69",
+    ),
+  ];
+
+  let root = common::seg_path();
+  for (relative, expected) in FILES {
+    let path = root.join(relative);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    assert_eq!(
+      common::sha256_hex(&bytes),
+      *expected,
+      "sha256 drift on pyannote_segmentation.mlmodelc/{relative}. These bytes ARE the issue-#15 \
+       fp16-guard repair; the pre-repair FluidInference artifact is contract-identical and would \
+       pass every other gate while restoring a −45440 `segments` minimum on ComputeUnits::All. \
+       Re-download from FinDIT-Studio/speakerkit-coreml at the pinned revision, or re-baseline \
+       this pin deliberately."
+    );
+  }
+}
+
+/// The shipped segmentation graph reaches its powerset log-probabilities through
+/// the FUSED `reduce_log_sum_exp` → `sub` tail, and contains no `log` op that a
+/// vanishing epsilon could leave unguarded. Reading the MIL is what the whole
+/// issue-#15 investigation turned on — the docs asserted "raw powerset logits"
+/// and nobody went looking for the `log` — so the structural claim is asserted,
+/// not narrated. `tests/fp16_guards.rs` checks epsilon FLOORS across every
+/// vendor; this checks the one structural property that makes this graph
+/// epsilon-free in the first place.
+#[test]
+#[ignore = "requires local speakerkit models (SPEAKERKIT_TEST_MODELS)"]
+fn segmentation_graph_has_no_log_op() {
+  let mil = common::seg_path().join("model.mil");
+  let text =
+    std::fs::read_to_string(&mil).unwrap_or_else(|e| panic!("read {}: {e}", mil.display()));
+  assert!(
+    text.contains("reduce_log_sum_exp"),
+    "pyannote_segmentation/model.mil has no `reduce_log_sum_exp`: this is not the fused-tail \
+     conversion the fp16 repair rests on"
+  );
+  assert!(
+    !text.contains("= log("),
+    "pyannote_segmentation/model.mil grew a `log` op back. The decomposed `softmax` → `log` tail \
+     is what saturated to −45440 on the ANE; a re-conversion that reintroduces it must be \
+     re-audited, not accepted."
+  );
 }
 
 #[test]

--- a/crates/coremlit/tests/speaker/model_io.rs
+++ b/crates/coremlit/tests/speaker/model_io.rs
@@ -84,24 +84,114 @@
 //! the fused `reduce_log_sum_exp` → `sub` form — no `log` op at all, nothing to
 //! saturate — and the same measurement gives **−31.80** on `All`.
 //!
-//! **What this swap does NOT do.** It is end-to-end inert on the whole
-//! multi-speaker DER corpus: with only this artifact changed, every gated
-//! number on clips 06 / 09 / 10 / 14 is bit-identical to the pre-swap
-//! measurement, including clip 09's 5-of-8-speaker collapse
-//! (`parity_shipping_der`'s known-defect pin, unchanged). The clip-09 defect is
-//! a segmentation-conversion defect — the model cross-product attributes it
-//! there, and the embedder is exonerated at cosine 1.000000 — but its mechanism
-//! is the fp16 conversion's ordinary tail precision (1091 of 608 437 powerset
-//! argmax frames flip against dia-ort's fp32 ONNX), not the vanished epsilon,
-//! and the re-conversion is still fp16, so it does not move it. The swap
-//! removes a real, silent, four-orders-of-magnitude corruption on the default
-//! placement; it does not repair clip 09.
+//! **What this swap does NOT do — an OBSERVATION, not an enforced property.**
+//! Re-running `parity_shipping_der`'s four gated clips (06 / 14 / 10 / 09)
+//! with only this artifact changed reproduced every gated number, clip 09's
+//! 5-of-8-speaker collapse included (its known-defect pin still passes
+//! unchanged). Environment: Apple M1 Max, macOS 26.5 (build 25F71), arm64;
+//! CoreML through this crate at each arm's own placement (`CpuOnly` for the
+//! fp32 control, `CpuOnly` and `All` for the int8 arms); the reference side is
+//! dia's ONNX on `ort`'s CPU EP.
+//!
+//! No test turns that into a guarantee, and the wording must not pretend
+//! otherwise. Nothing compares a pre-swap number against a post-swap number:
+//! the gates that run afterwards bound reference-agreement within ±1 pp on the
+//! gated clips (`SHIPPING_ABS_DELTA_MAX`) and ±0.05 pp on clip 09's pins
+//! (`DER_PIN_TOL`), so a swap that moved a number by anything short of those
+//! bounds would still pass every one of them.
+//!
+//! - *Established*: on those FOUR clips — four of the eight ≥ 3-speaker clips
+//!   in dia's parity corpus, not the whole multi-speaker corpus — on this
+//!   host, the two artifacts produced the same gated numbers.
+//! - *Not established*: inertness on the other four ≥ 3-speaker clips
+//!   (08 / 11 / 12 / 13), on any other host or macOS build, or at exact bit
+//!   level anywhere.
+//! - *What would settle it*: a differential gate storing each clip's pre-swap
+//!   speaker count and DER and asserting EXACT equality against the post-swap
+//!   run, across all eight ≥ 3-speaker clips. That gate does not exist; this
+//!   paragraph is its honest substitute.
+//!
+//! The swap removes a real, silent, four-orders-of-magnitude corruption on the
+//! default placement (see the measurement above); it does not repair clip 09.
+//! For what does and does not cause clip 09, see "Clip 09" below — the
+//! attribution belongs to a cross-product run at the SHIPPING configuration,
+//! not to this swap.
 //!
 //! The published re-conversions of `wespeaker`/`wespeaker_int8` are
 //! deliberately NOT adopted: the int8 one is also a re-palettization, and it
 //! moves clip 14's shipping ANE arm from 0.8178 % to 1.4860 % DER, past
 //! `parity_shipping_der`'s ±1 pp bound (isolated by swapping one artifact at a
 //! time; see issue #15). Their `fp16_guards` pins therefore stand.
+//!
+//! # Clip 09: what the cross-products establish, and at WHICH configuration
+//!
+//! Two model cross-products exist. They were run at different configurations,
+//! **they disagree**, and neither speaks for the other. Both hold one audio
+//! buffer, one chunk grid, one decode and one clustering constant, varying
+//! only which conversion computes a stage.
+//!
+//! **(a) fp32 embedder (`wespeaker.mlmodelc`) on `CpuOnly`** — the original
+//! run (issue #15). In that configuration the CoreML path does not undercount;
+//! it produces no answer at all:
+//!
+//! ```text
+//! ONNX-seg   + ONNX-emb     8 spk, 0.0000 %   the dia-ort reference
+//! COREML-seg + ONNX-emb     Err(AmbiguousAliveCluster sp[13] = 1.706e-7)
+//! ONNX-seg   + COREML-emb   8 spk, 0.0000 %
+//! COREML-seg + COREML-emb   Err(AmbiguousAliveCluster sp[13] = 1.700e-7)
+//! ```
+//!
+//! - *Established*: at fp32/`CpuOnly`, the segmentation conversion alone is
+//!   SUFFICIENT to produce that `Err`, and the fp32 embedder alone is not.
+//! - *Not established by (a)*: anything about the int8 embedder or about
+//!   `ComputeUnits::All` — a different artifact, different kernels, and not
+//!   even the same failure (a refusal to cluster, versus the silent 5-of-8
+//!   undercount this crate ships). The sentence this doc carried until
+//!   2026-07-26, "the embedder is exonerated", generalized (a) to a
+//!   configuration it never touched.
+//!
+//! **(b) int8 embedder (`wespeaker_v2.mlmodelc`) on `ComputeUnits::All` — the
+//! SHIPPING configuration.** `tests/speaker/backend_factorial.rs` runs the
+//! identical design where the defect actually lives, same clip, same host:
+//!
+//! ```text
+//! segmentation | embedding | spk |      DER |     conf
+//! -------------+-----------+-----+----------+---------
+//!         ONNX |      ONNX |   8 |  0.0000% |  0.0000%
+//!         ONNX |    COREML |   5 | 16.5904% | 16.5904%
+//!       COREML |      ONNX |   9 |  1.3011% |  1.3011%
+//!       COREML |    COREML |   5 | 16.5904% | 16.5904%
+//! ```
+//!
+//! - *Established at the shipping configuration*: swapping ONLY the
+//!   **embedding** conversion, over dia's own reference segmentation,
+//!   reproduces the shipping collapse exactly — 5 of 8 speakers, 16.5904 %
+//!   DER, 11 999 confusion units, the same numbers as the all-CoreML corner.
+//!   Swapping ONLY the **segmentation** conversion does not: it OVERcounts by
+//!   one (9 speakers, 1.3011 %), a real defect an order of magnitude smaller
+//!   that the shipping arm masks. Both corners reproduce their independently
+//!   pinned numbers (dia-ort's 8 / 0.0000 %; `parity_shipping_der`'s
+//!   5 / 16.5904 %), which is what makes the hybrid cells readable at all.
+//! - *Not established*: WHICH property of the CoreML embedding path carries
+//!   it. The factor varied is the BACKEND, so the implicated object is the
+//!   shipping bundle — int8 palettization **plus** `All` placement **plus**
+//!   that conversion — as one unit. Nor does any of it extend beyond clip 09,
+//!   this host, or these two configurations.
+//! - *What would settle the remainder*: the same hybrid harness with the
+//!   reference segmentation held fixed and the embedding arm run as fp32
+//!   CoreML on `All` and as int8 CoreML on `CpuOnly`. Those two cells separate
+//!   quantization from placement; nothing measured so far does.
+//!
+//! The mechanism INSIDE the segmentation graph is a further step again, and it
+//! is not established either: `segments` is the only tensor either graph
+//! exposes, so a divergence in it cannot be attributed to the log-softmax tail
+//! rather than to the trunk feeding it. Measured on this clip at `All`, the
+//! CoreML segmentation differs from dia's ONNX by at most 0.6574 in
+//! log-probability and flips 565 of 608 437 powerset argmax frames (0.0929 %);
+//! of those flips only 50 carry an exact tie at the CoreML row maximum, and a
+//! tie is the ONLY argmax change a monotone per-row shift can produce — so at
+//! least 515 of them originate upstream of the tail. `backend_factorial`'s
+//! `seg_divergence` carries the full argument and its caveats.
 //!
 //! # Licenses (`Models/speakerkit/README.md`)
 //!
@@ -156,21 +246,57 @@
 //!   from "smaller ⇒ faster on the ANE" without measuring is what produced
 //!   the wrong claim.
 //!
-//!   The DECISION is still correct, for a different reason: int8 does not
-//!   move the CLUSTERING decision. On `10_mrbeast_clean_water` — the clip
+//!   The DECISION still stands, on different evidence: int8 **preserves the
+//!   measured speaker count and stays inside the DER bounds this suite
+//!   selected**. It is not accuracy-free, and the replacement rationale must
+//!   not repeat the original's mistake of claiming more than was measured.
+//!
+//!   *Established* — `parity_shipping_der.rs`, four gated clips
+//!   (06 / 14 / 10 / 09), Apple M1 Max, macOS 26.5 (build 25F71), arm64:
+//!   int8 and fp32 agree on the speaker count on every clip whose fp32
+//!   control clusters at all, and on `10_mrbeast_clean_water` — the clip
 //!   that exposed the argmax source's spurious 8th speaker — the
-//!   precision-isolated int8 arm clusters identically to fp32 (0.0000 %
-//!   standard-collar DER, zero confusion) while carrying a *worse*
-//!   embedding cosine (~0.90-0.92) than argmax's ~0.94, and no clip in the
-//!   gated set has ever shown int8 and fp32 disagreeing on the speaker
-//!   count. That is the noise-vs-warp distinction: quantization scatter is
-//!   roughly isotropic and survives the frozen community-1 LDA+PLDA basis,
-//!   whereas argmax's front-end change is a systematic rotation that does
-//!   not. So int8 is chosen because it is free in accuracy terms and cheap
-//!   in footprint — NOT because it is faster. The evidence lives in
-//!   `parity_shipping_der.rs`; a parity gate (spec §6.2) separately confirms
-//!   quantization doesn't reintroduce the NaN/Inf corruption dia already
-//!   routes around `ort`'s CoreML EP for (spec §1).
+//!   precision-isolated `int8/CpuOnly` arm clusters so that not one
+//!   collar-scored frame differs from the fp32 control
+//!   (`der_std(fp32, int8).err_units() == 0`, asserted, not narrated), while
+//!   carrying a *worse* embedding cosine (~0.90-0.92) than argmax's ~0.94.
+//!   That is the noise-vs-warp distinction: quantization scatter is roughly
+//!   isotropic and survives the frozen community-1 LDA+PLDA basis, whereas
+//!   argmax's front-end change is a systematic rotation that does not.
+//!
+//!   *The accuracy cost int8 does carry*, from that same suite: against the
+//!   independent pyannote reference, int8 agrees worse than the fp32 control
+//!   by up to +0.2209 pp (`int8/CpuOnly`) and +0.4217 pp (`int8/All`, the
+//!   literal shipping config) — inside `SHIPPING_ABS_DELTA_MAX`'s ±1 pp
+//!   bound, but not zero. On `14_mrbeast_strongman_robot` int8 moves
+//!   0.7832 % of collar-scored speech to a different speaker than the fp32
+//!   control put it under — on a clip whose fp32 CoreML control already
+//!   carries ~0.39 % confusion against dia-ort with no quantization involved
+//!   (`SHIPPING_CONFUSION_TRIPWIRE`'s doc), so the increment is of the same
+//!   order as the conversion's own. "Within the selected bound" is the
+//!   claim; "free" is not.
+//!
+//!   *Not established*: that int8 is accuracy-neutral on 8-speaker audio.
+//!   Clip 09 cannot adjudicate the precision axis at all — its fp32 control
+//!   returns `Err(AmbiguousAliveCluster)` and produces no diarization to
+//!   compare against — so int8-vs-fp32 there is UNMEASURED, not equal. What
+//!   IS measured on clip 09 is worse for this DECISION than "unmeasured":
+//!   `backend_factorial.rs` shows the shipping embedding path (this int8
+//!   artifact on `All`) sufficient on its own to collapse 8 speakers to 5
+//!   there — see "Clip 09" above. That does not overturn the DECISION, which
+//!   rests on the clips whose fp32 control clusters, but it is the open
+//!   question against it. Nothing here extends past these four clips, this
+//!   host, or these two placements.
+//!
+//!   *What would settle it*: the fp32 control clustering on clip 09 (which
+//!   is the clip-09 defect itself, see "Segmentation provenance" above),
+//!   plus the four remaining ≥ 3-speaker corpus clips (08 / 11 / 12 / 13)
+//!   measured on the same precision axis.
+//!
+//!   The evidence lives in `parity_shipping_der.rs`; a parity gate
+//!   (spec §6.2) separately confirms quantization doesn't reintroduce the
+//!   NaN/Inf corruption dia already routes around `ort`'s CoreML EP for
+//!   (spec §1).
 //!
 //!   `FBank.mlmodelc` + `Embedding.mlmodelc` (the split fbank-then-embed
 //!   pipeline) are NOT targeted per spec §2.4: wespeaker_v2 computes fbank

--- a/crates/coremlit/tests/speaker/model_io.rs
+++ b/crates/coremlit/tests/speaker/model_io.rs
@@ -172,15 +172,49 @@
 //!   that the shipping arm masks. Both corners reproduce their independently
 //!   pinned numbers (dia-ort's 8 / 0.0000 %; `parity_shipping_der`'s
 //!   5 / 16.5904 %), which is what makes the hybrid cells readable at all.
-//! - *Not established*: WHICH property of the CoreML embedding path carries
-//!   it. The factor varied is the BACKEND, so the implicated object is the
-//!   shipping bundle — int8 palettization **plus** `All` placement **plus**
-//!   that conversion — as one unit. Nor does any of it extend beyond clip 09,
-//!   this host, or these two configurations.
-//! - *What would settle the remainder*: the same hybrid harness with the
-//!   reference segmentation held fixed and the embedding arm run as fp32
-//!   CoreML on `All` and as int8 CoreML on `CpuOnly`. Those two cells separate
-//!   quantization from placement; nothing measured so far does.
+//! - *Not established by (b)*: WHICH property of the CoreML embedding path
+//!   carries it. The factor varied is the BACKEND, so the implicated object is
+//!   the shipping bundle — int8 palettization **plus** `All` placement **plus**
+//!   that conversion — as one unit. That is what (c) separates.
+//!
+//! **(c) The embedding path's three properties, separated.**
+//! `backend_factorial.rs`'s `embedding_precision_x_placement` holds dia's
+//! reference segmentation fixed for every arm and runs the embedding arm across
+//! precision x placement, same clip and host:
+//!
+//! ```text
+//! cell | embedding arm            | spk |      DER |     conf | err units
+//! -----+--------------------------+-----+----------+----------+----------
+//!    A | ONNX fp32 / ort CPU EP   |   8 |  0.0000% |  0.0000% |         0
+//!    B | CoreML int8 / All        |   5 | 16.5904% | 16.5904% |     11999
+//!    C | CoreML fp32 / All        |   7 |  2.5427% |  2.5427% |      1839
+//!    D | CoreML int8 / CpuOnly    |   6 | 16.3636% | 16.3636% |     11835
+//!    E | CoreML fp32 / CpuOnly    |   8 |  0.0000% |  0.0000% |         0
+//! ```
+//!
+//! - *Established*: **the embedding CONVERSION is exonerated.** Cell E — the
+//!   same CoreML graph with both other factors removed — reproduces dia-ort
+//!   frame-perfectly: 8 of 8 speakers and `err_units == 0`, not one
+//!   collar-scored speaker-frame different, at mean AND minimum cosine
+//!   1.000000 against dia's fp32 ONNX over all 2 114 `(chunk, slot)` rows.
+//!   *(b)*'s "the CoreML embedding path" must not be read as "the CoreML
+//!   embedding conversion".
+//! - *Established*: the two remaining factors are separable, additive on
+//!   speaker count, and very unequal on error mass. **int8 palettization costs
+//!   2 speakers at BOTH placements** (E 8 -> D 6; C 7 -> B 5) and 11 835 of the
+//!   shipping arm's 11 999 error units — 98.6 % of it. **The `All` placement
+//!   costs 1 speaker at BOTH precisions** (E 8 -> C 7; D 6 -> B 5) and 1 839 /
+//!   164 error units respectively. Neither factor alone reproduces the shipping
+//!   5-of-8 collapse.
+//! - *Not established*: anything about the REMEDY's cost. Every arm here runs
+//!   over ONNX segmentation, which is not what this crate ships, and no
+//!   fp32/`All` DER arm exists for the gated clips (06 / 14 / 10) —
+//!   `parity_shipping_der` measures fp32 only on `CpuOnly`. Nor does any of it
+//!   extend beyond clip 09 or this host.
+//! - *What would settle the remainder*: an fp32/`All` arm added to
+//!   `parity_shipping_der`'s per-clip measurement, so the speakers cell C
+//!   recovers on clip 09 can be priced against what fp32 does to clip 14 — the
+//!   clip that already sits nearest a clustering decision boundary.
 //!
 //! The mechanism INSIDE the segmentation graph is a further step again, and it
 //! is not established either: `segments` is the only tensor either graph
@@ -276,22 +310,34 @@
 //!   order as the conversion's own. "Within the selected bound" is the
 //!   claim; "free" is not.
 //!
-//!   *Not established*: that int8 is accuracy-neutral on 8-speaker audio.
-//!   Clip 09 cannot adjudicate the precision axis at all — its fp32 control
-//!   returns `Err(AmbiguousAliveCluster)` and produces no diarization to
-//!   compare against — so int8-vs-fp32 there is UNMEASURED, not equal. What
-//!   IS measured on clip 09 is worse for this DECISION than "unmeasured":
-//!   `backend_factorial.rs` shows the shipping embedding path (this int8
-//!   artifact on `All`) sufficient on its own to collapse 8 speakers to 5
-//!   there — see "Clip 09" above. That does not overturn the DECISION, which
-//!   rests on the clips whose fp32 control clusters, but it is the open
-//!   question against it. Nothing here extends past these four clips, this
-//!   host, or these two placements.
+//!   *Refuted on 8-speaker audio, and this is the open question against the
+//!   DECISION.* This paragraph used to say clip 09 "cannot adjudicate the
+//!   precision axis at all", because `parity_shipping_der`'s fp32 control
+//!   there returns `Err(AmbiguousAliveCluster)` and produces nothing to
+//!   compare against. That control is confounded: it runs CoreML
+//!   segmentation, and the segmentation conversion has its own clip-09
+//!   defect. With dia's reference segmentation held fixed instead, the fp32
+//!   control clusters fine and the precision axis IS measurable —
+//!   `backend_factorial.rs`'s `embedding_precision_x_placement`, "Clip 09"
+//!   table (c) above. It costs **2 speakers at both placements** (8 -> 6 on
+//!   `CpuOnly`, 7 -> 5 on `All`) and 11 835 of the shipping arm's 11 999
+//!   error units. On this clip int8 is not accuracy-neutral by a wide margin;
+//!   it is the dominant term in the collapse.
 //!
-//!   *What would settle it*: the fp32 control clustering on clip 09 (which
-//!   is the clip-09 defect itself, see "Segmentation provenance" above),
-//!   plus the four remaining ≥ 3-speaker corpus clips (08 / 11 / 12 / 13)
-//!   measured on the same precision axis.
+//!   That does not overturn the DECISION, which rests on the clips whose fp32
+//!   control clusters and where the count is preserved — but it converts "the
+//!   open question against it" from a suspicion into a measurement. Nothing
+//!   here extends past these four clips, this host, or these two placements.
+//!
+//!   *What would settle it*: an fp32/`All` arm in `parity_shipping_der`'s
+//!   per-clip measurement, so the two speakers fp32 recovers on clip 09 can be
+//!   priced against what fp32 does to clip 14 (the clip nearest a clustering
+//!   decision boundary) — plus the four remaining ≥ 3-speaker corpus clips
+//!   (08 / 11 / 12 / 13) measured on the same precision axis. Note the
+//!   candidate remedy here is the ALREADY-STAGED fp32 `wespeaker.mlmodelc`,
+//!   not the published re-palettized `wespeaker_int8` re-conversion whose
+//!   clip-14 regression is recorded above; they are different artifacts and
+//!   only the latter has been measured to cost clip 14.
 //!
 //!   The evidence lives in `parity_shipping_der.rs`; a parity gate
 //!   (spec §6.2) separately confirms quantization doesn't reintroduce the

--- a/crates/coremlit/tests/speaker/parity_embed.rs
+++ b/crates/coremlit/tests/speaker/parity_embed.rs
@@ -5,8 +5,9 @@
 //!
 //! dia-ort runs the **fp32** `wespeaker_resnet34_lm.onnx` (26.7 MB float32).
 //! The conversion-fidelity gate therefore compares it against the **fp32**
-//! CoreML sibling `wespeaker.mlmodelc` ([`common::embed_fp32_path`]) — NOT the
-//! int8-palettized shipping artifact `wespeaker_v2.mlmodelc`. T3 measured
+//! CoreML sibling `wespeaker.mlmodelc` ([`common::embed_fp32_path`], the
+//! SHIPPING artifact since issue #15) — NOT the retired int8-palettized
+//! `wespeaker_v2.mlmodelc`. T3 measured
 //! ~0.90-0.92 cosine int8-vs-fp32 (pure quantization cost); comparing int8
 //! CoreML against fp32 ort would fold that quantization loss into the gate and
 //! produce a FALSE fail. The int8 path is measured separately below as
@@ -155,7 +156,7 @@ fn embedding_parity_fp32_vs_dia_ort() {
   );
 }
 
-/// INFORMATIONAL — int8 CoreML (`wespeaker_v2.mlmodelc`, the shipping artifact)
+/// INFORMATIONAL — int8 CoreML (`wespeaker_v2.mlmodelc`, the RETIRED sibling)
 /// vs fp32 dia-ort. Characterizes int8 quantization cost (T3: ~0.90-0.92); NOT
 /// a conversion-fidelity gate, asserts only [`INT8_SANITY_FLOOR`].
 #[test]

--- a/crates/coremlit/tests/speaker/parity_seg.rs
+++ b/crates/coremlit/tests/speaker/parity_seg.rs
@@ -10,8 +10,10 @@
 //! **Both sides emit `log(softmax(·))`, not raw logits** — this file, the
 //! golden's `seg_logits` field name, and `generate_goldens.rs` all said
 //! "raw logits, neither side softmaxes" until the graphs were read.
-//! `pyannote_segmentation.mlmodelc/model.mil` ends `softmax` → `log` →
-//! `-> (segments)` (quoted in `crate::segment`'s module doc), and the
+//! `pyannote_segmentation.mlmodelc/model.mil` ends `reduce_log_sum_exp` →
+//! `sub` → `-> (segments)` — the fused form of the `softmax` → `log` tail it
+//! carried before the issue-#15 re-conversion, both quoted in
+//! `crate::segment`'s module doc — and the
 //! committed ORT golden is log-probabilities on its own arithmetic: all
 //! 4123 values are `<= 0` and every 7-class row satisfies
 //! `sum(exp(row)) == 1.000000`. The comparison below is therefore still

--- a/crates/coremlit/tests/speaker/parity_shipping_der.rs
+++ b/crates/coremlit/tests/speaker/parity_shipping_der.rs
@@ -94,6 +94,19 @@
 //!    because the shipping embedding path is int8 on `All`, which no arm here
 //!    isolates.
 //!
+//!    That older reading is now **refuted**, and this suite's own fp32 control
+//!    is why it survived so long: the control is CONFOUNDED, because it runs
+//!    CoreML segmentation, and the segmentation conversion's separate clip-09
+//!    defect is what makes it unable to answer.
+//!    `backend_factorial.rs`'s `embedding_precision_x_placement` holds dia's
+//!    reference segmentation fixed instead, at which point the fp32 control
+//!    clusters and the precision axis is measurable: int8 costs **2 speakers at
+//!    both placements** (8 → 6 on `CpuOnly`, 7 → 5 on `All`) and 11 835 of the
+//!    shipping arm's 11 999 error units, while the CoreML embedding conversion
+//!    at fp32 on `CpuOnly` reproduces dia-ort frame-perfectly. On clip 09 the
+//!    defect is mostly int8's; the `All` placement adds the third lost speaker;
+//!    the conversion itself adds none.
+//!
 //! # The diagnostic: confusion, not DER
 //!
 //! DER decomposes into miss + false-alarm + confusion. Miss/FA move with
@@ -1295,6 +1308,16 @@ shipping_der_gate! {
   /// int8/All numbers pinned below (see the module doc's point 2). This is a real,
   /// separately-actionable defect, and it is pinned here rather than deleted so it
   /// cannot be forgotten.
+  ///
+  /// The fp32 control being "worse than int8" HERE is an artifact of this
+  /// suite's design, not a property of fp32: every arm above runs CoreML
+  /// segmentation, so the control carries the segmentation conversion's own
+  /// clip-09 defect on top of whatever the embedder does. Swap in dia's
+  /// reference segmentation and the ordering reverses — fp32/`CpuOnly` becomes
+  /// frame-perfect (8 speakers, 0 error units) and int8 is what costs 2
+  /// speakers. See `backend_factorial.rs`'s `embedding_precision_x_placement`.
+  /// Read the fp32 rows below as "fp32 plus a defective segmenter", never as
+  /// "fp32".
   ///
   /// The assertion is on the KNOWN-BAD state, pinned field by field by
   /// [`assert_clip09_known_defect`]: clip identity, the reference and oracle counts,

--- a/crates/coremlit/tests/speaker/parity_shipping_der.rs
+++ b/crates/coremlit/tests/speaker/parity_shipping_der.rs
@@ -1,127 +1,46 @@
-//! **The shipping-precision DER gate**: does the int8 embedder speakerkit
-//! actually ships (`wespeaker_v2.mlmodelc`) diarize multi-speaker audio the
-//! same way the fp32 embedder every other gate measures (`wespeaker.mlmodelc`)
-//! does?
+//! **The shipping-configuration DER gate**: does the diarizer configuration
+//! speakerkit actually ships — the fp32 `wespeaker.mlmodelc` embedder with
+//! both CoreML models on [`ComputeUnits::All`] — diarize multi-speaker audio
+//! the way dia's own ONNX reference does, and what does each compute
+//! placement cost against that?
 //!
-//! # Why this suite exists (the hole it closes)
+//! # History: why the shipping embedder is fp32 (issue #15)
 //!
-//! Every DER number this crate has ever produced came from the **fp32**
-//! embedder. `parity_e2e.rs` loads `common::embed_fp32_path()` in *all three*
-//! of its pipeline runners, deliberately and correctly: its job is to isolate
-//! the CoreML-vs-ONNX *conversion* physics against dia-ort's fp32
-//! `wespeaker_resnet34_lm.onnx`, so precision must be held constant.
+//! Until issue #15 this crate shipped the int8-palettized
+//! `wespeaker_v2.mlmodelc`, and this suite's job was the precision axis. That
+//! configuration SILENTLY COLLAPSED 8-speaker audio: 5 of 8 speakers at
+//! 16.5904 % DER (100 % confusion) on clip 09, where dia-ort is
+//! frame-perfect. The attribution chain lives in
+//! `tests/speaker/backend_factorial.rs`:
 //!
-//! But `ModelSource::load` — the shipping entry point — loads
-//! `wespeaker_v2.mlmodelc`, the **int8-palettized** artifact
-//! (`src/source/mod.rs`; `wespeaker_v2` is byte-identical to
-//! `wespeaker_int8`, `tests/model_io.rs`). int8-vs-fp32 embeddings agree to
-//! only ~0.90-0.92 cosine (T3) — a *larger* divergence than the ~0.94 that
-//! the `ArgmaxSource` carries. And ~0.94 was **not** benign: on the
-//! 7-speaker clip the argmax source invented a spurious 8th speaker and
-//! scored 3.33 % DER that was **100 % confusion** — a genuine clustering
-//! failure, while FluidAudio and dia-ort both landed 7 speakers exactly.
+//! - the embedding conversion itself is EXONERATED (fp32/`CpuOnly` over dia's
+//!   reference segmentation reproduces dia-ort frame-perfectly, min cosine
+//!   1.000000 over all 2 114 rows);
+//! - the int8 palettization costs 2 speakers at either placement, and its
+//!   perturbation is a COHERENT shared displacement (half the delta mass in
+//!   one direction, 23x the isotropic null) that compresses between-speaker
+//!   margins in the frozen community-1 PLDA space while leaving
+//!   within-cluster tightness untouched — `quantization_error_structure`
+//!   pins that mechanism;
+//! - the `All` placement's fp16 scatter costs 1 further speaker on that clip
+//!   at either precision.
 //!
-//! So the shipping default was never measured on the axis that just failed.
-//! This suite measures it.
+//! int8 offered no stable speed edge to lose: across two warm
+//! [`shipping_embedder_cost_int8_vs_fp32`] runs the int8-vs-fp32 extraction
+//! difference stayed ≤ ~15 % on every placement with the SIGN flipping
+//! between runs — inside scheduler variability, which is why that bench
+//! prints rather than asserts a winner (regimes and numbers in
+//! `model_io.rs`'s DECISION). What palettization bought was ~21 MB of
+//! footprint. The palettization is also
+//! structurally aggressive: 38 per-tensor 8-bit LUTs, one flat 256-entry
+//! codebook per whole tensor, covering even the deterministic DSP constants
+//! (the STFT cos/sin bases and the mel filterbank) and the 5120→256 embedding
+//! head. Issue #15 retired it from the shipping selection
+//! (`FluidAudioArtifacts::resolve`); it stays on disk as a tested,
+//! non-shipping sibling so the factorial's record remains reproducible.
 //!
-//! # Why a lower cosine need not mean worse clustering
-//!
-//! `dia`'s clustering is NOT intra-space geometry. `PldaTransform::new()`
-//! takes no data: it loads a **frozen, pretrained** LDA (256→128) + PLDA fit
-//! on the native kaldi-fbank WeSpeaker distribution. LDA/PLDA is not
-//! rotation-invariant, so an embedding that is *systematically warped* can
-//! rotate speaker-discriminative directions into the learned nuisance
-//! subspace — dia's own source records that merely pinning eigenvector signs
-//! "avoids a 38 % DER divergence", i.e. an *orthogonal* basis change swung DER
-//! 38 points. That is the argmax failure mode: a domain warp (a different
-//! fbank front-end) against a frozen basis.
-//!
-//! Quantization is a different physical process — roughly isotropic, unbiased
-//! noise that adds scatter without systematically rotating the discriminative
-//! directions. Whether that distinction *actually holds* is an empirical
-//! question, not an argument. Hence: measure.
-//!
-//! # What the measurement found
-//!
-//! It holds wherever the fp32 control can be measured. **int8 preserves the
-//! speaker-count decision on every clip whose fp32 control clusters (the 3 / 4 /
-//! 7-speaker references), and on the 7-speaker clip that broke argmax the
-//! precision-isolated int8/CpuOnly arm clusters IDENTICALLY to fp32 on every
-//! collar-scored frame — 0.0000 % standard DER, zero confusion, asserted — while
-//! carrying a *worse* embedding cosine than argmax does.** (Identity here is
-//! standard-collar `err_units == 0`, not literal output equality: ~6 sub-collar
-//! frames differ at no-collar, and `int8/All` folds in ANE placement for
-//! 0.0405 % — see [`shipping_int8_der_10_mrbeast_clean_water_7spk`].) Cosine does
-//! not predict clustering; the *kind* of perturbation does.
-//!
-//! The 8-speaker clip (09) is the sole exception, and it is NOT a
-//! speaker-count-preservation result: on it the fp32 control cannot cluster at
-//! all and int8 UNDERCOUNTS (5-6 of 8). That is a separate CoreML-path defect,
-//! pinned as a known defect (§5.10;
-//! [`shipping_int8_der_09_mrbeast_dollar_date_8spk_known_defect`]) — not evidence
-//! that int8 preserves the count on 8-speaker audio, which it does not.
-//!
-//! Two things the measurement also surfaced, which the framing above did not
-//! anticipate:
-//!
-//! 1. **int8 is not bit-identical to fp32 everywhere.** On clip 14 it moves
-//!    0.78 % of scored speech between (correctly-counted) speakers. But the
-//!    fp32 CoreML control ALREADY carries 0.39 % confusion against dia-ort on
-//!    that same clip, with no quantization involved — clip 14's clustering sits
-//!    near a decision boundary where any perturbation (the ONNX→CoreML
-//!    conversion itself, int8, or ANE placement) moves a marginal assignment.
-//!    int8's increment is of the same order as the conversion's own, and costs
-//!    only +0.22 DER points against the reference.
-//! 2. **The CoreML path has a real defect on 8-speaker audio.** On clip 09 the
-//!    *fp32 control* makes dia's clustering return
-//!    `Err(Centroid(AmbiguousAliveCluster { .. }))` — no diarization at all —
-//!    while dia-ort clusters it fine and int8 still answers (undercounting,
-//!    5-6 of 8). Pinned in
-//!    [`shipping_int8_der_09_mrbeast_dollar_date_8spk_known_defect`].
-//!
-//!    WHICH CoreML conversion produces it is a question this suite cannot
-//!    answer — every one of its speakerkit arms runs CoreML segmentation AND
-//!    CoreML embedding, so the two never vary independently.
-//!    `backend_factorial.rs` runs that cross-product at this suite's own
-//!    shipping configuration and finds the CoreML **embedding** path
-//!    sufficient on its own (5 of 8 speakers at 16.5904 % over dia's reference
-//!    segmentation — this suite's pinned shipping numbers, exactly), with the
-//!    segmentation conversion contributing a separate, smaller overcount
-//!    (9 speakers, 1.3011 %). So the older reading of this bullet — that the
-//!    defect is "not int8's" — holds only in the narrow sense the fp32 control
-//!    licenses: the fp32/`CpuOnly` arm fails WORSE (it cannot answer at all).
-//!    It is not evidence that the shipping embedding path is uninvolved,
-//!    because the shipping embedding path is int8 on `All`, which no arm here
-//!    isolates.
-//!
-//!    That older reading is now **refuted**, and this suite's own fp32 control
-//!    is why it survived so long: the control is CONFOUNDED, because it runs
-//!    CoreML segmentation, and the segmentation conversion's separate clip-09
-//!    defect is what makes it unable to answer.
-//!    `backend_factorial.rs`'s `embedding_precision_x_placement` holds dia's
-//!    reference segmentation fixed instead, at which point the fp32 control
-//!    clusters and the precision axis is measurable: int8 costs **2 speakers at
-//!    both placements** (8 → 6 on `CpuOnly`, 7 → 5 on `All`) and 11 835 of the
-//!    shipping arm's 11 999 error units, while the CoreML embedding conversion
-//!    at fp32 on `CpuOnly` reproduces dia-ort frame-perfectly. On clip 09 the
-//!    defect is mostly int8's; the `All` placement adds the third lost speaker;
-//!    the conversion itself adds none.
-//!
-//! # The diagnostic: confusion, not DER
-//!
-//! DER decomposes into miss + false-alarm + confusion. Miss/FA move with
-//! *speech/non-speech* boundaries — benign jitter the 0.25 s collar exists to
-//! absorb. **Confusion** means speech was attributed to the WRONG speaker.
-//! Argmax was caught by confusion (3.33 % DER, all of it confusion, plus a
-//! speaker-count flip).
-//!
-//! But confusion is a cross-artifact AGREEMENT statistic, not a correctness
-//! one, so it is the *diagnostic*, not the tight gate. What gates is the pair
-//! of DECISION metrics: the **speaker count** (exact equality — the thing
-//! argmax violated) and **agreement with the independent reference**
-//! ([`SHIPPING_ABS_DELTA_MAX`]). Confusion carries only a gross-regression
-//! tripwire ([`SHIPPING_CONFUSION_TRIPWIRE`]); read that constant's doc before
-//! touching it.
+//! With precision fixed at fp32, the axis that remains is PLACEMENT, and that
+//! is what this suite now measures and gates.
 //!
 //! # The arms (all fed ONE audio buffer — the input-identity proof)
 //!
@@ -130,16 +49,49 @@
 //! input is a harness bug, not a finding; this exact trap produced a fake
 //! "86 % divergence" in a sibling crate):
 //!
-//! | arm | embedder | compute | role |
+//! | arm | segmentation | embedder | role |
 //! |---|---|---|---|
-//! | `dia-ort` | fp32 ONNX | ort CPU | the oracle |
-//! | `fp32/CpuOnly` | `wespeaker.mlmodelc` | `CpuOnly` | the CONTROL (reproduces `parity_e2e`'s config) |
-//! | `int8/CpuOnly` | `wespeaker_v2.mlmodelc` | `CpuOnly` | the precision axis, isolated |
-//! | `int8/All` | `wespeaker_v2.mlmodelc` | `All` | the **literal shipping default** |
+//! | `dia-ort` | dia ONNX | dia fp32 ONNX | the oracle |
+//! | `sAll+eAll` | CoreML `All` | CoreML `All` | the **literal shipping default** |
+//! | `sAll+eCpu` | CoreML `All` | CoreML `CpuOnly` | the embedder-placement control |
+//! | `sCpu+eCpu` | CoreML `CpuOnly` | CoreML `CpuOnly` | the all-CPU deterministic fallback |
 //!
-//! Grid geometry (`num_chunks` / `num_output_frames`) is asserted equal across
-//! every arm AND against dia-ort's own pipeline, so no comparison is made
-//! across a misaligned framing.
+//! Every speakerkit arm loads the embedder through the SAME
+//! `FluidAudioArtifacts` resolver production uses, so the shipping arm IS the
+//! shipping selection by construction. Grid geometry (`num_chunks` /
+//! `num_output_frames`) is asserted equal across every arm AND against
+//! dia-ort's own pipeline, so no comparison is made across a misaligned
+//! framing.
+//!
+//! # The gates
+//!
+//! [`gate`] (clips 06 / 14 / 10): **G0** every arm clusters; **G1** every
+//! arm's speaker count equals dia-ort's (the decision metric — the one argmax
+//! violated 7→8, and the one the retired int8 embedder violated 8→5);
+//! **G2** the shipping placement stays within [`SHIPPING_ABS_DELTA_MAX`] of
+//! the CPU-embedder control on reference agreement; **G3** arm-vs-control
+//! confusion under [`SHIPPING_CONFUSION_TRIPWIRE`].
+//!
+//! Clip 09 (8 speakers) cannot run the plain gate: its two CONTROL arms sit
+//! on a real, pinned segmentation knife edge — a spurious 9th speaker with
+//! the embedder on CPU, and diaric's alive-band `Err` refusal with everything
+//! on CPU, each pinned as its own observed outcome (reading both as one
+//! near-threshold cluster is the interpretation the pattern supports, not an
+//! asserted cross-arm identity — [`assert_clip09_record`]'s doc carries the
+//! distinction). Its SHIPPING arm is gated at 8 of 8 speakers with a pinned
+//! DER band, and the control states are pinned fail-if-changed.
+//!
+//! # The diagnostic: confusion, not DER
+//!
+//! DER decomposes into miss + false-alarm + confusion. Miss/FA move with
+//! *speech/non-speech* boundaries — benign jitter the 0.25 s collar exists to
+//! absorb. **Confusion** means speech was attributed to the WRONG speaker.
+//! Argmax was caught by confusion (3.33 % DER, all of it confusion, plus a
+//! speaker-count flip); the int8 collapse was 100 % confusion too. But
+//! confusion between two of our own arms is an AGREEMENT statistic, not a
+//! correctness one, so it carries only the gross-regression tripwire
+//! ([`SHIPPING_CONFUSION_TRIPWIRE`]); the tight gates are the speaker count
+//! (exact) and reference agreement ([`SHIPPING_ABS_DELTA_MAX`]).
 //!
 //! # The clips
 //!
@@ -148,14 +100,9 @@
 //! speaker-count ladder at the lowest runtime — the regime where clustering can
 //! actually fail. The full ≥ 3-speaker membership and this selection are pinned
 //! against silent drift by [`shipping_clip_selection_is_the_documented_subset`].
-//! `parity_e2e`'s fixtures (2 speakers, ≤ 30 s) cannot
-//! express this failure: argmax scored 0.0000 % on them and still broke at 7
-//! speakers. That is the whole reason this suite exists — **the gate must run
-//! on audio hard enough to fail.**
-//!
-//! 06/14/10 are gated by [`gate`]. 09 is a pinned known defect (its fp32
-//! control cannot cluster at all), so it cannot gate the precision axis; it
-//! asserts the known-bad state instead, and fails on purpose if that is fixed.
+//! `parity_e2e`'s fixtures (2 speakers, ≤ 30 s) cannot express this failure:
+//! argmax scored 0.0000 % on them and still broke at 7 speakers, and the int8
+//! collapse needed 8. **The gate must run on audio hard enough to fail.**
 //!
 //! # The reference (pyannote's output, not ground truth)
 //!
@@ -163,7 +110,7 @@
 //! `manifest.json`), not human labels — the upstream reference implementation
 //! the stack targets. Absolute DER here means "distance to pyannote 4.0.4",
 //! reported honestly as such. The *decision* gate is against dia-ort and the
-//! fp32 control, which are apples-to-apples.
+//! placement controls, which are apples-to-apples.
 //!
 //! `#[ignore]`d (needs the gitignored `Models/speakerkit`, the sibling
 //! `diarization` ONNX + fixtures, and `ort`). Run with:
@@ -171,6 +118,16 @@
 //! ```text
 //! cargo test -p coremlit --features speaker-oracle --test speaker_parity_shipping_der -- --ignored --nocapture
 //! ```
+//!
+//! When swapping a `Models/speakerkit` artifact, finish staging the WHOLE
+//! bundle before any model-gated run starts — stage aside and rename, rather
+//! than copying files into a live bundle one by one. The byte pins read every
+//! file of a bundle, so a partially-staged swap fails them deterministically
+//! with hashes that look plausible (pre-repair siblings share bytes), and the
+//! failure looks like a code regression until the mtimes are checked. With
+//! multiple checkouts on one machine, `SPEAKERKIT_TEST_MODELS` additionally
+//! pins WHICH tree a run reads (the default resolves from the building
+//! checkout's manifest path).
 #![cfg(feature = "speaker-oracle")]
 
 mod common;
@@ -195,65 +152,64 @@ use der_calc::{
 // The gate bounds
 // ══════════════════════════════════════════════════════════════════════
 
-/// **The decision gate.** Ceiling on |DER(int8 vs pyannote) − DER(fp32 vs
-/// pyannote)| (standard, 0.25 s collar): how much *agreement with the
-/// independent reference* the shipping quantization may cost, relative to the
-/// fp32 control every existing gate measures.
+/// **The decision gate.** Ceiling on |DER(arm vs pyannote) − DER(control vs
+/// pyannote)| (standard, 0.25 s collar) for the shipping placement
+/// (`sAll+eAll`) and the all-CPU fallback (`sCpu+eCpu`), each against the
+/// CPU-embedder control (`sAll+eCpu`): how much *agreement with the
+/// independent reference* a compute placement may cost.
 ///
-/// This is a bound against the INDEPENDENT reference, not bit-agreement with
-/// another of our own artifacts, which is why it is the tight one. The argmax clustering failure cost +3.33
-/// points here and would blow through it 3×. Measured worst for int8: +0.2209 %
-/// (`int8/CpuOnly`) and +0.4217 % (`int8/All`, the literal shipping config) —
-/// both well inside. Never loosened.
+/// Derivation (issue #15 re-derivation; Apple M1 Max, macOS 26.5 build
+/// 25F71, arm64, release harness, the byte-pinned fp16-safe artifacts).
+/// Measured placement deltas on the three count-stable gated clips:
+///
+/// ```text
+/// clip |  Δ(sAll+eAll − ctrl) | Δ(sCpu+eCpu − ctrl)
+///   06 |            +0.3069pp |           +0.0508pp
+///   14 |            +0.2843pp |           +0.3220pp
+///   10 |            +0.0369pp |           +0.0000pp
+/// ```
+///
+/// Worst measured |Δ| = 0.3220 pp. The bound is 1 pp: ≥ 3x the worst
+/// measured placement drift (headroom for scheduler/host variation without
+/// absorbing a real regression), and 3.3x BELOW the smallest known real
+/// clustering failure on this axis — the argmax source's +3.33 pp — so that
+/// failure class cannot pass. Clip 09 is excluded from this gate: its
+/// control arms sit on the pinned segmentation knife edge
+/// ([`assert_clip09_record`]), so its shipping arm carries its own pinned
+/// band instead. Never loosened.
 const SHIPPING_ABS_DELTA_MAX: f64 = 0.01;
 
-/// Gross-regression tripwire on the **confusion** component of the int8-vs-fp32
-/// parity DER — speech attributed to a DIFFERENT speaker than the fp32 control
-/// put it under.
+/// Gross-regression tripwire on the **confusion** component of the
+/// arm-vs-control parity DER — speech attributed to a DIFFERENT speaker than
+/// the CPU-embedder control put it under.
 ///
 /// # Why this is a tripwire and not a tight bound (read before changing it)
 ///
-/// This suite was written expecting confusion to be ~0 for anything short of a
-/// real clustering failure, and gated it at 0.5 % a priori. The measurement
-/// falsified the premise, and the reason matters:
-///
-/// - clips 06 (3 spk) and 10 (7 spk): int8-vs-fp32 confusion is **0.0000 %** —
-///   int8 clusters *identically* to fp32 on every collar-scored frame
-///   (`der_std` `err_units == 0`; clip 10's identity is asserted in
-///   [`shipping_int8_der_10_mrbeast_clean_water_7spk`]).
-/// - clip 14 (4 spk): **0.7832 %** — over that 0.5 %. But on the SAME clip the
-///   **fp32 CoreML control already carries 0.39 % confusion against dia-ort**,
-///   with zero quantization involved. Clip 14's clustering simply sits near a
-///   decision boundary, where *any* perturbation — the ONNX→CoreML conversion
-///   itself, int8, or ANE placement — moves a marginal assignment. The
-///   quantization is not special; it is one perturbation among three of the
-///   same magnitude.
-///
-/// So int8-vs-fp32 confusion is a cross-artifact AGREEMENT proxy, not a
-/// correctness metric, and a tight bound on it would gate something the fp32
-/// path does not itself achieve — the exact anti-pattern `parity_seg.rs` and
-/// `parity_e2e.rs` already re-scoped in this repo ("gate the decision metric;
-/// report the raw"). The decision metrics here are the speaker count (exact
-/// equality, asserted) and [`SHIPPING_ABS_DELTA_MAX`] (agreement vs the
-/// reference); both hold with margin.
-///
-/// This tripwire therefore guards only against a CATASTROPHIC clustering
-/// regression. It is set above the measured marginal drift (worst 0.7832 %) and
-/// below the one known real failure on this axis — the argmax source's 3.33 %
-/// DER, 100 % of it confusion, plus a spurious 8th speaker — so that failure
-/// still trips it. Same role as `parity_e2e`'s `STRICT_JITTER_TRIPWIRE`, and
-/// the same rule: it is a controller decision, and it is never raised to hide a
+/// Arm-vs-control confusion is a cross-placement AGREEMENT proxy, not a
+/// correctness metric: clip 14's clustering sits near a decision boundary
+/// where ANY perturbation (the conversion itself, a placement, formerly the
+/// int8 quantization) moves a marginal assignment, so a tight bound here
+/// would gate something no placement pair achieves. The decision metrics are
+/// the speaker count (exact equality, G1) and [`SHIPPING_ABS_DELTA_MAX`]
+/// (agreement vs the reference); this tripwire only guards against a
+/// CATASTROPHIC clustering divergence between placements. It sits well above
+/// the placement-drift scale the deltas above imply (every arm-vs-control
+/// DER is ≤ ~0.4 pp on the count-stable clips, and confusion is bounded by
+/// that DER) and below the one known real failure on this axis — the argmax
+/// source's 3.33 % DER, 100 % of it confusion — so that failure still trips
+/// it. It is a controller decision, and it is never raised to hide a
 /// regression.
 const SHIPPING_CONFUSION_TRIPWIRE: f64 = 0.02;
 
 /// Two-sided tolerance (±0.05 pp) on the clip-09 known-defect DER pins
 /// ([`assert_clip09_known_defect`]) — the SAME band `parity_e2e`'s `DER_PIN_TOL`
-/// uses, for the same reason: the int8/CpuOnly pipeline is deterministic and the
-/// int8/All value reproduced EXACTLY across two independent full runs (spec
-/// §5.9), so the band exists only to absorb a stray flipped frame on a different
-/// CoreML build, not to hide movement. The pinned drifts here are ~16 pp, ~330×
-/// this band, so any clustering-decision change fires immediately. Never widened
-/// to make the pin pass; the clip-09 pin is a fail-if-fixed owner decision.
+/// uses, for the same reason: the pipeline is deterministic per placement and
+/// the int8-era clip-09 values reproduced EXACTLY across two independent full
+/// runs (spec §5.9), so the band exists only to absorb a stray flipped frame
+/// on a different CoreML build, not to hide movement. The knife-edge states
+/// this band pins are speaker-count and error-mode changes far larger than
+/// it, so any clustering-decision change fires immediately. Never widened to
+/// make a pin pass.
 const DER_PIN_TOL: f64 = 0.000_5;
 
 /// A dia parity-corpus clip with ≥ 3 reference speakers — the regime where
@@ -494,14 +450,22 @@ fn dia_ort_run(samples: &[f32], plda: &dia::plda::PldaTransform) -> DiaOrtRun {
 }
 
 /// speakerkit's FluidAudio source over an explicitly-chosen embedder artifact
-/// and placement — the one knob this suite varies.
-fn fluidaudio_extraction(samples: &[f32], embed_path: &Path, cu: ComputeUnits) -> Extraction {
+/// and per-model placements — the knobs this suite varies. Segmentation and
+/// embedder placements are independent in production
+/// ([`coremlit::audio::speaker::extract::ComputeOptions`] carries one
+/// [`ComputeUnits`] per model), so every arm names both.
+fn fluidaudio_extraction(
+  samples: &[f32],
+  embed_path: &Path,
+  seg_cu: ComputeUnits,
+  emb_cu: ComputeUnits,
+) -> Extraction {
   let seg = SegmentModel::from_file_with(
     common::seg_path(),
-    SegmentModelOptions::new().with_compute(cu),
+    SegmentModelOptions::new().with_compute(seg_cu),
   )
   .expect("load pyannote_segmentation.mlmodelc");
-  let embed = EmbedModel::from_file_with(embed_path, EmbedModelOptions::new().with_compute(cu))
+  let embed = EmbedModel::from_file_with(embed_path, EmbedModelOptions::new().with_compute(emb_cu))
     .expect("load wespeaker embedder");
   FluidAudioSource::with_options(seg, embed, Options::new())
     .extract(samples)
@@ -518,12 +482,12 @@ fn fluidaudio_extraction(samples: &[f32], embed_path: &Path, cu: ComputeUnits) -
 /// `Pipeline(Centroid(AmbiguousAliveCluster { .. }))`, its deliberate bail-out
 /// when a cluster's alive-value lands in the SIMD guard band around the
 /// threshold). Whether a given arm hits that is itself a first-class
-/// measurement — if the shipping int8 arm errors where the fp32 control
-/// succeeds, the shipping default cannot diarize that audio AT ALL, which is a
-/// far worse defect than any DER. Unwrapping would report it as an opaque
-/// harness panic; and keeping the TYPED [`diaric::offline::Error`] (not a
-/// `String`) is what lets [`assert_clip09_known_defect`] match the exact
-/// `AmbiguousAliveCluster` variant, not merely assert `is_err`.
+/// measurement — an arm that errors where the oracle clusters means that
+/// configuration cannot diarize the audio AT ALL, which is a far worse defect
+/// than any DER. Unwrapping would report it as an opaque harness panic; and
+/// keeping the TYPED [`diaric::offline::Error`] (not a `String`) is what lets
+/// [`assert_clip09_record`] match the exact `AmbiguousAliveCluster` variant,
+/// not merely assert `is_err`.
 fn diarize_extraction_segs(
   ext: &Extraction,
   plda: &diaric::plda::PldaTransform,
@@ -583,7 +547,13 @@ struct ClipCtx<'a> {
 
 /// Runs one arm end-to-end and re-proves it consumed the untouched buffer on
 /// the untouched grid.
-fn run_arm(ctx: &ClipCtx<'_>, tag: &'static str, embed_path: &Path, cu: ComputeUnits) -> Arm {
+fn run_arm(
+  ctx: &ClipCtx<'_>,
+  tag: &'static str,
+  embed_path: &Path,
+  seg_cu: ComputeUnits,
+  emb_cu: ComputeUnits,
+) -> Arm {
   let ClipCtx {
     clip,
     samples,
@@ -593,7 +563,7 @@ fn run_arm(ctx: &ClipCtx<'_>, tag: &'static str, embed_path: &Path, cu: ComputeU
   } = *ctx;
 
   let t0 = Instant::now();
-  let ext = fluidaudio_extraction(samples, embed_path, cu);
+  let ext = fluidaudio_extraction(samples, embed_path, seg_cu, emb_cu);
   let extract_s = t0.elapsed().as_secs_f64();
 
   // ── INPUT-IDENTITY PROOF. The buffer every arm consumed must still be the
@@ -656,15 +626,21 @@ struct Measurement {
   /// count.)
   dia_spk: usize,
   reference: Vec<Seg>,
-  fp32: Arm,
-  int8_cpu: Arm,
-  int8_all: Arm,
+  /// `seg@All + fp32@All` — the literal shipping default, through the
+  /// production resolver.
+  shipping: Arm,
+  /// `seg@All + fp32@CpuOnly` — the EMBEDDER-placement control: identical
+  /// segmentation tensors, embedder moved to IEEE CPU kernels.
+  emb_cpu: Arm,
+  /// `seg@CpuOnly + fp32@CpuOnly` — the all-CPU deterministic fallback, the
+  /// configuration `parity_e2e`'s Part A gates on its own corpus.
+  all_cpu: Arm,
 }
 
-/// Measures one clip across all four arms and prints the full report. Asserts
-/// only the things that make the measurement *meaningful at all* (audio
-/// identity, grid identity, reference speaker count); the product gate is
-/// [`gate`].
+/// Measures one clip across the oracle + three fp32 arms and prints the full
+/// report. Asserts only the things that make the measurement *meaningful at
+/// all* (audio identity, grid identity, reference speaker count); the product
+/// gate is [`gate`].
 ///
 /// Split per-clip (rather than one loop over the clip table) because these are
 /// 10-24 minute recordings: each clip is ~4 full pipeline passes, so per-clip
@@ -678,9 +654,8 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
     audio.display()
   );
   assert!(
-    common::embed_path().exists() && common::embed_fp32_path().exists(),
-    "need BOTH wespeaker_v2.mlmodelc (int8, shipping) and wespeaker.mlmodelc (fp32) under {} \
-     (set SPEAKERKIT_TEST_MODELS)",
+    common::embed_fp32_path().exists(),
+    "need wespeaker.mlmodelc (fp32, shipping) under {} (set SPEAKERKIT_TEST_MODELS)",
     common::models_dir().display()
   );
 
@@ -748,8 +723,8 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
   let dia_spk = distinct_speakers(&dia.segs).len();
 
   // ── The three speakerkit arms, all on the SAME buffer, the SAME (measured,
-  // diaric) PLDA and the SAME grid. Only the embedder artifact and the
-  // placement vary.
+  // diaric) PLDA, the SAME shipping artifact and the SAME grid. Only the two
+  // model placements vary.
   let ctx = ClipCtx {
     clip: clip.name,
     samples: &samples,
@@ -757,25 +732,33 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
     plda: &plda_dc,
     dia: &dia,
   };
-  // The int8 embedder path comes from the SAME resolver production uses
-  // (`AnySource::load`'s FluidAudio arm), so "the shipping int8 arm" IS the
-  // shipping selection by construction — not a second copy of the path via
-  // `common::embed_path()` that could drift from production (finding 3). fp32 is
-  // the CONTROL and deliberately stays the non-shipping `wespeaker.mlmodelc`.
-  let shipping = FluidAudioArtifacts::resolve(common::models_dir());
-  let fp32 = run_arm(
+  // The shipping embedder path comes from the SAME resolver production uses
+  // (`AnySource::load`'s FluidAudio arm), so the shipping arm IS the shipping
+  // selection by construction — not a second copy of the path via
+  // `common::embed_fp32_path()` that could drift from production (finding 3).
+  // The control arms move ONE placement at a time off that default.
+  let artifacts = FluidAudioArtifacts::resolve(common::models_dir());
+  let shipping = run_arm(
     &ctx,
-    "fp32/CpuOnly",
-    &common::embed_fp32_path(),
+    "sAll+eAll",
+    artifacts.embedder(),
+    ComputeUnits::All,
+    ComputeUnits::All,
+  );
+  let emb_cpu = run_arm(
+    &ctx,
+    "sAll+eCpu",
+    artifacts.embedder(),
+    ComputeUnits::All,
     ComputeUnits::CpuOnly,
   );
-  let int8_cpu = run_arm(
+  let all_cpu = run_arm(
     &ctx,
-    "int8/CpuOnly",
-    shipping.embedder(),
+    "sCpu+eCpu",
+    artifacts.embedder(),
+    ComputeUnits::CpuOnly,
     ComputeUnits::CpuOnly,
   );
-  let int8_all = run_arm(&ctx, "int8/All", shipping.embedder(), ComputeUnits::All);
 
   // ══ REPORT (unconditional — printed BEFORE any assertion) ══
   //
@@ -785,24 +768,24 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
   println!(
     "[{}] speaker counts: reference={ref_spk} dia-ort={dia_spk} {}={} {}={} {}={}",
     clip.name,
-    fp32.tag,
-    fp32.spk_str(),
-    int8_cpu.tag,
-    int8_cpu.spk_str(),
-    int8_all.tag,
-    int8_all.spk_str(),
+    shipping.tag,
+    shipping.spk_str(),
+    emb_cpu.tag,
+    emb_cpu.spk_str(),
+    all_cpu.tag,
+    all_cpu.spk_str(),
   );
   println!(
     "[{}] extract wall-clock (CONTENDED when clips run in parallel — NOT a latency \
      measurement; see shipping_embedder_cost_int8_vs_fp32): dia-ort={dia_s:.1}s {}={:.1}s \
      {}={:.1}s {}={:.1}s",
     clip.name,
-    fp32.tag,
-    fp32.extract_s,
-    int8_cpu.tag,
-    int8_cpu.extract_s,
-    int8_all.tag,
-    int8_all.extract_s,
+    shipping.tag,
+    shipping.extract_s,
+    emb_cpu.tag,
+    emb_cpu.extract_s,
+    all_cpu.tag,
+    all_cpu.extract_s,
   );
 
   println!(
@@ -810,7 +793,7 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
     clip.name,
     fmt_der("ABS dia-ort      std   ", &der_std(&reference, &dia.segs))
   );
-  for arm in [&fp32, &int8_cpu, &int8_all] {
+  for arm in [&shipping, &emb_cpu, &all_cpu] {
     match &arm.segs {
       Ok(segs) => {
         println!(
@@ -834,30 +817,22 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
     }
   }
 
-  // The precision axis, ISOLATED: int8 vs the fp32 control at the SAME compute
-  // placement, same audio, same clustering — ONLY the embedder artifact differs.
-  //
-  // `CONVERSION fp32 vs dia-ort` is the yardstick every int8 number must be read
-  // against: it is the drift the ONNX→CoreML conversion ALREADY carries at fp32,
-  // before any quantization exists.
-  //
-  // `SHIPPING int8/All vs fp32/CpuOnly` deliberately confounds two axes
-  // (precision AND placement); it is the LITERAL shipping config, reported so the
-  // shipped behaviour is visible, but the clean precision signal is the CpuOnly
-  // pair.
-  for (tag, hyp) in [
+  // The placement axes, ISOLATED: the embedder placement (shipping vs emb_cpu:
+  // identical segmentation tensors, embedder All -> CpuOnly) and the
+  // segmentation placement on top of a CPU embedder (emb_cpu vs all_cpu). Same
+  // audio, same artifact, same clustering — ONLY a placement differs per pair.
+  for (tag, pair) in [
     (
-      "PRECISION  int8     vs fp32    std",
-      Some((&fp32, &int8_cpu)),
+      "EMB-PLACE  sAll+eAll vs sAll+eCpu std",
+      (&shipping, &emb_cpu),
     ),
     (
-      "SHIPPING   int8/All vs fp32    std",
-      Some((&fp32, &int8_all)),
+      "SEG-PLACE  sAll+eCpu vs sCpu+eCpu std",
+      (&emb_cpu, &all_cpu),
     ),
   ] {
-    if let Some((r, h)) = hyp
-      && let (Ok(rs), Ok(hs)) = (&r.segs, &h.segs)
-    {
+    let (r, h) = pair;
+    if let (Ok(rs), Ok(hs)) = (&r.segs, &h.segs) {
       println!("[{}] {}", clip.name, fmt_der(tag, &der_std(rs, hs)));
       println!(
         "[{}] {}",
@@ -872,9 +847,9 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
     }
   }
   for (tag, arm) in [
-    ("CONVERSION fp32     vs dia-ort std", &fp32),
-    ("PRECISION  int8     vs dia-ort std", &int8_cpu),
-    ("SHIPPING   int8/All vs dia-ort std", &int8_all),
+    ("SHIPPING   sAll+eAll vs dia-ort std", &shipping),
+    ("CONTROL    sAll+eCpu vs dia-ort std", &emb_cpu),
+    ("ALL-CPU    sCpu+eCpu vs dia-ort std", &all_cpu),
   ] {
     match &arm.segs {
       Ok(s) => println!("[{}] {}", clip.name, fmt_der(tag, &der_std(&dia.segs, s))),
@@ -885,38 +860,47 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
     }
   }
 
-  // The one-line verdict, with the CONVERSION cost printed alongside so the int8
-  // number is never read without its yardstick: whatever quantization costs must
-  // be judged against what the ONNX→CoreML conversion already costs at fp32.
-  if let Ok(f) = &fp32.segs {
-    let abs_fp32 = der_std(&reference, f).der;
-    let conv_conf = der_std(&dia.segs, f).confusion;
+  // The one-line verdict: what the shipping placement costs against the
+  // CPU-embedder control, vs the independent reference. Clip 09 is EXCLUDED
+  // from the two bounds printed here (its control arms sit on the pinned
+  // segmentation knife edge, so cross-count deltas are not placement noise —
+  // see `assert_clip09_record`); its line says so instead of printing bounds
+  // it is not held to, so a value above a bound next to a green result cannot
+  // be misread as a gate that failed to fire.
+  if let Ok(f) = &emb_cpu.segs {
+    let abs_control = der_std(&reference, f).der;
     let d = |a: &Arm| {
       a.segs
         .as_ref()
-        .map_or(f64::NAN, |s| der_std(&reference, s).der - abs_fp32)
+        .map_or(f64::NAN, |s| der_std(&reference, s).der - abs_control)
     };
     let conf = |a: &Arm| {
       a.segs
         .as_ref()
         .map_or(f64::NAN, |s| der_std(f, s).confusion)
     };
+    let bounds = if clip.name == "09_mrbeast_dollar_date" {
+      "[clip 09: informational only — EXCLUDED from the placement gates; governed by its own \
+       pinned record]"
+        .to_string()
+    } else {
+      format!(
+        "[GATE: ±{:.4}%]  ||  tripwire {:.4}%",
+        SHIPPING_ABS_DELTA_MAX * 100.0,
+        SHIPPING_CONFUSION_TRIPWIRE * 100.0
+      )
+    };
     println!(
-      "[{}] ΔDER(int8/CpuOnly − fp32) vs pyannote = {:+.4}%  |  ΔDER(int8/All − fp32) = {:+.4}%  \
-       [GATE: ±{:.4}%]  ||  int8-vs-fp32 CONFUSION = {:.4}%  (tripwire {:.4}%)  vs  the CoreML \
-       CONVERSION's OWN confusion at fp32 = {:.4}% — the yardstick",
+      "[{}] ΔDER(sAll+eAll − sAll+eCpu) vs pyannote = {:+.4}%  ||  shipping-vs-control \
+       CONFUSION = {:.4}%  {bounds}",
       clip.name,
-      d(&int8_cpu) * 100.0,
-      d(&int8_all) * 100.0,
-      SHIPPING_ABS_DELTA_MAX * 100.0,
-      conf(&int8_cpu) * 100.0,
-      SHIPPING_CONFUSION_TRIPWIRE * 100.0,
-      conv_conf * 100.0,
+      d(&shipping) * 100.0,
+      conf(&shipping) * 100.0,
     );
   } else {
     println!(
-      "[{}] ΔDER not computable — the fp32 CONTROL failed to cluster, so this clip cannot \
-       adjudicate the precision axis at all (see the pinned known-defect test)",
+      "[{}] ΔDER not computable — the CPU-embedder CONTROL failed to cluster (see the clip-09 \
+       record if this is clip 09)",
       clip.name
     );
   }
@@ -926,9 +910,9 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
     ref_spk,
     dia_spk,
     reference,
-    fp32,
-    int8_cpu,
-    int8_all,
+    shipping,
+    emb_cpu,
+    all_cpu,
   }
 }
 
@@ -936,30 +920,34 @@ fn measure(clip: &MultiSpkClip) -> Measurement {
 // The gate (pure assertions over a completed Measurement)
 // ══════════════════════════════════════════════════════════════════════
 
-/// The product gate for a clip whose fp32 control is VALID.
+/// The product gate for a clip on which every placement is expected to hold
+/// the oracle's clustering decision.
 ///
 /// Asserts, in order:
 /// - **G0** every arm clustered at all (dia-ort did, so a speakerkit-arm failure
 ///   is a CoreML-path defect, not a dia limitation on this audio);
-/// - **G1** the speaker-count decision is identical across dia-ort, the fp32
-///   control and both int8 arms — the metric argmax violated (7→8);
-/// - **G2** int8's agreement with the independent pyannote reference is within
-///   [`SHIPPING_ABS_DELTA_MAX`] of the fp32 control's;
-/// - **G3** the int8-vs-fp32 confusion stays under
+/// - **G1** the speaker-count decision is identical to dia-ort's across the
+///   shipping configuration and both placement controls — the metric argmax
+///   violated (7→8) and the metric the retired int8 embedder violated on
+///   8-speaker audio (8→5);
+/// - **G2** the shipping placement's agreement with the independent pyannote
+///   reference is within [`SHIPPING_ABS_DELTA_MAX`] of the CPU-embedder
+///   control's (and likewise the all-CPU fallback's);
+/// - **G3** the arm-vs-control confusion stays under
 ///   [`SHIPPING_CONFUSION_TRIPWIRE`] (gross-regression guard only — read that
 ///   constant's doc for why it is a tripwire and not a tight bound).
 fn gate(m: &Measurement) {
   let clip = m.clip;
 
   // ── G0: every arm produced an answer.
-  let failed: Vec<String> = [&m.fp32, &m.int8_cpu, &m.int8_all]
+  let failed: Vec<String> = [&m.shipping, &m.emb_cpu, &m.all_cpu]
     .into_iter()
     .filter_map(|a| a.segs.as_ref().err().map(|e| format!("{} → {e}", a.tag)))
     .collect();
   assert!(
     failed.is_empty(),
     "{clip}: dia-ort clustered this clip ({} speakers), but {} speakerkit arm(s) could NOT: \
-     {}. A CoreML embedder whose embeddings dia cannot cluster is a HARD product failure — \
+     {}. A CoreML pipeline whose embeddings dia cannot cluster is a HARD product failure — \
      the pipeline returns Err on real {}-speaker audio. Do NOT paper over this.",
     m.dia_spk,
     failed.len(),
@@ -967,69 +955,69 @@ fn gate(m: &Measurement) {
     m.ref_spk,
   );
 
-  let (fp32, int8_cpu, int8_all) = (m.fp32.segs(), m.int8_cpu.segs(), m.int8_all.segs());
-  let (fp32_spk, int8_cpu_spk, int8_all_spk) = (m.fp32.spk(), m.int8_cpu.spk(), m.int8_all.spk());
+  let (shipping, emb_cpu, all_cpu) = (m.shipping.segs(), m.emb_cpu.segs(), m.all_cpu.segs());
+  let (ship_spk, emb_cpu_spk, all_cpu_spk) = (m.shipping.spk(), m.emb_cpu.spk(), m.all_cpu.spk());
 
-  // ── G1 (THE DECISION METRIC). Quantization must not change how many speakers
-  // the pipeline finds. Exact equality, no tolerance: a speaker-count flip is
-  // never boundary jitter. This assertion, on THESE clips, is the one that would
-  // have caught argmax (it invented a spurious 8th speaker on the 7-speaker clip
-  // while the existing Part B only `println!`ed the count and exited 0).
+  // ── G1 (THE DECISION METRIC). No placement may change how many speakers the
+  // pipeline finds. Exact equality against the ORACLE's count, no tolerance: a
+  // speaker-count flip is never boundary jitter. This assertion, on THESE
+  // clips, is the one that would have caught argmax (it invented a spurious
+  // 8th speaker on the 7-speaker clip while the pre-rework Part B only
+  // `println!`ed the count and exited 0).
   assert_eq!(
-    fp32_spk, m.dia_spk,
-    "{clip}: the fp32 CONTROL disagrees with dia-ort on speaker count ({fp32_spk} vs {}) — \
-     the control is broken; fix that before reading the int8 result",
+    ship_spk, m.dia_spk,
+    "{clip}: the SHIPPING configuration (seg@All + fp32@All) disagrees with dia-ort on speaker \
+     count ({ship_spk} vs {}) — a product defect in the configuration we actually ship.",
     m.dia_spk
   );
   assert_eq!(
-    int8_cpu_spk, fp32_spk,
-    "{clip}: the SHIPPING int8 embedder changed the speaker-count decision ({int8_cpu_spk} vs \
-     the fp32 control's {fp32_spk}) — quantization is degrading clustering, exactly the failure \
-     mode the argmax source exhibited. This is a product defect in the shipping default."
+    emb_cpu_spk, m.dia_spk,
+    "{clip}: the CPU-embedder control (seg@All + fp32@CpuOnly) disagrees with dia-ort on speaker \
+     count ({emb_cpu_spk} vs {}) — the embedder-placement axis changed a clustering decision.",
+    m.dia_spk
   );
   assert_eq!(
-    int8_all_spk, fp32_spk,
-    "{clip}: the shipping default (int8 + ComputeUnits::All) changed the speaker-count decision \
-     ({int8_all_spk} vs the fp32 control's {fp32_spk}) — a product defect in the configuration \
-     we actually ship."
+    all_cpu_spk, m.dia_spk,
+    "{clip}: the all-CPU fallback (seg@CpuOnly + fp32@CpuOnly) disagrees with dia-ort on speaker \
+     count ({all_cpu_spk} vs {}) — the deterministic fallback configuration is broken.",
+    m.dia_spk
   );
 
-  // ── G2 (REFERENCE AGREEMENT, the tight bound). The shipping default may not
-  // cost measurable agreement with the independent reference relative to the
-  // fp32 control. A bound against the independent reference, not bit-agreement
-  // with another of our own artifacts. argmax cost +3.33 points here and would
-  // blow through it 3×. Never loosened.
-  let abs_fp32 = der_std(&m.reference, fp32).der;
-  for (tag, hyp) in [("int8/CpuOnly", int8_cpu), ("int8/All", int8_all)] {
-    let delta = der_std(&m.reference, hyp).der - abs_fp32;
+  // ── G2 (REFERENCE AGREEMENT, the tight bound). The shipping placement may
+  // not cost measurable agreement with the independent reference relative to
+  // the CPU-embedder control. A bound against the independent reference, not
+  // bit-agreement with another of our own artifacts. argmax cost +3.33 points
+  // here and would blow straight through it. Never loosened.
+  let abs_control = der_std(&m.reference, emb_cpu).der;
+  for (tag, hyp) in [("sAll+eAll", shipping), ("sCpu+eCpu", all_cpu)] {
+    let delta = der_std(&m.reference, hyp).der - abs_control;
     assert!(
       delta.abs() <= SHIPPING_ABS_DELTA_MAX,
-      "{clip}: ΔDER({tag} − fp32) vs pyannote = {:+.4}%, over the ±{:.4}% bound — the shipping \
-       quantization measurably degrades agreement with the reference. Do NOT loosen.",
+      "{clip}: ΔDER({tag} − sAll+eCpu) vs pyannote = {:+.4}%, over the ±{:.4}% bound — a \
+       placement measurably degrades agreement with the reference. Do NOT loosen.",
       delta * 100.0,
       SHIPPING_ABS_DELTA_MAX * 100.0
     );
   }
 
   // ── G3 (GROSS CLUSTERING REGRESSION). Tripwire only — see the constant's doc.
-  for (tag, hyp) in [("int8/CpuOnly", int8_cpu), ("int8/All", int8_all)] {
-    let conf = der_std(fp32, hyp).confusion;
+  for (tag, hyp) in [("sAll+eAll", shipping), ("sCpu+eCpu", all_cpu)] {
+    let conf = der_std(emb_cpu, hyp).confusion;
     assert!(
       conf <= SHIPPING_CONFUSION_TRIPWIRE,
-      "{clip}: {tag}-vs-fp32 DER confusion {:.4}% exceeds the gross-regression tripwire {:.4}% \
-       — far past the marginal-assignment drift the CoreML conversion itself already carries, \
-       indicating quantization is genuinely breaking clustering. Investigate; do NOT raise the \
-       tripwire to pass.",
+      "{clip}: {tag}-vs-control DER confusion {:.4}% exceeds the gross-regression tripwire \
+       {:.4}% — far past marginal-assignment drift, indicating a placement is genuinely breaking \
+       clustering. Investigate; do NOT raise the tripwire to pass.",
       conf * 100.0,
       SHIPPING_CONFUSION_TRIPWIRE * 100.0
     );
   }
 }
 
-/// Declares one shipping-int8 DER gate, binding the wrapper's NAME to the clip it
+/// Declares one shipping DER gate, binding the wrapper's NAME to the clip it
 /// LOADS (codex r7 F1). Two compile-time assertions gate each wrapper:
 /// [`const_str_eq`] proves the function name is exactly
-/// `shipping_int8_der_<fixture>_<count>spk[suffix]`, and [`clip_ref_spk`] proves
+/// `shipping_der_<fixture>_<count>spk[suffix]`, and [`clip_ref_spk`] proves
 /// `<count>` equals the fixture's speaker count in [`MULTI_SPEAKER_CLIPS`] (whose
 /// membership and counts are pinned to the RTTM corpus by
 /// [`shipping_clip_selection_is_the_documented_subset`]). The body resolves the
@@ -1039,7 +1027,7 @@ fn gate(m: &Measurement) {
 ///
 /// A bare row `name : "fixture" @ count` gets the default `gate(&measure(…))`
 /// body. `=> |m| { … }` supplies a custom body with the [`Measurement`] bound to
-/// `m`; `+ "suffix"` extends the checked name (clip 09's `_known_defect`).
+/// `m`; `+ "suffix"` extends the checked name.
 macro_rules! shipping_der_gate {
   ( $(#[$meta:meta])* $name:ident : $fixture:literal @ $count:literal ) => {
     shipping_der_gate! {
@@ -1051,12 +1039,12 @@ macro_rules! shipping_der_gate {
     const _: () = assert!(
       const_str_eq(
         stringify!($name),
-        concat!("shipping_int8_der_", $fixture, "_", $count, "spk" $(, $suffix)?),
+        concat!("shipping_der_", $fixture, "_", $count, "spk" $(, $suffix)?),
       ),
       concat!(
         "shipping gate `", stringify!($name), "` disagrees with its fixture/count `",
         $fixture, "` @ ", stringify!($count),
-        " — a wrapper name must be shipping_int8_der_<fixture>_<count>spk",
+        " — a wrapper name must be shipping_der_<fixture>_<count>spk",
       ),
     );
     const _: () = assert!(
@@ -1078,110 +1066,105 @@ macro_rules! shipping_der_gate {
 
 shipping_der_gate! {
   /// 3 speakers, 977.7 s.
-  shipping_int8_der_06_long_recording_3spk : "06_long_recording" @ 3
+  shipping_der_06_long_recording_3spk : "06_long_recording" @ 3
 }
 
 shipping_der_gate! {
   /// 4 speakers, 1103.0 s. The clip where clustering sits nearest a decision
-  /// boundary: the fp32 CoreML control already carries ~0.39 % confusion against
-  /// dia-ort here BEFORE any quantization, and int8 adds a similar increment. The
-  /// speaker count and the reference-agreement bound both still hold — see
+  /// boundary: the fp32 CoreML pipeline already carries ~0.39 % confusion
+  /// against dia-ort here with no placement or precision perturbation
+  /// involved, so any placement drift shows up here first — see
   /// [`SHIPPING_CONFUSION_TRIPWIRE`].
-  shipping_int8_der_14_mrbeast_strongman_robot_4spk : "14_mrbeast_strongman_robot" @ 4
+  shipping_der_14_mrbeast_strongman_robot_4spk : "14_mrbeast_strongman_robot" @ 4
 }
 
 shipping_der_gate! {
   /// 7 speakers, 619.5 s — **the clip that caught the argmax source** (spurious
-  /// 8th speaker, 3.33 % DER, 100 % confusion). The single most important row: on
-  /// the precision axis (int8/CpuOnly vs the fp32/CpuOnly control, placement held
-  /// constant) int8 clusters it IDENTICALLY — 0.0000 % standard DER, zero
-  /// confusion, **asserted below** (`der_std(fp32, int8).err_units() == 0`, not
-  /// one collar-scored frame differs) — and lands 7 speakers, despite carrying a
-  /// *worse* embedding cosine than argmax does.
-  ///
-  /// Two precise caveats behind the word "identically", so it is not read as
-  /// literal output identity: this is agreement on the *collar-scored* frames.
-  /// At the no-collar `der_strict` level the two arms differ on ~6 sub-collar
-  /// frames (0.0100 %), and the `int8/All` arm — which also folds in ANE
-  /// placement — carries 0.0405 % against the fp32 control (still well inside
-  /// [`gate`]). So the identity that is asserted is exactly the one measured:
-  /// standard-collar `err_units == 0`, on the int8/CpuOnly precision arm.
-  shipping_int8_der_10_mrbeast_clean_water_7spk : "10_mrbeast_clean_water" @ 7 => |m| {
-    gate(&m);
-
-    // Clip-10-specific, the headline this test rests on: on the precision axis
-    // (int8/CpuOnly vs fp32/CpuOnly) int8 clusters this 7-speaker clip so that not
-    // one collar-scored frame differs. `gate()`'s G2/G3 only bound reference-
-    // agreement within ±1 pp / 2 % confusion, which would pass a regression all the way from EXACT
-    // agreement to ~0.9 % — so the "0.0000 % DER, zero confusion" claim is
-    // ASSERTED here, not merely documented. `gate(&m)` above already proved every
-    // arm clustered, so `segs()` cannot panic.
-    let precision = der_std(m.fp32.segs(), m.int8_cpu.segs());
-    assert_eq!(
-      precision.err_units(),
-      0,
-      "10: int8/CpuOnly no longer clusters IDENTICALLY to the fp32 control on the collar-scored \
-       frames ({} err units / {:.4}% standard DER, {} of them confusion) — the precision-isolated \
-       identity this test's headline rests on has regressed. This is the single clip proving a \
-       worse-than-argmax embedding cosine still clusters correctly; re-measure and update the doc \
-       + this assertion deliberately.",
-      precision.err_units(),
-      precision.der * 100.0,
-      precision.conf_units,
-    );
-  }
+  /// 8th speaker, 3.33 % DER, 100 % confusion). [`gate`]'s G1 count equality
+  /// on this clip is the assertion that failure class cannot pass.
+  shipping_der_10_mrbeast_clean_water_7spk : "10_mrbeast_clean_water" @ 7
 }
 
 // ══════════════════════════════════════════════════════════════════════
-// Clip 09 — the PINNED KNOWN DEFECT (§5.10)
+// Clip 09 — the 8-speaker clip: gated SHIPPING arm, pinned placement knife
+// edge
 // ══════════════════════════════════════════════════════════════════════
 
-/// Everything clip 09's known-defect state must satisfy, extracted from a
-/// [`Measurement`] (or synthesized by the mutation test) so
-/// [`assert_clip09_known_defect`] is a pure function both can call.
+/// Everything clip 09's record must satisfy, extracted from a [`Measurement`]
+/// (or synthesized by the mutation test) so [`assert_clip09_record`] is a pure
+/// function both can call.
 #[derive(Clone, Copy)]
 struct Clip09Observed<'a> {
   /// The fixture this was measured on — asserted, so the pin cannot silently
-  /// re-target a DIFFERENT undercounting clip.
+  /// re-target a different clip.
   clip: &'a str,
   /// Distinct speakers in `reference.rttm`.
   ref_spk: usize,
   /// dia-ort's (the ONNX oracle's) speaker count.
   dia_spk: usize,
-  /// The fp32 CONTROL's clustering outcome, carrying diaric's TYPED error so the
-  /// pin can match the exact `AmbiguousAliveCluster` variant, not just `is_err`.
-  fp32: &'a Result<Vec<Seg>, diaric::offline::Error>,
-  /// int8/CpuOnly's speaker count.
-  int8_cpu_spk: usize,
-  /// int8/All (the shipping default) speaker count.
-  int8_all_spk: usize,
-  /// int8/CpuOnly's standard DER vs the pyannote reference.
-  int8_cpu_der: Der,
-  /// int8/All's standard DER vs the pyannote reference.
-  int8_all_der: Der,
+  /// The SHIPPING arm's (seg@All + fp32@All) speaker count.
+  ship_spk: usize,
+  /// The SHIPPING arm's standard DER vs the pyannote reference.
+  ship_der: Der,
+  /// The CPU-embedder control's (seg@All + fp32@CpuOnly) speaker count.
+  emb_cpu_spk: usize,
+  /// The CPU-embedder control's standard DER vs the pyannote reference.
+  emb_cpu_der: Der,
+  /// The all-CPU arm's (seg@CpuOnly + fp32@CpuOnly) clustering outcome,
+  /// carrying diaric's TYPED error so the pin can match the exact
+  /// `AmbiguousAliveCluster` variant, not just `is_err`.
+  all_cpu: &'a Result<Vec<Seg>, diaric::offline::Error>,
 }
 
-/// The measured clip-09 known-defect record (§5.9/§5.10), pinned field by field
-/// so a single-value regression in EITHER direction fails — the fail-if-fixed
-/// gate this whole test rests on. Every field is exercised in both directions,
-/// hermetically, by [`clip09_known_defect_pins_every_field`].
+/// The measured clip-09 record, pinned field by field so a single-value change
+/// in EITHER direction fails. Every field is exercised in both directions,
+/// hermetically, by [`clip09_record_pins_every_field`].
 ///
-/// Two independent full runs reproduced these EXACTLY (spec §5.9): reference &
-/// dia-ort oracle both 8 speakers; fp32/CpuOnly hits dia's typed
-/// `Pipeline(Centroid(AmbiguousAliveCluster { .. }))` bail-out (NO diarization at
-/// all); int8/CpuOnly 6 speakers, 16.4590 % DER; int8/All (SHIPPING) 5 speakers,
-/// 16.5904 % DER, 100 % CONFUSION (0 miss, 0 FA).
-fn assert_clip09_known_defect(o: &Clip09Observed<'_>) {
-  // Identity: the pin is clip-09-specific (its fp32 control cannot cluster), so a
-  // fixture-resolution drift onto another undercounting clip must fail loudly,
-  // never silently re-target.
+/// Measured (issue #15 remedy matrix + this suite, Apple M1 Max, macOS 26.5
+/// build 25F71, arm64; fp16-safe `pyannote_segmentation` + fp16-safe fp32
+/// `wespeaker`, `Models/speakerkit` at the byte-pinned revisions):
+///
+/// - reference (pyannote 4.0.4) and `dia-ort` (the ONNX oracle): **8**
+///   speakers each; dia-ort is frame-perfect against the reference.
+/// - **SHIPPING (seg@All + fp32@All): 8 of 8 speakers, 2.9810 % DER** —
+///   the count is RIGHT and the residual is confusion against the oracle's
+///   assignment, not a lost speaker. (The retired int8 embedder returned 5
+///   of 8 at 16.5904 % on this exact composition; the swap is the issue-#15
+///   fix.)
+/// - **seg@All + fp32@CpuOnly: 9 speakers, 1.3011 %** — with the embedder on
+///   IEEE CPU kernels (bit-near dia's own ONNX), a spurious 9th cluster
+///   survives clustering. This is the segmentation conversion's defect class:
+///   `backend_factorial`'s `COREML-seg + ONNX-emb` cell overcounts the same
+///   way (9 speakers, 1.3011 %). Lower DER, wrong count — and the count
+///   decision outranks the DER value.
+/// - **seg@CpuOnly + fp32@CpuOnly: `Err(Pipeline(Centroid(
+///   AmbiguousAliveCluster)))`** — a cluster's VBx prior (recorded
+///   1.700e-7 on this host) lands inside diaric's deliberate ±2x guard band
+///   around the 1e-7 alive-cutoff, and diaric refuses to make a
+///   CPU-backend-dependent call. The all-CPU fallback cannot diarize this
+///   clip at all.
+///
+/// The three placement outcomes {8, 9, Err} are pinned SEPARATELY — each is
+/// its own observed fact. Reading them as one spurious near-threshold
+/// cluster whose alive/ambiguous/absorbed state flips with placement is the
+/// INTERPRETATION the pattern supports (one extra cluster when clustering
+/// resolves, an alive-band refusal when it cannot), but no assertion here
+/// ties the three outcomes to the same cluster — VBx cluster identities are
+/// not stable across arms, so the `Err` pin deliberately matches the VARIANT
+/// and not its `cluster`/`value` fields. What the pins enforce: the
+/// segmentation conversion's residual clip-09 defect — real, an order of
+/// magnitude smaller than the fixed embedder collapse — cannot be forgotten
+/// and cannot silently change shape in any arm.
+fn assert_clip09_record(o: &Clip09Observed<'_>) {
+  // Identity: the pin is clip-09-specific, so a fixture-resolution drift onto
+  // another clip must fail loudly, never silently re-target.
   assert_eq!(
     o.clip, "09_mrbeast_dollar_date",
-    "clip-09 defect pin ran on {} — the fixture selection drifted",
+    "clip-09 record ran on {} — the fixture selection drifted",
     o.clip
   );
-  // Reference AND oracle both see 8 speakers, so int8's undercount below is a real
-  // defect, not a reference artifact.
+  // Reference AND oracle both see 8 speakers, so the arms below are held to a
+  // real count, not a reference artifact.
   assert_eq!(
     o.ref_spk, 8,
     "09: reference.rttm no longer holds 8 speakers ({})",
@@ -1190,59 +1173,54 @@ fn assert_clip09_known_defect(o: &Clip09Observed<'_>) {
   assert_eq!(
     o.dia_spk, 8,
     "09: dia-ort (the ONNX oracle) no longer clusters this clip at 8 speakers ({}) — the oracle \
-     moved; re-establish it before trusting the defect pin",
+     moved; re-establish it before trusting this record",
     o.dia_spk
   );
-  // THE DEFECT: the fp32 CoreML control does not merely fail — it fails with
-  // diaric's TYPED AmbiguousAliveCluster bail-out (a near-zero cluster weight
-  // inside the SIMD guard band). Matching the VARIANT (not just `is_err`, and not
-  // the fragile `cluster`/`value` fields) is what makes "the known defect is
-  // fixed" the only way this can go green.
+  // THE GATE: the shipping configuration finds all 8 speakers. This is the
+  // issue-#15 fix; a count below 8 is the collapse returning, a count above
+  // is the segmentation knife edge escaping into the shipping placement.
+  assert_eq!(
+    o.ship_spk, 8,
+    "09: the SHIPPING configuration (seg@All + fp32@All) no longer finds 8 of 8 speakers ({}). \
+     Below 8 is the issue-#15 collapse class returning; above 8 is a spurious cluster surfacing \
+     at the shipping placement (the overcount class the segmentation conversion produces — \
+     backend_factorial's COREML-seg + ONNX-emb cell). Either way: investigate, do not re-pin \
+     without attribution.",
+    o.ship_spk
+  );
+  assert_clip09_der_decomposed("sAll+eAll (SHIPPING)", o.ship_der, 0.029_810);
+  // The CPU-embedder control: a spurious 9th cluster survives (the
+  // segmentation conversion's overcount class). If this becomes 8, the
+  // seg-side knife edge is gone and clip 09 belongs in the plain `gate(..)`
+  // set; if it becomes an Err, the ambiguity refusal moved into this
+  // placement. Both are deliberate re-baselines.
+  assert_eq!(
+    o.emb_cpu_spk, 9,
+    "09: seg@All + fp32@CpuOnly moved from the pinned 9 speakers to {} — this arm's spurious \
+     cluster changed state; re-measure all three placements and re-pin deliberately",
+    o.emb_cpu_spk
+  );
+  assert_clip09_der_value("sAll+eCpu", o.emb_cpu_der, 0.013_011);
+  // The all-CPU arm: diaric's typed refusal. Matching the VARIANT (not just
+  // `is_err`, and not the unstable `cluster`/`value` fields) is what makes
+  // "this arm stopped refusing" the only way this can go green — and is why
+  // the record's doc presents the one-cluster reading as interpretation, not
+  // an asserted identity across arms.
   assert!(
     matches!(
-      o.fp32,
+      o.all_cpu,
       Err(diaric::offline::Error::Pipeline(
         diaric::pipeline::Error::Centroid(
           diaric::cluster::centroid::Error::AmbiguousAliveCluster { .. }
         )
       ))
     ),
-    "09: the fp32 CoreML control no longer fails with Pipeline(Centroid(AmbiguousAliveCluster)). \
-     Either it now CLUSTERS (the known defect is fixed — promote clip 09 into the gated set \
-     `gate(&measure(..))` and delete this pin), or it fails a DIFFERENT way (a new defect — \
-     investigate). Got: {:?}",
-    o.fp32.as_ref().err()
+    "09: seg@CpuOnly + fp32@CpuOnly no longer fails with \
+     Pipeline(Centroid(AmbiguousAliveCluster)). Either it now CLUSTERS (the segmentation knife \
+     edge moved — re-measure and re-pin all three placements) or it fails a DIFFERENT way (a new \
+     defect — investigate). Got: {:?}",
+    o.all_cpu.as_ref().err()
   );
-  // Same-side rule on the reference-count bound: both int8 arms must stay BELOW 8
-  // (undercounting = the broken side). If either reaches 8 the path improved, and
-  // this must fire deliberately.
-  assert!(
-    o.int8_cpu_spk < o.ref_spk && o.int8_all_spk < o.ref_spk,
-    "09: int8 no longer UNDERCOUNTS (cpu={}, all={}, reference={}) — the CoreML path improved; \
-     re-measure and re-gate this clip.",
-    o.int8_cpu_spk,
-    o.int8_all_spk,
-    o.ref_spk
-  );
-  // Exact counts, both directions.
-  assert_eq!(
-    o.int8_cpu_spk, 6,
-    "09: int8/CpuOnly speaker count moved from the pinned 6 to {}",
-    o.int8_cpu_spk
-  );
-  assert_eq!(
-    o.int8_all_spk, 5,
-    "09: the SHIPPING int8/All speaker count moved from the pinned 5 to {}",
-    o.int8_all_spk
-  );
-  // int8/All (SHIPPING): DER two-sided AND its full decomposition — 100 %
-  // CONFUSION (0 miss, 0 FA), because after overlap-skip every scored frame has
-  // one reference and one hypothesis speaker, so the 3 unmapped reference speakers
-  // land entirely in confusion.
-  assert_clip09_der_decomposed("int8/All (SHIPPING)", o.int8_all_der, 0.165_904);
-  // int8/CpuOnly: DER value two-sided (a deterministic arm; only the shipping
-  // arm's decomposition is separately pinned, per §5.10).
-  assert_clip09_der_value("int8/CpuOnly", o.int8_cpu_der, 0.164_590);
 }
 
 /// A clip-09 arm's DER, pinned two-sided (±[`DER_PIN_TOL`]) with its full
@@ -1283,89 +1261,64 @@ fn assert_clip09_der_value(tag: &str, d: Der, pinned: f64) {
 }
 
 shipping_der_gate! {
-  /// **Clip 09 (8 speakers, 1042.0 s) — a PINNED KNOWN DEFECT, not a passing gate.**
+  /// **Clip 09 (8 speakers, 1042.0 s) — the issue-#15 clip: the SHIPPING arm is
+  /// gated at 8 of 8 speakers; the two placement controls are pinned at their
+  /// measured knife-edge states.**
   ///
-  /// This clip cannot gate the int8 question, because the **fp32 control itself is
-  /// broken on it**. Measured (two independent full runs, reproduced exactly —
-  /// §5.9/§5.10):
+  /// This clip cannot run the plain [`gate`] body, because its two control
+  /// arms do not hold the oracle's count — a real, pinned property of the
+  /// segmentation conversion on this clip, not a suite defect: a spurious
+  /// cluster lands ALIVE (9 speakers) with the embedder on CPU kernels, and
+  /// diaric refuses inside its ambiguity band (`Err`) with the whole
+  /// pipeline on CPU — two separately-pinned outcomes.
+  /// [`assert_clip09_record`] carries the full measured record and what may
+  /// be read as shared cause versus what is pinned; every field's
+  /// both-directions sensitivity is proven hermetically by
+  /// [`clip09_record_pins_every_field`].
   ///
-  /// - `dia-ort` (ONNX fp32): clusters fine, 8 speakers.
-  /// - `fp32/CpuOnly` CoreML: **`diarize_offline` returns `Err`** — dia's typed
-  ///   `Pipeline(Centroid(AmbiguousAliveCluster { cluster: 13, value: 1.70e-7,
-  ///   threshold: 1e-7, lo: 5e-8, hi: 2e-7 }))`. dia refuses to decide whether a
-  ///   cluster is alive; the pipeline produces NO diarization at all.
-  /// - `int8/CpuOnly`: clusters, finds **6** speakers (16.4590 % DER).
-  /// - `int8/All` (the shipping default): clusters, finds **5** speakers
-  ///   (16.5904 % DER, 100 % confusion).
-  /// - reference (pyannote 4.0.4): **8** speakers.
-  ///
-  /// So on 8-speaker audio the CoreML path is defective at BOTH precisions this
-  /// suite measures — the fp32 control worse than int8, since it cannot answer at
-  /// all. That is as far as these four arms reach: they never vary the two CoreML
-  /// conversions independently, so "int8 is not the culprit" is NOT among the
-  /// things they establish. `backend_factorial.rs`, which does vary them, finds
-  /// the CoreML embedding path on `All` sufficient on its own to reproduce the
-  /// int8/All numbers pinned below (see the module doc's point 2). This is a real,
-  /// separately-actionable defect, and it is pinned here rather than deleted so it
-  /// cannot be forgotten.
-  ///
-  /// The fp32 control being "worse than int8" HERE is an artifact of this
-  /// suite's design, not a property of fp32: every arm above runs CoreML
-  /// segmentation, so the control carries the segmentation conversion's own
-  /// clip-09 defect on top of whatever the embedder does. Swap in dia's
-  /// reference segmentation and the ordering reverses — fp32/`CpuOnly` becomes
-  /// frame-perfect (8 speakers, 0 error units) and int8 is what costs 2
-  /// speakers. See `backend_factorial.rs`'s `embedding_precision_x_placement`.
-  /// Read the fp32 rows below as "fp32 plus a defective segmenter", never as
-  /// "fp32".
-  ///
-  /// The assertion is on the KNOWN-BAD state, pinned field by field by
-  /// [`assert_clip09_known_defect`]: clip identity, the reference and oracle counts,
-  /// the fp32 control's TYPED `AmbiguousAliveCluster` bail-out, both int8 counts,
-  /// and both int8 DERs (the shipping arm with its miss/FA/confusion
-  /// decomposition). If ANY moves — most importantly if the CoreML path is fixed
-  /// and the fp32 control starts clustering — **this test fails on purpose**, the
-  /// signal to promote clip 09 into [`gate`]'s gated set and delete this test.
-  /// (Every field's both-directions sensitivity is proven hermetically by
-  /// [`clip09_known_defect_pins_every_field`].) It is deliberately NOT an
-  /// unfalsifiable `println!` (the mistake `parity_e2e`'s Part B made, where a real
-  /// 3.33 % DER failure still exits 0).
-  shipping_int8_der_09_mrbeast_dollar_date_8spk_known_defect
-    : "09_mrbeast_dollar_date" @ 8 + "_known_defect" => |m| {
-    // The shipping int8 arms must still ANSWER to score their DER; a failure here is
-    // itself a regression (the shipping default went from "answers, undercounts" to
-    // "cannot answer"), reported before the DER pin so the numbers still print.
-    let (int8_cpu, int8_all) = match (&m.int8_cpu.segs, &m.int8_all.segs) {
-      (Ok(_), Ok(_)) => (m.int8_cpu.segs(), m.int8_all.segs()),
+  /// History: the shipping arm of this clip returned 5 of 8 speakers at
+  /// 16.5904 % DER (100 % confusion) until the int8-palettized embedder was
+  /// retired — the collapse `backend_factorial.rs` attributes to the
+  /// palettization's coherent embedding-space displacement, with the `All`
+  /// placement contributing one further lost speaker. The mechanism and the
+  /// factorial are pinned there; the DECISION record is
+  /// `tests/speaker/model_io.rs`.
+  shipping_der_09_mrbeast_dollar_date_8spk
+    : "09_mrbeast_dollar_date" @ 8 => |m| {
+    // The shipping and CPU-embedder arms must ANSWER to score their DER; a
+    // failure is itself a regression (the configuration went from "answers"
+    // to "cannot answer"), reported before any pin so the numbers still print.
+    let (shipping, emb_cpu) = match (&m.shipping.segs, &m.emb_cpu.segs) {
+      (Ok(_), Ok(_)) => (m.shipping.segs(), m.emb_cpu.segs()),
       _ => panic!(
-        "09: an int8 arm now fails to cluster (cpu={:?}, all={:?}). The shipping default regressed \
-         from 'answers, but undercounts' to 'cannot answer at all' on 8-speaker audio.",
-        m.int8_cpu.segs.as_ref().err(),
-        m.int8_all.segs.as_ref().err(),
+        "09: an fp32 arm now fails to cluster (sAll+eAll={:?}, sAll+eCpu={:?}) — a regression \
+         from 'answers' to 'cannot answer' on 8-speaker audio.",
+        m.shipping.segs.as_ref().err(),
+        m.emb_cpu.segs.as_ref().err(),
       ),
     };
 
-    assert_clip09_known_defect(&Clip09Observed {
+    assert_clip09_record(&Clip09Observed {
       clip: m.clip,
       ref_spk: m.ref_spk,
       dia_spk: m.dia_spk,
-      fp32: &m.fp32.segs,
-      int8_cpu_spk: m.int8_cpu.spk(),
-      int8_all_spk: m.int8_all.spk(),
-      int8_cpu_der: der_std(&m.reference, int8_cpu),
-      int8_all_der: der_std(&m.reference, int8_all),
+      ship_spk: m.shipping.spk(),
+      ship_der: der_std(&m.reference, shipping),
+      emb_cpu_spk: m.emb_cpu.spk(),
+      emb_cpu_der: der_std(&m.reference, emb_cpu),
+      all_cpu: &m.all_cpu.segs,
     });
   }
 }
 
-/// [`assert_clip09_known_defect`] pins EVERY field, in BOTH directions — proven
-/// here hermetically (no models, no fixtures): the known-good record passes, and
-/// every single-field perturbation fails. Without this a field could silently go
-/// unpinned, and a real clip-09 regression in it would pass green.
+/// [`assert_clip09_record`] pins EVERY field, in BOTH directions — proven
+/// here hermetically (no models, no fixtures): the measured record passes, and
+/// every single-field perturbation fails. Without this a field could silently
+/// go unpinned, and a real clip-09 change in it would pass green.
 #[test]
-fn clip09_known_defect_pins_every_field() {
-  // diaric's typed bail-out — the exact variant the fp32 control hits.
-  let fp32_defect: Result<Vec<Seg>, diaric::offline::Error> =
+fn clip09_record_pins_every_field() {
+  // diaric's typed bail-out — the exact variant the all-CPU arm hits.
+  let all_cpu_err: Result<Vec<Seg>, diaric::offline::Error> =
     Err(diaric::offline::Error::Pipeline(
       diaric::pipeline::Error::Centroid(diaric::cluster::centroid::Error::AmbiguousAliveCluster {
         cluster: 13,
@@ -1376,25 +1329,25 @@ fn clip09_known_defect_pins_every_field() {
       }),
     ));
 
-  let cpu_der = clip09_synth_der(0.164_590);
-  let all_der = clip09_synth_der(0.165_904);
+  let ship_der = clip09_synth_der(0.029_810);
+  let emb_cpu_der = clip09_synth_der(0.013_011);
   let good = Clip09Observed {
     clip: "09_mrbeast_dollar_date",
     ref_spk: 8,
     dia_spk: 8,
-    fp32: &fp32_defect,
-    int8_cpu_spk: 6,
-    int8_all_spk: 5,
-    int8_cpu_der: cpu_der,
-    int8_all_der: all_der,
+    ship_spk: 8,
+    ship_der,
+    emb_cpu_spk: 9,
+    emb_cpu_der,
+    all_cpu: &all_cpu_err,
   };
   // The measured record passes.
-  assert_clip09_known_defect(&good);
+  assert_clip09_record(&good);
 
   // The VARIANT is matched, not its field values: a DIFFERENT
-  // AmbiguousAliveCluster still passes, so the pin does not over-fit the fragile
-  // `cluster: 13` / `value: 1.70e-7`.
-  let fp32_other_fields: Result<Vec<Seg>, diaric::offline::Error> =
+  // AmbiguousAliveCluster still passes, so the pin does not over-fit the
+  // fragile `cluster: 13` / `value: 1.70e-7`.
+  let all_cpu_other_fields: Result<Vec<Seg>, diaric::offline::Error> =
     Err(diaric::offline::Error::Pipeline(
       diaric::pipeline::Error::Centroid(diaric::cluster::centroid::Error::AmbiguousAliveCluster {
         cluster: 99,
@@ -1404,20 +1357,20 @@ fn clip09_known_defect_pins_every_field() {
         hi: 9e-8,
       }),
     ));
-  assert_clip09_known_defect(&Clip09Observed {
-    fp32: &fp32_other_fields,
+  assert_clip09_record(&Clip09Observed {
+    all_cpu: &all_cpu_other_fields,
     ..good
   });
 
   // ── Every single-field perturbation must FAIL. ──
   fn reject(label: &str, o: &Clip09Observed<'_>) {
     let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-      assert_clip09_known_defect(o);
+      assert_clip09_record(o);
     }));
     assert!(
       res.is_err(),
-      "mutation '{label}' did NOT fail the clip-09 pin — that field is unpinned, so a real \
-       regression in it would pass silently"
+      "mutation '{label}' did NOT fail the clip-09 record — that field is unpinned, so a real \
+       change in it would pass silently"
     );
   }
 
@@ -1434,144 +1387,132 @@ fn clip09_known_defect_pins_every_field() {
   reject("dia_spk hi", &Clip09Observed { dia_spk: 9, ..good });
   reject("dia_spk lo", &Clip09Observed { dia_spk: 7, ..good });
   reject(
-    "int8_cpu_spk hi",
+    "ship_spk lo (the collapse class)",
     &Clip09Observed {
-      int8_cpu_spk: 7,
+      ship_spk: 7,
       ..good
     },
   );
   reject(
-    "int8_cpu_spk lo",
+    "ship_spk hi (the knife edge escaping)",
     &Clip09Observed {
-      int8_cpu_spk: 5,
+      ship_spk: 9,
       ..good
     },
   );
   reject(
-    "int8_cpu_spk fixed",
+    "emb_cpu_spk lo (knife edge resolved)",
     &Clip09Observed {
-      int8_cpu_spk: 8,
+      emb_cpu_spk: 8,
       ..good
     },
   );
   reject(
-    "int8_all_spk hi",
+    "emb_cpu_spk hi",
     &Clip09Observed {
-      int8_all_spk: 6,
-      ..good
-    },
-  );
-  reject(
-    "int8_all_spk lo",
-    &Clip09Observed {
-      int8_all_spk: 4,
-      ..good
-    },
-  );
-  reject(
-    "int8_all_spk fixed",
-    &Clip09Observed {
-      int8_all_spk: 8,
+      emb_cpu_spk: 10,
       ..good
     },
   );
 
-  // fp32 control: "fixed" (clusters) and a DIFFERENT error variant both fail.
-  let fp32_fixed: Result<Vec<Seg>, diaric::offline::Error> = Ok(Vec::new());
+  // all-CPU arm: "resolved" (clusters) and a DIFFERENT error variant both fail.
+  let all_cpu_fixed: Result<Vec<Seg>, diaric::offline::Error> = Ok(Vec::new());
   reject(
-    "fp32 fixed (Ok)",
+    "all_cpu resolved (Ok)",
     &Clip09Observed {
-      fp32: &fp32_fixed,
+      all_cpu: &all_cpu_fixed,
       ..good
     },
   );
-  let fp32_wrong_variant: Result<Vec<Seg>, diaric::offline::Error> = Err(
+  let all_cpu_wrong_variant: Result<Vec<Seg>, diaric::offline::Error> = Err(
     diaric::offline::Error::Pipeline(diaric::pipeline::Error::InvalidActiveRatio(0.5)),
   );
   reject(
-    "fp32 wrong variant",
+    "all_cpu wrong variant",
     &Clip09Observed {
-      fp32: &fp32_wrong_variant,
+      all_cpu: &all_cpu_wrong_variant,
       ..good
     },
   );
 
-  // int8/All DER + FULL decomposition (both directions).
+  // SHIPPING DER + FULL decomposition (both directions).
   reject(
-    "all der hi",
+    "ship der hi",
     &Clip09Observed {
-      int8_all_der: clip09_synth_der(0.165_904 + 2.0 * DER_PIN_TOL),
+      ship_der: clip09_synth_der(0.029_810 + 2.0 * DER_PIN_TOL),
       ..good
     },
   );
   reject(
-    "all der lo",
+    "ship der lo",
     &Clip09Observed {
-      int8_all_der: clip09_synth_der(0.165_904 - 2.0 * DER_PIN_TOL),
+      ship_der: clip09_synth_der(0.029_810 - 2.0 * DER_PIN_TOL),
       ..good
     },
   );
   reject(
-    "all miss_units",
+    "ship miss_units",
     &Clip09Observed {
-      int8_all_der: Der {
+      ship_der: Der {
         miss_units: 1,
-        ..all_der
+        ..ship_der
       },
       ..good
     },
   );
   reject(
-    "all fa_units",
+    "ship fa_units",
     &Clip09Observed {
-      int8_all_der: Der {
+      ship_der: Der {
         fa_units: 1,
-        ..all_der
+        ..ship_der
       },
       ..good
     },
   );
   reject(
-    "all confusion hi",
+    "ship confusion hi",
     &Clip09Observed {
-      int8_all_der: Der {
-        confusion: all_der.confusion + 2.0 * DER_PIN_TOL,
-        ..all_der
+      ship_der: Der {
+        confusion: ship_der.confusion + 2.0 * DER_PIN_TOL,
+        ..ship_der
       },
       ..good
     },
   );
   reject(
-    "all confusion lo",
+    "ship confusion lo",
     &Clip09Observed {
-      int8_all_der: Der {
-        confusion: all_der.confusion - 2.0 * DER_PIN_TOL,
-        ..all_der
+      ship_der: Der {
+        confusion: ship_der.confusion - 2.0 * DER_PIN_TOL,
+        ..ship_der
       },
       ..good
     },
   );
 
-  // int8/CpuOnly DER value (both directions; its decomposition is not pinned).
+  // CPU-embedder control DER value (both directions; its decomposition is not
+  // separately pinned).
   reject(
-    "cpu der hi",
+    "emb_cpu der hi",
     &Clip09Observed {
-      int8_cpu_der: clip09_synth_der(0.164_590 + 2.0 * DER_PIN_TOL),
+      emb_cpu_der: clip09_synth_der(0.013_011 + 2.0 * DER_PIN_TOL),
       ..good
     },
   );
   reject(
-    "cpu der lo",
+    "emb_cpu der lo",
     &Clip09Observed {
-      int8_cpu_der: clip09_synth_der(0.164_590 - 2.0 * DER_PIN_TOL),
+      emb_cpu_der: clip09_synth_der(0.013_011 - 2.0 * DER_PIN_TOL),
       ..good
     },
   );
 }
 
 /// A synthetic [`Der`] for the clip-09 mutation test: standard DER = confusion =
-/// `der`, zero miss/FA (clip 09's undercount is 100 % confusion). Only the fields
-/// [`assert_clip09_known_defect`] reads need be meaningful; the rest are inert.
+/// `der`, zero miss/FA (both pinned clip-09 arms' error is pure confusion). Only
+/// the fields [`assert_clip09_record`] reads need be meaningful; the rest are
+/// inert.
 fn clip09_synth_der(der: f64) -> Der {
   Der {
     der,
@@ -1585,12 +1526,15 @@ fn clip09_synth_der(der: f64) -> Der {
     scored_frames: 1,
     err_frames: 1,
     num_ref_spk: 8,
-    num_hyp_spk: 5,
+    num_hyp_spk: 8,
   }
 }
 
-/// What switching the shipping default from int8 to fp32 would COST: model
-/// load time and steady-state inference latency, measured cleanly.
+/// What each candidate shipping configuration COSTS: model load time and
+/// steady-state extraction latency, measured cleanly, with the segmentation
+/// and embedder placements varied INDEPENDENTLY (they are independent knobs in
+/// production — [`coremlit::audio::speaker::extract::ComputeOptions`] carries one
+/// [`ComputeUnits`] per model).
 ///
 /// The per-arm `extract_s` printed by [`measure`] conflates model LOAD
 /// (a one-off, and on `All` a first-run ANE compile that can take minutes) with
@@ -1598,8 +1542,9 @@ fn clip09_synth_der(der: f64) -> Der {
 /// usable latency. This test measures the two phases separately, one config at a
 /// time, with a warm-up pass so no ANE compile lands inside the timed region.
 ///
-/// The segmentation model is identical in every arm, so the *difference* between
-/// two arms' extract times is exactly the embedder's contribution.
+/// Rows sharing a segmentation placement differ only in the embedder's
+/// artifact/placement, so their `extract_s` difference is the embedder's own
+/// contribution.
 ///
 /// Reported, not gated: latency is hardware-dependent, and a wall-clock bound
 /// would be a flaky gate. The DER gates above are the ones that must hold.
@@ -1607,7 +1552,7 @@ fn clip09_synth_der(der: f64) -> Der {
 #[ignore = "requires Models/speakerkit; latency benchmark (reported, not gated)"]
 fn shipping_embedder_cost_int8_vs_fp32() {
   // A 120 s slice of the 7-speaker clip: long enough that per-chunk steady-state
-  // cost dominates fixed overhead, short enough to run four configs twice.
+  // cost dominates fixed overhead, short enough to run every config twice.
   const BENCH_S: usize = 120;
   let all = common::load_wav_16k_mono(&clip_audio_path(
     clip_by_name("10_mrbeast_clean_water").name,
@@ -1617,28 +1562,51 @@ fn shipping_embedder_cost_int8_vs_fp32() {
 
   println!("\n══ embedder cost: {audio_s:.1} s of 10_mrbeast_clean_water ══");
   println!(
-    "{:<16} {:>10} {:>12} {:>10} {:>12}",
-    "config", "load_s", "extract_s", "RTF", "per-chunk_ms"
+    "{:<32} {:>10} {:>12} {:>10} {:>12}",
+    "config (seg / embedder)", "load_s", "extract_s", "RTF", "per-chunk_ms"
   );
 
-  for (tag, embed_path, cu) in [
-    ("int8/All", common::embed_path(), ComputeUnits::All),
-    ("fp32/All", common::embed_fp32_path(), ComputeUnits::All),
-    ("int8/CpuOnly", common::embed_path(), ComputeUnits::CpuOnly),
+  for (tag, embed_path, seg_cu, emb_cu) in [
     (
-      "fp32/CpuOnly",
+      "seg@All + int8@All",
+      common::embed_path(),
+      ComputeUnits::All,
+      ComputeUnits::All,
+    ),
+    (
+      "seg@All + fp32@All",
       common::embed_fp32_path(),
+      ComputeUnits::All,
+      ComputeUnits::All,
+    ),
+    (
+      "seg@All + fp32@CpuOnly",
+      common::embed_fp32_path(),
+      ComputeUnits::All,
+      ComputeUnits::CpuOnly,
+    ),
+    (
+      "seg@CpuOnly + fp32@CpuOnly",
+      common::embed_fp32_path(),
+      ComputeUnits::CpuOnly,
+      ComputeUnits::CpuOnly,
+    ),
+    (
+      "seg@CpuOnly + int8@CpuOnly",
+      common::embed_path(),
+      ComputeUnits::CpuOnly,
       ComputeUnits::CpuOnly,
     ),
   ] {
     let t0 = Instant::now();
     let seg = SegmentModel::from_file_with(
       common::seg_path(),
-      SegmentModelOptions::new().with_compute(cu),
+      SegmentModelOptions::new().with_compute(seg_cu),
     )
     .expect("load segmentation");
-    let embed = EmbedModel::from_file_with(&embed_path, EmbedModelOptions::new().with_compute(cu))
-      .expect("load embedder");
+    let embed =
+      EmbedModel::from_file_with(&embed_path, EmbedModelOptions::new().with_compute(emb_cu))
+        .expect("load embedder");
     let load_s = t0.elapsed().as_secs_f64();
 
     let source = FluidAudioSource::with_options(seg, embed, Options::new());
@@ -1653,37 +1621,37 @@ fn shipping_embedder_cost_int8_vs_fp32() {
     assert_eq!(ext.num_chunks(), num_chunks, "{tag}: chunk count unstable");
 
     println!(
-      "{tag:<16} {load_s:>10.2} {extract_s:>12.2} {:>9.1}× {:>12.1}",
+      "{tag:<32} {load_s:>10.2} {extract_s:>12.2} {:>9.1}× {:>12.1}",
       audio_s / extract_s,
       extract_s * 1000.0 / num_chunks as f64,
     );
   }
   println!(
-    "(RTF = audio seconds processed per wall-clock second; higher is faster. \
-     Segmentation is identical across arms, so int8-vs-fp32 extract_s deltas are \
-     the embedder's own cost.)"
+    "(RTF = audio seconds processed per wall-clock second; higher is faster. Rows sharing a seg \
+     placement differ only in the embedder, so their extract_s delta is the embedder's own cost.)"
   );
 }
 
-/// The shipping default really is the int8 artifact — the premise this whole
-/// suite rests on. It pins the exact selection at its source of truth: the pure
-/// [`FluidAudioArtifacts::resolve`] that `AnySource::load` itself uses. If that
-/// resolver is ever repointed at the fp32 `wespeaker.mlmodelc`, this fails —
-/// and so does the hermetic `FluidAudioArtifacts` unit test — because both read
-/// production's own selection, not a parallel copy of the path (finding 3: the
-/// old version asserted only the enum variant and directory sizes, so repointing
-/// the loader passed everything while the DER arms went on loading their own
-/// `common::embed_path()`).
+/// The shipping default really is the fp32 artifact — the premise this whole
+/// suite rests on since issue #15 retired the int8 embedder. It pins the exact
+/// selection at its source of truth: the pure [`FluidAudioArtifacts::resolve`]
+/// that `AnySource::load` itself uses. If that resolver is ever repointed back
+/// at the int8 `wespeaker_v2.mlmodelc`, this fails — and so does the hermetic
+/// `FluidAudioArtifacts` unit test — because both read production's own
+/// selection, not a parallel copy of the path (finding 3: an earlier version
+/// asserted only the enum variant and directory sizes, so repointing the
+/// loader passed everything while the DER arms went on loading their own
+/// path).
 ///
 /// Needs only the model directory (no audio, no ort), so it runs cheaply — but
 /// it is still `#[ignore]`d because it loads the real artifacts.
 #[test]
 #[ignore = "requires Models/speakerkit"]
-fn shipping_default_is_the_int8_embedder() {
+fn shipping_default_is_the_fp32_embedder() {
   let root = common::models_dir();
   assert!(
-    root.join("wespeaker_v2.mlmodelc").exists(),
-    "wespeaker_v2.mlmodelc (int8) missing under {}",
+    root.join("wespeaker.mlmodelc").exists(),
+    "wespeaker.mlmodelc (fp32) missing under {}",
     root.display()
   );
   // The selection, pinned at production's source of truth. `AnySource::load`
@@ -1692,8 +1660,8 @@ fn shipping_default_is_the_int8_embedder() {
   // ships — not a re-encoding of it.
   let artifacts = FluidAudioArtifacts::resolve(&root);
   assert!(
-    artifacts.embedder().ends_with("wespeaker_v2.mlmodelc"),
-    "AnySource::load's FluidAudio embedder resolves to {}, not the int8 wespeaker_v2.mlmodelc — \
+    artifacts.embedder().ends_with("wespeaker.mlmodelc"),
+    "AnySource::load's FluidAudio embedder resolves to {}, not the fp32 wespeaker.mlmodelc — \
      the shipping default moved, so the DER gates in this suite are now measuring the wrong \
      artifact",
     artifacts.embedder().display()
@@ -1705,8 +1673,11 @@ fn shipping_default_is_the_int8_embedder() {
     matches!(source, AnySource::FluidAudio(_)),
     "the default Source is no longer FluidAudio — re-derive which embedder ships"
   );
-  // Documented sizes, so the cost of switching the default to fp32 is visible
-  // right where the decision is gated (int8 ≈ 7.6 MB vs fp32 ≈ 28.1 MB).
+  // Documented sizes, so the accepted footprint cost of the fp32 default is
+  // visible right where the selection is gated (fp32 ≈ 29.4 MB vs the retired
+  // int8's ≈ 8.0 MB — issue #15 accepted the +21 MB to fix the 8-speaker
+  // collapse; the int8 artifact stays on disk as a tested, non-shipping
+  // sibling).
   let du = |p: &Path| -> u64 {
     fn walk(p: &Path) -> u64 {
       std::fs::read_dir(p).map_or(0, |rd| {
@@ -1720,13 +1691,13 @@ fn shipping_default_is_the_int8_embedder() {
     }
     walk(p)
   };
-  let int8 = du(artifacts.embedder());
-  let fp32 = du(&common::embed_fp32_path());
+  let fp32 = du(artifacts.embedder());
+  let int8 = du(&root.join("wespeaker_v2.mlmodelc"));
   println!(
-    "shipping embedder wespeaker_v2 (int8) = {:.1} MB | wespeaker (fp32) = {:.1} MB | \
+    "shipping embedder wespeaker (fp32) = {:.1} MB | retired wespeaker_v2 (int8) = {:.1} MB | \
      fp32 costs {:+.1} MB ({:.1}×)",
-    int8 as f64 / 1e6,
     fp32 as f64 / 1e6,
+    int8 as f64 / 1e6,
     (fp32 as f64 - int8 as f64) / 1e6,
     fp32 as f64 / int8 as f64,
   );
@@ -1756,14 +1727,16 @@ fn shipping_default_is_the_int8_embedder() {
 /// The selected four span the speaker-count ladder — 3 / 4 / 7 / 8 — at the
 /// lowest runtime that covers it. The other four ≥ 3-speaker clips are excluded
 /// deliberately: 08 (3 spk) duplicates 06's minimal-≥3 case, and 11 (6), 13 (11),
-/// 12 (15) are higher counts whose shipping int8 behaviour is UNMEASURED (§5.9
+/// 12 (15) are higher counts whose shipping-configuration behaviour is
+/// UNMEASURED in this suite (§5.9
 /// measured only 06 / 14 / 10 / 09), each adding ~10 min to an already ~65-min
 /// suite (~+40 min for all four). Adding one is NOT free here: this suite runs
-/// once and pins measured values, so a new gated clip needs a measured int8
-/// baseline FIRST — a blind gate on an unmeasured clip could fail with no way to
-/// tell a real defect from a missing expectation. Clip 12 (the known
-/// FluidAudio-breach clip) has the highest marginal value and is first to add
-/// once measured.
+/// once and pins measured values, so a new gated clip needs a measured
+/// baseline FIRST — a blind gate on an unmeasured clip could fail with no way
+/// to tell a real defect from a missing expectation. Clip 12 (the known
+/// FluidAudio-breach clip, whose fp32 all-CPU arm parity_e2e's stress set
+/// already measures) has the highest marginal value and is first to add once
+/// measured on all three placements.
 #[test]
 #[ignore = "requires the sibling diarization parity fixtures (no models needed)"]
 fn shipping_clip_selection_is_the_documented_subset() {

--- a/crates/coremlit/tests/speaker/parity_shipping_der.rs
+++ b/crates/coremlit/tests/speaker/parity_shipping_der.rs
@@ -72,12 +72,27 @@
 //!    conversion itself, int8, or ANE placement) moves a marginal assignment.
 //!    int8's increment is of the same order as the conversion's own, and costs
 //!    only +0.22 DER points against the reference.
-//! 2. **The CoreML path has a real defect on 8-speaker audio, and it is NOT
-//!    int8's.** On clip 09 the *fp32 control* makes dia's clustering return
+//! 2. **The CoreML path has a real defect on 8-speaker audio.** On clip 09 the
+//!    *fp32 control* makes dia's clustering return
 //!    `Err(Centroid(AmbiguousAliveCluster { .. }))` — no diarization at all —
 //!    while dia-ort clusters it fine and int8 still answers (undercounting,
 //!    5-6 of 8). Pinned in
 //!    [`shipping_int8_der_09_mrbeast_dollar_date_8spk_known_defect`].
+//!
+//!    WHICH CoreML conversion produces it is a question this suite cannot
+//!    answer — every one of its speakerkit arms runs CoreML segmentation AND
+//!    CoreML embedding, so the two never vary independently.
+//!    `backend_factorial.rs` runs that cross-product at this suite's own
+//!    shipping configuration and finds the CoreML **embedding** path
+//!    sufficient on its own (5 of 8 speakers at 16.5904 % over dia's reference
+//!    segmentation — this suite's pinned shipping numbers, exactly), with the
+//!    segmentation conversion contributing a separate, smaller overcount
+//!    (9 speakers, 1.3011 %). So the older reading of this bullet — that the
+//!    defect is "not int8's" — holds only in the narrow sense the fp32 control
+//!    licenses: the fp32/`CpuOnly` arm fails WORSE (it cannot answer at all).
+//!    It is not evidence that the shipping embedding path is uninvolved,
+//!    because the shipping embedding path is int8 on `All`, which no arm here
+//!    isolates.
 //!
 //! # The diagnostic: confusion, not DER
 //!
@@ -1271,10 +1286,15 @@ shipping_der_gate! {
   ///   (16.5904 % DER, 100 % confusion).
   /// - reference (pyannote 4.0.4): **8** speakers.
   ///
-  /// So on 8-speaker audio the CoreML path is defective *regardless of precision*
-  /// — and int8 is not the culprit; it is the arm that still returns an answer.
-  /// This is a real, separately-actionable defect (see the task report), and it is
-  /// pinned here rather than deleted so it cannot be forgotten.
+  /// So on 8-speaker audio the CoreML path is defective at BOTH precisions this
+  /// suite measures — the fp32 control worse than int8, since it cannot answer at
+  /// all. That is as far as these four arms reach: they never vary the two CoreML
+  /// conversions independently, so "int8 is not the culprit" is NOT among the
+  /// things they establish. `backend_factorial.rs`, which does vary them, finds
+  /// the CoreML embedding path on `All` sufficient on its own to reproduce the
+  /// int8/All numbers pinned below (see the module doc's point 2). This is a real,
+  /// separately-actionable defect, and it is pinned here rather than deleted so it
+  /// cannot be forgotten.
   ///
   /// The assertion is on the KNOWN-BAD state, pinned field by field by
   /// [`assert_clip09_known_defect`]: clip identity, the reference and oracle counts,


### PR DESCRIPTION
Closes #15's shipping defect: the diarizer recovered **5 of 8 speakers at 16.5904 % DER** on clip 09. It now recovers **8 of 8 at 2.9810 %**.

## The change is one line

```diff
- embedder: root.join("wespeaker_v2.mlmodelc"),   // int8, palettized
+ embedder: root.join("wespeaker.mlmodelc"),      // fp32, fp16-safe
```

Placements unchanged — both `All`. **Ten non-comment source lines** in total; everything else in this diff is evidence, gates and documentation.

## Why int8 broke it — magnitude was never the mechanism

| arm | mean \|Δ\| | coherence | frac>0 | err units |
|---|---|---|---|---|
| int8 · `All` | **0.25264** | 0.2473 | 0.9669 | 11 999 |
| fp32 · `All` | 0.18897 | **0.0624** | **0.6026** | 1 839 |
| int8 · `CpuOnly` | 0.12223 | **0.5039** | **0.9868** | 11 835 |

int8/`CpuOnly` perturbs embeddings **less** than fp32/`All` (0.122 vs 0.189) and does **6.4× more damage**. The discriminator is *coherence*, not size: int8 palettization applies a **coherent one-signed displacement** — 97–99 % of components moving the same way, bias ≈ 2.4 % of embedding norm, coherence 0.504 against an independent-scatter null of `1/√2114 ≈ 0.022` — which drags whole speaker centroids together. `All` placement adds a *larger but isotropic* perturbation that averages out inside a cluster.

Artifact-level cause: 38 per-tensor 8-bit LUTs, one flat 256-entry codebook per tensor. Weight-space error is zero-mean per tensor; the output-space bias arises from a fixed ΔW acting on shared activation statistics.

This **refutes the previous `parity_shipping_der` rationale** that quantization is benign isotropic noise. That rationale is retired with the artifact, and the refutation is now a pinned gate.

## Measured, four gate clips, real pipeline

| clip (ref spk) | ships now | int8 (retired) |
|---|---|---|
| 09 (8) | **8 @ 2.9810 %** | 5 @ 16.5904 % |
| 06 (3) | 3 @ 0.3469 % | 3 @ 0.3451 % |
| 14 (4) | 4 @ 0.3584 % | 4 @ 1.1788 % |
| 10 (7) | 7 @ 0.0369 % | 7 @ 0.0369 % |

Every arm is 0 miss / 0 false-alarm — all error is confusion, so segmentation is intact and only speaker identity was collapsing.

**fp32/`CpuOnly` was measured and rejected.** Lower DER on every clip, but it over-segments clip 09 to **9** speakers, and `seg@CpuOnly + emb@CpuOnly` returns `Err(AmbiguousAliveCluster)`. `All` is the only composition that lands 8/8. Extraction cost is a wash: the int8-vs-fp32 difference is ≤ ~15 % on every placement **with the sign flipping between runs** (4.33/4.95 then 4.13/4.65 on `All`) — inside warm-run scheduler variability. The stable cost axis is placement, not precision.

**No documented bound was loosened.** Clip 09 is excluded from the general placement/confusion gates by existing design and carries its own pinned band, deliberately re-baselined with evidence.

## Review

Five adversarial rounds, **thirteen findings, none in the fix** — codex called the artifact swap sound and every finding landed in the evidence apparatus around it. The most valuable one could only be found by reading across files: **this branch's own swap destroyed a control it advertised**, because the factorial cited `parity_shipping_der`'s int8 corner as its independent anchor and the swap made that suite resolve fp32. The anchor was rebuilt in-suite and **executed** — 57 minutes through `FluidAudioSource::extract` + `Extraction::diarize`, reproducing `5 speakers, 16.5904 %, 11 999 units` and agreeing with the hand-assembled corner.

Rounds also removed a false causal attribution (a fixture doc blamed the segmentation tail for a collapse its own factorial attributes to the embedder), a gate that accepted `b.mean_norm = NaN`, cells whose `der` was carried but never read, and several claims stronger than their guards. Two claims were **retracted** rather than guarded, because the data did not support them.

The branch now states, in the code, **which figures are guarded invariants and which are reported measurements** — the distinction four rounds of review kept turning on.

## Gates

`fmt · clippy --all-features --all-targets -D warnings · doc -D warnings · fp16_guards (24) · model_io · backend_factorial · parity_shipping_der · der_gate_inventory` — all 0, run by the reviewing context.

Model-gated on the shipped artifact set: production control, mechanism probe, precision × placement factorial, four-clip DER matrix, e2e parity + determinism, stress clips — all green. 28 mechanism mutations plus the clip-09 and precision-placement mutation proofs each fire.

## Not established

One host (M1 Max, macOS 26.5). Corpus clips 08/11/13 unmeasured under the new config. A repaired int8 quantization is characterized as tractable — grouped or per-channel LUTs, exempting the head and DSP constants — but not attempted: no validated conversion environment exists in-repo. The segmentation knife edge is **pinned, not repaired**; it is the residual behind the 2.98 % and the phantom-ninth-speaker risk at CPU placements.