### PR TITLE
feat(coremlit/speaker): stage speakerkit via MODELS_LOCK and gate three model tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
             Models/embedkit-granite/granite-97m-multilingual-r2
             Models/siglip2-naflex/siglip2-base-patch16-naflex-512
             Models/ced/ced-tiny
+            Models/speakerkit
           key: models-${{ hashFiles('MODELS_LOCK') }}
       - name: Download models (cache miss)
         id: download
@@ -143,16 +144,27 @@ jobs:
           set -euo pipefail
 
           # MODELS_LOCK is the source of truth for what gets downloaded, not
-          # just a cache-busting key: it has a fixed five-table shape (the
+          # just a cache-busting key: it has a fixed seven-table shape (the
           # whisperkit-coreml model repo, selector field `include`; the
           # tokenizer repo, selector field `files`; the embedkit-coreml granite
           # repo, selector field `include`; the siglip2-naflex-coreml tokenizer
           # sidecar, selector field `include`; the cedkit-coreml `ced-tiny`
-          # bundle, selector field `include`), each with its own `revision`.
-          # Pull repo/selector/revision out by hand instead of hardcoding them
-          # here, so a MODELS_LOCK edit is what changes what this job downloads
-          # — no TOML crate needed for five fixed tables. Tables are selected by
-          # INDEX, so appending is safe but reordering MODELS_LOCK is not.
+          # bundle, selector field `include`; the speakerkit BASE layer,
+          # selector field `include`; the speakerkit OVERLAY, selector field
+          # `include`, a SPACE-SEPARATED pattern list), each with its own
+          # `revision`. Pull repo/selector/revision out by hand instead of
+          # hardcoding them here, so a MODELS_LOCK edit is what changes what
+          # this job downloads — no TOML crate needed for seven fixed tables.
+          # Tables are selected by INDEX, so appending is safe but reordering
+          # MODELS_LOCK is not.
+          #
+          # For tables 6 and 7 the index is more than a parser detail: both
+          # land in Models/speakerkit/ and both publish
+          # `pyannote_segmentation.mlmodelc` and `wespeaker.mlmodelc`, so the
+          # LAST one downloaded decides which bytes the shipping pipeline gets.
+          # 6 is the base layer, 7 is the fp16-guard-repaired overlay that must
+          # win. See the ORDER box in MODELS_LOCK's header, and the
+          # "Verify speakerkit overlay" step below, which proves the winner.
           lock=MODELS_LOCK
 
           table_header() { # Nth `["..."]` header line, unquoted.
@@ -187,6 +199,33 @@ jobs:
           ced_repo=$(table_header 5)
           ced_include=$(table_field 5 include)
           ced_revision=$(table_field 5 revision)
+          # 6 = the speakerkit BASE layer, 7 = the OVERLAY. Downloaded in THAT
+          # order below; see MODELS_LOCK's header.
+          speakerkit_base_repo=$(table_header 6)
+          speakerkit_base_include=$(table_field 6 include)
+          speakerkit_base_revision=$(table_field 6 revision)
+          speakerkit_overlay_repo=$(table_header 7)
+          speakerkit_overlay_include=$(table_field 7 include)
+          speakerkit_overlay_revision=$(table_field 7 revision)
+          # The overlay selector is a SPACE-SEPARATED pattern list, expanded to
+          # one `--include` flag per pattern (`hf` 1.19 accepts the flag
+          # repeatedly; verified against 1.19.0). A single glob cannot express
+          # it: `*.mlmodelc/*` would also drag in that repo's NOT-adopted
+          # `wespeaker_int8` re-conversion over the base-layer bytes the
+          # byte-identity gate and the fp16_guards pin are cut against. See
+          # MODELS_LOCK's table 7.
+          #
+          # `pipx install` above pins no version, so a future `hf` COULD stop
+          # accepting the repeated flag. That direction is fail-closed either
+          # way: an unknown-option error fails here, and a last-flag-wins
+          # regression would stage only `CHECKSUMS.sha256`, leaving the base
+          # layer's pre-repair graphs in place — which the overlay check below
+          # refuses by hash.
+          read -ra speakerkit_overlay_patterns <<< "$speakerkit_overlay_include"
+          speakerkit_overlay_flags=()
+          for pattern in "${speakerkit_overlay_patterns[@]}"; do
+            speakerkit_overlay_flags+=(--include "$pattern")
+          done
 
           # Index-selected tables mean an APPENDED table this parser does not
           # know about is silently ignored — MODELS_LOCK would say CI downloads
@@ -195,8 +234,8 @@ jobs:
           # it. Pin the count so teaching the lock a new table forces teaching
           # the parser too.
           table_count=$(sed -n 's/^\["\(.*\)"\]$/\1/p' "$lock" | grep -c . || true)
-          if [ "$table_count" -ne 5 ]; then
-            echo "::error::MODELS_LOCK has $table_count tables but this parser handles exactly 5 — a table was added or removed without updating the download step, so it would be silently ignored" >&2
+          if [ "$table_count" -ne 7 ]; then
+            echo "::error::MODELS_LOCK has $table_count tables but this parser handles exactly 7 — a table was added or removed without updating the download step, so it would be silently ignored" >&2
             exit 1
           fi
 
@@ -205,6 +244,8 @@ jobs:
           echo "MODELS_LOCK: granite=$granite_repo@$granite_revision include=$granite_include"
           echo "MODELS_LOCK: siglip=$siglip_repo@$siglip_revision include=$siglip_include"
           echo "MODELS_LOCK: ced=$ced_repo@$ced_revision include=$ced_include"
+          echo "MODELS_LOCK: speakerkit-base=$speakerkit_base_repo@$speakerkit_base_revision include=$speakerkit_base_include"
+          echo "MODELS_LOCK: speakerkit-overlay=$speakerkit_overlay_repo@$speakerkit_overlay_revision include=$speakerkit_overlay_include"
 
           # Fail LOUD on any empty extraction: `hf download repo` with no
           # selector silently fetches the WHOLE repository, so a future
@@ -213,12 +254,22 @@ jobs:
           for v in model_repo model_include model_revision tokenizer_repo tokenizer_files tokenizer_revision \
                    granite_repo granite_include granite_revision \
                    siglip_repo siglip_include siglip_revision \
-                   ced_repo ced_include ced_revision; do
+                   ced_repo ced_include ced_revision \
+                   speakerkit_base_repo speakerkit_base_include speakerkit_base_revision \
+                   speakerkit_overlay_repo speakerkit_overlay_include speakerkit_overlay_revision; do
             if [ -z "${!v}" ]; then
               echo "::error::MODELS_LOCK parse produced empty '$v' — format drift? fix the lock or the parser" >&2
               exit 1
             fi
           done
+          # The overlay's expansion is checked separately: the emptiness loop
+          # above sees the RAW string, not the flag array actually passed to
+          # `hf`, so a value that is non-empty but expands to no pattern would
+          # slip through and fetch the WHOLE repository.
+          if [ "${#speakerkit_overlay_flags[@]}" -eq 0 ]; then
+            echo "::error::MODELS_LOCK's speakerkit overlay include ($speakerkit_overlay_include) expanded to no --include pattern; hf would fetch the whole repository" >&2
+            exit 1
+          fi
 
           pipx install "huggingface_hub[cli]"
           hf download "$model_repo" --include "$model_include" --revision "$model_revision" \
@@ -253,6 +304,28 @@ jobs:
           # — the layout tests/ced/common/mod.rs resolves without CED_TEST_MODELS.
           hf download "$ced_repo" --include "$ced_include" --revision "$ced_revision" \
             --local-dir Models/ced
+          # ---------------------------------------------------------------
+          # speakerkit, in TWO layers into ONE directory. THE ORDER OF THESE
+          # TWO COMMANDS IS A CORRECTNESS INVARIANT, not a style choice.
+          #
+          # Both repos publish `pyannote_segmentation.mlmodelc` and
+          # `wespeaker.mlmodelc`, and the second download overwrites the first.
+          # The BASE layer goes first; the OVERLAY — the two issue-#15
+          # re-conversions whose fp16 guards actually survive the ANE — goes
+          # last and wins. Reverse them and CI stages contract-identical
+          # PRE-REPAIR graphs that pass every load/shape test while saturating
+          # `segments` to -45440 on the default placement. The order comes from
+          # MODELS_LOCK's table order (6 then 7), so it is reviewable in the
+          # lock file rather than buried here, and the very next step re-hashes
+          # both graphs to prove which bytes actually landed.
+          #
+          # `--local-dir Models/speakerkit` is the directory
+          # tests/speaker/common/mod.rs resolves without SPEAKERKIT_TEST_MODELS
+          # (the gate step below sets it anyway, explicitly).
+          hf download "$speakerkit_base_repo" --include "$speakerkit_base_include" \
+            --revision "$speakerkit_base_revision" --local-dir Models/speakerkit
+          hf download "$speakerkit_overlay_repo" "${speakerkit_overlay_flags[@]}" \
+            --revision "$speakerkit_overlay_revision" --local-dir Models/speakerkit
       # EVERY step below carries
       # `if: ${{ !cancelled() && steps.download.outcome != 'failure' }}`, and
       # that is not boilerplate — it is the fix for a failure mode this job
@@ -319,26 +392,121 @@ jobs:
           fi
           cd "$bundle"
           shasum -a 256 -c ../CHECKSUMS.sha256
+      # The speakerkit tree is staged in TWO layers into ONE directory (see the
+      # download step and MODELS_LOCK's ORDER box), so it needs one check the
+      # single-source granite and CED trees do not: proof of WHICH layer won the
+      # two filename collisions. That proof comes first, before the byte-level
+      # checksum verification, because a wrong overlay order is a specific,
+      # nameable mistake and must be reported as itself rather than as anonymous
+      # hash drift 100 MB and one full build later.
+      - name: Verify speakerkit overlay and artifact checksums
+        id: speakerkit_checksums
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
+        run: |
+          set -euo pipefail
+          root=Models/speakerkit
+          if [ ! -d "$root" ]; then
+            echo "::error::$root is absent after download/cache-restore — the speaker model gates would have nothing to run against" >&2
+            exit 1
+          fi
+
+          # 1. DID THE OVERLAY LAND? The two graphs the pipeline SHIPS must be
+          # the fp16-guard-repaired re-conversions, not the base layer's
+          # pre-repair originals. Those originals are contract-identical —
+          # same filenames, same feature names, shapes and dtypes — so they
+          # load, they run, and they pass every structural gate while
+          # `segments` saturates to -45440 on the default ComputeUnits::All
+          # placement (issue #15). Only the bytes tell them apart.
+          #
+          # The two sha256s below are the `model.mil` pins from
+          # crates/coremlit/tests/speaker/model_io.rs
+          # (`fp16_safe_segmentation_matches_pinned_sha256` and
+          # `fp16_safe_wespeaker_fp32_matches_pinned_sha256`). They are copied
+          # here deliberately, so this check is INDEPENDENT of the gate that
+          # runs much later; the hermetic test
+          # `ci_stages_the_speakerkit_overlay_last_and_proves_it_won` in
+          # tests/whisper/models_lock.rs keeps the two copies from drifting.
+          overlay_bad=""
+          for pin in \
+            "pyannote_segmentation.mlmodelc:ded0d1ee11d77976b5c706ce667d0c8cb49977d3fe4367cccbd7b582bdb86dec" \
+            "wespeaker.mlmodelc:cff0cfe914078e9336754a9b38a68c2cdd88ca7b6bf97568ad551ab03ae1b666"; do
+            bundle="${pin%%:*}"
+            expected="${pin##*:}"
+            mil="$root/$bundle/model.mil"
+            if [ ! -f "$mil" ]; then
+              echo "::error::$mil is absent — the speakerkit overlay download did not land its shipping graphs" >&2
+              exit 1
+            fi
+            actual=$(shasum -a 256 "$mil" | cut -d' ' -f1)
+            echo "== $bundle/model.mil: $actual =="
+            if [ "$actual" != "$expected" ]; then
+              overlay_bad="$overlay_bad $bundle(got=$actual want=$expected)"
+            fi
+          done
+          if [ -n "$overlay_bad" ]; then
+            echo "::error::speakerkit OVERLAY DID NOT WIN:$overlay_bad — the shipping graphs are not the fp16-guard-repaired re-conversions MODELS_LOCK's last speakerkit table pins. The overwhelmingly likely cause is download ORDER: both speakerkit tables land in Models/speakerkit/ and publish these same filenames, so the LAST one downloaded wins, and the base layer must not be last. Check MODELS_LOCK's table order (base then overlay) and the order of the two hf download commands in the step above. If the bytes changed deliberately, re-baseline tests/speaker/model_io.rs's pins and these two together." >&2
+            exit 1
+          fi
+
+          # 2. Byte-level verification of every staged file from the overlay
+          # repo, against the `CHECKSUMS.sha256` it ships — the granite/CED
+          # contract, on every run rather than only on cache misses, so a
+          # truncated download and a tampered or partially-restored cache entry
+          # both fail here. The BASE layer's repo ships no checksum file
+          # (MODELS_LOCK says so); its bytes are covered by the per-file pins in
+          # tests/speaker/model_io.rs and by the fp16 graph sweep below.
+          #
+          # The checksum file cannot be fed to `shasum -c` whole. It lists its
+          # OWN name with the sha256 of an empty file, and it lists the
+          # `wespeaker_int8` and `.mlpackage` paths MODELS_LOCK's overlay
+          # selector deliberately does not stage. So verify the filtered subset
+          # covering exactly the two staged bundles — and pin the line count,
+          # because a filter that rots into matching nothing would otherwise
+          # "verify" an empty set. (`shasum -c` is itself fail-closed on a
+          # missing file, a hash mismatch, and a file with no valid lines; the
+          # count guard is what makes the FILTER non-vacuous.)
+          cd "$root"
+          filtered=$(mktemp)
+          grep -E '^[0-9a-f]{64}  \./(pyannote_segmentation|wespeaker)\.mlmodelc/' CHECKSUMS.sha256 > "$filtered" || true
+          filtered_lines=$(grep -c . "$filtered" || true)
+          if [ "$filtered_lines" -ne 10 ]; then
+            echo "::error::expected 10 CHECKSUMS.sha256 lines covering the two staged speakerkit bundles, found $filtered_lines — the overlay repo's file list changed at the pinned revision, or the filter no longer matches it" >&2
+            exit 1
+          fi
+          echo "== verifying $filtered_lines checksummed files =="
+          shasum -a 256 -c "$filtered"
       # build.rs UN-ignores the fp16 graph sweep
       # (`every_shipped_model_graph_survives_fp16`) when Models/ is present, so
       # the `-- --ignored` (ignored-ONLY) runs below EXCLUDE it exactly when the
       # models are here — and the modelless `check` job skips it too (ignored
       # there). Run the coremlit sweep binary's ordinary suite here so a newly
       # vanishing fp16 guard cannot merge green. This runner downloads WHISPER,
-      # GRANITE and CED-TINY (per MODELS_LOCK), so COREMLIT_FP16_SWEEP_VENDORS
-      # narrows the vendor manifest to exactly the vendors staged here
-      # (fail-closed: unset would demand EVERY pinned vendor), plus `vadkit`,
-      # which needs no download — it is committed, so requiring it here makes
-      # DELETING the vendored model a hard CI failure rather than a silent drop
-      # of the sweep's second clean control. Naming them ALL is what makes a
-      # vanished vendor tree a failure instead of a quiet drop in coverage; the
-      # absent speakerkit/alignkit/argmax vendors stay the documented escape.
-      # `ced` is a THIRD clean control: the sweep walks Models/ whole, so the
-      # staged CED graph is audited either way — naming it in the manifest is
-      # what turns "the CED download vanished" into a failure instead of a
-      # silent loss of that coverage. `siglip2-naflex` is deliberately NOT here:
-      # MODELS_LOCK stages its tokenizer sidecar alone, so that vendor tree
-      # holds no `.mlmodelc` for the sweep to audit.
+      # GRANITE, CED-TINY and SPEAKERKIT (per MODELS_LOCK), so
+      # COREMLIT_FP16_SWEEP_VENDORS narrows the vendor manifest to exactly the
+      # vendors staged here (fail-closed: unset would demand EVERY pinned
+      # vendor), plus `vadkit`, which needs no download — it is committed, so
+      # requiring it here makes DELETING the vendored model a hard CI failure
+      # rather than a silent drop of the sweep's second clean control. Naming
+      # them ALL is what makes a vanished vendor tree a failure instead of a
+      # quiet drop in coverage; the absent alignkit/argmax vendors stay the
+      # documented escape. `ced` is a THIRD clean control: the sweep walks
+      # Models/ whole, so the staged CED graph is audited either way — naming
+      # it in the manifest is what turns "the CED download vanished" into a
+      # failure instead of a silent loss of that coverage.
+      #
+      # `speakerkit` is different in kind from the other four, and that is why
+      # adding it is worth more than one more clean control: it is the first
+      # vendor named here that carries PINNED DEFECTS. FIVE of the sweep's ten
+      # KNOWN_DEFECTS entries live under it (Segmentation, wespeaker_v2,
+      # wespeaker_int8, PLDA, PldaRho), so half the defect roster moves from
+      # local/dev-only verification to every PR — pinned in BOTH directions, so
+      # an unannounced re-conversion that REPAIRS one of them is as loud as a
+      # new defect would be. The sweep also reaches the two shipping graphs,
+      # which have no pin precisely because issue #15 repaired them, making it a
+      # second, independent witness that the overlay step above staged the right
+      # bytes. `siglip2-naflex` is deliberately NOT here: MODELS_LOCK stages its
+      # tokenizer sidecar alone, so that vendor tree holds no `.mlmodelc` for
+      # the sweep to audit.
       # fp16_guards is a core test — no feature needed. See the
       # coverage-boundary note in crates/coremlit/tests/fp16_guards.rs.
       #
@@ -349,7 +517,7 @@ jobs:
       - name: fp16 graph sweep
         id: fp16_guards
         if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
-        run: COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite,vadkit,ced cargo test -p coremlit --test fp16_guards
+        run: COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite,vadkit,ced,speakerkit cargo test -p coremlit --test fp16_guards
       - name: fp16 sweep inventory
         id: fp16_inventory
         if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
@@ -521,6 +689,62 @@ jobs:
             echo "::error::CED tiny gates failed:$failed" >&2
             exit 1
           fi
+      # The speaker (diarization) model gates, now that MODELS_LOCK stages the
+      # speakerkit artifact set. Three targets, and the set is deliberately
+      # smaller than `tests/speaker/` holds:
+      #
+      #   - `speaker_model_io` introspects every staged bundle and byte-pins the
+      #     three that carry a provenance decision;
+      #   - `speaker_parity_seg` / `speaker_parity_embed` run the two shipping
+      #     graphs against committed goldens and fixtures.
+      #
+      # `speaker_parity_diarize_wiring` is NOT here and cannot be: its fixtures
+      # live in the SIBLING `diarization` repository
+      # (`../../../diarization/tests/parity/fixtures/`, overridable via
+      # DIA_PARITY_FIXTURES), which no runner has at any staging size. It stays a
+      # local/dev gate.
+      #
+      # The three argmax targets (`speaker_argmax_model_io`,
+      # `speaker_parity_argmax_accuracy`, `speaker_parity_argmax_swift`) are NOT
+      # here for a different and firmer reason: the argmax artifact repo declares
+      # NO license on Hugging Face, so undeclared-means-all-rights-reserved
+      # applies to those converted graphs and this repository does not fetch them
+      # in CI at all. NOTICE records that; adding an ARGMAX_TEST_MODELS download
+      # here would quietly reverse a licensing decision, not just widen coverage.
+      #
+      # SPEAKERKIT_TEST_MODELS is set explicitly even though the default resolves
+      # to the same path: the gates then name the directory this job staged,
+      # rather than silently depending on the workspace-relative fallback.
+      #
+      # Same two vacuum holes as the granite/siglip/CED steps, closed the same
+      # way, and the same failure-collecting loop: a red target costs its own
+      # verdict, not the two after it.
+      - name: Speaker model gates
+        id: speaker_gates
+        if: ${{ !cancelled() && steps.download.outcome != 'failure' }}
+        env:
+          SPEAKERKIT_TEST_MODELS: ${{ github.workspace }}/Models/speakerkit
+        run: |
+          set -euo pipefail
+          seg=Models/speakerkit/pyannote_segmentation.mlmodelc
+          if [ ! -d "$seg" ]; then
+            echo "::error::speakerkit bundle $seg is absent — the model gates below must FAIL here, never skip" >&2
+            exit 1
+          fi
+          failed=""
+          for target in speaker_model_io speaker_parity_seg speaker_parity_embed; do
+            listed=$(cargo test -p coremlit --features speaker --test "$target" -- --list --ignored 2>/dev/null | grep -c ': test$' || true)
+            if [ "$listed" -eq 0 ]; then
+              echo "::error::$target lists 0 ignored tests — it failed to build, or its model gates were deleted, renamed, or un-ignored, so an ignored-only run would pass vacuously" >&2
+              exit 1
+            fi
+            echo "== $target: $listed model gate(s) =="
+            cargo test -p coremlit --features speaker --test "$target" -- --ignored || failed="$failed $target"
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::speaker gates failed:$failed" >&2
+            exit 1
+          fi
       # The anti-vacuum guard for the JOB, mirroring the per-target
       # `--list --ignored` counts inside the gates above: those refuse a gate
       # that runs zero tests, and this refuses a gate that never runs at all.
@@ -548,6 +772,8 @@ jobs:
             granite-model-gates=${{ steps.granite_gates.outcome }}
             siglip-tokenizer-gates=${{ steps.siglip_gates.outcome }}
             ced-model-gates=${{ steps.ced_gates.outcome }}
+            speakerkit-checksums=${{ steps.speakerkit_checksums.outcome }}
+            speaker-model-gates=${{ steps.speaker_gates.outcome }}
         run: |
           set -euo pipefail
           printf '%s' "$LEDGER"

--- a/MODELS_LOCK
+++ b/MODELS_LOCK
@@ -3,17 +3,43 @@
 # different revisions) to force a re-download.
 #
 # This file is CONSUMED, not decorative: ci.yml's "Download models (cache
-# miss)" step hand-parses the five tables below (small sed/awk block, no
-# TOML crate — see the comment there) to build all five `hf download`
+# miss)" step hand-parses the seven tables below (small sed/awk block, no
+# TOML crate — see the comment there) to build all seven `hf download`
 # commands, including `--revision`. Editing a repo name, selector, or
 # revision here changes what CI actually downloads next run, exactly like
 # editing any other lock file. Table ORDER is load-bearing: that parser
 # selects a table by INDEX (1 = whisper model, 2 = whisper tokenizer,
-# 3 = granite, 4 = siglip tokenizer, 5 = ced-tiny), so tables may be
-# appended but never reordered without editing ci.yml to match. Appending is
-# only safe because ci.yml ALSO asserts the table COUNT it knows how to
-# parse: a sixth table added here without teaching the parser about it fails
-# that job loudly instead of being silently ignored.
+# 3 = granite, 4 = siglip tokenizer, 5 = ced-tiny, 6 = speakerkit BASE,
+# 7 = speakerkit OVERLAY), so tables may be appended but never reordered
+# without editing ci.yml to match. Appending is only safe because ci.yml
+# ALSO asserts the table COUNT it knows how to parse: an eighth table added
+# here without teaching the parser about it fails that job loudly instead of
+# being silently ignored.
+#
+# ###########################################################################
+# # ORDER IS AN ARTIFACT-CORRECTNESS INVARIANT, NOT JUST A PARSER INDEX.    #
+# #                                                                         #
+# # Tables 6 and 7 BOTH download into `Models/speakerkit/`, and they BOTH   #
+# # publish files named `pyannote_segmentation.mlmodelc/` and               #
+# # `wespeaker.mlmodelc/`. The second download OVERWRITES the first, so the #
+# # LAST table to run decides which bytes the shipping pipeline gets.       #
+# #                                                                         #
+# # Table 6 (FluidInference) is the BASE layer: seven of the nine staged    #
+# # bundles come from it and nothing else publishes them, and it also       #
+# # carries PRE-REPAIR copies of the other two. Table 7 (FinDIT-Studio) is  #
+# # the OVERLAY: those other two, as the issue-#15 fp16-guard-repaired      #
+# # re-conversions, and they MUST WIN.                                      #
+# #                                                                         #
+# # Swap those two tables and CI silently stages the pre-repair             #
+# # segmentation graph — whose inert `log(epsilon = 0)` saturates           #
+# # `segments` to −45440 on the default ANE placement — and the pre-repair  #
+# # embedder, whose pooling guards vanish in fp16. Both are                 #
+# # contract-identical and pass every load/shape test. Only bytes tell them #
+# # apart, which is why ci.yml's "Verify speakerkit overlay and artifact    #
+# # checksums" step hashes both graphs against the pins in                  #
+# # crates/coremlit/tests/speaker/model_io.rs BEFORE any gate runs, and     #
+# # fails the job naming this ordering as the cause.                        #
+# ###########################################################################
 #
 # LOUD FOLLOW-UP: `revision = "main"` on the two whisper tables is a MOVING
 # target, not a real lock — CI can still download different upstream bytes
@@ -22,9 +48,15 @@
 # a deliberate user follow-up: it requires live network access (`hf api ...`
 # or the HF web UI) to look up each repo's current commit SHA. Until that
 # lands, treat `cache-epoch` bumps as the only reliable way to force a
-# fresh, verified download of them. The granite and ced tables are NOT in
-# that state: each pins an immutable commit SHA, and ci.yml verifies the
-# downloaded bytes against the `CHECKSUMS.sha256` those artifacts ship.
+# fresh, verified download of them. The granite, ced and speakerkit tables
+# are NOT in that state: each pins an immutable commit SHA. Of those, the
+# granite, ced and FinDIT-Studio speakerkit artifacts additionally ship a
+# `CHECKSUMS.sha256` that ci.yml verifies the downloaded bytes against;
+# FluidInference's repo ships NO checksum file, so its bundles are covered
+# instead by the per-file SHA-256 pins in
+# crates/coremlit/tests/speaker/model_io.rs (`wespeaker_v2.mlmodelc`) and by
+# the `tests/fp16_guards.rs` graph sweep, which reads every staged
+# `model.mil` and pins its guard sites in both directions.
 cache-epoch = 1
 
 ["argmaxinc/whisperkit-coreml"]
@@ -104,3 +136,89 @@ revision = "eb514c2ab66fb702d43c742add0be5b091b02dab"
 ["FinDIT-Studio/cedkit-coreml"]
 include  = "ced-tiny/*"
 revision = "96d504716c4e2ebe6182312f65c4ee6c23921a5d"
+
+# ===========================================================================
+# speakerkit, layer 1 of 2 — the BASE. **MUST STAY BEFORE the table below.**
+# See the ORDER box in this file's header for what breaks if it does not.
+# ===========================================================================
+#
+# The `audio::speaker` artifact set (`Models/speakerkit/`, the directory
+# tests/speaker/common/mod.rs resolves by default, overridable via
+# `SPEAKERKIT_TEST_MODELS`). Nine `.mlmodelc` bundles end up staged; SEVEN of
+# them come from here and nothing else publishes them:
+#
+#   | bundle                    | read by                                   |
+#   |---------------------------|-------------------------------------------|
+#   | `wespeaker_v2.mlmodelc`   | speaker_model_io, fp16 sweep pin          |
+#   | `wespeaker_int8.mlmodelc` | speaker_model_io, fp16 sweep pin          |
+#   | `Segmentation.mlmodelc`   | speaker_model_io, fp16 sweep pin          |
+#   | `Embedding.mlmodelc`      | speaker_model_io                          |
+#   | `FBank.mlmodelc`          | speaker_model_io                          |
+#   | `PLDA.mlmodelc`           | fp16 sweep pin                            |
+#   | `PldaRho.mlmodelc`        | fp16 sweep pin                            |
+#
+# `include = "*.mlmodelc/*"` deliberately also pulls this repo's
+# `pyannote_segmentation.mlmodelc` and `wespeaker.mlmodelc` (35.2 MB that the
+# next table then overwrites). That is not an oversight and not waste to
+# "optimize away" by narrowing the selector: it is the SAME base-then-overlay
+# sequence the dev-time procedure in tests/speaker/model_io.rs documents, so
+# CI builds byte-for-byte the tree a developer builds, and the ordering
+# invariant this file shouts about is a REAL one that a real check can catch
+# rather than a claim that happens to be inert today. Narrow this and the
+# overlay verification stops proving anything about ordering.
+#
+# The selector excludes the ~56 MB nothing reads: `mlpackages/` (uncompiled
+# source packages), `plots/`, the loose `.png` timing charts, `README.md`,
+# `config.json` and `plda-parameters.json`. 72.8 MB is downloaded here, of
+# which the 35.2 MB in those two colliding bundles is replaced immediately by
+# the next table; 37.6 MB of it survives as the seven bundles above.
+#
+# This repo ships NO `CHECKSUMS.sha256`. Its bytes are pinned instead by
+# `int8_wespeaker_matches_fluidinference_pinned_sha256` in
+# tests/speaker/model_io.rs (every file of `wespeaker_v2.mlmodelc`), by the
+# byte-identity gate against `wespeaker_int8.mlmodelc`, and by
+# tests/fp16_guards.rs, which parses every staged `model.mil` and pins its
+# guard sites in BOTH directions — a repair is as much a failure as a new
+# defect. The revision is the one tests/speaker/model_io.rs's provenance
+# section names and every one of those pins was cut against.
+["FluidInference/speaker-diarization-coreml"]
+include  = "*.mlmodelc/*"
+revision = "1ed7a662fdc7109e36d822db793ee6eebdaf8594"
+
+# ===========================================================================
+# speakerkit, layer 2 of 2 — the OVERLAY. **MUST STAY AFTER the table above.**
+# This table wins the two filename collisions, and the whole shipping
+# pipeline's numerical behavior depends on it winning them.
+# ===========================================================================
+#
+# The two artifacts `audio::speaker` actually SHIPS, both issue-#15
+# re-conversions of the same upstream weights with fp16-survivable guards:
+#
+#   | bundle                             | read by                            |
+#   |------------------------------------|------------------------------------|
+#   | `pyannote_segmentation.mlmodelc`   | speaker_parity_seg, speaker_model_io |
+#   | `wespeaker.mlmodelc`               | speaker_parity_embed, speaker_model_io |
+#
+# `include` is a SPACE-SEPARATED pattern list (ci.yml expands it into one
+# `--include` flag per pattern; `hf` 1.19 accepts the flag repeatedly). It has
+# to be a list rather than one glob because the obvious `*.mlmodelc/*` would
+# ALSO drag in this repo's `wespeaker_int8.mlmodelc` — a re-palettization that
+# is NOT adopted (it regresses clip 14's int8 ANE arm from 0.8178 % to
+# 1.4860 % DER) and whose arrival would break both the
+# `wespeaker_v2 == wespeaker_int8` byte-identity gate and that bundle's
+# fp16_guards pin. The int8 sibling must stay FluidInference's, from table 6.
+#
+# `CHECKSUMS.sha256` is in the list on purpose: this repo DOES ship one, and
+# ci.yml verifies every staged file against it. Two cautions for whoever
+# touches that step — the checksum file lists its own name with the sha256 of
+# an EMPTY file, and it also lists the `wespeaker_int8`/`.mlpackage` paths this
+# selector deliberately skips, so a bare `shasum -c CHECKSUMS.sha256` fails in
+# three ways at once. ci.yml therefore verifies the filtered subset covering
+# exactly the two staged bundles, and pins the expected line count so a
+# filter that rots into matching nothing cannot pass vacuously.
+#
+# Total staged from here: 35.2 MB, overwriting the same two bundles from
+# table 6.
+["FinDIT-Studio/speakerkit-coreml"]
+include  = "pyannote_segmentation.mlmodelc/* wespeaker.mlmodelc/* CHECKSUMS.sha256"
+revision = "3db69988bf2de12bab250614d6ac2b03d35132a2"

--- a/crates/coremlit/FEATURE_MAP.md
+++ b/crates/coremlit/FEATURE_MAP.md
@@ -133,6 +133,18 @@ that let vadkit be committed instead. Each target declares its gates once per
 size, so the CI step filters on `tiny::`; the `mini`/`small`/`base` gates stay
 local/dev gates against an owner-staged `CED_TEST_MODELS` tree.
 
+`speaker` splits the same way, with one wrinkle no other kit has: its artifact
+set is staged from TWO repositories into one directory, and the second overlays
+the first (MODELS_LOCK's last two tables, and the ORDER box in its header).
+`model-tests` runs `speaker_model_io`, `speaker_parity_seg` and
+`speaker_parity_embed` there. Four speaker targets deliberately stay out:
+`speaker_parity_diarize_wiring`, whose fixtures live in the sibling
+`diarization` repository (`DIA_PARITY_FIXTURES`) that no runner has, and the
+three argmax targets (`speaker_argmax_model_io`,
+`speaker_parity_argmax_accuracy`, `speaker_parity_argmax_swift`), because the
+argmax artifact repo declares no license — so this repository does not fetch
+those graphs in CI at all (NOTICE records the reasoning).
+
 ## Curated CI parity-oracle list
 
 The three third-party oracles get their own CI job (`parity`), which runs

--- a/crates/coremlit/tests/fp16_guards.rs
+++ b/crates/coremlit/tests/fp16_guards.rs
@@ -49,14 +49,15 @@
 //! # Coverage boundary (`COREMLIT_FP16_SWEEP_VENDORS`)
 //!
 //! By default the sweep requires EVERY vendor named by a [`KNOWN_DEFECTS`] pin to
-//! be present. CI's model job, however, downloads WHISPER and GRANITE only (per
-//! MODELS_LOCK), so it sets
-//! `COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite` to narrow the
-//! manifest EXPLICITLY: there the sweep proves it runs and that the whisper mel
-//! and granite norm controls are clean, but it CANNOT verify the speakerkit /
-//! alignkit / argmax defect pins — those models are not downloaded. Full pin
-//! verification (every [`KNOWN_DEFECTS`] entry) is a local/dev gate that needs
-//! the complete `Models/` tree. The override is fail-closed — absence of it
+//! be present. CI's model job stages only part of the tree (per MODELS_LOCK), so
+//! it names what it stages —
+//! `COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite,vadkit,ced,speakerkit`
+//! — narrowing the manifest EXPLICITLY. There the sweep proves it runs, that the
+//! whisper mel, granite norm, vadkit STFT and CED controls are clean, and that
+//! the FIVE `speakerkit/` defect pins still hold in both directions; it CANNOT
+//! verify the alignkit / argmax pins, whose models that job does not download.
+//! Full pin verification (every [`KNOWN_DEFECTS`] entry) is a local/dev gate that
+//! needs the complete `Models/` tree. The override is fail-closed — absence of it
 //! requires ALL pinned vendors — so narrowing coverage is always an explicit,
 //! reviewable act in ci.yml, never the silent side effect of a deleted
 //! directory, which is the whole point of the manifest.
@@ -1762,13 +1763,12 @@ fn vendor_of(path: &str) -> &str {
 /// absence of the override is the strictest setting.
 ///
 /// `COREMLIT_FP16_SWEEP_VENDORS` (comma-separated) OVERRIDES the manifest for a
-/// deliberately-partial tree: CI's model job downloads WHISPER and GRANITE only
-/// (per MODELS_LOCK) and sets
-/// `COREMLIT_FP16_SWEEP_VENDORS=whisperkit-coreml,embedkit-granite`, so there the
-/// sweep requires both staged vendors and audits their graphs while the absent
-/// speakerkit/alignkit/argmax vendors are the DOCUMENTED escape, not a silent
-/// skip. Narrowing coverage is thus an explicit, reviewable act; the full pin
-/// verification remains a local/dev gate (see the module docs' coverage boundary).
+/// deliberately-partial tree: CI's model job stages part of the tree (per
+/// MODELS_LOCK) and names exactly that part, so there the sweep requires every
+/// staged vendor and audits its graphs while the absent alignkit/argmax vendors
+/// are the DOCUMENTED escape, not a silent skip. Narrowing coverage is thus an
+/// explicit, reviewable act; the full pin verification remains a local/dev gate
+/// (see the module docs' coverage boundary, which carries the current value).
 ///
 /// A present-but-EMPTY override (`""`, whitespace, or only commas) is a HARD
 /// ERROR, not an empty manifest — see [`vendor_manifest`].
@@ -2100,20 +2100,21 @@ fn a_missing_pinned_vendor_fails_the_sweep_not_silently_skips() {
   );
 }
 
-/// F3/F1 reconciliation: the CI model job's scope sweeps CLEAN. With
-/// `expected_vendors = {whisperkit-coreml, embedkit-granite, vadkit}` — what that
-/// job sets via `COREMLIT_FP16_SWEEP_VENDORS`: the two vendors MODELS_LOCK
-/// stages, plus `vadkit`, which that job does not download because the artifact
-/// is COMMITTED to the repository — a tree containing the clean whisper mel, the
-/// clean granite norms and the real vadkit STFT guard sweeps green: all three
-/// expected vendors are present and their graphs are clean, and the absent
-/// speakerkit/alignkit/argmax pins are the DOCUMENTED escape (verified by the
-/// full local/dev gate, not here). This is the exact scenario the model job
-/// runs; proving it here keeps the ci.yml wiring honest even though Actions cannot
-/// run in-repo, and it is what would go red if the vendored model were deleted
-/// while ci.yml still demanded it. It also proves the narrowed manifest does NOT
-/// demand the pinned vendors — the fail-closed default does that only when the
-/// override is unset.
+/// F3/F1 reconciliation: the CLEAN-CONTROL half of the CI model job's scope
+/// sweeps clean. `expected_vendors = {whisperkit-coreml, embedkit-granite,
+/// vadkit}` is the subset of `COREMLIT_FP16_SWEEP_VENDORS` that carries no
+/// [`KNOWN_DEFECTS`] pin: two vendors MODELS_LOCK stages, plus `vadkit`, which
+/// that job does not download because the artifact is COMMITTED to the
+/// repository. A tree containing the clean whisper mel, the clean granite norms
+/// and the real vadkit STFT guard sweeps green — every expected vendor present
+/// and clean, with the pinned vendors' absence the DOCUMENTED escape. Proving it
+/// here keeps the ci.yml wiring honest even though Actions cannot run in-repo,
+/// and it is what would go red if the vendored model were deleted while ci.yml
+/// still demanded it. It also proves the narrowed manifest does NOT demand the
+/// pinned vendors — the fail-closed default does that only when the override is
+/// unset. The pinned vendors the job DOES stage (`speakerkit`, five pins) are
+/// audited against the real tree on the runner; the missing-vendor direction is
+/// [`a_missing_pinned_vendor_fails_the_sweep_not_silently_skips`].
 #[test]
 fn the_ci_model_job_scope_sweeps_clean() {
   let tree = TempTree::new("ci_model_job_scope");

--- a/crates/coremlit/tests/whisper/models_lock.rs
+++ b/crates/coremlit/tests/whisper/models_lock.rs
@@ -7,7 +7,7 @@
 //! that read them.
 //!
 //! No TOML crate: this is a deliberately tiny hand-rolled reader over the
-//! lock's fixed five-table shape (`["repo/name"]` headers, single-line
+//! lock's fixed seven-table shape (`["repo/name"]` headers, single-line
 //! `key = "value"` fields), mirroring the sed/awk parsing `ci.yml` itself
 //! performs at CI time — not a general TOML parser.
 
@@ -140,8 +140,8 @@ fn lock_parses_and_every_table_has_a_selector_and_a_revision() {
 
   assert_eq!(
     tables.len(),
-    5,
-    "MODELS_LOCK: expected exactly five tables, found {}",
+    7,
+    "MODELS_LOCK: expected exactly seven tables, found {}",
     tables.len()
   );
   for table in &tables {
@@ -179,9 +179,15 @@ fn ci_workflow_derives_downloads_from_the_lock_instead_of_hardcoding_them() {
       "openai/whisper-tiny",
       "FinDIT-Studio/embedkit-coreml",
       "FinDIT-Studio/siglip2-naflex-coreml",
-      "FinDIT-Studio/cedkit-coreml"
+      "FinDIT-Studio/cedkit-coreml",
+      "FluidInference/speaker-diarization-coreml",
+      "FinDIT-Studio/speakerkit-coreml"
     ],
-    "MODELS_LOCK's table names or their order changed — update this test alongside it"
+    "MODELS_LOCK's table names or their order changed — update this test alongside it. The last \
+     two are not interchangeable: both download into Models/speakerkit/ and both publish \
+     `pyannote_segmentation.mlmodelc` and `wespeaker.mlmodelc`, so the LAST one wins those two \
+     filenames and it must be the fp16-guard-repaired overlay. See \
+     `ci_stages_the_speakerkit_overlay_last_and_proves_it_won`"
   );
 
   // The literal repo strings belong to MODELS_LOCK alone. If ci.yml also
@@ -223,6 +229,14 @@ fn ci_workflow_derives_downloads_from_the_lock_instead_of_hardcoding_them() {
     "download step doesn't invoke hf with a lock-derived $ced_repo"
   );
   assert!(
+    ci_contents.contains("hf download \"$speakerkit_base_repo\""),
+    "download step doesn't invoke hf with a lock-derived $speakerkit_base_repo"
+  );
+  assert!(
+    ci_contents.contains("hf download \"$speakerkit_overlay_repo\""),
+    "download step doesn't invoke hf with a lock-derived $speakerkit_overlay_repo"
+  );
+  assert!(
     ci_contents.contains("--revision \"$model_revision\""),
     "download step doesn't pass a lock-derived --revision for the model repo"
   );
@@ -241,6 +255,14 @@ fn ci_workflow_derives_downloads_from_the_lock_instead_of_hardcoding_them() {
   assert!(
     ci_contents.contains("--revision \"$ced_revision\""),
     "download step doesn't pass a lock-derived --revision for the ced repo"
+  );
+  assert!(
+    ci_contents.contains("--revision \"$speakerkit_base_revision\""),
+    "download step doesn't pass a lock-derived --revision for the speakerkit base repo"
+  );
+  assert!(
+    ci_contents.contains("--revision \"$speakerkit_overlay_revision\""),
+    "download step doesn't pass a lock-derived --revision for the speakerkit overlay repo"
   );
 
   // ci.yml selects tables by INDEX, so an appended table it does not extract is
@@ -276,6 +298,17 @@ fn ci_workflow_derives_downloads_from_the_lock_instead_of_hardcoding_them() {
     "ci.yml no longer verifies the CED bundle against its shipped CHECKSUMS.sha256 (read from \
      inside the .mlmodelc, whose root its paths are relative to), which MODELS_LOCK's header \
      claims it does"
+  );
+
+  // And a third shape for the speakerkit overlay, which cannot reuse either of
+  // the two above: its checksum file lists its OWN name with the sha256 of an
+  // empty file, plus the `wespeaker_int8`/`.mlpackage` paths MODELS_LOCK's
+  // selector deliberately does not stage, so `shasum -c` over the whole file
+  // fails on a correct tree. ci.yml verifies the filtered subset from stdin.
+  assert!(
+    ci_contents.contains("shasum -a 256 -c \"$filtered\""),
+    "ci.yml no longer verifies the staged speakerkit overlay files against the CHECKSUMS.sha256 \
+     that artifact ships, which MODELS_LOCK's header claims it does"
   );
 }
 
@@ -353,6 +386,131 @@ fn ci_runs_the_ced_gates_for_exactly_the_size_the_lock_stages() {
   );
 }
 
+/// The two speakerkit tables are the one place in MODELS_LOCK where table order
+/// decides which BYTES ship, not merely which parser variable gets which value.
+///
+/// Both download into `Models/speakerkit/` and both publish
+/// `pyannote_segmentation.mlmodelc` and `wespeaker.mlmodelc`, so the last one
+/// downloaded wins those two filenames. The base layer's copies are
+/// FluidInference's PRE-REPAIR conversions: contract-identical — same feature
+/// names, shapes and dtypes — so they load, run, and pass every structural gate
+/// while an inert `log(epsilon = 0)` saturates `segments` to -45440 on the
+/// default `ComputeUnits::All` placement (issue #15). Only bytes tell them
+/// apart.
+///
+/// So this pins three things that must move together: the lock's order, the
+/// order of the two `hf download` commands ci.yml derives from it, and the
+/// early overlay check that re-hashes both graphs. That last one is what turns
+/// a wrong order into a named failure instead of anonymous "sha256 drift"
+/// reported a full build later by `speaker_model_io` — and its expected hashes
+/// are a deliberate SECOND copy of that gate's pins, so this test also holds
+/// the two copies together.
+#[test]
+fn ci_stages_the_speakerkit_overlay_last_and_proves_it_won() {
+  let Some((lock_path, workflow_path)) = repo_files() else {
+    return;
+  };
+  let lock_contents = fs::read_to_string(lock_path).expect("MODELS_LOCK reads");
+  let tables = parse_lock(&lock_contents);
+  let ci_contents = fs::read_to_string(workflow_path).expect(".github/workflows/ci.yml reads");
+
+  let index_of = |name: &str| {
+    tables
+      .iter()
+      .position(|t| t.name == name)
+      .unwrap_or_else(|| panic!("MODELS_LOCK has no {name:?} table"))
+  };
+  let base = index_of("FluidInference/speaker-diarization-coreml");
+  let overlay = index_of("FinDIT-Studio/speakerkit-coreml");
+  assert!(
+    base < overlay,
+    "MODELS_LOCK stages the speakerkit OVERLAY (table {}) before the BASE layer (table {}), so \
+     the base layer's PRE-REPAIR pyannote_segmentation/wespeaker graphs would overwrite the \
+     fp16-guard-repaired ones the pipeline ships",
+    overlay + 1,
+    base + 1
+  );
+
+  // The overlay selector must not be widened to a bare `*.mlmodelc/*`: that
+  // would also stage the overlay repo's `wespeaker_int8` re-conversion over the
+  // base layer's bytes, breaking both the `wespeaker_v2 == wespeaker_int8`
+  // byte-identity gate and that bundle's fp16_guards pin (the re-palettization
+  // regresses clip 14's int8 ANE arm from 0.8178 % to 1.4860 % DER).
+  let overlay_include =
+    field(&tables[overlay], "include").expect("the speakerkit overlay table has an `include`");
+  for bundle in ["pyannote_segmentation.mlmodelc/*", "wespeaker.mlmodelc/*"] {
+    assert!(
+      overlay_include.split(' ').any(|p| p == bundle),
+      "MODELS_LOCK's speakerkit overlay `include` ({overlay_include:?}) does not name {bundle:?}, \
+       so that shipping graph would stay the base layer's pre-repair conversion"
+    );
+  }
+  assert!(
+    !overlay_include.split(' ').any(|p| p == "*.mlmodelc/*"),
+    "MODELS_LOCK's speakerkit overlay `include` ({overlay_include:?}) globs every bundle, which \
+     stages that repo's NOT-adopted wespeaker_int8 re-conversion over the base layer's bytes"
+  );
+
+  // ci.yml emits the two downloads in lock order; pin that it still does, since
+  // the lock order above is only load-bearing if the workflow follows it.
+  let base_cmd = ci_contents
+    .find("hf download \"$speakerkit_base_repo\"")
+    .expect("ci.yml never downloads the speakerkit base layer");
+  let overlay_cmd = ci_contents
+    .find("hf download \"$speakerkit_overlay_repo\"")
+    .expect("ci.yml never downloads the speakerkit overlay");
+  assert!(
+    base_cmd < overlay_cmd,
+    "ci.yml downloads the speakerkit overlay BEFORE the base layer, so the base layer's \
+     pre-repair graphs overwrite the shipping ones no matter what MODELS_LOCK's table order says"
+  );
+
+  // The early overlay check, and its two expected hashes — which must be the
+  // same bytes `tests/speaker/model_io.rs` pins. A re-baseline there that
+  // forgets ci.yml (or the reverse) leaves CI asserting bytes no gate accepts.
+  let model_io = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/speaker/model_io.rs");
+  let model_io =
+    fs::read_to_string(&model_io).unwrap_or_else(|e| panic!("read {}: {e}", model_io.display()));
+  for (bundle, gate) in [
+    (
+      "pyannote_segmentation.mlmodelc",
+      "fp16_safe_segmentation_matches_pinned_sha256",
+    ),
+    (
+      "wespeaker.mlmodelc",
+      "fp16_safe_wespeaker_fp32_matches_pinned_sha256",
+    ),
+  ] {
+    let needle = format!("\"{bundle}:");
+    let rest = ci_contents
+      .split_once(&needle)
+      .unwrap_or_else(|| {
+        panic!(
+          "ci.yml's speakerkit overlay check carries no `{bundle}:<sha256>` pin, so a wrong \
+           download order would only surface later as anonymous hash drift"
+        )
+      })
+      .1;
+    let hash = rest.get(..64).unwrap_or_default();
+    assert!(
+      hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()),
+      "ci.yml's `{bundle}` overlay pin is not a 64-hex-digit sha256: {hash:?}"
+    );
+    assert!(
+      model_io.contains(gate),
+      "tests/speaker/model_io.rs no longer defines {gate:?}, the gate ci.yml's overlay pin for \
+       {bundle:?} is a second copy of"
+    );
+    assert!(
+      model_io.contains(hash),
+      "ci.yml pins {bundle}/model.mil at sha256 {hash}, which appears nowhere in \
+       tests/speaker/model_io.rs — the early overlay check and the {gate} gate have drifted \
+       apart, so CI would demand bytes that gate rejects (or accept bytes it would reject). \
+       Re-baseline both together."
+    );
+  }
+}
+
 /// GitHub's default step condition is `success()`, so one red step marks every
 /// step after it `skipped` — and `skipped` is silent. `model-tests` ran that
 /// way for four weeks: a stale assertion in the whisper suite went red the day
@@ -401,6 +559,7 @@ fn ci_model_tests_gates_cannot_be_silently_skipped() {
     "name: Granite model gates",
     "name: SigLIP tokenizer gates",
     "name: CED model gates (tiny)",
+    "name: Speaker model gates",
   ] {
     assert!(
       gates.iter().any(|step| step.contains(gate)),


### PR DESCRIPTION
The speakerkit artifact set was the last kit whose model gates had no CI coverage. `Models/speakerkit/` is gitignored and dev-staged, so `speaker_model_io`, `speaker_parity_seg` and `speaker_parity_embed` ran only on a machine that had fetched the models by hand — and, as it turns out, only on one that had fetched them *correctly*. MODELS_LOCK now stages the set and `model-tests` runs those three gates.

## Why this takes two tables, and why their order is a correctness invariant

Both `FluidInference/speaker-diarization-coreml` and `FinDIT-Studio/speakerkit-coreml` publish `pyannote_segmentation.mlmodelc` and `wespeaker.mlmodelc`, and both land in `Models/speakerkit/`. The last download wins those two filenames.

- **Table 6 (base)** — the seven bundles nothing else publishes, plus PRE-REPAIR copies of the two shipping graphs.
- **Table 7 (overlay)** — the issue-#15 re-conversions whose fp16 guards survive the ANE.

The two are **contract-identical**: same feature names, shapes, dtypes. A swapped order loads, runs, and passes every structural gate while `segments` saturates to `-45440` on the default placement. Only bytes tell them apart. This is not hypothetical — it is exactly how a locally staged tree drifts into the pre-repair state, and one already had.

The order is therefore defended three times:

1. MODELS_LOCK's header carries an ORDER box, and each table's heading states which side of the pair it must stay on.
2. `Verify speakerkit overlay and artifact checksums` re-hashes both `model.mil`s against `tests/speaker/model_io.rs`'s pins **before any gate builds**, and fails naming download order as the cause. Measured: base layer alone leaves `97f2dec6`/`2e0751ae`; the overlay replaces them with `ded0d1ee`/`cff0cfe9`.
3. `ci_stages_the_speakerkit_overlay_last_and_proves_it_won` pins the lock order, the order of the two derived `hf download` commands, and the agreement between ci.yml's copied hashes and model_io.rs's pins.

## Checksums

The overlay repo ships a `CHECKSUMS.sha256`, but it **cannot be fed to `shasum -c` whole**: it lists its own filename against the sha256 of an *empty* file, and covers paths the selector deliberately skips — a bare `shasum -c` fails on a correct tree. CI verifies the filtered 10-line subset covering the two staged bundles, with the line count pinned so a rotted filter cannot "verify" nothing. The base repo ships no checksum file; its bytes are covered by model_io.rs's per-file pins and by the fp16 graph sweep.

## Couplings

`COREMLIT_FP16_SWEEP_VENDORS` gains `speakerkit` — the first vendor in that manifest carrying **pinned defects** rather than clean controls. Five of the sweep's ten `KNOWN_DEFECTS` entries live under it, so half the defect roster moves from local-only to every PR, pinned in both directions. The sweep doubles as an independent witness on the overlay: a pre-repair segmentation graph makes it red with `NEW fp16-vanishing guard in an unpinned model`.

`crates/coremlit/build.rs` is **deliberately unchanged**. `VENDORED` lists paths the repository *commits*, whose presence says nothing about whether models were fetched. `Models/speakerkit/` is gitignored like whisper's, granite's and ced's, so its presence is precisely the signal `models_present` asks about. Adding it would suppress that signal and, on a machine that had staged only speakerkit, leave the sweep ignored with something to sweep.

## What stays out of CI, and why

- `speaker_parity_diarize_wiring` reads fixtures from the sibling `diarization` repository. No runner has them at any staging size.
- `speaker_argmax_model_io`, `speaker_parity_argmax_accuracy`, `speaker_parity_argmax_swift` need artifacts from a repository that **declares no license on Hugging Face**. NOTICE records this; the change does not weaken it. No model artifact is committed to this repository by this PR.

## Size

Staged: nine `.mlmodelc` bundles, 70 MB on disk (108 MB downloaded on a cache miss). Excluded: `mlpackages/`, `plots/`, and the loose `.png` charts — ~56 MB nothing reads.

## Validation

```
fmt=0  clippy=0  lock=0  yml=0
speaker_model_io      11 model gate(s)   exit 0
speaker_parity_seg     1 model gate      exit 0
speaker_parity_embed   2 model gates     exit 0
fp16 sweep (COREMLIT_FP16_SWEEP_VENDORS incl. speakerkit): 24 passed, 0 failed
```

Run against a directory staged by the two `hf download` commands this PR's parser actually emits — not against a pre-existing local tree. Four falsifiers were each observed red first: pre-repair `model.mil` staged; MODELS_LOCK tables swapped; one hex digit changed in ci.yml's pin; pre-repair graph staged (fp16 sweep).

`cargo test -p coremlit --features speaker` is red on a machine whose local `Models/speakerkit/` holds the pre-repair bytes. That failure predates this branch — every line changed in `fp16_guards.rs` is a doc comment — and is the condition this PR makes CI catch.
