### PR TITLE
fix(coremlit/ci): un-break model-tests, and stop one red step from silently disabling the gates below it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,14 +358,22 @@ jobs:
       # WHISPERKIT_TEST_MODELS); then the whisper pipeline's model-gated suite.
       # The align/speaker/vad model gates need models this runner does not
       # download and stay local/dev gates, exactly as before the restructure.
+      #
+      # `--no-fail-fast` for the same reason the steps carry `!cancelled()`,
+      # one level down: these two invocations span MANY test targets, and cargo
+      # stops at the first target that fails. That is not theoretical here —
+      # `whisper_parity_es` was red before the tokenizer assertion above it ever
+      # existed, and hid `whisper_parity_jfk`, `whisper_pipeline`,
+      # `whisper_streaming` and `whisper_rtf_gate` behind it for a month. One
+      # red target must cost you that target's verdict, not the four after it.
       - name: Core model gates
         id: core_gates
         if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
-        run: cargo test -p coremlit -- --ignored
+        run: cargo test -p coremlit --no-fail-fast -- --ignored
       - name: Whisper model gates
         id: whisper_gates
         if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
-        run: cargo test -p coremlit --features whisper -- --ignored
+        run: cargo test -p coremlit --features whisper --no-fail-fast -- --ignored
       # The `whisper,vad` composition gates (Silero-driven long-form chunking).
       # They need whisper-tiny, so they belong here rather than in `check`, and
       # they were dark until the VAD model was committed — this runner has no
@@ -411,6 +419,12 @@ jobs:
           # embeds the granite tokenizer (it is a ~24 MB sidecar the artifact
           # ships and `TextEmbedder::load` reads), so those gates read the staged
           # artifact tree and are `#[ignore]`d like every other model gate.
+          # A red target reports ITS verdict and the loop keeps going: six gate
+          # suites run here, and under `set -e` the first failure would hide the
+          # five after it — the same masking this job just spent a month in, one
+          # level down. A VACUUM still aborts immediately, because that is a
+          # configuration error rather than a gate result.
+          failed=""
           for target in granite_model_io granite_parity_embed granite_placement granite_embed_long \
                         granite_tokenizer_identity; do
             listed=$(cargo test -p coremlit --features granite --test "$target" -- --list --ignored 2>/dev/null | grep -c ': test$' || true)
@@ -419,7 +433,7 @@ jobs:
               exit 1
             fi
             echo "== $target: $listed model gate(s) =="
-            cargo test -p coremlit --features granite --test "$target" -- --ignored
+            cargo test -p coremlit --features granite --test "$target" -- --ignored || failed="$failed $target"
           done
           # The in-lib granite tokenizer/chunking gates (`--lib`), same reason
           # and the same anti-vacuum guard.
@@ -429,7 +443,11 @@ jobs:
             exit 1
           fi
           echo "== --lib: $listed model gate(s) =="
-          cargo test -p coremlit --features granite --lib -- --ignored
+          cargo test -p coremlit --features granite --lib -- --ignored || failed="$failed --lib"
+          if [ -n "$failed" ]; then
+            echo "::error::granite gates failed:$failed" >&2
+            exit 1
+          fi
       # The two siglip TOKENIZER gates. They are `#[ignore]`d like every other
       # siglip model gate — not because they load a model (they call no
       # `Model::load` at all) but because they read the staged artifact tree:
@@ -487,6 +505,9 @@ jobs:
             echo "::error::CED bundle $bundle is absent — the model gates below must FAIL here, never skip" >&2
             exit 1
           fi
+          # Failure-collecting for the same reason as the granite loop above: a
+          # red target must cost its own verdict, not the three after it.
+          failed=""
           for target in ced_model_io ced_parity_logits ced_placement ced_e2e; do
             listed=$(cargo test -p coremlit --features ced --test "$target" -- --list --ignored tiny:: 2>/dev/null | grep -c ': test$' || true)
             if [ "$listed" -eq 0 ]; then
@@ -494,8 +515,12 @@ jobs:
               exit 1
             fi
             echo "== $target: $listed tiny model gate(s) =="
-            cargo test -p coremlit --features ced --test "$target" -- --ignored tiny::
+            cargo test -p coremlit --features ced --test "$target" -- --ignored tiny:: || failed="$failed $target"
           done
+          if [ -n "$failed" ]; then
+            echo "::error::CED tiny gates failed:$failed" >&2
+            exit 1
+          fi
       # The anti-vacuum guard for the JOB, mirroring the per-target
       # `--list --ignored` counts inside the gates above: those refuse a gate
       # that runs zero tests, and this refuses a gate that never runs at all.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
             Models/ced/ced-tiny
           key: models-${{ hashFiles('MODELS_LOCK') }}
       - name: Download models (cache miss)
+        id: download
         if: steps.models.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
@@ -252,6 +253,32 @@ jobs:
           # — the layout tests/ced/common/mod.rs resolves without CED_TEST_MODELS.
           hf download "$ced_repo" --include "$ced_include" --revision "$ced_revision" \
             --local-dir Models/ced
+      # EVERY step below carries
+      # `if: ${{ !cancelled() && steps.download.outcome != 'failure' }}`, and
+      # that is not boilerplate — it is the fix for a failure mode this job
+      # actually had. GitHub's default step condition is `success()`, so ONE red
+      # gate marks every later gate `skipped`, and `skipped` is silent: the job
+      # reports the single failure it hit and says nothing about the ones it
+      # never attempted. That is exactly what happened here — a stale assertion
+      # in the whisper suite went red the day it merged and stayed red for four
+      # weeks, and the four gate steps below it (Whisper+VAD, granite, SigLIP,
+      # CED) have between them NEVER executed on CI: each was added after the
+      # step above it was already permanently red, so every one of them has
+      # reported `skipped` on every run it has ever been part of — the granite
+      # gates since the day after they were written.
+      #
+      # These gates are INDEPENDENT of each other: a corrupt granite bundle
+      # says nothing about whether the CED graph loads. So each reports its own
+      # verdict and the job aggregates them, and one red gate can no longer hide
+      # another's result. A failed DOWNLOAD is the one real dependency (nothing
+      # below can run without the artifacts), so that alone still short-circuits
+      # — and `steps.download.outcome` is `skipped`, not `failure`, on a cache
+      # hit, so the common path is unaffected.
+      #
+      # The `Gate ledger` step at the end of the job then refuses the residue:
+      # a step added later WITHOUT this condition would reintroduce the silent
+      # skip, so the ledger fails the job if any named gate did not run.
+
       # Runs on EVERY run, not just cache misses, so a truncated download AND a
       # tampered or partially-restored cache entry both fail here rather than
       # surfacing later as a confusing parity or model_io failure. The bundle
@@ -260,6 +287,8 @@ jobs:
       # file that is missing, a hash mismatch, and a checksum file with no valid
       # lines each exit non-zero.
       - name: Verify granite artifact checksums
+        id: granite_checksums
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
         run: |
           set -euo pipefail
           bundle_root=Models/embedkit-granite/granite-97m-multilingual-r2
@@ -279,6 +308,8 @@ jobs:
       # "No such file or directory" lines, which `shasum -c` exits non-zero on —
       # fail-closed either way, but loudly wrong rather than quietly wrong.
       - name: Verify CED artifact checksums
+        id: ced_checksums
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
         run: |
           set -euo pipefail
           bundle=Models/ced/ced-tiny/ced_tiny.mlmodelc
@@ -315,19 +346,33 @@ jobs:
       # runner has downloaded vendors, so build.rs emits cfg(models_present) and
       # the walk covers all of Models/, vadkit included. The modelless
       # check/features jobs deliberately leave the sweep #[ignore]d (build.rs).
-      - run: COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite,vadkit,ced cargo test -p coremlit --test fp16_guards
-      - run: crates/coremlit/tests/fp16_sweep_inventory.sh
+      - name: fp16 graph sweep
+        id: fp16_guards
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
+        run: COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite,vadkit,ced cargo test -p coremlit --test fp16_guards
+      - name: fp16 sweep inventory
+        id: fp16_inventory
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
+        run: crates/coremlit/tests/fp16_sweep_inventory.sh
       # Core model-gated suite (tiny_model etc., whisper-tiny via
       # WHISPERKIT_TEST_MODELS); then the whisper pipeline's model-gated suite.
       # The align/speaker/vad model gates need models this runner does not
       # download and stay local/dev gates, exactly as before the restructure.
-      - run: cargo test -p coremlit -- --ignored
-      - run: cargo test -p coremlit --features whisper -- --ignored
+      - name: Core model gates
+        id: core_gates
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
+        run: cargo test -p coremlit -- --ignored
+      - name: Whisper model gates
+        id: whisper_gates
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
+        run: cargo test -p coremlit --features whisper -- --ignored
       # The `whisper,vad` composition gates (Silero-driven long-form chunking).
       # They need whisper-tiny, so they belong here rather than in `check`, and
       # they were dark until the VAD model was committed — this runner has no
       # other way to get it. Same anti-vacuum guard as the granite/siglip steps.
       - name: Whisper + Silero-VAD composition gates
+        id: whisper_vad_gates
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
         run: |
           set -euo pipefail
           listed=$(cargo test -p coremlit --features whisper,vad --test whisper_vad_source -- --list --ignored 2>/dev/null | grep -c ': test$' || true)
@@ -352,6 +397,8 @@ jobs:
       # The hermetic granite suites (tokenizer identity, in-lib) are the
       # `features` job's, not this one's.
       - name: Granite model gates
+        id: granite_gates
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
         run: |
           set -euo pipefail
           bundle=Models/embedkit-granite/granite-97m-multilingual-r2/granite_97m_512.mlmodelc
@@ -398,6 +445,8 @@ jobs:
       # deleted, renamed, un-ignored, or that failed to BUILD runs 0 tests and
       # exits 0, so the ignored-only `--list` count refuses it.
       - name: SigLIP tokenizer gates
+        id: siglip_gates
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
         run: |
           set -euo pipefail
           tokenizer=Models/siglip2-naflex/siglip2-base-patch16-naflex-512/tokenizer.json
@@ -429,6 +478,8 @@ jobs:
       # deleted `tiny` module still report the OTHER three sizes' gates as a
       # non-zero count and then run zero — the exact vacuum the guard refuses.
       - name: CED model gates (tiny)
+        id: ced_gates
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
         run: |
           set -euo pipefail
           bundle=Models/ced/ced-tiny/ced_tiny.mlmodelc
@@ -445,3 +496,43 @@ jobs:
             echo "== $target: $listed tiny model gate(s) =="
             cargo test -p coremlit --features ced --test "$target" -- --ignored tiny::
           done
+      # The anti-vacuum guard for the JOB, mirroring the per-target
+      # `--list --ignored` counts inside the gates above: those refuse a gate
+      # that runs zero tests, and this refuses a gate that never runs at all.
+      #
+      # `!cancelled()` alone, deliberately — this must report even when the
+      # download failed, because "the download died and took ten gates with it"
+      # is precisely the fact the old job swallowed. A `skipped` outcome here
+      # can only mean a step lost its condition or the download failed; either
+      # way the job must be red and must SAY which gates did not execute.
+      #
+      # Adding a gate step above means adding its id here. Forgetting to is the
+      # benign direction (the new gate is simply unwatched); forgetting the
+      # `if:` on it is the harmful one, and it is the one this catches.
+      - name: Gate ledger (a gate that never ran proves nothing)
+        if: ${{ !cancelled() }}
+        env:
+          LEDGER: |
+            granite-checksums=${{ steps.granite_checksums.outcome }}
+            ced-checksums=${{ steps.ced_checksums.outcome }}
+            fp16-graph-sweep=${{ steps.fp16_guards.outcome }}
+            fp16-sweep-inventory=${{ steps.fp16_inventory.outcome }}
+            core-model-gates=${{ steps.core_gates.outcome }}
+            whisper-model-gates=${{ steps.whisper_gates.outcome }}
+            whisper-vad-gates=${{ steps.whisper_vad_gates.outcome }}
+            granite-model-gates=${{ steps.granite_gates.outcome }}
+            siglip-tokenizer-gates=${{ steps.siglip_gates.outcome }}
+            ced-model-gates=${{ steps.ced_gates.outcome }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$LEDGER"
+          # `skipped` is the gate that never ran; an EMPTY outcome is a typo in
+          # an id above, which would leave that gate unwatched — both are the
+          # same defect (a gate whose fate this step cannot report) and both
+          # fail here.
+          missing=$(printf '%s' "$LEDGER" | sed -nE 's/^ *([^=]*)=(skipped)?$/\1/p' | paste -sd' ' -)
+          if [ -n "$missing" ]; then
+            echo "::error::these gate steps did not run, or this step cannot tell: $missing — a red step must not silently disable the gates after it (see the note above the first gate), so this job fails on their absence, not on their result" >&2
+            exit 1
+          fi
+          echo "all gates executed"

--- a/crates/coremlit/src/audio/whisper/tokenizer/tests.rs
+++ b/crates/coremlit/src/audio/whisper/tokenizer/tests.rs
@@ -2,7 +2,18 @@ use std::path::PathBuf;
 
 use super::*;
 
-fn tiny() -> WhisperTokenizer {
+/// The staged whisper-tiny tokenizer folder.
+///
+/// Its CONTENTS beyond `tokenizer.json` are a staging detail, not a property
+/// of this crate, and no test may assert on them: a local
+/// `hf download openai/whisper-tiny tokenizer.json` leaves the folder holding
+/// that file alone, while the three-file `files` selector MODELS_LOCK hands CI
+/// (`tokenizer.json tokenizer_config.json config.json`) lands the checkpoint's
+/// own `tokenizer_config.json` beside it. Both stagings resolve the cleanup
+/// flag to `true` -- the first through Swift's `or:` default, the second by
+/// reading the `"clean_up_tokenization_spaces": true` every OpenAI Whisper
+/// checkpoint ships -- so a test that needs one shape must CONSTRUCT it.
+fn tiny_folder() -> PathBuf {
   let root = std::env::var_os("WHISPERKIT_TEST_MODELS").map_or_else(
     || {
       PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -11,7 +22,11 @@ fn tiny() -> WhisperTokenizer {
     },
     PathBuf::from,
   );
-  WhisperTokenizer::from_folder(root.join("tokenizers/whisper-tiny")).unwrap()
+  root.join("tokenizers/whisper-tiny")
+}
+
+fn tiny() -> WhisperTokenizer {
+  WhisperTokenizer::from_folder(tiny_folder()).unwrap()
 }
 
 #[test]
@@ -870,23 +885,30 @@ fn decode_cleans_the_leading_space_off_the_ellipsis_token() {
   assert!(t.clean_up_tokenization_spaces);
   assert_eq!(t.decode(&[1097], false).unwrap(), "...");
 
-  // And the real fixture folder resolves to `true` -- by Swift's `or:` default
-  // rather than by reading the flag, which is worth saying out loud: the folder
-  // `from_folder` is handed holds only `tokenizer.json`. The checkpoint's own
-  // `tokenizer_config.json` does set `"clean_up_tokenization_spaces": true`,
-  // i.e. the same answer, but it sits a HuggingFace snapshot layer below (at
-  // `models/openai/whisper-tiny/`) and is not on the path this function reads.
-  let root = std::env::var_os("WHISPERKIT_TEST_MODELS").map_or_else(
-    || {
-      PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .join("Models")
-    },
-    PathBuf::from,
-  );
-  let folder = root.join("tokenizers/whisper-tiny");
-  assert!(!folder.join("tokenizer_config.json").exists());
-  assert!(clean_up_tokenization_spaces_from(&folder));
+  // And the cleanup that produces that answer is reached by Swift's `or:`
+  // DEFAULT, not by a configured flag -- worth saying out loud, because a
+  // folder carrying no `tokenizer_config.json` at all is a shape this crate
+  // supports (`from_folder` requires only `tokenizer.json`) and the one where
+  // the ellipsis fix could silently stop applying.
+  //
+  // That folder is CONSTRUCTED, not looked for. Asserting the staged folder
+  // has no `tokenizer_config.json` is an assertion about whoever staged it,
+  // not about this crate -- see `tiny_folder` -- and it is what made this test
+  // pass on a dev box and fail on CI for a month.
+  let bare = tempfile::tempdir().unwrap();
+  std::fs::copy(
+    tiny_folder().join("tokenizer.json"),
+    bare.path().join("tokenizer.json"),
+  )
+  .unwrap();
+  assert!(!bare.path().join("tokenizer_config.json").exists());
+  let bare_tokenizer = WhisperTokenizer::from_folder(bare.path()).unwrap();
+  assert!(bare_tokenizer.clean_up_tokenization_spaces);
+  assert_eq!(bare_tokenizer.decode(&[1097], false).unwrap(), "...");
+
+  // The staged folder then resolves `true` under EITHER shape, which is the
+  // only thing about it this test is entitled to depend on.
+  assert!(clean_up_tokenization_spaces_from(&tiny_folder()));
 }
 
 #[test]

--- a/crates/coremlit/tests/whisper/models_lock.rs
+++ b/crates/coremlit/tests/whisper/models_lock.rs
@@ -1,8 +1,10 @@
 //! `MODELS_LOCK` governs what CI's `model-tests` job downloads (see the
 //! lock file's own header comment and `.github/workflows/ci.yml`'s
 //! "Download models (cache miss)" step). These checks are hermetic — no
-//! network, no models — and guard the two ways that contract can silently
-//! rot: the lock stops parsing, or the workflow stops actually reading it.
+//! network, no models — and guard the three ways that contract can silently
+//! rot: the lock stops parsing, the workflow stops actually reading it, or
+//! the workflow keeps downloading the artifacts but stops RUNNING the gates
+//! that read them.
 //!
 //! No TOML crate: this is a deliberately tiny hand-rolled reader over the
 //! lock's fixed five-table shape (`["repo/name"]` headers, single-line
@@ -34,6 +36,48 @@ fn repo_files() -> Option<(PathBuf, PathBuf)> {
     eprintln!("models_lock checks skipped: not in the repository workspace");
     None
   }
+}
+
+/// The step condition every gate in ci.yml's `model-tests` job must carry.
+///
+/// `!cancelled()` is what makes a gate independent of the ones before it;
+/// `steps.download.outcome != 'failure'` keeps the ONE genuine dependency —
+/// nothing below can run without the artifacts. `outcome` is `skipped`, not
+/// `failure`, when the download is itself skipped on a cache hit, so the
+/// common path stays unaffected.
+const GATE_GUARD: &str = "if: ${{ !cancelled() && steps.download.outcome != 'failure' }}";
+
+/// The `model-tests` job's steps, in order, each as its own raw YAML text.
+///
+/// Text-based like `parse_lock`, and for the same reason: the point is to read
+/// what ci.yml literally says, not to model YAML. A step begins at exactly six
+/// columns of indent followed by `- name:`/`- uses:`/`- run:`, which no line
+/// inside a `run: |` block (indented ten) can imitate, and the job ends at the
+/// next key indented two columns.
+fn model_tests_steps(ci: &str) -> Vec<String> {
+  let job = ci
+    .split_once("\n  model-tests:\n")
+    .expect("ci.yml has no `model-tests` job")
+    .1;
+  let mut steps: Vec<String> = Vec::new();
+  for line in job.lines() {
+    let body = line.trim_start();
+    if !body.is_empty() && line.len() - body.len() == 2 {
+      break;
+    }
+    if ["- name:", "- uses:", "- run:"].iter().any(|start| {
+      line
+        .strip_prefix("      ")
+        .is_some_and(|l| l.starts_with(start))
+    }) {
+      steps.push(String::new());
+    }
+    if let Some(step) = steps.last_mut() {
+      step.push_str(line);
+      step.push('\n');
+    }
+  }
+  steps
 }
 
 fn field<'a>(table: &'a LockTable, key: &str) -> Option<&'a str> {
@@ -307,4 +351,85 @@ fn ci_runs_the_ced_gates_for_exactly_the_size_the_lock_stages() {
      ({list_filter:?}), so a deleted or renamed `{size}` module could still count the other \
      sizes' gates and then run none"
   );
+}
+
+/// GitHub's default step condition is `success()`, so one red step marks every
+/// step after it `skipped` — and `skipped` is silent. `model-tests` ran that
+/// way for four weeks: a stale assertion in the whisper suite went red the day
+/// it merged, and the four gate steps below it (Whisper+VAD, granite, SigLIP,
+/// CED) have between them never executed on CI at all — each was added after
+/// the step above it was already permanently red.
+///
+/// These gates are independent — a corrupt granite bundle says nothing about
+/// whether the CED graph loads — so each carries [`GATE_GUARD`] and reports its
+/// own verdict. A failed DOWNLOAD is the one genuine dependency and still
+/// short-circuits them all.
+///
+/// ci.yml's own `Gate ledger` step catches a gate that did not run, but only on
+/// a run where something else already failed; in a green run a gate step added
+/// without the guard is invisible until the day it matters. This catches that
+/// at authoring time, in the modelless `check` job.
+#[test]
+fn ci_model_tests_gates_cannot_be_silently_skipped() {
+  let Some((_, workflow_path)) = repo_files() else {
+    return;
+  };
+  let ci_contents = fs::read_to_string(workflow_path).expect(".github/workflows/ci.yml reads");
+  let steps = model_tests_steps(&ci_contents);
+
+  let download = steps
+    .iter()
+    .position(|step| step.contains("id: download"))
+    .expect("ci.yml's model-tests job has no step with `id: download`");
+  let (gates, ledger) = steps[download + 1..]
+    .split_last()
+    .map(|(last, rest)| (rest, last))
+    .expect("ci.yml's model-tests job has no steps after the download");
+
+  assert!(
+    ledger.contains("name: Gate ledger") && ledger.contains("if: ${{ !cancelled() }}"),
+    "ci.yml's model-tests job must END with the `Gate ledger` step, guarded by `!cancelled()` \
+     alone so it reports even when the download died and took every gate with it; its last step \
+     is instead:\n{ledger}"
+  );
+
+  // Vacuum guard: a parse that produced no steps would pass every loop below.
+  // These five are the gate steps the four-week outage darkened.
+  for gate in [
+    "name: Whisper model gates",
+    "name: Whisper + Silero-VAD composition gates",
+    "name: Granite model gates",
+    "name: SigLIP tokenizer gates",
+    "name: CED model gates (tiny)",
+  ] {
+    assert!(
+      gates.iter().any(|step| step.contains(gate)),
+      "ci.yml's model-tests job has no `{gate}` step after the download — either it was removed, \
+       or this test stopped parsing the job (it found {} step(s))",
+      gates.len()
+    );
+  }
+
+  for step in gates {
+    assert!(
+      step.contains(GATE_GUARD),
+      "this model-tests step does not carry `{GATE_GUARD}`, so a failure in any step before it \
+       marks it `skipped` and the job reports nothing about the gate that never ran:\n{step}"
+    );
+    let id = step
+      .lines()
+      .find_map(|line| line.trim().strip_prefix("id: "))
+      .unwrap_or_else(|| {
+        panic!(
+          "this model-tests step has no `id:`, so the `Gate ledger` step cannot \
+           report whether it ran:\n{step}"
+        )
+      });
+    let entry = format!("=${{{{ steps.{id}.outcome }}}}");
+    assert!(
+      ledger.contains(&entry),
+      "the `Gate ledger` step never reads step {id:?} ({entry:?}), so that gate could be skipped \
+       without the job saying so"
+    );
+  }
 }


### PR DESCRIPTION
`model-tests` has failed on **every run since 2026-07-24**, and since #65 merged on 07-26 the cause has been a single assertion. Everything after it in the job reported `skipped`.

## The test

```
crates/coremlit/src/audio/whisper/tokenizer/tests.rs:888
assertion failed: !folder.join("tokenizer_config.json").exists()
```

That is not a property of this crate — it is a property of whoever staged the tokenizer folder.

**The lock's selector never changed.** `MODELS_LOCK`'s `["openai/whisper-tiny"]` table has read `files = "tokenizer.json tokenizer_config.json config.json"` since the lock's first commit (`eb21f88`, 2026-07-12) — *fourteen days before the test was written* (`78ad68a`, 2026-07-26). The only later touch was a quoting normalisation. So this is not a stale test that a widened `include` overtook; it is a test that has **never once passed on CI**, born red on the day it merged. A dev box that fetched only `tokenizer.json` sees the other shape, which is why it passes locally.

Both shapes resolve the flag to `true` — the checkpoint's own `tokenizer_config.json` sets `"clean_up_tokenization_spaces": true` — so what the assertion was really guarding is that the ellipsis cleanup is reached by Swift's `or:` **default** rather than by a configured flag. That is now **constructed**: a tempdir holding `tokenizer.json` alone, loaded through `from_folder`, asserted to clean `Ġ...` → `...`.

That covers strictly more than the old line did. Inverting the missing-config fallback to `false` leaves the pre-existing `assert!(t.clean_up_tokenization_spaces)` **green** under CI's staging — only the constructed folder catches it. Under CI's shape, that fallback previously had no end-to-end coverage here at all; the `!exists()` line was not testing it, it was crashing on it.

`tiny_folder()` now documents the divergence and the rule it implies: no test may assert on the staged folder's contents beyond `tokenizer.json`.

## The bigger defect: four gate steps that have never run

GitHub's default step condition is `success()`, so one red step marks every later step `skipped` — and `skipped` is silent. The four gate steps below the whisper suite have **between them never executed on CI**:

| gate step | added | executions |
|---|---|---|
| Granite model gates | `ba052b8`, 07-27 | 0 |
| SigLIP tokenizer gates | `49052e5`, 08-22 | 0 |
| Whisper + Silero-VAD composition gates | `c8ea189`, 08-22 | 0 |
| CED model gates (tiny) | `e13647a`, 08-22 | 0 |

Each was added *after* the step above it was already permanently red.

So every step after the download now carries `if: ${{ !cancelled() && steps.download.outcome != 'failure' }}`. These gates are independent of each other; a failed **download** is the one real dependency, and `outcome` is `skipped`, not `failure`, on a cache hit, so the common path is unaffected. A closing **`Gate ledger`** step then fails the job — naming names — if any gate reports `skipped` or an unresolved outcome. A green `model-tests` that ran nine of ten gates is no longer expressible.

`ci_model_tests_gates_cannot_be_silently_skipped` pins this at authoring time rather than only on a run where something else already failed: it reads the job's steps out of `ci.yml` and requires the guard, an `id`, and a matching ledger entry on each.

## Verification

CI's condition was reproduced locally by staging a tokenizer folder that *does* contain `tokenizer_config.json` (the three files `MODELS_LOCK` selects). The old assertion fails there at exactly `tests.rs:888:3`; the new test passes under **both** stagings.

Four mutations, each caught:

| mutation | caught by |
|---|---|
| missing-config fallback → `false` | the constructed bare folder (the only assertion that catches it under CI's staging) |
| guard dropped from a gate step | `ci_model_tests_gates_cannot_be_silently_skipped` |
| ledger entry dropped | same |
| ledger itself guarded on the download | same |
| gate step renamed away | same |

## Side effect

Because `model-tests` has never succeeded, `actions/cache` has never *saved* the model cache (its post step is skipped on job failure) — every run since 07-24 re-downloaded the full model set. A green run will populate it for the first time.

---

## What the first CI run on this branch found

The whisper `--lib` target went **`113 passed; 1 failed` → `114 passed; 0 failed`** — the assertion is fixed — and all four dark gate steps executed for the first time and **passed**:

| step | before | this branch |
|---|---|---|
| Whisper model gates | fail | fail (see below) |
| Whisper + Silero-VAD composition gates | `skipped` (always) | **pass** |
| Granite model gates | `skipped` (always) | **pass** |
| SigLIP tokenizer gates | `skipped` (always) | **pass** |
| CED model gates (tiny) | `skipped` (always) | **pass** |
| Gate ledger | — | pass (all ten gates executed) |

Every other job on the PR (`check`, all 14 `features` combos, all 4 `parity` combos) passes, so `cargo clippy --all-targets --all-features -- -D warnings` is green on CI.

## …and one level down, the same defect again

`cargo test` stops at the **first failing target**, so unmasking the tokenizer assertion only exposed the next masked failure:

```
tests/whisper/common/mod.rs:177
es_tiny_matches_golden_tokens_and_segments — GOLDEN TOKEN MISMATCH
```

That test was **already red on 2026-07-26, before the tokenizer assertion was written** (run `30194767648`) and has been hidden behind it ever since. Behind *it*, in target order, sit `whisper_parity_jfk`, `whisper_pipeline`, `whisper_streaming` and `whisper_rtf_gate` — four more targets whose CI state is still unknown.

The second commit adds `--no-fail-fast` to the two multi-target invocations and makes the granite (6 suites) and CED (4 suites) per-target loops collect failures instead of aborting on the first. A *vacuum* still aborts immediately — that is a configuration error, not a gate result.

## What is deliberately NOT fixed here

`es_tiny_matches_golden_tokens_and_segments` is untouched. Its divergence is a **one-fp16-ULP argmax tie**:

```
ours    34980:  13.6250
golden  15112:  13.6172
MARGIN:         +0.0078      (= 2^-7, one fp16 ULP at that magnitude)
```

The test's own report calls a thin margin "hardware drift before a pipeline logic bug", and this is thinner than the 0.1 floor that text names. It passes on the author's machine and fails on the runner — the same host-portability problem #36 documents and that keeps `vad_parity_swift` off CI entirely.

Whether to stamp the whisper goldens with a host class (the `check_host_class` mechanism the VAD parity path already has), or to keep these gates local, is a design call rather than a plumbing one, so it is left for a follow-up. `model-tests` stays red on that one target — but now it stays red on *only* that one target, with the other nine gates reporting their own verdicts.
