### PR TITLE
fix(coremlit/whisper): make the re-admission defect unrepresentable — Rule W, and delete the machinery that detected it

### DIFF
--- a/crates/coremlit/src/audio/whisper/audio/chunker/mod.rs
+++ b/crates/coremlit/src/audio/whisper/audio/chunker/mod.rs
@@ -53,7 +53,8 @@ impl AudioChunk {
 /// (`Extensions+Internal.swift:112-130`): empty input becomes one
 /// full-range clip; an odd final timestamp runs to `content_frames`; pairs
 /// are consumed in order. Ordering and upper bounds are NOT validated,
-/// like Swift.
+/// like Swift. The pairing itself lives in `seek_clip_ranges`, which the
+/// streaming engine reads the same option through.
 ///
 /// # Errors
 /// [`AudioError::InvalidClipRange`] for a negative or non-finite
@@ -72,22 +73,40 @@ pub fn prepare_seek_clips(
       end: bad,
     });
   }
-  let mut seek_points: Vec<usize> = clip_timestamps
+  let seek_points: Vec<usize> = clip_timestamps
     .iter()
     .map(|seconds| (seconds * SAMPLE_RATE as f32).round() as usize)
     .collect();
-  if seek_points.is_empty() {
-    seek_points.push(0);
+  Ok(seek_clip_ranges(&seek_points, 0, content_frames))
+}
+
+/// The PAIRING rule behind [`prepare_seek_clips`], in whatever unit the caller
+/// measures its own timeline in: an empty list is one segment running from
+/// `audio_start`, an odd final point runs to `audio_end`, and everything else is
+/// consumed as `(start, end)` pairs in order — half-open, since a clip's end is
+/// where the next decode begins.
+///
+/// Ports the body of `DecodingOptions.prepareSeekClips`
+/// (`Extensions+Internal.swift:112-130`) minus the seconds-to-samples
+/// conversion, so the sample-domain chunker and the seconds-domain streaming
+/// engine (`ProvenancedResult::arriving`, which reads the same option to decide
+/// what a hypothesis's decoder could have SEEN) cannot drift into two readings
+/// of one `clip_timestamps` (codex round 14, finding 1). Only the two sentinels
+/// differ between them: the chunker knows the content length, and the streaming
+/// engine, which holds no audio at all, leaves the odd tail unbounded.
+///
+/// Ordering and upper bounds are NOT validated, like Swift and like
+/// [`prepare_seek_clips`]: an out-of-order pair yields an empty range, which
+/// every caller must already be correct for.
+pub(crate) fn seek_clip_ranges<T: Copy>(points: &[T], audio_start: T, audio_end: T) -> Vec<(T, T)> {
+  let mut points = points.to_vec();
+  if points.is_empty() {
+    points.push(audio_start);
   }
-  if seek_points.len() % 2 == 1 {
-    seek_points.push(content_frames);
+  if points.len() % 2 == 1 {
+    points.push(audio_end);
   }
-  Ok(
-    seek_points
-      .chunks(2)
-      .map(|pair| (pair[0], pair[1]))
-      .collect(),
-  )
+  points.chunks(2).map(|pair| (pair[0], pair[1])).collect()
 }
 
 /// Shifts segments (seek, times, and word times) by an absolute chunk

--- a/crates/coremlit/src/audio/whisper/audio/chunker/mod.rs
+++ b/crates/coremlit/src/audio/whisper/audio/chunker/mod.rs
@@ -53,8 +53,7 @@ impl AudioChunk {
 /// (`Extensions+Internal.swift:112-130`): empty input becomes one
 /// full-range clip; an odd final timestamp runs to `content_frames`; pairs
 /// are consumed in order. Ordering and upper bounds are NOT validated,
-/// like Swift. The pairing itself lives in `seek_clip_ranges`, which the
-/// streaming engine reads the same option through.
+/// like Swift.
 ///
 /// # Errors
 /// [`AudioError::InvalidClipRange`] for a negative or non-finite
@@ -73,40 +72,22 @@ pub fn prepare_seek_clips(
       end: bad,
     });
   }
-  let seek_points: Vec<usize> = clip_timestamps
+  let mut seek_points: Vec<usize> = clip_timestamps
     .iter()
     .map(|seconds| (seconds * SAMPLE_RATE as f32).round() as usize)
     .collect();
-  Ok(seek_clip_ranges(&seek_points, 0, content_frames))
-}
-
-/// The PAIRING rule behind [`prepare_seek_clips`], in whatever unit the caller
-/// measures its own timeline in: an empty list is one segment running from
-/// `audio_start`, an odd final point runs to `audio_end`, and everything else is
-/// consumed as `(start, end)` pairs in order — half-open, since a clip's end is
-/// where the next decode begins.
-///
-/// Ports the body of `DecodingOptions.prepareSeekClips`
-/// (`Extensions+Internal.swift:112-130`) minus the seconds-to-samples
-/// conversion, so the sample-domain chunker and the seconds-domain streaming
-/// engine (`ProvenancedResult::arriving`, which reads the same option to decide
-/// what a hypothesis's decoder could have SEEN) cannot drift into two readings
-/// of one `clip_timestamps` (codex round 14, finding 1). Only the two sentinels
-/// differ between them: the chunker knows the content length, and the streaming
-/// engine, which holds no audio at all, leaves the odd tail unbounded.
-///
-/// Ordering and upper bounds are NOT validated, like Swift and like
-/// [`prepare_seek_clips`]: an out-of-order pair yields an empty range, which
-/// every caller must already be correct for.
-pub(crate) fn seek_clip_ranges<T: Copy>(points: &[T], audio_start: T, audio_end: T) -> Vec<(T, T)> {
-  let mut points = points.to_vec();
-  if points.is_empty() {
-    points.push(audio_start);
+  if seek_points.is_empty() {
+    seek_points.push(0);
   }
-  if points.len() % 2 == 1 {
-    points.push(audio_end);
+  if seek_points.len() % 2 == 1 {
+    seek_points.push(content_frames);
   }
-  points.chunks(2).map(|pair| (pair[0], pair[1])).collect()
+  Ok(
+    seek_points
+      .chunks(2)
+      .map(|pair| (pair[0], pair[1]))
+      .collect(),
+  )
 }
 
 /// Shifts segments (seek, times, and word times) by an absolute chunk

--- a/crates/coremlit/src/audio/whisper/audio/chunker/mod.rs
+++ b/crates/coremlit/src/audio/whisper/audio/chunker/mod.rs
@@ -47,6 +47,27 @@ impl AudioChunk {
   }
 }
 
+/// The sample a clip timestamp actually lands on — the ONE rounding
+/// [`prepare_seek_clips`] applies to a `clip_timestamps` entry, named so that a
+/// caller which COMPUTES a clip time can ask where it will land instead of
+/// assuming its own seconds-domain arithmetic survives the trip.
+///
+/// It exists for `crate::audio::whisper::stream::agreement`'s watermark, which
+/// is read in BOTH coordinate systems: `LocalAgreement::watermark_filtered`
+/// compares it against word starts in seconds, and
+/// `LocalAgreement::decoding_options_for_next` hands the same value to
+/// `clip_timestamps`, where this rounding decides which audio the next stride
+/// re-reads. A seconds-domain step too small to change this value moves the
+/// filter and not the clip (#94, codex round 7 on PR #95, finding 2), so the
+/// engine asks this function rather than inventing a second rounding of its own.
+///
+/// `as usize` saturates: a negative or non-finite input lands on `0`, which
+/// [`prepare_seek_clips`] rejects before ever calling this.
+#[inline]
+pub(crate) fn clip_seek_sample(seconds: f32) -> usize {
+  (seconds * SAMPLE_RATE as f32).round() as usize
+}
+
 /// Turns `clip_timestamps` seconds into `(start, end)` sample ranges.
 ///
 /// Ports `DecodingOptions.prepareSeekClips`
@@ -74,7 +95,7 @@ pub fn prepare_seek_clips(
   }
   let mut seek_points: Vec<usize> = clip_timestamps
     .iter()
-    .map(|seconds| (seconds * SAMPLE_RATE as f32).round() as usize)
+    .map(|&seconds| clip_seek_sample(seconds))
     .collect();
   if seek_points.is_empty() {
     seek_points.push(0);

--- a/crates/coremlit/src/audio/whisper/result/mod.rs
+++ b/crates/coremlit/src/audio/whisper/result/mod.rs
@@ -2872,7 +2872,7 @@ fn merge_results(results: &[TranscriptionResult], skip_empty_texts: bool) -> Tra
 /// dropping now governs the **segment id mapping** too, not just the text
 /// (see [`merge_transcription_results_with_options`]). Delegating to the plain
 /// (drop-OFF) merge collapsed a survivor id gap `[0, 2]` back to a dense
-/// `[0, 1]`, and [`crate::audio::whisper::stream::agreement::LocalAgreement::finalize`] — the
+/// `[0, 1]`, and `LocalAgreement::finalize` — the
 /// default streaming path — inherited that loss at finalization. Threading the
 /// same `options` the results were decoded under keeps the merged **segments**
 /// honoring the drop even when the merged text does not come from them.

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -105,39 +105,18 @@
 //!   An advance therefore holds back only what fits [`MAX_HOLDBACK_PREFILL_TOKENS`]
 //!   and CONFIRMS the rest; see `budgeted_split`.
 //!
-//!   The same split now also clears the prefill's OTHER reduction (codex round
-//!   8, finding 1): `prefill_tokens` drops every id at or above the vocabulary's
-//!   `special_token_begin`, and a word with no tokens contributes nothing to the
-//!   prefix at all, so either kind of held word leaves the engine reasoning
-//!   about text the decoder was never given — the premise
-//!   [`LocalAgreement::decoding_options_for_next`]'s retarget makes. It was
-//!   recorded as a residual for as long as the
-//!   argument was "`add_word_timestamps` strips those ids from everything this
-//!   crate emits", which is true and does not reach
-//!   [`LocalAgreement::ingest`]'s public hand-built path. **[BEHAVIOUR CHANGE]**
-//!   an advance takes such a word OUT of the holdback instead of holding it, so
-//!   more words leave the holdback per advance and `finalize`'s text keeps a
-//!   word it previously let a later hypothesis supersede. Unreachable through
-//!   [`LocalAgreementTranscriber`], whose words come from
-//!   `add_word_timestamps`.
-//!
-//!   **The threshold is the engine's, not a constant**
-//!   ([`LocalAgreement::special_token_begin`] **[new public accessor,
-//!   builder, and setter]**). It defaults to [`MIN_SPECIAL_TOKEN_BEGIN`]
-//!   **[public const]**, the minimum `special_token_begin` over the vocabularies
-//!   this crate is expected to load — a bound rather than the threshold, which is
-//!   what a hermetic engine can hold on its own and the only direction that errs
-//!   safely. Nothing makes that bound hold, though (codex round 12, finding 2):
-//!   [`crate::audio::whisper::tokenizer::WhisperTokenizer::from_folder`] accepts
-//!   any parseable `tokenizer.json` and probes `<|endoftext|>` for its own
-//!   threshold, so an artifact below the floor walks straight back into round 8's
-//!   defect. [`LocalAgreementTranscriber::new`] therefore hands the engine the
-//!   loaded vocabulary's own value — exact, and nothing to remember; a caller
-//!   driving `ingest` directly against such an artifact sets it itself.
-//!   Rejecting the artifact at LOAD would close the same hole by refusing a
-//!   vocabulary the rest of this crate decodes correctly, over a premise only
-//!   this module has a stake in, so the loader is left alone. The default is
-//!   today's constant, so no existing caller moves.
+//!   The split bounds the LENGTH trim only. `prefill_tokens` reduces a prefix a
+//!   second way — it drops every id at or above the loaded vocabulary's
+//!   `special_token_begin`, and a word carrying no tokens contributes nothing at
+//!   all — and this engine does not model that (codex round 8, finding 1;
+//!   round 12, finding 2). It does not have to:
+//!   `segment::update_segments_with_word_timings` strips exactly those ids from
+//!   every [`WordTiming`] this crate emits and emits no word at all for an
+//!   all-special alignment entry, so the pipeline cannot produce such a word,
+//!   and [`LocalAgreement::new`]/[`LocalAgreement::ingest`] are `pub(crate)`
+//!   (see the seal), so no caller outside this crate can hand one in either.
+//!   The residual the id filter used to carry is closed by the API surface
+//!   rather than by a vocabulary threshold the hermetic engine cannot know.
 //!
 //!   **A widened-past word is CONFIRMED on the spot.** The argument is round 8's:
 //!   a word the prefill cannot carry is neither corroborable nor revisable by a
@@ -245,7 +224,6 @@ use crate::audio::whisper::{
   result::{TranscriptionResult, WordTiming, merge_transcription_results_with_words},
   task_facts::{SpanKnowledge, TaskFactsAccumulator},
   text::{find_longest_common_prefix, find_longest_different_suffix},
-  tokenizer::MIN_SPECIAL_TOKEN_BEGIN,
   transcribe::WhisperKit,
 };
 
@@ -319,24 +297,15 @@ pub const DEFAULT_AGREEMENT_COUNT_NEEDED: usize = 2;
 /// but one: where nothing can be held it holds nothing, and the advance confirms
 /// the whole agreed prefix.
 ///
-/// The trim is a LENGTH bound only, and it is not the only way `prefill_tokens`
-/// reduces a prefix: it also drops every id at or above the vocabulary's
-/// `special_token_begin`, and contributes nothing at all for a word carrying no
-/// tokens. `budgeted_split` tests each candidate word against
-/// [`LocalAgreement::special_token_begin`] — the loaded vocabulary's own value
-/// where the engine was told it, and [`MIN_SPECIAL_TOKEN_BEGIN`] otherwise — and
-/// widens past every word that fails, exactly as it widens past an over-budget
-/// one. So no prefill this engine issues is ever trimmed OR filtered.
-///
-/// That id filter used to be recorded here as a residual, on the evidence that
-/// `add_word_timestamps` strips exactly those ids from every [`WordTiming`] it
-/// emits (`segment::update_segments_with_word_timings`, Swift
-/// `SegmentSeeker.swift:551-554`; an all-special timing emits no word at all).
-/// The evidence is correct — this crate's pipeline never produces such a word —
-/// but it does not cover [`LocalAgreement::ingest`], which is public and takes a
-/// hand-built [`TranscriptionResult`]. That path could hold back a filtered
-/// word, honestly pass the retarget, and still be recorded `prefilled`
-/// (codex round 8, finding 1); see `budgeted_split`.
+/// The trim is a LENGTH bound only. `prefill_tokens` also drops every id at or
+/// above the loaded vocabulary's `special_token_begin`, and contributes nothing
+/// at all for a word carrying no tokens — which `budgeted_split` does not model,
+/// because it cannot arise: `add_word_timestamps` strips exactly those ids from
+/// every [`WordTiming`] this crate emits and emits no word at all for an
+/// all-special alignment entry (`segment::update_segments_with_word_timings`,
+/// Swift `SegmentSeeker.swift:551-554`), and the engine's constructor and
+/// `ingest` are `pub(crate)`, so no caller outside this crate can hand one in
+/// (codex round 8, finding 1; codex round 12, finding 2).
 pub const MAX_HOLDBACK_PREFILL_TOKENS: usize = MAX_TOKEN_CONTEXT / 2;
 
 /// The LocalAgreement-2 hypothesis-confirmation engine: consumes one
@@ -383,9 +352,6 @@ pub struct LocalAgreement {
   /// [`Self::ingest`]) — the finalized schedule is the adjudicated `None` and the
   /// finalized span is restored from the merged surviving result (round 10).
   ingested_facts: TaskFactsAccumulator,
-  /// The vocabulary threshold `budgeted_split` tests a candidate held-back
-  /// word's ids against — see [`Self::special_token_begin`].
-  special_token_begin: u32,
 }
 
 impl Default for LocalAgreement {
@@ -410,7 +376,6 @@ impl LocalAgreement {
       confirmed_words: Vec::new(),
       results: Vec::new(),
       ingested_facts: TaskFactsAccumulator::new(),
-      special_token_begin: MIN_SPECIAL_TOKEN_BEGIN,
     }
   }
 
@@ -449,53 +414,6 @@ impl LocalAgreement {
     } else {
       agreement_count_needed
     };
-    self
-  }
-
-  // -- special_token_begin ---------------------------------------------------
-  /// The vocabulary's first special-token id, as this engine understands it:
-  /// `budgeted_split` holds back a word only when every one of its token ids is
-  /// BELOW this, because
-  /// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens) drops the
-  /// rest before the decoder is given a single one of them.
-  ///
-  /// Defaults to [`MIN_SPECIAL_TOKEN_BEGIN`], the minimum over the vocabularies
-  /// this crate is expected to load — a BOUND, which is all a hermetic engine
-  /// can hold on its own and is the only direction that errs safely (see that
-  /// constant's own doc). The bound is not an invariant, though:
-  /// [`crate::audio::whisper::tokenizer::WhisperTokenizer::from_folder`] loads
-  /// any parseable `tokenizer.json` and probes `<|endoftext|>` for its own
-  /// threshold, so an artifact whose threshold is LOWER makes the default an
-  /// over-estimate — the engine would hold a word whose ids that artifact's
-  /// `prefill_tokens` erases, so the prefill the engine promises the next
-  /// hypothesis is one the decoder is given only part of (codex round 12,
-  /// finding 2).
-  ///
-  /// So it is a value rather than a constant. [`LocalAgreementTranscriber::new`]
-  /// sets it from the pipeline's own loaded vocabulary, which is exact and needs
-  /// nothing remembered; a caller driving [`Self::ingest`] directly against an
-  /// unusual artifact sets it with [`Self::with_special_token_begin`]. Leaving
-  /// it alone is exactly the behaviour every release before this one had.
-  #[inline(always)]
-  pub const fn special_token_begin(&self) -> u32 {
-    self.special_token_begin
-  }
-  /// Builder form of [`Self::set_special_token_begin`].
-  #[must_use]
-  #[inline(always)]
-  pub const fn with_special_token_begin(mut self, special_token_begin: u32) -> Self {
-    self.set_special_token_begin(special_token_begin);
-    self
-  }
-  /// Sets [`Self::special_token_begin`] in place. Unclamped, and deliberately:
-  /// a value ABOVE the deciding vocabulary's own threshold makes the engine hold
-  /// a word the decoder never receives, and a value below it only confirms a
-  /// word a round earlier than it had to. The caller owns the artifact, so the
-  /// caller supplies the fact, and it is checked where it can be:
-  /// [`LocalAgreementTranscriber`] reads it off the vocabulary itself.
-  #[inline(always)]
-  pub const fn set_special_token_begin(&mut self, special_token_begin: u32) -> &mut Self {
-    self.special_token_begin = special_token_begin;
     self
   }
 
@@ -740,7 +658,7 @@ impl LocalAgreement {
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
         let requested = common.len() - self.agreement_count_needed;
-        let mut split = budgeted_split(common, requested, self.special_token_begin);
+        let mut split = budgeted_split(common, requested);
         // RULE W -- THE SPLIT MAY NOT CUT AT A TIED START (#94, at its source).
         //
         // The watermark is the first held-back word's start, and it is also the
@@ -932,47 +850,23 @@ impl LocalAgreement {
 ///
 /// The holdback is not merely "the last few agreed words": it is the text
 /// [`LocalAgreement::decoding_options_for_next`] forces into the next
-/// hypothesis, and `prefill_tokens` reduces `prefix_tokens` on its way there in
-/// two independent ways — it keeps only the last [`MAX_HOLDBACK_PREFILL_TOKENS`]
-/// ids, and it drops every id at or above the vocabulary's
-/// `special_token_begin`. A holdback the decoder cannot be given whole is not a
-/// holdback at all — the words the filter erases would be neither reproduced
-/// (the decoder never sees their tokens) nor confirmed (an advance replaces the
-/// holdback with the new `common[split..]`), so they would simply vanish from
-/// the transcript.
+/// hypothesis, and
+/// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens) keeps only
+/// the last [`MAX_HOLDBACK_PREFILL_TOKENS`] ids of it. A holdback the decoder
+/// cannot be given whole is not a holdback at all — the words the trim erases
+/// would be neither reproduced (the decoder never sees their tokens) nor
+/// confirmed (an advance replaces the holdback with the new `common[split..]`),
+/// so they would simply vanish from the transcript.
 ///
-/// **Both filters are enforced here, and the id one is enforced against
-/// `special_token_begin`** (codex round 8, finding 1) — the deciding
-/// vocabulary's own threshold, which
-/// [`LocalAgreement::special_token_begin`] carries and
-/// [`LocalAgreementTranscriber::new`] reads off the pipeline's loaded tokenizer.
-/// A word with no tokens at all fails the same test for a different reason: it
-/// contributes nothing to `prefix_tokens`, so the decoder is never given it
-/// either, and no threshold is needed to see that.
-///
-/// The engine holds no tokenizer of its own, so with nothing supplied that value
-/// is [`MIN_SPECIAL_TOKEN_BEGIN`] — a BOUND rather than the threshold, which is
-/// what a hermetic engine can hold and which errs in the only safe direction.
-/// The bound is not self-enforcing (codex round 12, finding 2):
-/// [`crate::audio::whisper::tokenizer::WhisperTokenizer::from_folder`] accepts
-/// any parseable `tokenizer.json` and probes `<|endoftext|>` for its threshold,
-/// so an artifact below the floor turns the bound into an over-estimate and
-/// walks straight back into round 8's defect — a word held on the strength of a
-/// filter that will erase it. Rejecting such an artifact at load would fix it by
-/// refusing a vocabulary this crate otherwise decodes correctly, for a premise
-/// only this module has a stake in; supplying the real value fixes it where the
-/// value is known and costs nothing where it is not. See
-/// [`LocalAgreement::special_token_begin`].
-///
-/// That this engine could not evaluate the id filter used to be recorded as a
-/// residual, on the evidence that `add_word_timestamps` strips exactly those ids
-/// from every [`WordTiming`] it emits (and emits no word at all for an
-/// all-special alignment entry). The evidence is correct and the pipeline really
-/// is clean. What it does not cover is [`LocalAgreement::ingest`] itself, which
-/// is public and takes a hand-built [`TranscriptionResult`], so a caller can
-/// hold back a word carrying filtered ids and then use
-/// [`LocalAgreement::decoding_options_for_next`] honestly, leaving the engine
-/// promising the decoder text it will never be given.
+/// `prefill_tokens` reduces a prefix a SECOND way — it drops every id at or
+/// above the loaded vocabulary's `special_token_begin` — and this does not model
+/// that (codex round 8, finding 1). The premise that made it a residual is now
+/// total rather than partial: `segment::update_segments_with_word_timings`
+/// strips exactly those ids from every [`WordTiming`] this crate emits and emits
+/// no word at all for an all-special alignment entry, so the pipeline cannot
+/// produce such a word, and [`LocalAgreement::new`]/[`LocalAgreement::ingest`]
+/// are `pub(crate)`, so no caller outside this crate can hand one in. See this
+/// module's doc.
 ///
 /// Widening the split instead takes that head OUT of the holdback and CONFIRMS
 /// it. That is not a weaker claim than any other agreed word carries: `common`
@@ -1023,19 +917,8 @@ impl LocalAgreement {
 /// bites only for a direct caller that raised
 /// [`LocalAgreement::agreement_count_needed`] far enough, and for that caller
 /// the count becomes a maximum rather than an exact width.
-fn budgeted_split(common: &[WordTiming], requested: usize, special_token_begin: u32) -> usize {
-  // THE ID FILTER FIRST, as a floor. `prefill_tokens` drops ids at or above the
-  // vocabulary's `special_token_begin` and contributes nothing at all for a word
-  // with no tokens, so a holdback containing either is one the decoder is not
-  // given whole -- and the split has to clear the LAST such word, not the first,
-  // since the holdback is `common[split..]` and only a split past a word removes
-  // it. Widening past it can never re-introduce one, so this floor and the
-  // budget loop below compose in one direction: the loop only ever moves `split`
-  // further right.
-  let mut split = common[requested..]
-    .iter()
-    .rposition(|word| !prefill_carries_whole(word, special_token_begin))
-    .map_or(requested, |last| requested + last + 1);
+fn budgeted_split(common: &[WordTiming], requested: usize) -> usize {
+  let mut split = requested;
   let mut tokens: usize = common[split..]
     .iter()
     .map(|word| word.tokens_slice().len())
@@ -1050,25 +933,6 @@ fn budgeted_split(common: &[WordTiming], requested: usize, special_token_begin: 
     split += 1;
   }
   split
-}
-
-/// Whether [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens)
-/// carries this word's tokens into the initial prompt WHOLE — the property every
-/// held-back word has to have for
-/// [`LocalAgreement::decoding_options_for_next`]'s retarget to promise the
-/// decoder text it will actually be given.
-///
-/// Two ways to fail, and the empty one needs no vocabulary knowledge at all: a
-/// word with NO tokens contributes nothing to `prefix_tokens`, so a prefix equal
-/// to the holdback is equal to a sequence that never mentions it. The other is
-/// the id filter, tested against `special_token_begin` — the deciding
-/// vocabulary's own threshold where the engine was told it
-/// ([`LocalAgreement::special_token_begin`]), and otherwise the floor
-/// [`MIN_SPECIAL_TOKEN_BEGIN`]; see `budgeted_split` for why over-estimating the
-/// special range is the safe direction.
-fn prefill_carries_whole(word: &WordTiming, special_token_begin: u32) -> bool {
-  let tokens = word.tokens_slice();
-  !tokens.is_empty() && tokens.iter().all(|&id| id < special_token_begin)
 }
 
 // ---------------------------------------------------------------------
@@ -1108,20 +972,11 @@ impl<'ctx, B> LocalAgreementTranscriber<'ctx, B> {
   /// has nothing to agree over without word timings); Swift leaves this to
   /// a user-supplied CLI flag instead.
   ///
-  /// Also hands the engine `kit`'s own vocabulary threshold. The engine's
-  /// default, [`MIN_SPECIAL_TOKEN_BEGIN`], is a bound over the vocabularies this
-  /// crate is expected to load, and nothing makes an artifact honour it — but
-  /// this driver holds the very tokenizer whose
-  /// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens) call will
-  /// apply the filter the bound is standing in for, so on this path the exact
-  /// value is free and nothing has to be remembered (codex round 12,
-  /// finding 2). See [`LocalAgreement::special_token_begin`].
   pub fn new(kit: &'ctx WhisperKit<B>, options: DecodingOptions) -> Self {
     Self {
       kit,
       options: options.with_word_timestamps(),
-      agreement: LocalAgreement::new()
-        .with_special_token_begin(kit.tokenizer().special_tokens().special_token_begin()),
+      agreement: LocalAgreement::new(),
       buffer: Vec::new(),
       transcribed_samples: 0,
     }

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -76,15 +76,18 @@
 //!   BACKING OFF when the forward search would run off the end of `common`,
 //!   because widening past a tied run that reaches that end would empty the
 //!   holdback and anchor the watermark on the run's own last word, and finally
-//!   DEFERRING the round outright where the prefill budget floor sits at or
+//!   DEFERRING the round outright — where the prefill budget floor sits at or
 //!   above every legal boundary, which is where the back-off has nowhere legal
-//!   to land. And where the holdback is empty anyway — a single word the prefill
-//!   cannot carry WHOLE is the only thing that can still do that —
-//!   `LocalAgreement::ingest` anchors the watermark at
-//!   `end.max(start.next_up())` rather than at `end`, since `end == start` for a
-//!   zero-duration word. `next_up` is the IMMEDIATE f32 successor: it refuses
-//!   exactly the one instant the confirmed word occupies and no span of
-//!   instants, which an `end + epsilon` tolerance would not have managed.
+//!   to land, and where the budget FORCES the empty holdback but the watermark
+//!   that advance would set lies past a word the newer hypothesis produced
+//!   beyond `common`. And where the holdback is empty anyway — a single word the
+//!   prefill cannot carry WHOLE is the only thing that can still do that, and
+//!   only while it strands nothing — `LocalAgreement::ingest` anchors the
+//!   watermark at `empty_holdback_watermark`'s `end.max(start.next_up())` rather
+//!   than at `end`, since `end == start` for a zero-duration word. `next_up` is
+//!   the IMMEDIATE f32 successor: it refuses exactly the one instant the
+//!   confirmed word occupies and no span of instants, which an `end + epsilon`
+//!   tolerance would not have managed.
 //!
 //!   The DEFERRAL closes a DELETION rather than a re-confirmation (codex round 3
 //!   on PR #95). A tied run whose own tokens exceed
@@ -101,6 +104,23 @@
 //!   falsifier. Deferring costs nothing on the round itself, since
 //!   `LocalAgreement::finalize` emits the same words either way, and TAIL growth
 //!   relieves it.
+//!
+//!   The FORCED empty holdback — the arm that first repair deliberately left
+//!   alone — strands the same way and needs the same guard (codex round 3 on
+//!   PR #95, second finding). Where the budget floor itself reaches
+//!   `common.len()` the split ran off the end unconditionally, deciding on
+//!   `common` alone and never looking at what the newer hypothesis produced past
+//!   it. What that costs is a RETRACTION rather than a deletion: the round's own
+//!   `LocalAgreement::finalize` PUBLISHES the stranded word through
+//!   `find_longest_different_suffix`, and only the NEXT hypothesis loses it, so
+//!   `confirmed_words`' append-only guarantee is intact throughout and cannot
+//!   see it. The forced advance is therefore taken exactly while it strands
+//!   nothing, which is also the whole of what keeps its original case alive: a
+//!   `common` with nothing beyond it has no anchor to wait for, and deferring
+//!   there would wait forever.
+//!   `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` is the
+//!   falsifier, and it needs both of its `finalize` points — the retraction is
+//!   only visible across two.
 //!
 //!   The first shape of this rule widened unconditionally and left the empty
 //!   holdback anchored at `end`, which put the ORIGINAL duplicate-confirmation
@@ -198,11 +218,13 @@
 //!   advance can leave the holdback EMPTY** and the watermark anchored on the
 //!   last confirmed word's own far edge instead of the first held one's start.
 //!   A single word whose OWN tokens exceed the budget is now the only thing that
-//!   can do that — Rule W's own widening backs off, and DEFERS where the
-//!   back-off has nowhere legal to land, rather than emptying (see
-//!   `split_at_a_strict_boundary`) — and the
-//!   anchor is `end.max(start.next_up())`, so a zero-duration word there is
-//!   still strictly behind the watermark. It has to:
+//!   can do that, and only on a round where nothing the newer hypothesis
+//!   produced beyond `common` starts before the watermark it would set — Rule
+//!   W's own widening backs off, and DEFERS both where the back-off has nowhere
+//!   legal to land and where the forced advance would strand such a word, rather
+//!   than emptying (see `split_at_a_strict_boundary`) — and the
+//!   anchor is `empty_holdback_watermark`'s `end.max(start.next_up())`, so a
+//!   zero-duration word there is still strictly behind the watermark. It has to:
 //!   stopping while one word remained left a single word whose OWN tokens exceed
 //!   the budget held anyway, and the cap silently did not cap (codex round 7,
 //!   finding 2). What followed was data loss rather than a stall — the next
@@ -234,9 +256,10 @@
 //!   `LocalAgreement::finalize` instead emits the final hypothesis's own
 //!   post-watermark words on that path (`holdback_superseded` is the flag), and
 //!   on the DEFERRED one too (`split_deferred`), where the hypotheses agreed but
-//!   no legal split existed at or above the prefill budget floor so the holdback
-//!   is an earlier agreement's and Swift's sum would drop everything between it
-//!   and `common`'s end. It keeps Swift's shape everywhere else — including when
+//!   the only split available was one Rule W refuses — nothing legal at or above
+//!   the prefill budget floor, or a forced empty holdback that would strand the
+//!   hypothesis's own suffix — so the holdback is an earlier agreement's and
+//!   Swift's sum would drop everything between it and `common`'s end. It keeps Swift's shape everywhere else — including when
 //!   the final hypothesis contributes nothing at or past the watermark, where
 //!   nothing supersedes the holdback. How much of the holdback that path actually replaces is the
 //!   window's question, below; what is NOT replaced is emitted ahead of the
@@ -365,8 +388,19 @@
 //!    (codex round 3 on PR #95;
 //!    `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix`), which
 //!    is what restores this sentence.
+//!
+//!    It is narrower again since round 3's second finding: the word this drops
+//!    must be one no hypothesis had produced YET at the moment of the advance.
+//!    A word already visible past `common` when the split runs is not dropped —
+//!    the forced arm defers rather than stranding it
+//!    (`a_forced_empty_holdback_defers_rather_than_retracting_its_suffix`). So
+//!    what remains is exactly the word the NEXT decode invents at an instant
+//!    already settled, which is the one case no watermark can tell from a
+//!    re-offer.
 //!    `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed` drives it
-//!    at count 1, and `the_split_never_cuts_at_a_tied_start` sweeps both counts.
+//!    at count 1 — its dropped `" B"` arrives one hypothesis later, which is why
+//!    it is still dropped — and `the_split_never_cuts_at_a_tied_start` sweeps
+//!    both counts.
 //! 2. **A repeat the engine's record cannot account for** is the stream's own,
 //!    on the untied input — and on a TIED one Rule W deletes it instead. Both
 //!    directions are pinned:
@@ -431,8 +465,9 @@ pub enum AgreementOutcome {
   /// The watermark is unchanged. Three routes reach it: there is no previous
   /// result to agree with yet (the first ingested result); the new hypothesis
   /// disagreed with the previous one, in which case the result was dropped
-  /// rather than kept; or the two agreed and the round was DEFERRED because no
-  /// legal split exists at or above the prefill budget floor (see
+  /// rather than kept; or the two agreed and the round was DEFERRED because
+  /// every split Rule W would accept is one the prefill budget refuses, or the
+  /// one the budget forces would strand the hypothesis's own suffix (see
   /// `split_at_a_strict_boundary`), in which case the result was kept like any
   /// other agreeing one. The deferral is deliberately not its own variant: what
   /// this value reports is whether the watermark moved, and no in-crate caller
@@ -524,9 +559,11 @@ pub struct LocalAgreement {
   /// had words to agree over — exactly the pair `finalize` reasons about.
   holdback_superseded: bool,
   /// Whether the most recent WORDED hypothesis AGREED with the previous one and
-  /// the round still did not advance, because
-  /// `split_at_a_strict_boundary` found no legal boundary at or above the
-  /// prefill budget floor (#94, codex round 3 on PR #95). `Self::finalize` needs
+  /// the round still did not advance, because `split_at_a_strict_boundary` had
+  /// no acceptable boundary to advance to: none legal at or above the prefill
+  /// budget floor, or a forced empty holdback whose watermark would have
+  /// stranded a word this hypothesis produced beyond `common` (#94, codex
+  /// round 3 on PR #95, both findings). `Self::finalize` needs
   /// it for the same reason it needs [`Self::holdback_superseded`]: on such a
   /// round the holdback belongs to an EARLIER agreement while
   /// [`Self::hypothesis_words`] already re-covers that whole span and more, so
@@ -855,29 +892,36 @@ impl LocalAgreement {
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
         let requested = common.len() - self.agreement_count_needed;
-        // RULE W'S DEFERRAL (#94, codex round 3 on PR #95). `None` is "the two
-        // hypotheses agreed, but no legal boundary sits at or above the prefill
-        // budget floor" -- a tied run whose OWN tokens exceed the budget puts
-        // the floor strictly inside the run, so every boundary the forward
-        // search and the back-off can reach ties, and split 0, the one boundary
-        // a tied run always leaves legal, is below the floor.
+        // RULE W'S DEFERRAL (#94, codex round 3 on PR #95, both findings).
+        // `None` is "the two hypotheses agreed, but every advance available is
+        // one Rule W refuses", and two states reach it. A tied run whose OWN
+        // tokens exceed the budget puts the floor strictly inside the run, so
+        // every boundary the forward search and the back-off can reach ties, and
+        // split 0, the one boundary a tied run always leaves legal, is below the
+        // floor. Or the budget FORCES the empty holdback and the watermark that
+        // advance would anchor lies past a word this hypothesis produced beyond
+        // `common` -- which is why `hypothesis_words` past `common` is passed
+        // in: on `common` alone that arm cannot see what it would strand.
         //
-        // Widening off the end there -- what the old fallback did -- confirms
-        // the whole run, empties the holdback and anchors the watermark strictly
-        // PAST the run's instant. Every word the newest hypothesis produced at
-        // that same instant beyond `common` is then stranded: nothing confirmed
-        // it, the next worded ingest filters it out of BOTH hypotheses at once,
-        // and `finalize` has nothing left to recover it from. A deletion, which
-        // is this module's non-preferred direction.
+        // Advancing in either state empties the holdback and anchors the
+        // watermark strictly PAST the last confirmed instant. Every word the
+        // newest hypothesis produced at that same instant beyond `common` is
+        // then stranded: nothing confirmed it, the next worded ingest filters it
+        // out of BOTH hypotheses at once, and `finalize` has nothing left to
+        // recover it from -- after THIS round's `finalize` already published it
+        // through `find_longest_different_suffix`. A deletion, and on the forced
+        // arm a retraction, which is this module's non-preferred direction.
         //
         // So the round simply does not advance. It costs nothing that round --
         // `finalize` emits `confirmed ++ hypothesis_words` either way, see
         // `Self::finalize` -- and it is not the blocking policy this issue's
         // ledger refuted for deadlock: TAIL growth relieves it, the same relief
         // `split_at_a_strict_boundary`'s back-off already relies on, since one
-        // word starting strictly later opens a boundary above the floor.
+        // word starting strictly later opens a boundary above the floor and one
+        // word joining `common` gives an interior split something to hold.
         let boundary = split_at_a_strict_boundary(
           common,
+          &self.hypothesis_words[common.len()..],
           requested,
           self.confirmed_words.last().map(WordTiming::start),
         );
@@ -891,21 +935,15 @@ impl LocalAgreement {
           // start, which `split_at_a_strict_boundary` has already placed STRICTLY
           // past the last confirmed word's start.
           //
-          // With NOTHING held back -- which now takes a single word whose OWN
+          // With NOTHING held back -- which takes a single word whose OWN
           // tokens exceed the prefill budget, the one thing that pushes the
-          // budget floor to `common.len()`; an over-budget tied RUN defers
-          // instead (see `split_at_a_strict_boundary`) -- there is no held word
-          // to measure against and the still-open span begins where the
-          // confirmed one ends.
-          // `end` is the answer whenever the last confirmed word has any duration
-          // at all; where it does NOT, `end == start` and the word would satisfy
-          // `watermark_filtered`'s own `start >= watermark` against its own
-          // confirmation, which is the whole of #94. The watermark is therefore the
-          // first instant that is strictly past that start: `next_up` is the
-          // IMMEDIATE f32 successor, so nothing representable lies between it and
-          // the start it excludes, and it is a successor rather than a tolerance --
-          // no span of instants is moved, only the single instant the confirmed
-          // word already occupies is refused.
+          // budget floor to `common.len()`, on a round where nothing beyond
+          // `common` would be stranded by the result; an over-budget tied RUN
+          // and a live strand both defer instead (see
+          // `split_at_a_strict_boundary`) -- there is no held word to measure
+          // against, and `empty_holdback_watermark` is the answer. That is the
+          // SAME function the deferral decision above consults, deliberately:
+          // the guard and the value it guards may not drift apart.
           //
           // Monotone: every word of `common` starts at or past the old watermark,
           // `end >= start` for any word the pipeline emits, and `next_up` only
@@ -918,9 +956,9 @@ impl LocalAgreement {
           // fallback is unreachable and only keeps this total.
           self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
             || {
-              common.last().map_or(self.last_agreed_seconds, |last| {
-                last.end().max(last.start().next_up())
-              })
+              common
+                .last()
+                .map_or(self.last_agreed_seconds, empty_holdback_watermark)
             },
             WordTiming::start,
           );
@@ -1122,7 +1160,8 @@ impl LocalAgreement {
 ///    over the HEAD of the offered list, which only an advance can move, whereas
 ///    this defers a split position that TAIL growth relieves, and it advances
 ///    the holdback rather than refusing the round.
-/// 3. **`None` -- DEFER** where the budget floor is `1` or more and no legal
+/// 3. **`None` -- DEFER**, on either of two states. The first is where the
+///    budget floor is `1` or more and no legal
 ///    boundary sits at or above it. A tied run whose OWN tokens exceed
 ///    `MAX_HOLDBACK_PREFILL_TOKENS` is the shape: the floor lands strictly
 ///    inside the run, every boundary the search and the back-off can reach ties,
@@ -1147,9 +1186,21 @@ impl LocalAgreement {
 ///    `finalize` emits `confirmed ++ hypothesis_words` either way (see
 ///    `LocalAgreement::finalize`) -- and the divergence is entirely in what
 ///    LATER ingests can still see.
-/// 4. **`Some(common.len())`** -- tested FIRST in the code, since it is a
-///    property of the budget alone and neither search runs on it. Only where the
-///    BUDGET FLOOR itself reaches `common.len()` is that length
+///
+///    The second state is arm 4's, refused: the budget FORCES the empty
+///    holdback, and the watermark that advance would set --
+///    `empty_holdback_watermark(common.last())` -- lies strictly past a word of
+///    `beyond_common`. That word is stranded exactly as above, and what it costs
+///    is one step worse: this round's own `finalize` PUBLISHES it, through
+///    `find_longest_different_suffix`, so losing it on the next ingest RETRACTS
+///    transcript rather than merely never emitting it. `confirmed_words`'
+///    append-only guarantee never sees it -- the word was never confirmed. The
+///    same relief applies: tail growth either moves the strand into `common`,
+///    where an ordinary interior split can hold it, or opens a boundary above
+///    the floor.
+/// 4. **`Some(common.len())`** -- tested FIRST in the code, since its condition
+///    is a property of the budget alone and neither search runs on it. Only
+///    where the BUDGET FLOOR itself reaches `common.len()` is that length
 ///    returned and the holdback left empty. That takes a LAST word whose own
 ///    tokens exceed the budget, since nothing else runs `budgeted_split`'s loop
 ///    off the end, and it is the one state where the empty holdback is FORCED:
@@ -1157,7 +1208,26 @@ impl LocalAgreement {
 ///    to wait for and deferring would wait forever. Confirming is round 7
 ///    finding 2's own repair, and `LocalAgreement::ingest`'s watermark then
 ///    anchors strictly past the last confirmed start rather than at its `end`.
-///    This arm is now the WHOLE of what reaches the empty holdback.
+///    This arm is the WHOLE of what reaches the empty holdback.
+///
+///    "There is no anchor to wait for" is a claim about `common` alone, and it
+///    is why this arm may not simply defer -- but the ADVANCE is not a property
+///    of `common` alone, which is what `beyond_common` is here to supply. Where
+///    a word past `common` would be stranded by this arm's own watermark, arm 3
+///    takes the round instead; where nothing is, this arm advances exactly as
+///    before. The guard is that narrow on purpose: widening it to "defer
+///    whenever the budget forces the empty holdback" re-opens round 7 finding
+///    2, which is the wait that never ends.
+///
+///    An EMPTY `common` reaches this arm too (`floor == 0 == common.len()`) and
+///    advances: there is no word to anchor a watermark on, so there is nothing
+///    to strand, and `LocalAgreement::ingest`'s own fallback leaves the
+///    watermark where it was. Like the `at == 0` check above it carries NO
+///    falsifier -- `LocalAgreement::ingest` only calls this with
+///    `common.len() >= agreement_count_needed`, which is clamped to at least one
+///    -- and, like it, it is written out so this function is total on its own
+///    terms rather than on its caller's clamp. Flipping it to defer reds nothing
+///    in this crate.
 ///
 /// So `agreement_count_needed` is a target rather than an exact width in EITHER
 /// direction: the budget can shorten the holdback (see `budgeted_split`) and
@@ -1172,10 +1242,25 @@ impl LocalAgreement {
 /// the offered filter, and the re-admission question is unrepresentable rather
 /// than defended against.
 ///
-/// It stays TOTAL under the `None` arm rather than becoming conditional again:
-/// a deferred round is not an advance, so it moves neither side of the
+/// It stays TOTAL under both `None` states rather than becoming conditional
+/// again: a deferred round is not an advance, so it moves neither side of the
 /// inequality and there is no state for the claim to be excluded from. `None`
-/// REMOVES reachable advances rather than adding unguarded ones.
+/// REMOVES reachable advances rather than adding unguarded ones, and the second
+/// state removes a strict subset of arm 4's, which the `next_up` anchor already
+/// carried.
+///
+/// # A second postcondition
+///
+/// After every advance, every word of the driving hypothesis that the advance
+/// did NOT confirm still satisfies `LocalAgreement::watermark_filtered`'s own
+/// `start >= last_agreed_seconds`, so the round cannot put a word it left
+/// unsettled out of the next round's reach. Where the split is interior this is
+/// free -- the watermark is `common[split].start()` and word starts inside one
+/// hypothesis are non-decreasing, so everything from `split` on is at or past
+/// it. Where the split is `common.len()` the watermark is strictly PAST the last
+/// confirmed start, so it is not free, and the `beyond_common` test in arm 4 is
+/// what buys it. `the_split_never_cuts_at_a_tied_start` sweeps it beside the
+/// first postcondition.
 ///
 /// It is a claim about the LAST confirmed word, and that is as strong as it needs
 /// to be exactly while word starts inside one hypothesis are non-decreasing --
@@ -1183,6 +1268,7 @@ impl LocalAgreement {
 /// for the backwards-starts input the `pub(crate)` seal excludes.
 fn split_at_a_strict_boundary(
   common: &[WordTiming],
+  beyond_common: &[WordTiming],
   requested: usize,
   confirmed_last_start: Option<f32>,
 ) -> Option<usize> {
@@ -1202,10 +1288,30 @@ fn split_at_a_strict_boundary(
     // prefill could carry, which takes a LAST word whose own tokens exceed
     // `MAX_HOLDBACK_PREFILL_TOKENS` (that is the only way the loop in
     // `budgeted_split` runs off the end). Confirming it is always available and
-    // is round 7 finding 2's own repair; deferring would wait for an anchor that
-    // can never arrive. `LocalAgreement::ingest`'s `next_up` anchor then keeps
-    // the postcondition on this path, and this arm is the whole of what still
-    // reaches it.
+    // is round 7 finding 2's own repair; deferring where nothing would be
+    // stranded would wait for an anchor that can never arrive.
+    //
+    // But the advance would anchor the watermark at
+    // `empty_holdback_watermark(common.last())`, and every word the newer
+    // hypothesis produced BEFORE that instant beyond `common` is stranded by it
+    // (codex round 3 on PR #95, second finding): the next worded ingest filters
+    // it out of both hypotheses at once, and it is a word THIS round's
+    // `LocalAgreement::finalize` already published through
+    // `find_longest_different_suffix`. So the forced advance is available
+    // exactly while it strands nothing, and the strand is what
+    // `beyond_common` is here to see -- without it this arm decides on `common`
+    // alone and cannot know what lies past it.
+    //
+    // `start < watermark` is `watermark_filtered`'s own `start >= watermark`
+    // negated, and totally so: every word of `beyond_common` reached this call
+    // through that filter, so none of their starts is NaN.
+    let strands_a_suffix = common.last().is_some_and(|last| {
+      let watermark = empty_holdback_watermark(last);
+      beyond_common.iter().any(|word| word.start() < watermark)
+    });
+    if strands_a_suffix {
+      return None;
+    }
     return Some(common.len());
   }
   let widened = requested.max(floor);
@@ -1326,6 +1432,28 @@ fn budgeted_split(common: &[WordTiming], requested: usize) -> usize {
     split += 1;
   }
   split
+}
+
+/// The watermark an advance that holds NOTHING back anchors at: the first
+/// instant strictly past `last`'s start, where `last` is the word that advance
+/// confirms last.
+///
+/// `end` is the answer whenever that word has any duration at all; where it does
+/// NOT, `end == start` and the word would satisfy
+/// `LocalAgreement::watermark_filtered`'s own `start >= watermark` against its
+/// own confirmation, which is the whole of #94. `next_up` is the IMMEDIATE `f32`
+/// successor, so nothing representable lies between the result and the start it
+/// excludes: exactly one instant is refused rather than a span, which an
+/// `end + epsilon` tolerance would not have managed.
+///
+/// It is a named function rather than an expression at its one obvious site
+/// because it has TWO callers with opposite jobs and they may not disagree.
+/// `LocalAgreement::ingest` SETS this watermark; `split_at_a_strict_boundary`
+/// decides whether setting it would strand a word the newer hypothesis produced
+/// beyond `common`, which is a question about this exact value. Computing it
+/// twice would let the guard drift off the thing it guards, silently.
+fn empty_holdback_watermark(last: &WordTiming) -> f32 {
+  last.end().max(last.start().next_up())
 }
 
 // ---------------------------------------------------------------------

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -51,27 +51,175 @@
 //!   [`STRIDE_SAMPLES`]-sized thresholds as samples are pushed in — a
 //!   deliberate regularization for that push-based shape, not a
 //!   byte-for-byte port of Swift's off-by-one starting point.
-//! - **A word already confirmed is not re-confirmed at the front of a
-//!   re-decode** (Swift `:372`/`:375`). Swift's hypothesis view is a bare
-//!   timestamp filter, `start >= lastAgreedSeconds`, and the watermark is the
-//!   first held-back word's start — so a word confirmed in the previous round
-//!   that shares that exact start (DTW row steps without a column advance, then
-//!   centisecond rounding; ties are pipeline-reachable) is pulled back in and
-//!   confirmed AGAIN. This port strips the leading run of the offered words that
-//!   reproduces the confirmed tail tied at the watermark. Adjudicated: Swift
-//!   shares the bug, and "confirmed once and stable" wins over parity.
+//! - **A word already confirmed is not re-confirmed by a re-decode** (Swift
+//!   `:372`/`:375`). Swift's hypothesis view is a bare timestamp filter,
+//!   `start >= lastAgreedSeconds`, and the watermark is the first held-back
+//!   word's start — so a word confirmed in the previous round that shares that
+//!   exact start (DTW row steps without a column advance, then centisecond
+//!   rounding; ties are pipeline-reachable) is pulled back in and confirmed
+//!   AGAIN. This port instead locates the FRONTIER between the settled span and
+//!   the still-open one, by aligning the engine's own record of that span (the
+//!   confirmed tail whose extent reaches the watermark, then the holdback)
+//!   against the offered words and refusing the offered prefix that every
+//!   optimal alignment attributes to the settled half — see
+//!   `LocalAgreement::watermark_filtered` for the algorithm, its ambiguity rule,
+//!   and the four things it deliberately leaves. Adjudicated: Swift shares the
+//!   bug, and "confirmed once and stable" wins over parity.
 //!
-//!   **That strip is known-incomplete.** It only catches a reproduction at the
-//!   very front of the offered list; an insertion ahead of it, an omission of
-//!   the confirmed tail's head, a partial front match, or a re-decode that
-//!   nudges the reproduction a hair past the watermark all slide past it. Four
-//!   adversarial-review rounds each defeated a stronger predicate, and
-//!   established that no predicate over (confirmed words, offered words,
-//!   watermark) can be right — occurrence identity is not recoverable from
-//!   those three. It is a design task, tracked with an executable acceptance
-//!   suite at <https://github.com/findit-studio/coremlit/issues/94>: ten
-//!   CHARACTERIZATION tests that pin today's wrong answers and go red the day
-//!   the defect is fixed.
+//!   **This changes what [`LocalAgreement::ingest`] returns on some inputs**,
+//!   against Swift and against this port's own previous leading-run strip. That
+//!   strip caught only a reproduction the hypothesis put at offset 0; a
+//!   reproduction behind an insertion, one missing the confirmed tail's head,
+//!   one behind a shorter false match, and one shifted a hair past the watermark
+//!   all rode through into `hypothesis_words`, where they either disagreed with
+//!   the previous hypothesis ([`AgreementOutcome::AwaitingAgreement`], the
+//!   result dropped from [`LocalAgreement::results_slice`]) or agreed and
+//!   confirmed a settled word a second time ([`AgreementOutcome::Advanced`]).
+//!   They now reach the same view a clean reproduction does, so those sequences
+//!   can return `Advanced` where they returned `AwaitingAgreement` and keep the
+//!   result where they dropped it. [`LocalAgreement::finalize`]'s own contract
+//!   is unchanged — it composes `confirmed_words`, `last_agreed_words`,
+//!   `prev_words` and `hypothesis_words` exactly as before — but the words those
+//!   now hold are the corrected ones, so its text changes on the same
+//!   sequences. <https://github.com/findit-studio/coremlit/issues/94> is the
+//!   record of the ten that move; each is a named property test in this
+//!   module's `tests`, alongside the constraints that bound the rule.
+//! - **`ingest` takes the options the result was decoded under, and the frontier
+//!   rule has TWO readings selected by them.** Swift's loop has no equivalent
+//!   parameter; its filter is the bare timestamp comparison and needs no premise.
+//!   The frontier's ambiguity tie-break here is not a preference, it is the
+//!   reading the PREFILL forces — and [`LocalAgreement::ingest`] is public and
+//!   takes an unmarked [`TranscriptionResult`], which carries no record of how it
+//!   was decoded (codex round 6, finding 1). So the premise is now supplied and
+//!   CHECKED rather than assumed: `ingest(result, decoded_under)` compares
+//!   `decoded_under` against the retarget it would have issued for its current
+//!   state (see `LocalAgreement::prefill_reproduces_holdback`) and reads the
+//!   smallest optimal seam only when that holds. A result decoded any other way
+//!   gets the largest match-supported optimal seam instead — refuse everything
+//!   any optimal alignment could read as a settled word coming back, because with
+//!   no prefill to appeal to a disputed head is unattributable and confirmation is
+//!   append-only. Two paths, two policies, each with its own standing
+//!   justification. See `LocalAgreement::watermark_filtered`, "Ambiguity rule",
+//!   for why the unmarked path does not instead BLOCK on the ambiguity.
+//!
+//!   **The premise belongs to the RESULT, not to the call that reads it** (codex
+//!   round 7, finding 1). `ingest` keeps the previous result raw and re-filters
+//!   it on every later call, so a premise derived from the current call and
+//!   reused for the stored one gives an unmarked result the marked frontier one
+//!   call later — undoing its refusal with no caller lying, and confirming words
+//!   on an agreement neither hypothesis offered. Each result is therefore paired
+//!   with its own premise the moment it arrives (`ProvenancedResult`), and
+//!   `watermark_filtered_with` takes only the pair; no signature in the engine
+//!   can carry a foreign one. **This changes what
+//!   [`LocalAgreement::ingest`] returns on a mixed-provenance sequence**, in the
+//!   opposite direction to the re-admission fix above: where an unmarked result
+//!   is followed by a marked one that repeats it, the pair no longer agrees, so
+//!   `ingest` returns [`AgreementOutcome::AwaitingAgreement`] where it returned
+//!   [`AgreementOutcome::Advanced`], the result is dropped rather than kept, and
+//!   the words that advance would have confirmed stay provisional — revisable by
+//!   the hypothesis after them. A single-provenance stream, which is every
+//!   stream [`LocalAgreementTranscriber`] can produce, is unaffected.
+//! - **The holdback holds only what the prefill carries WHOLE, with no
+//!   residual.** Swift's `agreementCountNeeded` is a hardcoded `2` it never
+//!   exposes, so the length case cannot arise there. Here
+//!   [`LocalAgreement::agreement_count_needed`] is settable with no upper bound,
+//!   while `prefill_tokens` keeps only the last `MAX_TOKEN_CONTEXT / 2` prefix
+//!   tokens — so a large enough holdback would be silently truncated, and its
+//!   head would be neither re-offered nor confirmed (codex round 6, finding 2).
+//!   An advance therefore holds back only what fits [`MAX_HOLDBACK_PREFILL_TOKENS`]
+//!   and CONFIRMS the rest; see `budgeted_split`.
+//!
+//!   The same split now also clears the prefill's OTHER reduction (codex round
+//!   8, finding 1): `prefill_tokens` drops every id at or above the vocabulary's
+//!   `special_token_begin`, and a word with no tokens contributes nothing to the
+//!   prefix at all, so either kind of held word leaves the engine reasoning
+//!   about text the decoder was never given — the exact premise the frontier's
+//!   marked reading rests on. It was recorded as a residual for as long as the
+//!   argument was "`add_word_timestamps` strips those ids from everything this
+//!   crate emits", which is true and does not reach
+//!   [`LocalAgreement::ingest`]'s public hand-built path. **[BEHAVIOUR CHANGE]**
+//!   an advance takes such a word OUT of the holdback instead of holding it, so
+//!   more words leave the holdback per advance and `finalize`'s text keeps a
+//!   word it previously let a later hypothesis supersede. Unreachable through
+//!   [`LocalAgreementTranscriber`], whose words come from
+//!   `add_word_timestamps`.
+//!
+//!   **The threshold is the engine's, not a constant**
+//!   ([`LocalAgreement::special_token_begin`] **[new public accessor,
+//!   builder, and setter]**). It defaults to [`MIN_SPECIAL_TOKEN_BEGIN`]
+//!   **[public const]**, the minimum `special_token_begin` over the vocabularies
+//!   this crate is expected to load — a bound rather than the threshold, which is
+//!   what a hermetic engine can hold on its own and the only direction that errs
+//!   safely. Nothing makes that bound hold, though (codex round 12, finding 2):
+//!   [`crate::audio::whisper::tokenizer::WhisperTokenizer::from_folder`] accepts
+//!   any parseable `tokenizer.json` and probes `<|endoftext|>` for its own
+//!   threshold, so an artifact below the floor walks straight back into round 8's
+//!   defect. [`LocalAgreementTranscriber::new`] therefore hands the engine the
+//!   loaded vocabulary's own value — exact, and nothing to remember; a caller
+//!   driving `ingest` directly against such an artifact sets it itself.
+//!   Rejecting the artifact at LOAD would close the same hole by refusing a
+//!   vocabulary the rest of this crate decodes correctly, over a premise only
+//!   this module has a stake in, so the loader is left alone. The default is
+//!   today's constant, so no existing caller moves.
+//!
+//!   **A widened-past word is not confirmed on the spot** (codex round 12,
+//!   finding 1). The argument for confirming it — neither corroborable nor
+//!   revisable, being behind both the clip and the forced prefill — is an
+//!   argument about the hypothesis that comes NEXT, and the split runs before it
+//!   exists. It holds for a continuation decoded under
+//!   [`LocalAgreement::decoding_options_for_next`] and for no other, and
+//!   confirming into the append-only list cannot be taken back. So the split
+//!   still widens (its retarget is the only coherent one either way) and the
+//!   widened-past words wait in [`LocalAgreement::pending_words_slice`] **[new
+//!   public accessor]** — settled by the first hypothesis this engine anchored
+//!   (one written to begin with the whole holdback, which they sit in front of),
+//!   revisable by any other, and dropped with the holdback they head when one
+//!   supersedes them. Two kinds of word skip the wait entirely: one the
+//!   still-open span can never reach (`end` at or before the watermark), since
+//!   nothing offered could ever overlap it; and every one of them when the
+//!   holdback comes back EMPTY, since with no anchor no later result could ever
+//!   clear the wait and the hold would end in the deletion round 7 finding 2
+//!   removed.
+//!
+//!   That second kind therefore CAN be confirmed while a later unanchored decode
+//!   still re-reads its audio, and the transcript then carries both readings
+//!   (codex round 13, finding 1, refuted rather than fixed). That is not a
+//!   property of this arm: `common[..requested]`, the mainline confirmation
+//!   Swift has and this port has never touched, appends with no overlap test of
+//!   any kind and lands in the same place whenever word ends inside a hypothesis
+//!   are non-monotone
+//!   (`an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too`). It is
+//!   the LocalAgreement-2 contract itself — confirmation follows agreement
+//!   between two consecutive hypotheses and is append-only — and whether an
+//!   offered word is a settled one coming BACK is the FRONTIER's question, which
+//!   `settled_seams` answers by alignment. Requiring a non-vacuous anchor
+//!   instead reinstates the indefinite hold, and also breaks
+//!   `with_nothing_held_back_both_frontiers_are_the_same_column`: leaving a word
+//!   pending beside an empty holdback makes `watermark_filtered_with`'s
+//!   `revisable` non-empty, so `settled_seams`' `after` row is no longer
+//!   identically zero and the vacuous premise stops being harmless. **[BEHAVIOUR CHANGE]** [`LocalAgreement::confirmed_words_slice`]
+//!   therefore gains a word that waits one `ingest` later than it did, and on a
+//!   MIXED-provenance stream an
+//!   unmarked hypothesis that revises one now replaces it instead of landing
+//!   beside it. Unreachable through [`LocalAgreementTranscriber`], which never
+//!   widens the split at all.
+//!
+//!   That split runs all the way to `common.len()` when it has to, so **an
+//!   advance can leave the holdback EMPTY** and the watermark anchored at the
+//!   last confirmed word's end instead of the first held one's start. It has to:
+//!   stopping while one word remained left a single word whose OWN tokens exceed
+//!   the budget held anyway, and the cap silently did not cap (codex round 7,
+//!   finding 2). What followed was data loss rather than a stall — the next
+//!   hypothesis was decoded from a prefix `prefill_tokens` trims, came back with
+//!   a word that is not the held one, disagreed, and
+//!   [`LocalAgreement::finalize`]'s `holdback_superseded` path replaced the
+//!   intact held word with that truncation. Confirming such a word is always
+//!   possible and is no weaker a claim: `common` is the prefix two hypotheses
+//!   agreed on, and a word outside the prefill budget is one no third hypothesis
+//!   decoded from that prefill could revise — see the pending-word entry above
+//!   for the qualifier that carries. Unreachable through
+//!   [`LocalAgreementTranscriber`], which never leaves
+//!   [`DEFAULT_AGREEMENT_COUNT_NEEDED`].
 //! - **The final hypothesis's holdback** (Swift `:418-419`, `let final =
 //!   lastAgreedWords + findLongestDifferentSuffix(prevWords,
 //!   hypothesisWords)`). That decomposition is only valid when the LAST
@@ -90,12 +238,116 @@
 //!   post-watermark words on that path (`holdback_superseded` is the flag), and
 //!   keeps Swift's shape everywhere else — including when the final hypothesis
 //!   contributes nothing at or past the watermark, where nothing supersedes the
-//!   holdback. Same adjudication as the re-admission divergence recorded on
+//!   holdback. How much of the holdback that path actually replaces is the
+//!   window's question, below; what is NOT replaced is emitted ahead of the
+//!   hypothesis's words rather than sending the whole thing back to Swift's
+//!   expression, whose prefix subtraction has no holdback to justify it once the
+//!   holdback is the thing being kept (codex round 14). Same adjudication as the re-admission divergence recorded on
 //!   `watermark_filtered`: Swift shares the bug, and a word confirmed once and
 //!   stable wins over parity. Nothing in this repo pins the streaming transcript
 //!   against a Swift capture (`tests/whisper/streaming.rs` "owns no golden"; the
 //!   token-for-token goldens are the BATCH decode's), so the divergence costs no
 //!   oracle comparison.
+//! - **A result only replaces the PART of the span its own window DECODED**
+//!   (codex round 13, finding 2; intervals and the split, codex round 14). Two
+//!   places install a hypothesis's words over the engine's still-open record of
+//!   the still-open span — [`LocalAgreement::pending_words_slice`] then
+//!   [`LocalAgreement::last_agreed_words_slice`]: the advance in
+//!   [`LocalAgreement::ingest`], and the `holdback_superseded` branch above.
+//!   Both justify it by calling the replacement a REVISION of what it replaces,
+//!   and both inferred that from `prefilled` being false — "decoded some other
+//!   way, so its decoder saw that audio". Nothing made it so. `ingest` is public
+//!   and states no requirement that an unmarked result's window reach the
+//!   watermark, and a caller resuming a stream at a clip point of its own
+//!   legitimately hands over one that does not. Such a decode produced no
+//!   revision of that record, because it produced nothing over its span at all —
+//!   so replacing the record with its words deletes text two hypotheses agreed
+//!   on and nothing contradicted.
+//!
+//!   The deciding fact was already in hand and merely unused:
+//!   [`DecodingOptions::clip_timestamps`](crate::audio::whisper::options::DecodingOptions::clip_timestamps_slice)
+//!   is the window the decode actually covered, and `ProvenancedResult` already
+//!   pairs a result with what was known when it arrived. The window now travels
+//!   with the result exactly as its prefill premise does
+//!   (`ProvenancedResult::decoded`, scanned by
+//!   `LocalAgreement::open_record_split`), and both replacement sites ask it
+//!   first.
+//!
+//!   THE WINDOW IS A SET OF INTERVALS. `clip_timestamps` is a list of
+//!   `(start, end)` PAIRS that splits the audio into segments — its own doc says
+//!   so, and [`crate::audio::whisper::transcribe::WhisperKit::transcribe`] hands
+//!   it to `chunker::prepare_seek_clips`, which decodes each pair as its own
+//!   clip. `[0.0, 0.5, 3.0]` therefore decodes `[0.0, 0.5)` and `[3.0, end)` and
+//!   NOTHING between, so a first-timestamp-plus-half-line reading called a
+//!   two-clip schedule a window over the whole audio and let a word from the
+//!   second range supersede a record inside the gap (round 14, finding 1). Both
+//!   readings come out of one derivation, `chunker::seek_clip_ranges`, which
+//!   `prepare_seek_clips` is also built on; only the sentinels differ, since a
+//!   hermetic engine has no content length and leaves an odd final point's tail
+//!   unbounded. The leading comparison is NON-STRICT and has to be:
+//!   [`LocalAgreement::decoding_options_for_next`] clips exactly AT the
+//!   watermark, which is exactly where the holdback begins, so a strict test
+//!   would fail the engine's own retarget on every stride.
+//!
+//!   THE ANSWER IS A BOUNDARY, NOT A VERDICT. One verdict for a whole record is
+//!   wrong in both directions (round 14, finding 2): a window that opens BETWEEN
+//!   two held words re-read only the second, and deciding at the record's head
+//!   confirms that second word irrevocably at the very moment a hypothesis that
+//!   did re-read it says it is something else — then emits the stale reading
+//!   beside its own revision. `open_record_split` returns the index where the
+//!   longest wholly-re-read SUFFIX begins; the prefix in front of it is
+//!   preserved (finalized) or confirmed (advanced), and only the suffix is
+//!   replaced. Word-level CONTAINMENT in ONE clip, so a word the window only
+//!   partly reaches, or that straddles two adjacent clips, is preserved: erring
+//!   wide costs a repetition, erring narrow deletes a word. Same direction, for
+//!   the same reason, as the advance's own `position` split.
+//!
+//!   **[BEHAVIOUR CHANGE]** on both sites. An advance whose hypothesis could not
+//!   re-read part of the record now CONFIRMS that part instead of dropping it —
+//!   the watermark passes it on the very next line, so nothing can ever be
+//!   offered over its span again and there is no third option that terminates;
+//!   it is the pending bucket's own terminating rule applied where the bucket's
+//!   anchor also runs out. And `finalize` emits that part ahead of the revision
+//!   rather than deleting it for a revision that does not exist. Conversely, the
+//!   part a window DID re-read is no longer confirmed or emitted beside its
+//!   replacement; and the divergence's tail is `hypothesis_words` on every
+//!   disagreeing path rather than only on the ones that re-read something, which
+//!   stops Swift's prefix subtraction from dropping a word both hypotheses
+//!   produced whenever the holdback it subtracts against is being kept. All of
+//!   it is unreachable through [`LocalAgreementTranscriber`], whose every stride
+//!   clips at the watermark and contains its own holdback whole.
+//!
+//!   Swift cannot have the defect and cannot have the fix: it has no
+//!   `decoded_under` to check, and on this path its `:418-419` emits
+//!   `lastAgreedWords` beside the final hypothesis anyway — the duplication the
+//!   `holdback_superseded` branch exists to remove, and, when the final
+//!   hypothesis re-covered nothing, the answer that happens to be right.
+//! - **`use_prefill_prompt` is forced on the retargeted options, but only once
+//!   there is a holdback to reproduce** (Swift `:364-367` sets only
+//!   `clipTimestamps` and `prefixTokens`).
+//!   [`DecodingOptions::prefix_tokens`](crate::audio::whisper::options::DecodingOptions::prefix_tokens_slice)
+//!   reaches the decoder through exactly one call,
+//!   [`crate::audio::whisper::decode::prefill_tokens`], which
+//!   [`crate::audio::whisper::transcribe::WhisperKit::transcribe`] makes only when
+//!   [`DecodingOptions::use_prefill_prompt`](crate::audio::whisper::options::DecodingOptions::use_prefill_prompt)
+//!   is set — so on a base with the prompt off, the prefix
+//!   [`LocalAgreement::decoding_options_for_next`] attaches is silently dropped
+//!   and the stream re-decodes each span with no anchor at all. Both this port
+//!   and Swift default the flag on, so this only diverges for a caller that
+//!   turned it off; it is forced for the same reason
+//!   [`LocalAgreementTranscriber::new`] forces `word_timestamps`, and because the
+//!   frontier rule's ambiguity tie-break is DECIDED by the prefill (see
+//!   `LocalAgreement::watermark_filtered`, "Ambiguity rule").
+//!
+//!   It is forced only while [`LocalAgreement::last_agreed_words_slice`] is
+//!   NON-EMPTY (codex round 6, finding 3). Before the first advance there is no
+//!   holdback, the prefix is empty, `settled` is empty too, and
+//!   `watermark_filtered` takes its `settled_len == 0` fast path — no frontier is
+//!   read, so no premise needs enforcing. Forcing the flag on those strides would
+//!   change the caller's prompt from a bare `<|startoftranscript|>` to the full
+//!   multilingual language/task/timestamp prefill for nothing, and a streaming
+//!   caller would get different decoding behaviour before LocalAgreement had
+//!   produced any state that justified the deviation.
 //! - **`push_samples` needs only `B: InferenceBackend`, not `+ Sync`.**
 //!   Its only backend-touching call is
 //!   [`crate::audio::whisper::transcribe::WhisperKit::transcribe`], whose own `impl`
@@ -107,13 +359,15 @@
 //!   InferenceBackend + Sync` here.
 
 use crate::audio::whisper::{
+  audio::chunker,
   backend::InferenceBackend,
-  constants::SAMPLE_RATE,
+  constants::{MAX_TOKEN_CONTEXT, SAMPLE_RATE},
   error::TranscribeError,
   options::DecodingOptions,
   result::{TranscriptionResult, WordTiming, merge_transcription_results_with_words},
   task_facts::{SpanKnowledge, TaskFactsAccumulator},
-  text::{find_longest_common_prefix, find_longest_different_suffix},
+  text::{find_longest_common_prefix, find_longest_different_suffix, normalized},
+  tokenizer::MIN_SPECIAL_TOKEN_BEGIN,
   transcribe::WhisperKit,
 };
 
@@ -168,6 +422,191 @@ impl AgreementOutcome {
 /// `agreementCountNeeded` local (`TranscribeCLI.swift:349`).
 pub const DEFAULT_AGREEMENT_COUNT_NEEDED: usize = 2;
 
+/// The most holdback tokens a prefill can carry and have EVERY one of them
+/// reach the decoder: [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens)
+/// keeps only the LAST `MAX_TOKEN_CONTEXT / 2` elements of
+/// [`DecodingOptions::prefix_tokens`](DecodingOptions::prefix_tokens_slice)
+/// (`prefix_tokens.len().saturating_sub(MAX_TOKEN_CONTEXT / 2)` — Swift
+/// `TextDecoder.swift:203`'s `.suffix`). Everything before that point is
+/// dropped before the initial prompt is even assembled, so it never enters
+/// `decode_text`'s `current_tokens` and never appears in the hypothesis.
+///
+/// That trim is silent, and the frontier rule in
+/// `LocalAgreement::watermark_filtered` is justified by the WHOLE holdback
+/// being forced into the next hypothesis — so a holdback that cannot survive
+/// this budget would leave the rule reasoning about text the decoder was never
+/// given. [`LocalAgreement::ingest`] therefore holds back only what fits, and
+/// `budgeted_split` guarantees that for EVERY input rather than for every input
+/// but one: where nothing can be held it holds nothing, and the advance confirms
+/// the whole agreed prefix.
+///
+/// The trim is a LENGTH bound only, and it is not the only way `prefill_tokens`
+/// reduces a prefix: it also drops every id at or above the vocabulary's
+/// `special_token_begin`, and contributes nothing at all for a word carrying no
+/// tokens. `budgeted_split` tests each candidate word against
+/// [`LocalAgreement::special_token_begin`] — the loaded vocabulary's own value
+/// where the engine was told it, and [`MIN_SPECIAL_TOKEN_BEGIN`] otherwise — and
+/// widens past every word that fails, exactly as it widens past an over-budget
+/// one. So no prefill this engine issues is ever trimmed OR filtered, and
+/// `LocalAgreement::prefill_reproduces_holdback` needs a clause for neither: a
+/// prefix EQUAL to the holdback is within budget and carried whole because the
+/// holdback is.
+///
+/// That id filter used to be recorded here as a residual, on the evidence that
+/// `add_word_timestamps` strips exactly those ids from every [`WordTiming`] it
+/// emits (`segment::update_segments_with_word_timings`, Swift
+/// `SegmentSeeker.swift:551-554`; an all-special timing emits no word at all).
+/// The evidence is correct — this crate's pipeline never produces such a word —
+/// but it does not cover [`LocalAgreement::ingest`], which is public and takes a
+/// hand-built [`TranscriptionResult`]. That path could hold back a filtered
+/// word, honestly pass the retarget, and still be recorded `prefilled`
+/// (codex round 8, finding 1); see `budgeted_split`.
+pub const MAX_HOLDBACK_PREFILL_TOKENS: usize = MAX_TOKEN_CONTEXT / 2;
+
+/// A result and the provenance it ARRIVED with, inseparable by construction.
+///
+/// `LocalAgreement::watermark_filtered_with` reads a result's frontier under one
+/// of two policies, and which one is right is a fact about how THAT result was
+/// decoded — not about the engine's state at the moment the frontier happens to
+/// be read. Those two moments are not the same moment:
+/// [`LocalAgreement::ingest`] keeps `prev_result` RAW and re-filters it on every
+/// later call, so a premise derived from the CURRENT call and reused for the
+/// stored one hands an unmarked result the MARKED frontier one call later. That
+/// undoes the unmarked refusal without any caller lying, and manufactures an
+/// agreement neither hypothesis offered: `find_longest_common_prefix` returns
+/// elements of the current hypothesis, but its LENGTH is set by both sides, and
+/// a `prev_words` read more permissively than its own provenance allows makes
+/// that length LONGER — which is what decides whether the watermark advances and
+/// how much lands in the append-only `LocalAgreement::confirmed_words_slice`
+/// (codex round 7, finding 1).
+///
+/// The pairing is the fix, and it is structural rather than a rule to remember.
+/// The fields are private to this module, [`ProvenancedResult::arriving`] is the
+/// only constructor and the only caller of
+/// [`LocalAgreement::prefill_reproduces_holdback`], and
+/// `watermark_filtered_with` takes the PAIR — so no signature anywhere in the
+/// engine has a channel through which a foreign premise could arrive, and the
+/// answer is immutable for as long as the engine keeps the result. Recorded once
+/// and read back, exactly as `LocalAgreement::holdback_superseded` is and for
+/// the same reason: a value a later call could re-derive differently is a value
+/// a later call WILL re-derive differently.
+mod provenance {
+  use super::{DecodingOptions, LocalAgreement, TranscriptionResult, WordTiming, chunker};
+
+  /// One ingested result, bound to the premise it arrived under. See the module
+  /// comment above for why the two travel together.
+  #[derive(Debug, Clone, PartialEq)]
+  pub(super) struct ProvenancedResult {
+    result: TranscriptionResult,
+    prefilled: bool,
+    window: Vec<(f32, f32)>,
+  }
+
+  impl ProvenancedResult {
+    /// Binds `result` to the premise `decoded_under` establishes against
+    /// `engine`'s state RIGHT NOW — which is the state the caller decoded
+    /// under, since [`LocalAgreement::ingest`] calls this before any of that
+    /// state moves — and to the WINDOW `decoded_under` says it was decoded in,
+    /// which needs no state at all (see [`Self::decoded`]).
+    pub(super) fn arriving(
+      result: TranscriptionResult,
+      engine: &LocalAgreement,
+      decoded_under: &DecodingOptions,
+    ) -> Self {
+      Self {
+        prefilled: engine.prefill_reproduces_holdback(decoded_under),
+        // `clip_timestamps` is a list of `(start, end)` PAIRS that splits the
+        // audio into segments, not a start (codex round 14, finding 1): its own
+        // doc says so, and `WhisperKit::transcribe` hands it straight to
+        // `chunker::prepare_seek_clips`, which pairs the points and decodes each
+        // pair as its own clip. So `[0.0, 0.5, 3.0]` decodes `[0.0, 0.5)` and
+        // `[3.0, end)` and nothing between — a schedule the round-13 reading
+        // (`first()`, then `[decoded_from, ..)`) called a window over the whole
+        // audio.
+        //
+        // Derived by `chunker::seek_clip_ranges`, which
+        // `prepare_seek_clips` is also built on, so the two cannot drift into
+        // two readings of one option. Both sentinels differ here: the seconds
+        // domain rather than samples, and an UNBOUNDED tail for an odd final
+        // point, because a hermetic engine holds no audio and so has no content
+        // length. That is the only place this reading is wider than the
+        // chunker's, and it is unreachable: every instant the two disagree about
+        // is past the end of the audio, and every word this window is ever asked
+        // about came out of a decode OF that audio.
+        window: chunker::seek_clip_ranges(
+          decoded_under.clip_timestamps_slice(),
+          0.0,
+          f32::INFINITY,
+        ),
+        result,
+      }
+    }
+
+    /// Whether this result's decoder saw the WHOLE of `word`'s audio — that is,
+    /// whether one clip of its schedule contains `[word.start(), word.end())`
+    /// entirely (codex round 13, finding 2; intervals per codex round 14,
+    /// finding 1).
+    ///
+    /// The engine reads this before letting a result's words REPLACE its own
+    /// still-open record of a span: `finalize`'s `holdback_superseded` branch
+    /// prefers the final hypothesis's words over that record because they are a
+    /// revision of it, and the advance replaces it with `common` for the same
+    /// reason — neither is true of a hypothesis whose window excluded the span.
+    /// Nothing checked it: `prefilled()` false was read as "decoded some other
+    /// way, so it saw that audio", and
+    /// [`LocalAgreement::ingest`] states no requirement that an unmarked
+    /// result's window reach the watermark at all.
+    ///
+    /// The leading comparison is NON-STRICT, and it has to be: the window
+    /// [`LocalAgreement::decoding_options_for_next`] issues begins exactly at
+    /// the watermark, which is exactly where the holdback begins, so a strict
+    /// test would fail the engine's own retarget on every stride. The two
+    /// values are the same `f32` — `last_agreed_seconds` is assigned from a
+    /// [`WordTiming::start`] — so the boundary compares exactly, the same
+    /// exactness [`LocalAgreement::prefill_reproduces_holdback`]'s own clip
+    /// clause already rests on. The trailing one is non-strict for the ordinary
+    /// half-open reason: a word that ENDS where the clip does was decoded whole
+    /// inside it.
+    ///
+    /// CONTAINMENT, not overlap, and containment in ONE clip rather than in the
+    /// union of several — "authorised only by real continuous coverage". A word
+    /// the window only partly reaches was only partly re-read, and a word that
+    /// straddles two adjacent clips was decoded in two pieces, neither of which
+    /// saw it whole; in both cases the decoder's reading of it is not a revision
+    /// of the whole word. Erring wide here (calling such a word uncovered)
+    /// leaves the record beside the partial re-reading, which costs a
+    /// repetition; erring narrow would delete it. Same direction the advance's
+    /// overlap split is drawn in, and for the same reason. A `NaN` or reversed
+    /// clip errs the same way for free: every comparison against it is false, so
+    /// it contains nothing.
+    pub(super) fn decoded(&self, word: &WordTiming) -> bool {
+      self
+        .window
+        .iter()
+        .any(|&(start, end)| start <= word.start() && word.end() <= end)
+    }
+
+    /// The hypothesis itself.
+    pub(super) const fn result(&self) -> &TranscriptionResult {
+      &self.result
+    }
+
+    /// Whether THIS result's own options established the prefill premise —
+    /// never any other result's.
+    pub(super) const fn prefilled(&self) -> bool {
+      self.prefilled
+    }
+
+    /// Unbinds the result, for the two places that need to OWN it (the
+    /// wordless-result append, and the kept-result clone).
+    pub(super) fn into_result(self) -> TranscriptionResult {
+      self.result
+    }
+  }
+}
+
+use provenance::ProvenancedResult;
+
 /// The LocalAgreement-2 hypothesis-confirmation engine: consumes one
 /// [`TranscriptionResult`] per call and tracks the growing prefix two
 /// consecutive hypotheses agree on. Pure — no backend, no I/O, fully
@@ -179,7 +618,11 @@ pub const DEFAULT_AGREEMENT_COUNT_NEEDED: usize = 2;
 pub struct LocalAgreement {
   agreement_count_needed: usize,
   last_agreed_seconds: f32,
-  prev_result: Option<TranscriptionResult>,
+  /// The previous hypothesis, kept RAW so each ingest can re-filter it against
+  /// the watermark that is current then — paired with the provenance it arrived
+  /// with, so that re-filter can only ever read the frontier THAT result's own
+  /// premise supports (see [`ProvenancedResult`]).
+  prev_result: Option<ProvenancedResult>,
   prev_words: Vec<WordTiming>,
   hypothesis_words: Vec<WordTiming>,
   last_agreed_words: Vec<WordTiming>,
@@ -196,6 +639,38 @@ pub struct LocalAgreement {
   /// had words to agree over — exactly the pair `finalize` reasons about.
   holdback_superseded: bool,
   confirmed_words: Vec<WordTiming>,
+  /// The head of the last advance's holdback that `budgeted_split` widened past
+  /// — words two consecutive hypotheses agreed on that
+  /// [`Self::decoding_options_for_next`]'s prefill cannot re-offer, and which
+  /// are therefore NOT YET in the append-only [`Self::confirmed_words`].
+  ///
+  /// The split has to widen: the retarget it produces (clip and prefill both
+  /// past these words) is the only coherent one, and leaving such a word IN the
+  /// holdback makes every marked continuation disagree with a prefill that
+  /// cannot reproduce it. What the split cannot know at the moment it runs is
+  /// whether the NEXT result will be one of those continuations — and confirming
+  /// on the spot is only sound if it is (codex round 12, finding 1). So the
+  /// split's WIDTH is decided at the advance and these words' DESTINATION is
+  /// decided one call later, by the premise that decides it — whether the next
+  /// result was written to BEGIN with the whole holdback, which every pending
+  /// word sits in front of ([`Self::prefill_reproduces_holdback`]).
+  ///
+  /// A result that could not have SEEN their audio settles them too, and for the
+  /// mirror-image reason (`Self::open_record_split`, codex round 13, finding 2):
+  /// a window that never reached these words revised nothing over their span, so
+  /// neither the advance nor [`Self::finalize`]'s superseded path may replace
+  /// them with it.
+  ///
+  /// Non-empty only while [`Self::last_agreed_words`] is: with nothing held back
+  /// there is no anchor a later result could be checked against, so a word left
+  /// here could never be cleared and is confirmed at the advance instead. See
+  /// the advance's own second split.
+  ///
+  /// Until then they are the head of the holdback in every respect except the
+  /// prefill: they align in `settled_seams`' revisable half, an advance replaces
+  /// them along with the rest of the holdback, and
+  /// [`Self::finalize`]'s `holdback_superseded` path drops them with it.
+  pending_words: Vec<WordTiming>,
   results: Vec<TranscriptionResult>,
   /// A sink for the reproducibility facts of EVERY ingested hypothesis —
   /// including the disagreeing ones dropped from [`Self::results`] but retained
@@ -209,6 +684,9 @@ pub struct LocalAgreement {
   /// [`Self::ingest`]) — the finalized schedule is the adjudicated `None` and the
   /// finalized span is restored from the merged surviving result (round 10).
   ingested_facts: TaskFactsAccumulator,
+  /// The vocabulary threshold `budgeted_split` tests a candidate held-back
+  /// word's ids against — see [`Self::special_token_begin`].
+  special_token_begin: u32,
 }
 
 impl Default for LocalAgreement {
@@ -231,8 +709,10 @@ impl LocalAgreement {
       last_agreed_words: Vec::new(),
       holdback_superseded: false,
       confirmed_words: Vec::new(),
+      pending_words: Vec::new(),
       results: Vec::new(),
       ingested_facts: TaskFactsAccumulator::new(),
+      special_token_begin: MIN_SPECIAL_TOKEN_BEGIN,
     }
   }
 
@@ -251,17 +731,19 @@ impl LocalAgreement {
     self
   }
   /// Sets [`Self::agreement_count_needed`] in place, clamped up to at
-  /// least `1`. Zero would hold back no words at all on an advance
+  /// least `1`. Zero would hold back no words at all on EVERY advance
   /// (`Self::ingest`'s `common[split..]` slice with `split ==
-  /// common.len()`), leaving no first held-back word to anchor
-  /// [`Self::last_agreed_seconds`] to — an algorithmically degenerate
+  /// common.len()`), so no hypothesis would ever be given an anchor to
+  /// re-decode from and LocalAgreement-2's second round of corroboration would
+  /// be switched off wholesale — an algorithmically degenerate
   /// configuration Swift's hardcoded `agreementCountNeeded = 2`
   /// (`TranscribeCLI.swift:349`) never reaches, since Swift never exposes
   /// this knob as configurable at all; its own `lastAgreedWords.first!`
   /// (`:385`) would force-unwrap-crash on the same input if it somehow
-  /// did. This setter is the only way to reach [`Self::agreement_count_needed`]
-  /// from outside the module, so clamping here keeps `ingest` panic-free
-  /// for every value this type can actually hold.
+  /// did. This port would not: an empty holdback is a state `ingest` handles
+  /// (`budgeted_split` can produce one for a word the prefill cannot carry, and
+  /// the watermark anchor covers it), so the clamp is about keeping the
+  /// ALGORITHM meaningful rather than about keeping it from panicking.
   #[inline(always)]
   pub const fn set_agreement_count_needed(&mut self, agreement_count_needed: usize) -> &mut Self {
     self.agreement_count_needed = if agreement_count_needed == 0 {
@@ -269,6 +751,54 @@ impl LocalAgreement {
     } else {
       agreement_count_needed
     };
+    self
+  }
+
+  // -- special_token_begin ---------------------------------------------------
+  /// The vocabulary's first special-token id, as this engine understands it:
+  /// `budgeted_split` holds back a word only when every one of its token ids is
+  /// BELOW this, because
+  /// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens) drops the
+  /// rest before the decoder is given a single one of them.
+  ///
+  /// Defaults to [`MIN_SPECIAL_TOKEN_BEGIN`], the minimum over the vocabularies
+  /// this crate is expected to load — a BOUND, which is all a hermetic engine
+  /// can hold on its own and is the only direction that errs safely (see that
+  /// constant's own doc). The bound is not an invariant, though:
+  /// [`crate::audio::whisper::tokenizer::WhisperTokenizer::from_folder`] loads
+  /// any parseable `tokenizer.json` and probes `<|endoftext|>` for its own
+  /// threshold, so an artifact whose threshold is LOWER makes the default an
+  /// over-estimate — the engine would hold a word whose ids that artifact's
+  /// `prefill_tokens` erases, and the equality
+  /// `Self::prefill_reproduces_holdback` checks would be satisfied by a prefix
+  /// the decoder is given only part of (codex round 12, finding 2).
+  ///
+  /// So it is a value rather than a constant. [`LocalAgreementTranscriber::new`]
+  /// sets it from the pipeline's own loaded vocabulary, which is exact and needs
+  /// nothing remembered; a caller driving [`Self::ingest`] directly against an
+  /// unusual artifact sets it with [`Self::with_special_token_begin`]. Leaving
+  /// it alone is exactly the behaviour every release before this one had.
+  #[inline(always)]
+  pub const fn special_token_begin(&self) -> u32 {
+    self.special_token_begin
+  }
+  /// Builder form of [`Self::set_special_token_begin`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn with_special_token_begin(mut self, special_token_begin: u32) -> Self {
+    self.set_special_token_begin(special_token_begin);
+    self
+  }
+  /// Sets [`Self::special_token_begin`] in place. Unclamped, and deliberately:
+  /// a value ABOVE the deciding vocabulary's own threshold makes the engine hold
+  /// a word the decoder never receives, and a value below it only confirms a
+  /// word a round earlier than it had to. The caller owns the artifact, so the
+  /// caller supplies the fact — the same trust model as
+  /// [`Self::ingest`]'s `decoded_under`, and checked the same way where it can
+  /// be: [`LocalAgreementTranscriber`] reads it off the vocabulary itself.
+  #[inline(always)]
+  pub const fn set_special_token_begin(&mut self, special_token_begin: u32) -> &mut Self {
+    self.special_token_begin = special_token_begin;
     self
   }
 
@@ -289,10 +819,44 @@ impl LocalAgreement {
     self.last_agreed_words.as_slice()
   }
 
+  // -- pending_words (Vec<WordTiming>) ---------------------------------------
+  /// The words the last advance agreed on but could not hold back — the ones
+  /// `budgeted_split` widened the split past because
+  /// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens) cannot
+  /// carry them into the next hypothesis whole.
+  ///
+  /// They sit BETWEEN [`Self::confirmed_words_slice`] and
+  /// [`Self::last_agreed_words_slice`], so the transcript a streaming caller can
+  /// read between pushes is the three concatenated in that order. They are not
+  /// confirmed: a hypothesis decoded some way OTHER than
+  /// [`Self::decoding_options_for_next`] MAY have seen their audio and revised
+  /// them, and [`Self::confirmed_words_slice`] is append-only and cannot take a
+  /// word back. The first hypothesis written to begin with this engine's own
+  /// holdback settles them — nothing it produces can precede that reproduction,
+  /// and these words are in front of it (see the field's own comment, and codex
+  /// round 12, finding 1). So does one whose own
+  /// [`DecodingOptions::clip_timestamps`](crate::audio::whisper::options::DecodingOptions::clip_timestamps_slice)
+  /// begin after them, for the opposite reason — it never decoded their audio at
+  /// all, so it revised nothing and the engine's record is all their span will
+  /// ever have (codex round 13, finding 2).
+  ///
+  /// Always empty for [`LocalAgreementTranscriber`], whose words come from
+  /// `add_word_timestamps` and whose holdback is two words wide.
+  #[inline(always)]
+  pub const fn pending_words_slice(&self) -> &[WordTiming] {
+    self.pending_words.as_slice()
+  }
+
   // -- confirmed_words (Vec<WordTiming>) -------------------------------------
   /// Word timings settled so far: every agreement's leading remainder,
   /// ahead of that agreement's own [`Self::agreement_count_needed`]-word
-  /// holdback.
+  /// holdback — and ahead of [`Self::pending_words_slice`], the part of that
+  /// holdback the prefill could not carry, which reaches this list one ingest
+  /// later than the rest of the remainder does.
+  ///
+  /// Append-only across the life of the engine: nothing here is ever rewritten,
+  /// reordered, or taken back, which is why a word the next hypothesis might
+  /// still revise waits in [`Self::pending_words_slice`] instead.
   #[inline(always)]
   pub const fn confirmed_words_slice(&self) -> &[WordTiming] {
     self.confirmed_words.as_slice()
@@ -313,79 +877,532 @@ impl LocalAgreement {
   /// `TranscribeCLI.swift:364-367` (`streamOptions.clipTimestamps =
   /// [lastAgreedSeconds]`; `streamOptions.prefixTokens =
   /// lastAgreedWords.flatMap { $0.tokens }`).
+  ///
+  /// # The prefill is a contract, not a hint
+  ///
+  /// [`DecodingOptions::prefix_tokens`](DecodingOptions::prefix_tokens_slice) is
+  /// read by exactly one place,
+  /// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens), and
+  /// [`crate::audio::whisper::transcribe::WhisperKit::transcribe`] only CALLS
+  /// that function when [`DecodingOptions::use_prefill_prompt`] is set — so on a
+  /// `base` with the prompt turned off, the prefix tokens this method attaches
+  /// are silently inert and the returned options are not retargeted at all.
+  /// This therefore sets it, the same way
+  /// [`LocalAgreementTranscriber::new`] forces
+  /// [`DecodingOptions::word_timestamps`] and for the same kind of reason: the
+  /// option is not a preference here, it is what makes the returned value mean
+  /// what its name says. **Documented deviation** — Swift `:364-367` sets only
+  /// the two fields and inherits `usePrefillPrompt` from the CLI flag, so a
+  /// `whisperkit-cli` run without `--use-prefill-prompt` streams with an inert
+  /// `prefixTokens` exactly as described. It defaults `true` on both sides, so
+  /// this only diverges for a caller that turned it off.
+  ///
+  /// What the prefill buys is the reason
+  /// `LocalAgreement::watermark_filtered`'s frontier can be read off an ambiguous
+  /// alignment at all. `prefill_tokens` appends these tokens to the initial
+  /// prompt, and `decode_text` FORCES every prompt position
+  /// (`next_token = current_tokens[token_index]` for `token_index <
+  /// initial_prompt_index`) before `finalize_decoding_result` keeps the whole
+  /// `SOT..=EOT` span — so the holdback is not something the next hypothesis
+  /// might predict, it is text the engine wrote into that hypothesis. Combined
+  /// with `clip_timestamps`, which puts the audio before the watermark outside
+  /// the decoded window entirely, a hypothesis produced from these options
+  /// BEGINS with a reproduction of the holdback, and nothing already confirmed
+  /// can precede it. See `LocalAgreement::watermark_filtered`, "Ambiguity rule".
+  ///
+  /// Hand the returned value back to [`Self::ingest`] alongside the result it
+  /// decoded: that is how the premise above becomes something the engine has
+  /// CHECKED rather than assumed. `ingest` compares what it is given against
+  /// what this method would issue for the same state, and falls back to the
+  /// unattributable frontier when they differ.
+  ///
+  /// # Before the first advance
+  ///
+  /// With an empty [`Self::last_agreed_words_slice`] there is nothing to
+  /// reproduce: the prefix is empty, `clip_timestamps` is at the watermark, and
+  /// [`DecodingOptions::use_prefill_prompt`] is left exactly as `base` had it.
+  /// The forcing above exists to make the frontier's tie-break sound, and with
+  /// no holdback there is no tie-break to make sound — before the first advance
+  /// [`Self::confirmed_words_slice`] is empty too, so `settled` is empty and
+  /// `watermark_filtered` takes its `settled_len == 0` fast path; after an
+  /// advance that could hold nothing (`budgeted_split`) a frontier IS read, but
+  /// the two policies name the same column when the holdback is empty (see
+  /// `Self::prefill_reproduces_holdback`). Overriding the caller's flag here
+  /// would change the initial prompt from a bare `<|startoftranscript|>` to the
+  /// full multilingual language/task/timestamp prefill for no reason the engine's
+  /// own state can point at (codex round 6, finding 3), and there would be no
+  /// prefix for it to carry in any case.
   pub fn decoding_options_for_next(&self, base: &DecodingOptions) -> DecodingOptions {
-    let prefix_tokens: Vec<u32> = self
+    let retargeted = base
+      .clone()
+      .with_clip_timestamps(vec![self.last_agreed_seconds])
+      .with_prefix_tokens(self.holdback_prefill_tokens());
+    if self.last_agreed_words.is_empty() {
+      // NOTHING IS HELD BACK, so there is no premise to enforce and the caller's
+      // own flag stands. Before the first advance `confirmed_words` is empty for
+      // exactly as long as `last_agreed_words` is, so `watermark_filtered`'s
+      // `settled_len` is zero and the frontier question never arises; after an
+      // advance whose budget could hold nothing (`budgeted_split`) it does
+      // arise, and the two policies answer it identically with an empty holdback
+      // (see `prefill_reproduces_holdback`). Either way the tie-break the prefill
+      // DECIDES is not being asked. Forcing the flag here would change the prompt
+      // from whatever the caller asked for to the full multilingual
+      // language/task/timestamp prefill, on strides where the engine holds no
+      // state that needs the deviation (codex round 6, finding 3). The prefix
+      // above is empty on this path, so nothing is silently dropped by leaving
+      // the prompt off either.
+      retargeted
+    } else {
+      retargeted.with_use_prefill_prompt()
+    }
+  }
+
+  /// The holdback as one token sequence — the exact value
+  /// [`Self::decoding_options_for_next`] attaches as
+  /// [`DecodingOptions::prefix_tokens`](DecodingOptions::prefix_tokens_slice),
+  /// and the value [`Self::prefill_reproduces_holdback`] compares a caller's
+  /// options against.
+  fn holdback_prefill_tokens(&self) -> Vec<u32> {
+    self
       .last_agreed_words
       .iter()
       .flat_map(|word| word.tokens_slice().iter().copied())
-      .collect();
-    base
-      .clone()
-      .with_clip_timestamps(vec![self.last_agreed_seconds])
-      .with_prefix_tokens(prefix_tokens)
+      .collect()
+  }
+
+  /// Whether `decoded_under` — the options a caller says the offered result was
+  /// decoded with — actually establishes the premise
+  /// `LocalAgreement::watermark_filtered`'s ambiguity rule is decided by: that
+  /// the offered hypothesis was written to BEGIN with this engine's whole
+  /// holdback, with nothing already confirmed able to precede it.
+  ///
+  /// Every clause is a thing that, if false, breaks that premise outright:
+  ///
+  /// - **An empty holdback** makes it vacuous — and harmlessly so, on both of the
+  ///   two ways it arises. Before the first advance `settled` is empty too, so
+  ///   `watermark_filtered` takes its fast path and no frontier is read at all.
+  ///   After an advance the budget could hold nothing (`budgeted_split`),
+  ///   `settled` is NOT empty and a frontier IS read — but with an empty holdback
+  ///   `settled_seams`' `after` row is identically zero, so `score(j)` is the
+  ///   non-decreasing `before[j]`, no column past the smallest optimal one is
+  ///   match-supported, and the two policies name the same frontier. The answer
+  ///   here cannot change any word either way
+  ///   (`with_nothing_held_back_both_frontiers_are_the_same_column`).
+  /// - **[`DecodingOptions::use_prefill_prompt`] off** means
+  ///   [`crate::audio::whisper::transcribe::WhisperKit::transcribe`] never calls
+  ///   [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens), so the
+  ///   prefix is inert and the hypothesis PREDICTED its head rather than being
+  ///   fed it.
+  /// - **A different [`DecodingOptions::clip_timestamps`](DecodingOptions::clip_timestamps_slice)**
+  ///   means the audio the settled words were recognized in was NOT excluded from
+  ///   the decoded window, so a settled word can precede the holdback in the
+  ///   offered list after all — which is precisely the reading the tie-break
+  ///   rules out.
+  /// - **A prefix that is not the holdback** is not a reproduction of it — and
+  ///   the test is equality, not "ends with". A prefix over
+  ///   [`MAX_HOLDBACK_PREFILL_TOKENS`] whose TAIL reproduces the holdback is
+  ///   refused by that same clause, and must be: `prefill_tokens` trims such a
+  ///   prefix to its last [`MAX_HOLDBACK_PREFILL_TOKENS`] tokens, which still
+  ///   carries the padding ahead of the holdback into the initial prompt, so the
+  ///   hypothesis does not BEGIN with the holdback. Equality also subsumes both
+  ///   of `prefill_tokens`'s reductions outright: `budgeted_split` leaves a
+  ///   holdback that is inside the budget AND carried whole by the id filter
+  ///   after every advance, so anything equal to that holdback is too — which is
+  ///   why neither reduction gets a clause of its own here. A clause for either
+  ///   would be a conjunct no input can falsify, the shape round 7 removed the
+  ///   length clause for.
+  ///
+  /// What it cannot check is that the caller actually DECODED with the options
+  /// it handed over; `TranscriptionResult` carries no provenance, and the
+  /// issue's impossibility argument already established that no predicate over
+  /// the word lists can recover it (two runs reach byte-identical
+  /// `(confirmed, offered, watermark, holdback)` and need opposite answers).
+  /// This is therefore the strongest premise the engine can hold: an explicit,
+  /// typed assertion by the caller, checked against what the engine itself would
+  /// have issued — not an unstated assumption about how `ingest` is called.
+  fn prefill_reproduces_holdback(&self, decoded_under: &DecodingOptions) -> bool {
+    if self.last_agreed_words.is_empty() {
+      return true;
+    }
+    if !decoded_under.use_prefill_prompt() {
+      return false;
+    }
+    if decoded_under.clip_timestamps_slice() != [self.last_agreed_seconds] {
+      return false;
+    }
+    // Equality, not `ends_with`: a prefix whose head is something else is not a
+    // reproduction of the holdback, however faithfully its TAIL reproduces one
+    // (`prefill_tokens` would force the head into the hypothesis too). Equality
+    // also subsumes both of `prefill_tokens`'s reductions: after every advance
+    // `budgeted_split` leaves a holdback inside `MAX_HOLDBACK_PREFILL_TOKENS`
+    // whose every word the id filter carries whole, so anything equal to it is
+    // within budget and unfiltered as well.
+    decoded_under.prefix_tokens_slice() == self.holdback_prefill_tokens()
+  }
+
+  /// The engine's own STILL-OPEN record of the span, in time order:
+  /// `pending_words` — the agreed-but-not-yet-irrevocable head — then
+  /// `last_agreed_words`, the holdback proper. The two places that would
+  /// REPLACE it read it through here so neither can forget half of it.
+  fn open_record(&self) -> impl DoubleEndedIterator<Item = &WordTiming> {
+    self
+      .pending_words
+      .iter()
+      .chain(self.last_agreed_words.iter())
+  }
+
+  /// How many words are in [`Self::open_record`].
+  fn open_record_len(&self) -> usize {
+    self.pending_words.len() + self.last_agreed_words.len()
+  }
+
+  /// WHERE `hypothesis`'s own decode window cuts the still-open record: the
+  /// index at which the record stops being the only estimate its span will ever
+  /// have and becomes something this hypothesis re-read and may replace (codex
+  /// round 13 finding 2, split per codex round 14 finding 2).
+  ///
+  /// Both places that replace the record ask this, and it is the same question
+  /// in both: the advance, which drops the record and installs `common` over
+  /// it, and [`Self::finalize`]'s `holdback_superseded` branch, which drops it
+  /// and installs the final hypothesis's own post-watermark words. Each
+  /// justifies itself by calling the replacement a REVISION of what it
+  /// replaces, and a decode whose window never reached a word produced no
+  /// revision of it — it produced nothing over its span at all, and the record
+  /// is then the only estimate that span will ever have.
+  ///
+  /// ONE VERDICT FOR THE WHOLE RECORD IS WRONG IN BOTH DIRECTIONS, which is why
+  /// this returns a boundary rather than a `bool`. Deciding it at the record's
+  /// first word alone lets a window that opens BETWEEN two held words confirm
+  /// the second one at the very moment a hypothesis that did re-read it says it
+  /// is something else — irrevocably, on the streaming face, with the stale
+  /// reading then emitted beside its own revision. That is the exact mirror of
+  /// round 13's defect, reached from the conservative side.
+  ///
+  /// The replaceable part is the longest SUFFIX every word of which
+  /// `ProvenancedResult::decoded` accepts, so this is `open_record_len()` minus
+  /// that suffix's length. A suffix rather than a per-word verdict because the
+  /// record is emitted as a prefix and word extents within a hypothesis are not
+  /// guaranteed monotone: an uncovered word anywhere pushes the boundary past
+  /// it, so a later word is never replaced out from behind a preserved one. That
+  /// is the erring-wide direction — a repetition at worst — and it is the same
+  /// direction, for the same reason, as the advance's own `position` split over
+  /// `common[requested..split]`.
+  ///
+  /// `0` when the record is empty, which is exactly "all of it is replaceable"
+  /// and harmlessly so: with nothing held and nothing pending there is nothing
+  /// to protect. `finalize` still has to spell that case out, because there
+  /// "replaceable" and "empty" have to reach the same branch — see the guard
+  /// there.
+  fn open_record_split(&self, hypothesis: &ProvenancedResult) -> usize {
+    self.open_record_len()
+      - self
+        .open_record()
+        .rev()
+        .take_while(|word| hypothesis.decoded(word))
+        .count()
+  }
+
+  /// Moves the record's first `keep` words — the part no window re-read — into
+  /// `confirmed`, and DROPS the rest, leaving both record buckets empty for the
+  /// caller to refill. The two replacement sites' shared tail.
+  ///
+  /// By field rather than through `&mut self` for the same reason
+  /// [`Self::watermark_filtered_with`] is: the advance calls it while `common`
+  /// still borrows `hypothesis_words`, and these three buckets are disjoint from
+  /// that one.
+  fn confirm_the_unread_prefix_and_drop_the_rest(
+    confirmed: &mut Vec<WordTiming>,
+    pending: &mut Vec<WordTiming>,
+    holdback: &mut Vec<WordTiming>,
+    keep: usize,
+  ) {
+    let from_pending = keep.min(pending.len());
+    confirmed.extend_from_slice(&pending[..from_pending]);
+    confirmed.extend_from_slice(&holdback[..keep - from_pending]);
+    pending.clear();
+    holdback.clear();
   }
 
   /// The agreement view of a result's words: everything at or past the
-  /// watermark, MINUS the already-confirmed words a tied start would
-  /// re-admit. The watermark is the first held-back word's start; a word
-  /// confirmed in the previous round can share that exact start (DTW row
-  /// steps without a column advance, then centisecond rounding — ties are
-  /// pipeline-reachable), and a bare timestamp filter would pull it back
-  /// in and confirm it AGAIN (phase-gate round-1 finding; Swift shares
-  /// the bug, and "confirmed once and stable" wins over parity here).
-  /// Confirmed words are time-ordered, so the re-admitted ones are
-  /// exactly the trailing run with `start >= watermark`, and they sit at
-  /// the front of the filtered list — skipping that count restores the
-  /// invariant on both sides of the prefix comparison.
+  /// watermark, MINUS the leading words that only re-offer words already
+  /// settled. The watermark is the first held-back word's start, and the
+  /// confirmed word in front of it is its immediate neighbour in one
+  /// hypothesis's word list, with no audio between them — so it can share that
+  /// exact start (DTW row steps without a column advance, then centisecond
+  /// rounding — ties are pipeline-reachable) or simply end on it, and a
+  /// re-decode can put it on either side of the cut. A bare timestamp filter
+  /// pulls it back in and confirms it AGAIN (phase-gate round-1 finding; Swift
+  /// shares the bug at `:372`/`:375`, and "confirmed once and stable" wins over
+  /// parity here).
   ///
-  /// **This rule is known-incomplete, and deliberately so.** It only catches a
-  /// reproduction the hypothesis puts at the very FRONT of its post-watermark
-  /// list: an insertion ahead of the reproduction, an omission of the confirmed
-  /// tail's head, or a re-decode that nudges the reproduction a hair past the
-  /// watermark all slide past it and confirm a settled word a second time. Four
-  /// adversarial-review rounds established that closing it needs occurrence
-  /// identity — which is NOT recoverable from the confirmed list, the offered
-  /// list and the watermark (two runs reach byte-identical triples and need
-  /// opposite answers) — so it is a design task, not a stronger predicate. The
-  /// counterexamples are executable rather than prose: the characterization
-  /// tests named in <https://github.com/findit-studio/coremlit/issues/94> carry
-  /// each one with its exact ingest sequence, the wrong answer it produces
-  /// today, and the correct one in the failure message.
-  fn watermark_filtered(&self, result: &TranscriptionResult) -> Vec<WordTiming> {
-    Self::watermark_filtered_with(result, self.last_agreed_seconds, &self.confirmed_words)
+  /// # The frontier is an alignment boundary, not a prefix match
+  ///
+  /// What the engine already knows about the span `[watermark, ..)` is
+  /// `settled ++ holdback`, in that order: `settled` is the trailing run of
+  /// [`Self::confirmed_words_slice`] whose extent REACHES the watermark — the
+  /// confirmed words a re-decode of that span could hand back — and `holdback` is
+  /// [`Self::last_agreed_words_slice`], still provisional, and the very text
+  /// [`Self::decoding_options_for_next`] prefills the next decode with. A fresh
+  /// hypothesis re-decodes that same span and continues past it, so the question
+  /// is not "does the offered list BEGIN with the confirmed tail" but "WHERE in
+  /// the offered list does the settled part stop and the still-open part start".
+  ///
+  /// `settled`'s scope is a SPAN question, and it is settled on the edge of each
+  /// word that faces the span: `offered` keeps a word whose start is at or past
+  /// the watermark, `settled` keeps a confirmed word whose END is. Testing
+  /// `start` on both sides — which this did until it was found to re-admit —
+  /// asks whether a confirmed word BEGINS inside the span, and every word that
+  /// straddles the boundary answers no while still being reachable from inside
+  /// it. See the scope comment in `watermark_filtered_with` for why the last
+  /// confirmed word straddles it on essentially every advance.
+  ///
+  /// This aligns the whole of `settled ++ holdback` against the offered list —
+  /// a longest-common-subsequence alignment over
+  /// [`normalized`](crate::audio::whisper::text::normalized) text, the same
+  /// equality [`find_longest_common_prefix`] agrees by — and reads the frontier
+  /// off where the alignment crosses the seam between the two halves. Insertions
+  /// and deletions on either side cost nothing beyond the matches they forgo, so
+  /// an insertion ahead of the reproduction, an omission of the confirmed tail's
+  /// head, a partial front match, and a re-decode that nudges every timestamp a
+  /// hair past the watermark all land on the same frontier as the clean case.
+  /// Deciding every position JOINTLY is also what makes "which occurrence is
+  /// this" a well-posed question at all: the two runs of the issue's
+  /// impossibility argument differ only in their HOLDBACK, and the holdback is
+  /// invisible to any rule that scans the offered list for one text match.
+  ///
+  /// # Ambiguity rule: two premises, two readings
+  ///
+  /// An LCS alignment is rarely unique, and the seam can fall at several columns
+  /// of the offered list. Which column is the frontier depends on something no
+  /// alignment can see — how the offered list was PRODUCED — so `prefilled`
+  /// carries the answer in, and [`Self::ingest`] does not assume it: it checks
+  /// the options the caller says the result was decoded under against the
+  /// retarget this engine would have issued (`Self::prefill_reproduces_holdback`).
+  ///
+  /// **With the premise established**, the frontier is the SMALLEST column any
+  /// optimal alignment puts the seam at — equivalently, the longest offered
+  /// prefix that *every* optimal alignment attributes to `settled`. Everything
+  /// the optimal alignments disagree about is attributed to the HOLDBACK.
+  ///
+  /// That direction is not a coin-flip dressed as a tie-break: it is the one the
+  /// engine itself forced. [`Self::decoding_options_for_next`] hands the next
+  /// decode `clip_timestamps = [watermark]` and `prefix_tokens =
+  /// holdback`, and a prefilled decode does not PREDICT its prefix, it is fed it
+  /// — `decode_text` overwrites the sampled token with the prompt token at every
+  /// prompt position, and the finalized `SOT..=EOT` token span keeps them. So a
+  /// hypothesis decoded from those options BEGINS with the holdback, and the
+  /// audio the settled words were recognized in is outside its window entirely.
+  /// When the seam is ambiguous because the offered head could be read either as
+  /// a settled word coming back or as the holdback's own first word, the second
+  /// reading is the one that matches how the list was produced — the first would
+  /// need the decoder to have DROPPED a token it was forced to emit. The
+  /// smallest optimal seam is exactly that reading, and it is why
+  /// `watermark_filtered` is the identity on every stride of
+  /// `jfk_simulated_stream_confirms_the_transcript`. Taking the LARGEST instead
+  /// would refuse the engine's own prefill.
+  ///
+  /// **Without it**, none of that argument is available: the engine wrote nothing
+  /// into this hypothesis, so a disputed head is UNATTRIBUTABLE. The frontier is
+  /// then the largest match-supported optimal seam — refuse every offered word
+  /// that *some* optimal alignment reads as a settled word coming back, because
+  /// [`Self::confirmed_words_slice`] is append-only and irrevocable and a second
+  /// confirmation cannot be taken back. That is a standing justification of its
+  /// own, not a bias: each policy is the reading its own premise supports, and
+  /// the two coincide wherever the optimal seam is unique. See
+  /// [`SettledSeams::unattributed`] for why the seam must be match-SUPPORTED
+  /// (the plain maximum refuses the whole hypothesis whenever `settled` matches
+  /// nothing) and for the proof that it is never smaller than the prefilled one.
+  ///
+  /// Kept also means OFFERED to the agreement comparison, not confirmed:
+  /// LocalAgreement-2 still needs a second hypothesis to corroborate a word
+  /// before it reaches [`Self::confirmed_words_slice`]. That is where "wait for
+  /// corroboration" lives on both paths.
+  ///
+  /// Refusing to ADVANCE on an ambiguous frontier — the other reading of "treat
+  /// an ambiguous boundary as disagreement", which trades liveness for safety on
+  /// purpose — would deadlock rather than stall, and would do it on the driver's
+  /// own steady state. The ambiguity is a function of `(settled, holdback,
+  /// offered)`; `settled` and `holdback` move only on an advance; and the
+  /// prefill makes the offered list BEGIN with the holdback on every stride
+  /// after one. So whenever a settled word's text matches the holdback's head — a
+  /// stutter at the watermark is exactly that — every stride reproduces the same
+  /// two optimal seams, the block re-arms itself, and the prefill it keeps
+  /// re-issuing is what re-creates it. Growing the offered list at the tail does
+  /// not clear it either: `before[j]` is unchanged for the disputed columns and
+  /// the extra words raise `after[j]` uniformly, so the tie survives every new
+  /// stride. The stall would be permanent in the literal sense, not eventual.
+  ///
+  /// **Blocking is not the right policy on the UNMARKED path either**, though the
+  /// argument above appeals to the prefill. Its load-bearing half does not: the
+  /// ambiguity persists under tail growth for reasons that are entirely a
+  /// property of the LCS scores, and a caller re-decoding a growing window off
+  /// unchanged audio reproduces the same head every stride whether or not it
+  /// prefills — a deterministic decoder does not need to be forced to repeat
+  /// itself. Blocking would then convert a bounded, visible cost (one repetition
+  /// of a settled word forgone) into an unbounded, silent one (the rest of the
+  /// stream never confirmed), and it would do it non-deterministically, which is
+  /// worse than doing it always. `a_recurring_ambiguity_would_never_clear_on_the_
+  /// unmarked_path` is that claim as a test, not an argument: it grows the offered
+  /// list stride after stride and shows both seams staying apart at every one.
+  ///
+  /// # What this deliberately leaves
+  ///
+  /// - **A repetition the engine's record cannot account for is read as the
+  ///   stream's own, not the decoder's.** When the offered list carries one more
+  ///   copy of a settled word than `settled ++ holdback` does, nothing the
+  ///   engine holds says whether the clip stuttered or the decode duplicated, so
+  ///   the extra copy is kept and can be confirmed a second time. That is the
+  ///   issue's two-run construction with the HOLDBACKS equal too, which the
+  ///   holdback therefore cannot separate. Pinned by
+  ///   `an_unaccounted_repeat_of_a_settled_word_is_kept_as_the_streams_own`.
+  /// - **Words offered AHEAD of a reproduced settled word are refused with
+  ///   it.** The settled word is already in the caller's hands and
+  ///   [`Self::confirmed_words_slice`] is append-only, so a word the hypothesis
+  ///   puts before a reproduction of it can go neither before it (the list is
+  ///   closed) nor after it (that would rewrite the confirmed prefix). Take the
+  ///   reproduction away and the choice disappears, which is why the two are
+  ///   pinned as a pair:
+  ///   `an_insertion_before_a_reproduced_confirmed_word_is_refused_with_it` and
+  ///   `an_insertion_that_reproduces_nothing_confirmed_keeps_its_word`.
+  /// - **Timestamps decide nothing beyond which words are in the span.** The
+  ///   alignment itself is over normalized TEXT only. Drawing a match window
+  ///   from the watermark instead was defeated by a reproduction shifted a hair
+  ///   past it (`a_reproduction_shifted_off_the_watermark_is_still_refused` is
+  ///   that sequence, now green), and a re-decode is free to move every
+  ///   timestamp it emits, so timings are evidence about the SPAN, not about
+  ///   occurrence identity within it. Both timestamp reads here are span reads:
+  ///   `offered`'s `start >= watermark` and `settled`'s `end >= watermark`.
+  /// - **A drift wider than the gap in front of the watermark still gets
+  ///   through.** `settled` reaches back through the confirmed words whose
+  ///   extent touches the watermark and stops at the first one that ends before
+  ///   it. A re-decode that moves such a word ACROSS the whole gap — past the
+  ///   silence or the intervening word that separated it from the span — offers
+  ///   it into a `settled` that does not hold it, and it can be confirmed a
+  ///   second time. No threshold closes this: widening the scope by a tolerance
+  ///   only moves the same cliff, and widening it to the whole confirmed list
+  ///   deletes a genuine later re-use instead
+  ///   (`a_confirmed_word_from_before_the_watermark_is_out_of_the_alignment` is
+  ///   that cost, and its gaps are load-bearing). What DOES close it is the
+  ///   contract above: under [`Self::decoding_options_for_next`] such a word is
+  ///   outside the clip window and behind the forced prefill, so no re-decode of
+  ///   the span can offer it at all. The residual is a result decoded some other
+  ///   way — which is exactly the path whose frontier is the unattributable
+  ///   reading, so the residual is a word offered from outside `settled`'s scope
+  ///   entirely, not a disputed seam.
+  /// - **Every word of `holdback` is one the prefill carries whole**, so this
+  ///   rule never reasons about text the decoder was not given.
+  ///   `budgeted_split` enforces BOTH of `prefill_tokens`'s reductions — the
+  ///   [`MAX_HOLDBACK_PREFILL_TOKENS`] trim and the `id < special_token_begin`
+  ///   filter, the latter against the vocabulary-independent floor
+  ///   [`MIN_SPECIAL_TOKEN_BEGIN`]
+  ///   — by CONFIRMING what it cannot hold rather than holding it. It was a
+  ///   residual until codex round 8, finding 1: `add_word_timestamps` really
+  ///   does strip those ids from everything this crate's pipeline emits, but
+  ///   [`Self::ingest`] is public and takes a hand-built
+  ///   [`TranscriptionResult`], so a caller could establish such a holdback,
+  ///   use [`Self::decoding_options_for_next`] honestly, and have the premise
+  ///   below recorded true for a hypothesis the decoder was given only part of.
+  ///
+  /// Issue <https://github.com/findit-studio/coremlit/issues/94> carries the
+  /// four defeated predecessors of this rule and the counterexample that killed
+  /// each; every one of them is a named test in this module's `tests`.
+  fn watermark_filtered(&self, hypothesis: &ProvenancedResult) -> Vec<WordTiming> {
+    Self::watermark_filtered_with(
+      hypothesis,
+      self.last_agreed_seconds,
+      &self.confirmed_words,
+      &self.pending_words,
+      &self.last_agreed_words,
+    )
   }
 
+  /// `hypothesis` carries its OWN premise (see [`ProvenancedResult`]) — there is
+  /// deliberately no separate `prefilled` parameter, so a result's frontier
+  /// cannot be read under another result's provenance.
+  ///
+  /// `pending` is the STILL-OPEN head of the holdback (see
+  /// [`Self::pending_words_slice`]) and joins the revisable half here rather
+  /// than the settled one. That is not a per-result reading: pending words leave
+  /// this state the instant a hypothesis arrives that cannot revise them (one
+  /// that arrives under this engine's own prefill promotes them into `confirmed`
+  /// before either list is filtered; one whose window never reached them is
+  /// handled at the advance, after both lists are filtered), so both sides of
+  /// the agreement comparison always see the same partition, and no premise from
+  /// one result can widen what another one settles.
   fn watermark_filtered_with(
-    result: &TranscriptionResult,
+    hypothesis: &ProvenancedResult,
     watermark: f32,
     confirmed: &[WordTiming],
+    pending: &[WordTiming],
+    holdback: &[WordTiming],
   ) -> Vec<WordTiming> {
-    // The confirmed tail that a tied start would re-admit, in order.
-    let tail_start = confirmed
-      .iter()
-      .rev()
-      .take_while(|word| word.start() >= watermark)
-      .count();
-    let readmit_candidates = &confirmed[confirmed.len() - tail_start..];
-    let filtered: Vec<WordTiming> = result
+    let offered: Vec<WordTiming> = hypothesis
+      .result()
       .all_words()
       .into_iter()
       .filter(|word| word.start() >= watermark)
       .collect();
-    // Strip only an ACTUALLY MATCHING prefix (normalized, the agreement's
-    // own equality — `find_longest_common_prefix` compares the same way):
-    // an unconditional count-skip dropped a PROVISIONAL word whenever a
-    // rewrite omitted a confirmed tied word and shifted everything left
-    // (phase-gate round-2 finding).
-    let strip = readmit_candidates
+    // The settled words that REACH the re-decoded span, and so could come back
+    // out of it: confirmed words are time-ordered, so those are the trailing run
+    // whose extent touches the watermark. Note the endpoint -- `end`, not
+    // `start`. Each list is tested against the watermark on the edge that FACES
+    // the span: `offered` above keeps a word whose LEADING edge is at or past it,
+    // and this keeps a confirmed word whose TRAILING edge is. A word is in the
+    // span when any part of it is, and testing `start` here asked instead
+    // whether the word BEGINS inside the span -- which is false for every word
+    // that straddles the boundary, and the last confirmed word straddles it on
+    // essentially every advance: DTW word timings abut (in
+    // `jfk_tiny_words_golden.json`, 20 of 21 consecutive pairs share an instant
+    // exactly), so `confirmed.last().end() == holdback[0].start() ==
+    // watermark`. Under `start` that word was in scope only in the degenerate
+    // tie where it also had a zero-length overlap with the holdback, and a
+    // re-decode that nudged it a hundredth of a second past the watermark
+    // re-offered it into an EMPTY settled set -- confirming it a second time
+    // (`a_word_whose_extent_reaches_the_watermark_is_in_the_alignment`).
+    // `end >= watermark` is a strict widening (`end >= start`), so the scope can
+    // only ever grow against the old rule, never shrink.
+    //
+    // A confirmed word that ends BEFORE the watermark is still out of the
+    // alignment: another word's audio, or silence, lies between it and the span,
+    // and letting it match a genuinely later re-use of the same text is how a
+    // scan-based rule eats the provisional words in front of it
+    // (`a_confirmed_word_from_before_the_watermark_is_out_of_the_alignment`,
+    // whose gaps are load-bearing for exactly this reason). That leaves a
+    // residual, stated in `watermark_filtered`'s doc: a re-decode free to move
+    // every timestamp it emits can move one further than that gap.
+    let settled_len = confirmed
       .iter()
-      .zip(&filtered)
-      .take_while(|(confirmed_word, candidate)| {
-        crate::audio::whisper::text::normalized(confirmed_word.word())
-          == crate::audio::whisper::text::normalized(candidate.word())
-      })
+      .rev()
+      .take_while(|word| word.end() >= watermark)
       .count();
-    filtered[strip..].to_vec()
+    if settled_len == 0 {
+      // No confirmed word's extent reaches this span, so nothing offered can be
+      // a re-admission of one. The alignment agrees (an empty `settled` scores
+      // zero against every prefix, so every seam is optimal and the smallest --
+      // and the smallest match-supported -- is 0); this is the fast path,
+      // not a special case. It is a no-op GIVEN the scope above is right --
+      // which is the load it carries, and why the endpoint it tests is
+      // pinned by a test rather than left to the reader.
+      return offered;
+    }
+    // `pending ++ holdback` is the engine's whole still-open record of the span:
+    // the head the prefill could not carry, then the part it did. Both halves
+    // are revisable, so both belong to `after` -- putting `pending` in `before`
+    // instead would refuse an offered head that re-covers it, which is the right
+    // treatment for a CONFIRMED word and the wrong one for a word that is not
+    // confirmed yet.
+    let revisable: Vec<WordTiming> = pending.iter().chain(holdback).cloned().collect();
+    let seams = settled_seams(
+      &confirmed[confirmed.len() - settled_len..],
+      &revisable,
+      &offered,
+    );
+    let frontier = if hypothesis.prefilled() {
+      seams.prefilled
+    } else {
+      seams.unattributed
+    };
+    offered[frontier..].to_vec()
   }
 
   /// Folds one freshly-decoded `result` into the engine. Ports
@@ -421,7 +1438,32 @@ impl LocalAgreement {
   /// Either way — agreeing, disagreeing, or no previous result — `result`
   /// becomes the new previous result for the next call (`:402`, outside
   /// the agreement `if`/`else` but still inside the has-words branch).
-  pub fn ingest(&mut self, result: TranscriptionResult) -> AgreementOutcome {
+  pub fn ingest(
+    &mut self,
+    result: TranscriptionResult,
+    decoded_under: &DecodingOptions,
+  ) -> AgreementOutcome {
+    // PROVENANCE IS BOUND HERE, ONCE, BEFORE ANY STATE MOVES -- `decoded_under`
+    // is checked against the watermark and holdback the caller decoded with,
+    // which are still the current ones at this point, and the answer then
+    // travels WITH the result for as long as the engine keeps it.
+    //
+    // Each of the two filtered views below reads its own result's premise, and
+    // there is no way for it to read the other's: `watermark_filtered_with`
+    // takes the PAIR. Deriving one flag here and reusing it for `prev_result`
+    // was round 7's finding 1 -- the previous result is stored RAW and
+    // re-filtered on every later call, so reusing this call's premise gives an
+    // unmarked result the marked frontier one call later, undoing its refusal
+    // with no caller lying. The old justification for sharing the flag ("a
+    // `prev_words` filtered more permissively can only make the two agree on
+    // FEWER words") had the direction backwards: `find_longest_common_prefix`
+    // returns elements of its SECOND argument, but its LENGTH is set by both,
+    // and a permissively-filtered `prev_words` keeps a leading word the
+    // conservative one dropped -- so the prefix gets LONGER, and length is what
+    // decides whether the watermark advances and how much reaches the
+    // append-only `confirmed_words`.
+    let hypothesis = ProvenancedResult::arriving(result, self, decoded_under);
+
     // Accumulate THIS hypothesis's reproducibility facts BEFORE any gate or
     // branch, so a hypothesis dropped from `results` on disagreement (:395-400,
     // `skipAppend`) still contributes them to `finalize` (codex round 8, F1). It
@@ -439,7 +1481,8 @@ impl LocalAgreement {
     // ordinals; `finalize` overwrites it with the merged surviving result's own
     // span, the authoritative id-ordinal count.
     self.ingested_facts.merge(
-      &result
+      &hypothesis
+        .result()
         .task_facts()
         .clone()
         .with_worker_schedule(None)
@@ -448,34 +1491,181 @@ impl LocalAgreement {
 
     // :371 gate — see this module's doc for "any segment" vs. Swift's
     // first-segment-only nil check.
-    let has_words = result
+    let has_words = hypothesis
+      .result()
       .segments_slice()
       .iter()
       .any(|segment| !segment.words_slice().is_empty());
     if !has_words {
-      self.results.push(result);
+      self.results.push(hypothesis.into_result());
       return AgreementOutcome::NoWordTimings;
     }
 
+    // THE PENDING WORDS' DESTINATION, decided here because here is the first
+    // moment the provenance that decides it exists (codex round 12, finding 1).
+    // `budgeted_split` widened past them at the last advance so the retarget
+    // could be coherent, and round 8's argument for confirming them on the spot
+    // -- neither corroborable nor revisable, being behind both the clip and the
+    // prefill -- is an argument about the hypothesis that comes NEXT, which the
+    // advance had not seen. THIS hypothesis's own premise is that argument's
+    // missing clause: a result written to begin with the whole holdback cannot
+    // put anything in front of that reproduction, and every pending word is in
+    // front of it, so such a result can neither corroborate nor revise one and
+    // they settle here. A result decoded any other way saw their audio and could,
+    // so they stay where they are.
+    //
+    // The premise is never the VACUOUS one: `prefill_reproduces_holdback`
+    // answers TRUE for anything when the holdback is empty, and the advance below
+    // leaves nothing pending in that state precisely so this consumer can never
+    // read it (see the anchor argument there). `pending_words` non-empty implies
+    // `last_agreed_words` non-empty, because only an advance sets either and an
+    // advance sets both together.
+    //
+    // Before the `has_words` gate this would also fire for a wordless result,
+    // which the gate above documents as leaving every agreement bookkeeping
+    // field untouched. Deferring past one costs nothing -- the next worded
+    // hypothesis makes the same call -- so the gate keeps its meaning.
+    if hypothesis.prefilled() {
+      self.confirmed_words.append(&mut self.pending_words);
+    }
+
+    // THE OTHER FACT `decoded_under` CARRIES, read here because here is where
+    // the state it is read against stops moving for this call (codex round 13,
+    // finding 2). The promotion above is the last thing to touch
+    // `pending_words` before the advance, and nothing below touches
+    // `last_agreed_words` until the advance replaces it -- so this is the record
+    // whose span the advance would drop, and the boundary computed now is the
+    // boundary at the moment it drops it.
+    let open_record_split = self.open_record_split(&hypothesis);
+
     // :372 — plus the readmit skip (see `watermark_filtered`).
-    self.hypothesis_words = self.watermark_filtered(&result);
+    self.hypothesis_words = self.watermark_filtered(&hypothesis);
 
     let mut advanced = false;
     let mut skip_append = false;
     // :374 — absent on the first-ever call, so nothing below runs and
     // this falls through to the `AwaitingAgreement` append below.
-    if let Some(prev_result) = &self.prev_result {
-      // :375-376 — the SAME filter as the hypothesis, so the two sides
-      // stay index-aligned for the prefix comparison.
-      self.prev_words =
-        Self::watermark_filtered_with(prev_result, self.last_agreed_seconds, &self.confirmed_words);
+    if let Some(previous) = &self.prev_result {
+      // :375-376 — the same filter as the hypothesis, against the CURRENT
+      // watermark, so the two sides stay index-aligned for the prefix
+      // comparison. Under its OWN premise, though: `previous` carries the
+      // provenance it arrived with, and this call cannot supply another.
+      self.prev_words = Self::watermark_filtered_with(
+        previous,
+        self.last_agreed_seconds,
+        &self.confirmed_words,
+        &self.pending_words,
+        &self.last_agreed_words,
+      );
       let common = find_longest_common_prefix(&self.prev_words, &self.hypothesis_words);
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
-        let split = common.len() - self.agreement_count_needed;
-        self.confirmed_words.extend_from_slice(&common[..split]);
+        let requested = common.len() - self.agreement_count_needed;
+        let split = budgeted_split(common, requested, self.special_token_begin);
+        // The still-open record is REPLACED here -- `pending_words` dropped and
+        // `last_agreed_words` overwritten -- because `common` is the span two
+        // hypotheses have just re-agreed over it. That is a claim about this
+        // hypothesis's WINDOW, and it used to be assumed: whatever was still
+        // pending had not been settled by the promotion above, from which the
+        // code concluded "so this hypothesis saw its audio". An unmarked result
+        // may legitimately clip LATER than the watermark, or skip the span
+        // between two clips of its schedule entirely, and then it saw none of
+        // it (codex round 13, finding 2; codex round 14, finding 1).
+        //
+        // What it could not re-read, it cannot revise, so THAT PART of the
+        // record is CONFIRMED instead of dropped -- the same claim every other
+        // confirmed word carries (two consecutive hypotheses agreed on it, and
+        // nothing that could see its audio has contradicted it), and the only
+        // alternative to deleting it: the watermark moves past these words on
+        // the very next line, so no future result can ever be offered over
+        // their span and holding them would be an indefinite wait ending in the
+        // deletion round 7 finding 2 removed. Time-ordered, too: they start at
+        // or before the old watermark and every word of `common` starts at or
+        // past it.
+        //
+        // The rest -- the suffix this hypothesis re-read -- is dropped, because
+        // `common` IS its revision and confirming it would make the superseded
+        // reading irrevocable beside its replacement (codex round 14, finding
+        // 2).
+        //
+        // On the promoted path the drain already emptied `pending_words`, and
+        // on every marked stride the retarget's own window begins exactly at
+        // the watermark and runs unbounded from there, so the whole record is
+        // inside it, `open_record_split` is 0, and this is the unchanged
+        // replacement.
+        Self::confirm_the_unread_prefix_and_drop_the_rest(
+          &mut self.confirmed_words,
+          &mut self.pending_words,
+          &mut self.last_agreed_words,
+          open_record_split,
+        );
         self.last_agreed_words = common[split..].to_vec();
-        self.last_agreed_seconds = self.last_agreed_words[0].start();
+        // The watermark is the first held-back word's start -- except when the
+        // budget could hold NOTHING (see `budgeted_split`), where the still-open
+        // span begins where the confirmed one ends. `common` is non-empty here
+        // (its length is at least `agreement_count_needed`, clamped to at least
+        // one), so the final fallback is unreachable and only keeps this total.
+        // Monotone either way: every word of `common` starts at or past the old
+        // watermark, and `end >= start`.
+        self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
+          || {
+            common
+              .last()
+              .map_or(self.last_agreed_seconds, WordTiming::end)
+          },
+          WordTiming::start,
+        );
+        // `common[requested..split]` is what the split had to widen past, and it
+        // splits ONE more time -- on whether anything could still speak to the
+        // word (codex round 12, finding 1). Two ways the answer is no, and a
+        // word that gets either is settled here and now on round 8's own
+        // argument rather than deferred:
+        //
+        // - **Nothing can overlap it.** Every word the engine will ever be
+        //   offered again is filtered to `start >= watermark`, so a word whose
+        //   extent ENDS at or before the watermark shares no instant with any of
+        //   them. Note the STRICT `>`, against the non-strict `end >= watermark`
+        //   `watermark_filtered_with` scopes `settled` by: the two answer
+        //   different questions and err in opposite directions on the abutting
+        //   word. There, erring wide costs one repetition of a settled word and
+        //   erring narrow confirms it twice; here, erring wide DELETES a word the
+        //   stream produced and nothing revised. Interval overlap is the exact
+        //   notion this one needs, and `[p.start, p.end)` overlaps
+        //   `[watermark, ..)` exactly when `p.end > watermark`.
+        // - **Nothing could ever clear it.** A pending word waits for a
+        //   hypothesis that provably cannot revise it, and the only such
+        //   hypothesis is one this engine ANCHORED -- prefilled with a holdback
+        //   that occupies the span in front of the word, so nothing it produces
+        //   can precede that reproduction. With the holdback EMPTY there is no
+        //   anchor and no future result can ever supply one, so waiting is not
+        //   deferral but an indefinite hold, ending in exactly the deletion round
+        //   7 finding 2 removed. Confirming instead is what that finding
+        //   requires, and this is where it keeps requiring it.
+        //
+        // Together they also keep this module's one cross-call invariant:
+        // `pending_words` non-empty implies `last_agreed_words` non-empty, which
+        // is what stops the promotion above from ever reading the vacuous
+        // premise.
+        //
+        // `position`, so what is confirmed is a PREFIX: word ends within a
+        // hypothesis are not guaranteed monotone, and a later short word must
+        // not be confirmed out from behind an overlapping earlier one.
+        let widened = &common[requested..split];
+        let overlapping = if self.last_agreed_words.is_empty() {
+          widened.len()
+        } else {
+          widened
+            .iter()
+            .position(|word| word.end() > self.last_agreed_seconds)
+            .unwrap_or(widened.len())
+        };
+        self.confirmed_words.extend_from_slice(&common[..requested]);
+        self
+          .confirmed_words
+          .extend_from_slice(&widened[..overlapping]);
+        self
+          .pending_words
+          .extend_from_slice(&widened[overlapping..]);
         advanced = true;
       } else {
         // :395-400 — disagreement; `result` is dropped below.
@@ -491,12 +1681,13 @@ impl LocalAgreement {
     // nothing can have been superseded.
     self.holdback_superseded = skip_append;
 
-    // :402 (unconditional) + :408-410 (`!skipAppend`).
+    // :402 (unconditional) + :408-410 (`!skipAppend`). The premise goes into
+    // `prev_result` with the result, never re-derived when it is read back.
     if skip_append {
-      self.prev_result = Some(result);
+      self.prev_result = Some(hypothesis);
     } else {
-      self.prev_result = Some(result.clone());
-      self.results.push(result);
+      self.results.push(hypothesis.result().clone());
+      self.prev_result = Some(hypothesis);
     }
 
     if advanced {
@@ -513,8 +1704,11 @@ impl LocalAgreement {
   /// ([`crate::audio::whisper::text::find_longest_different_suffix`] over the last
   /// ingested pair), both folded onto [`Self::confirmed_words_slice`] —
   /// **except when the final hypothesis DISAGREED**, where this port emits that
-  /// hypothesis's own post-watermark words instead of the superseded holdback
-  /// (see this module's doc, "The final hypothesis's holdback");
+  /// hypothesis's own post-watermark words instead — behind whatever part of the
+  /// record its own decode window never reached, which it does not supersede and
+  /// which is emitted ahead of them (see this module's doc, "The final
+  /// hypothesis's holdback", and "A result only replaces the PART of the span
+  /// its own window DECODED" for the window clause);
   /// [`merge_transcription_results_with_words`] then merges every kept
   /// [`Self::results_slice`] result with that word list as the merged
   /// text, under `options` — the same options the kept results were decoded
@@ -535,6 +1729,29 @@ impl LocalAgreement {
   /// the ingest strip carries only the wholly-unknown span, so the fold cannot
   /// supply the exact count, round 12); see [`Self::ingest`].
   pub fn finalize(mut self, options: &DecodingOptions) -> TranscriptionResult {
+    // The third conjunct is `ProvenancedResult::decoded` read off the FINAL
+    // hypothesis -- which is what `prev_result` holds here, since `ingest` sets
+    // it on every worded path and the wordless gate returns before it (codex
+    // round 13, finding 2). `holdback_superseded` is only ever set inside `if
+    // let Some(previous) = &self.prev_result`, so the `None` arm is unreachable
+    // while the branch below is live and is `0` only to keep this total.
+    let open_record_split = match self.prev_result.as_ref() {
+      Some(previous) => self.open_record_split(previous),
+      None => 0,
+    };
+    // AND NOTHING MORE. Round 13 made "this hypothesis re-read the record" a
+    // third conjunct here; the SPLIT above subsumes it, because a record nothing
+    // re-read gets `open_record_split == len` and is kept WHOLE by the branch
+    // itself. What a surviving conjunct would still decide is the tail --
+    // `hypothesis_words` here against `find_longest_different_suffix`'s
+    // remainder below -- and that subtraction is only sound when
+    // `last_agreed_words` holds the prefix it subtracts. On this path it does
+    // not: the record is the OLD holdback, unrelated to whatever prefix the last
+    // two hypotheses happen to share, so the conjunct's false arm dropped words
+    // both of them produced and nothing put back --
+    // `a_disagreeing_final_pair_keeps_the_words_both_hypotheses_agreed_on`'s
+    // defect with a non-empty holdback (codex round 14; the conjunct redded no
+    // test, and every shape that made it observable made it wrong).
     if self.holdback_superseded && !self.hypothesis_words.is_empty() {
       // DIVERGENCE from `:418-419` — see this module's doc for the full
       // argument. Swift's `lastAgreedWords + differentSuffix(prevWords,
@@ -552,9 +1769,46 @@ impl LocalAgreement {
       // disagrees, but it re-covers nothing, so there is no revision to prefer
       // and the provisional holdback remains the only estimate for that span.
       // That case stays on the Swift shape below, byte-identical.
+      //
+      // COVERAGE is the same argument reached from the other end (codex round
+      // 13, finding 2), and it is spent HERE rather than on the branch
+      // condition. "Already re-covers that exact span" is a claim about the
+      // final hypothesis's decode WINDOW, and it was assumed of every unmarked
+      // result rather than checked. A result whose clip schedule never reaches
+      // the holdback shares no instant with it: its words are not a revision of
+      // anything held, so dropping the record for them deletes words the stream
+      // agreed on and nothing contradicted. `open_record_split` is `len` for
+      // such a result, so the call below keeps the record WHOLE and only the
+      // hypothesis's own words follow it.
+      //
+      // And it is a BOUNDARY, not a verdict on the whole record (codex round 14,
+      // finding 2). A window that opens between two held words re-read only the
+      // second, so only the second is superseded; the first is kept, ahead of
+      // the revision, exactly where it sits in time. Reading the record's head
+      // alone got both halves wrong at once -- it emitted the re-read word
+      // beside its own revision, and it did so on the strength of a word the
+      // hypothesis never saw.
+      //
+      // `pending_words` is dropped with the part of the holdback it heads, and
+      // for the same reason: `hypothesis_words` re-covers that span carrying the
+      // revision, and emitting both would strand the superseded reading beside
+      // its replacement — the very defect this branch exists to prevent, reached
+      // one word earlier (codex round 12, finding 1). It is empty on every
+      // marked stream: a hypothesis that clips at the watermark settles the
+      // pending words on arrival, so only a hypothesis that could actually see
+      // their audio ever gets to supersede them.
+      Self::confirm_the_unread_prefix_and_drop_the_rest(
+        &mut self.confirmed_words,
+        &mut self.pending_words,
+        &mut self.last_agreed_words,
+        open_record_split,
+      );
       self.confirmed_words.append(&mut self.hypothesis_words);
     } else {
-      // `:418-419` verbatim.
+      // `:418-419` verbatim, with `pending_words` ahead of the holdback because
+      // that is where they sit in time. Nothing superseded them, so they are
+      // still the only estimate for their span.
+      self.confirmed_words.append(&mut self.pending_words);
       self.confirmed_words.append(&mut self.last_agreed_words);
       let suffix = find_longest_different_suffix(&self.prev_words, &self.hypothesis_words);
       self.confirmed_words.extend_from_slice(suffix);
@@ -584,6 +1838,319 @@ impl LocalAgreement {
     *merged.task_facts_mut() = facts.with_decoded_span(merged_span);
     merged
   }
+}
+
+// ---------------------------------------------------------------------
+// The settled/holdback frontier
+// ---------------------------------------------------------------------
+
+/// Where an advance splits `common` into the part that is CONFIRMED and the
+/// part that is HELD BACK, given the requested split — moved later until every
+/// word still held is one [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens)
+/// carries into the initial prompt WHOLE.
+///
+/// The holdback is not merely "the last few agreed words": it is the text
+/// [`LocalAgreement::decoding_options_for_next`] forces into the next
+/// hypothesis, and `prefill_tokens` reduces `prefix_tokens` on its way there in
+/// two independent ways — it keeps only the last [`MAX_HOLDBACK_PREFILL_TOKENS`]
+/// ids, and it drops every id at or above the vocabulary's
+/// `special_token_begin`. A holdback the decoder cannot be given whole is not a
+/// holdback at all — the words the filter erases would be neither reproduced
+/// (the decoder never sees their tokens) nor confirmed (an advance replaces the
+/// holdback with the new `common[split..]`), so they would simply vanish from
+/// the transcript.
+///
+/// **Both filters are enforced here, and the id one is enforced against
+/// `special_token_begin`** (codex round 8, finding 1) — the deciding
+/// vocabulary's own threshold, which
+/// [`LocalAgreement::special_token_begin`] carries and
+/// [`LocalAgreementTranscriber::new`] reads off the pipeline's loaded tokenizer.
+/// A word with no tokens at all fails the same test for a different reason: it
+/// contributes nothing to `prefix_tokens`, so the decoder is never given it
+/// either, and no threshold is needed to see that.
+///
+/// The engine holds no tokenizer of its own, so with nothing supplied that value
+/// is [`MIN_SPECIAL_TOKEN_BEGIN`] — a BOUND rather than the threshold, which is
+/// what a hermetic engine can hold and which errs in the only safe direction.
+/// The bound is not self-enforcing (codex round 12, finding 2):
+/// [`crate::audio::whisper::tokenizer::WhisperTokenizer::from_folder`] accepts
+/// any parseable `tokenizer.json` and probes `<|endoftext|>` for its threshold,
+/// so an artifact below the floor turns the bound into an over-estimate and
+/// walks straight back into round 8's defect — a word held on the strength of a
+/// filter that will erase it. Rejecting such an artifact at load would fix it by
+/// refusing a vocabulary this crate otherwise decodes correctly, for a premise
+/// only this module has a stake in; supplying the real value fixes it where the
+/// value is known and costs nothing where it is not. See
+/// [`LocalAgreement::special_token_begin`].
+///
+/// That this engine could not evaluate the id filter used to be recorded as a
+/// residual, on the evidence that `add_word_timestamps` strips exactly those ids
+/// from every [`WordTiming`] it emits (and emits no word at all for an
+/// all-special alignment entry). The evidence is correct and the pipeline really
+/// is clean. What it does not cover is [`LocalAgreement::ingest`] itself, which
+/// is public and takes a hand-built [`TranscriptionResult`] — the very call
+/// shape `decoded_under` exists to make safe. Such a caller can hold back a word
+/// carrying filtered ids, honestly pass the options
+/// [`LocalAgreement::decoding_options_for_next`] just issued, and have
+/// `ProvenancedResult` record `prefilled = true` for a hypothesis the decoder
+/// was fed only PART of the holdback for — the one premise
+/// `LocalAgreement::watermark_filtered`'s ambiguity rule rests on.
+///
+/// Widening the split instead takes that head OUT of the holdback. It is not a
+/// weaker claim than any other agreed word carries: `common` is the prefix two
+/// consecutive hypotheses agreed on, which is the whole of LocalAgreement-2's
+/// criterion, and [`LocalAgreement::finalize`] already appends the entire
+/// holdback to [`LocalAgreement::confirmed_words_slice`] unconditionally on its
+/// Swift-shaped path. What the holdback buys on top of that is one more round in
+/// which a third hypothesis could revise it — and a word the prefill cannot
+/// carry cannot be revised by one *that was decoded from the prefill*, because
+/// whatever such a hypothesis produces over that extent came from a DIFFERENT
+/// prefix and from audio the clip excludes, and is therefore neither a
+/// corroboration of the held word nor a revision of it.
+///
+/// **That qualifier is the whole of codex round 12, finding 1.** The argument
+/// above is about the hypothesis that comes NEXT, and the split runs before it
+/// exists. A caller who does not use
+/// [`LocalAgreement::decoding_options_for_next`] is subject to neither reduction
+/// — its decoder never sees a truncated prefix and its window is its own — so
+/// for it the held word is revisable after all, and confirming here would strand
+/// the stale reading beside the revision. So the split still widens (the
+/// retarget it produces is the only coherent one either way: a word the prefill
+/// cannot re-offer must not be the thing the next hypothesis is asked to
+/// reproduce), but the widened-past words land in
+/// [`LocalAgreement::pending_words_slice`] rather than in the append-only
+/// confirmed list, and [`LocalAgreement::ingest`] settles them the moment a
+/// hypothesis arrives that the engine itself anchored. Deferring the
+/// DESTINATION is available; deferring the SPLIT is not.
+///
+/// Widening is also the only one of the two repairs that repairs anything.
+/// REFUSING the marked reading for such a holdback — reading the unattributable
+/// frontier instead — leaves the unreproducible word in the holdback, where the
+/// next unanchored hypothesis disagrees with it and
+/// [`LocalAgreement::finalize`]'s `holdback_superseded` path deletes it: the
+/// same data loss round 7's finding 2 established for the budget, reached by the
+/// same route. On the frontier itself the refusal is not even conservative — it
+/// cuts the offered head as well, so the word the engine dropped AND the word it
+/// refused both leave the transcript
+/// (`a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held`
+/// carries the arithmetic). Neither seam is the repair, because the defect is
+/// the STATE, not the reading of it. The pending bucket does not reopen that
+/// choice: the seam a pending word is read under is still the one its own
+/// premise supports, and a marked continuation still finds the word out of the
+/// holdback and out of its way.
+///
+/// The split runs all the way to `common.len()` when it has to, so the holdback
+/// this leaves can be EMPTY. It has to (codex round 7, finding 2): stopping while
+/// one word remained still held a single word whose OWN tokens exceed the budget,
+/// and the cap silently did not cap. Refusing the prefill READING for it, which
+/// is what used to catch that residual, is the wrong instrument — the unmarked
+/// frontier is the right answer for a hypothesis the engine did not write, and it
+/// cannot put back a token the engine itself dropped. What followed was data
+/// loss, not a stall: the next hypothesis came back with the truncated word
+/// rather than the held one, disagreed, and
+/// [`LocalAgreement::finalize`]'s `holdback_superseded` path replaced the intact
+/// held word with that truncation. Made impossible here rather than refused
+/// downstream, because a refusal on a public, infallible `ingest` has no path to
+/// report on, and this needs none: taking the word out of the holdback is always
+/// available and is exactly the argument above.
+///
+/// Where the holdback comes back empty, [`LocalAgreement::ingest`] anchors the
+/// watermark at the last confirmed word's END rather than the first held word's
+/// start — see the anchor at its advance branch.
+/// [`LocalAgreement::agreement_count_needed`] is then a maximum that reached
+/// zero for that round, the same way it becomes a maximum for any holdback the
+/// budget shortens.
+///
+/// **Documented deviation**: with `agreement_count_needed` at its
+/// [`DEFAULT_AGREEMENT_COUNT_NEEDED`] — the only value
+/// [`LocalAgreementTranscriber`] can reach, since it exposes
+/// [`LocalAgreementTranscriber::agreement`] by shared reference only — a
+/// two-word holdback is nowhere near 112 tokens and this is the identity. It
+/// bites only for a direct caller that raised
+/// [`LocalAgreement::agreement_count_needed`] far enough, and for that caller
+/// the count becomes a maximum rather than an exact width.
+fn budgeted_split(common: &[WordTiming], requested: usize, special_token_begin: u32) -> usize {
+  // THE ID FILTER FIRST, as a floor. `prefill_tokens` drops ids at or above the
+  // vocabulary's `special_token_begin` and contributes nothing at all for a word
+  // with no tokens, so a holdback containing either is one the decoder is not
+  // given whole -- and the split has to clear the LAST such word, not the first,
+  // since the holdback is `common[split..]` and only a split past a word removes
+  // it. Widening past it can never re-introduce one, so this floor and the
+  // budget loop below compose in one direction: the loop only ever moves `split`
+  // further right.
+  let mut split = common[requested..]
+    .iter()
+    .rposition(|word| !prefill_carries_whole(word, special_token_begin))
+    .map_or(requested, |last| requested + last + 1);
+  let mut tokens: usize = common[split..]
+    .iter()
+    .map(|word| word.tokens_slice().len())
+    .sum();
+  // `split < common.len()`, not `split + 1 < common.len()`: stopping while one
+  // word was still held is what let a single oversized word through (codex round
+  // 7, finding 2). The empty holdback costs zero tokens, so this loop's
+  // postcondition -- `tokens <= MAX_HOLDBACK_PREFILL_TOKENS` -- now holds for
+  // every input rather than for every input but one.
+  while tokens > MAX_HOLDBACK_PREFILL_TOKENS && split < common.len() {
+    tokens -= common[split].tokens_slice().len();
+    split += 1;
+  }
+  split
+}
+
+/// Whether [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens)
+/// carries this word's tokens into the initial prompt WHOLE — the property every
+/// held-back word has to have for `LocalAgreement::prefill_reproduces_holdback`'s
+/// equality to mean what it says.
+///
+/// Two ways to fail, and the empty one needs no vocabulary knowledge at all: a
+/// word with NO tokens contributes nothing to `prefix_tokens`, so a prefix equal
+/// to the holdback is equal to a sequence that never mentions it. The other is
+/// the id filter, tested against `special_token_begin` — the deciding
+/// vocabulary's own threshold where the engine was told it
+/// ([`LocalAgreement::special_token_begin`]), and otherwise the floor
+/// [`MIN_SPECIAL_TOKEN_BEGIN`]; see `budgeted_split` for why over-estimating the
+/// special range is the safe direction.
+fn prefill_carries_whole(word: &WordTiming, special_token_begin: u32) -> bool {
+  let tokens = word.tokens_slice();
+  !tokens.is_empty() && tokens.iter().all(|&id| id < special_token_begin)
+}
+
+/// The two frontiers an optimal alignment of `settled ++ holdback` against
+/// `offered` admits: where `offered` stops re-covering `settled` and starts
+/// re-covering `holdback`, read once under each of the two premises
+/// [`LocalAgreement::ingest`] can be in. See `LocalAgreement::watermark_filtered`
+/// for what a frontier means and for the standing justification of each.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SettledSeams {
+  /// The number of leading `offered` words EVERY optimal alignment attributes
+  /// to `settled` — the smallest optimal seam. Everything the optimal
+  /// alignments disagree about goes to the HOLDBACK, which is the reading a
+  /// verified prefill forces: the engine WROTE the holdback into this
+  /// hypothesis, so a disputed head is the holdback's own reproduction.
+  prefilled: usize,
+  /// The number of leading `offered` words SOME optimal alignment attributes to
+  /// `settled`, counting only seams a settled MATCH actually supports — the
+  /// largest such optimal seam. This is the reading with no prefill to appeal
+  /// to: a disputed head is unattributable, and confirmation is append-only, so
+  /// it must not become a second confirmation of a word already handed to the
+  /// caller.
+  ///
+  /// The match-supported restriction (`before[j] > before[j - 1]`) is what keeps
+  /// this from degenerating. Take the plain maximum and a `settled` that matches
+  /// NOTHING makes every seam optimal at score zero, so the maximum is
+  /// `offered.len()` and the whole hypothesis is refused — a permanent stall
+  /// dressed as caution. Requiring the word immediately before the seam to be
+  /// matched to a settled word excludes exactly that padding, and the
+  /// restriction never empties the set: if `j` is optimal and
+  /// `before[j] == before[j - 1]` then `j - 1` is optimal too (`after` is
+  /// non-increasing, so `score(j - 1) >= score(j)`), so every optimal seam walks
+  /// down to a supported one — [`Self::prefilled`] itself is supported, being
+  /// the smallest. Hence `unattributed >= prefilled` always.
+  ///
+  /// With an EMPTY holdback the two are equal, which is what lets
+  /// [`LocalAgreement::prefill_reproduces_holdback`] answer such a state
+  /// vacuously: `after` is then identically zero, so `score(j)` is the
+  /// non-decreasing `before[j]`, and every column past the smallest optimal one
+  /// has `before[j] == before[j - 1]` and so is unsupported
+  /// (`with_nothing_held_back_both_frontiers_are_the_same_column`).
+  unattributed: usize,
+}
+
+/// Both seams of [`SettledSeams`], from one pair of LCS reads. See
+/// `LocalAgreement::watermark_filtered` for what the frontier means and why the
+/// tie breaks toward the HOLDBACK under a verified prefill — which is not a
+/// preference but the reading that matches how the offered list was produced,
+/// the engine having prefilled the decoder with that holdback itself.
+///
+/// The alignment is a longest-common-subsequence one over
+/// [`normalized`](crate::audio::whisper::text::normalized) text — the same
+/// equality [`find_longest_common_prefix`] agrees by. Insertion and deletion are
+/// the only edits (there is no "substitution": a revised word is a deletion and
+/// an insertion, and this equality admits no partial similarity to price one
+/// against the other), so minimizing edits is exactly maximizing matches and the
+/// whole rule reduces to two LCS reads:
+///
+/// - `before[j] == LCS(settled, offered[..j])` — how much of the settled half
+///   an alignment can still account for if the frontier is put at `j`;
+/// - `after[j] == LCS(holdback, offered[j..])` — the same for the holdback.
+///   Both come from one prefix DP: the second runs it over the two sequences
+///   REVERSED, which turns a suffix read into a prefix read.
+///
+/// Every alignment splits at the seam into one of each, and every such pair
+/// composes back into an alignment, so `max_j (before[j] + after[j])` IS the
+/// alignment's total and `{ j : before[j] + after[j] == max }` is exactly the
+/// set of columns an optimal alignment can put the seam at. Its MINIMUM refuses
+/// the offered prefix every optimal alignment settles and leaves everything they
+/// disagree about in the agreement game; its largest match-supported member
+/// refuses everything any of them could settle. Which one is the frontier is
+/// [`LocalAgreement::ingest`]'s call, on the premise it could verify.
+fn settled_seams(
+  settled: &[WordTiming],
+  holdback: &[WordTiming],
+  offered: &[WordTiming],
+) -> SettledSeams {
+  fn normalize(words: &[WordTiming]) -> Vec<String> {
+    words.iter().map(|word| normalized(word.word())).collect()
+  }
+  let settled_text = normalize(settled);
+  let holdback_text = normalize(holdback);
+  let offered_text = normalize(offered);
+
+  let settled: Vec<&str> = settled_text.iter().map(String::as_str).collect();
+  let offered: Vec<&str> = offered_text.iter().map(String::as_str).collect();
+  let holdback_reversed: Vec<&str> = holdback_text.iter().rev().map(String::as_str).collect();
+  let offered_reversed: Vec<&str> = offered.iter().rev().copied().collect();
+
+  let before = common_subsequence_with_every_prefix(&settled, &offered);
+  // Reversing both sides turns the suffix read into a prefix read:
+  // `after_reversed[m] == LCS(holdback, offered[len - m..])`, so the score for a
+  // frontier at `j` reads it at `len - j`.
+  let after_reversed = common_subsequence_with_every_prefix(&holdback_reversed, &offered_reversed);
+
+  let len = offered.len();
+  let score = |frontier: usize| before[frontier] + after_reversed[len - frontier];
+  // `0..=len` is never empty, so the `max` and the `find` always land; the
+  // defaults keep this total rather than panicking on an impossible state.
+  let best = (0..=len).map(score).max().unwrap_or(0);
+  let prefilled = (0..=len)
+    .find(|&frontier| score(frontier) == best)
+    .unwrap_or(0);
+  // The largest optimal seam a settled MATCH supports -- see
+  // `SettledSeams::unattributed` for why the plain maximum refuses the whole
+  // hypothesis whenever `settled` matches nothing, and for the proof that
+  // `prefilled` is always in this set (so the fallback below never fires).
+  let unattributed = (0..=len)
+    .rfind(|&frontier| {
+      score(frontier) == best && (frontier == 0 || before[frontier] > before[frontier - 1])
+    })
+    .unwrap_or(prefilled);
+  SettledSeams {
+    prefilled,
+    unattributed,
+  }
+}
+
+/// `out[j]` is the length of the longest common subsequence of `pattern` and
+/// `text[..j]`, for every `j` in `0..=text.len()` — the last row of the
+/// standard LCS table, computed with two rolling rows.
+///
+/// `out[0]` stays `0` on every row (nothing has a common subsequence with the
+/// empty prefix), which is why the row buffers are never re-zeroed.
+fn common_subsequence_with_every_prefix(pattern: &[&str], text: &[&str]) -> Vec<usize> {
+  let mut previous = vec![0usize; text.len() + 1];
+  let mut current = vec![0usize; text.len() + 1];
+  for pattern_word in pattern {
+    for (index, text_word) in text.iter().enumerate() {
+      current[index + 1] = if pattern_word == text_word {
+        previous[index] + 1
+      } else {
+        current[index].max(previous[index + 1])
+      };
+    }
+    core::mem::swap(&mut previous, &mut current);
+  }
+  previous
 }
 
 // ---------------------------------------------------------------------
@@ -622,11 +2189,21 @@ impl<'ctx, B> LocalAgreementTranscriber<'ctx, B> {
   /// copy of `options` — see this module's doc for why (LocalAgreement-2
   /// has nothing to agree over without word timings); Swift leaves this to
   /// a user-supplied CLI flag instead.
+  ///
+  /// Also hands the engine `kit`'s own vocabulary threshold. The engine's
+  /// default, [`MIN_SPECIAL_TOKEN_BEGIN`], is a bound over the vocabularies this
+  /// crate is expected to load, and nothing makes an artifact honour it — but
+  /// this driver holds the very tokenizer whose
+  /// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens) call will
+  /// apply the filter the bound is standing in for, so on this path the exact
+  /// value is free and nothing has to be remembered (codex round 12,
+  /// finding 2). See [`LocalAgreement::special_token_begin`].
   pub fn new(kit: &'ctx WhisperKit<B>, options: DecodingOptions) -> Self {
     Self {
       kit,
       options: options.with_word_timestamps(),
-      agreement: LocalAgreement::new(),
+      agreement: LocalAgreement::new()
+        .with_special_token_begin(kit.tokenizer().special_tokens().special_token_begin()),
       buffer: Vec::new(),
       transcribed_samples: 0,
     }
@@ -700,7 +2277,9 @@ where
       let end = (self.transcribed_samples + STRIDE_SAMPLES).min(self.buffer.len());
       let options = self.agreement.decoding_options_for_next(&self.options);
       let result = self.kit.transcribe(&self.buffer[..end], &options)?;
-      outcomes.push(self.agreement.ingest(result));
+      // The same `options` the result was decoded with, handed back so
+      // `ingest` can VERIFY the prefill premise rather than assume it.
+      outcomes.push(self.agreement.ingest(result, &options));
       self.transcribed_samples = end;
     }
     Ok(outcomes)

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -259,6 +259,12 @@
 //!   [`InferenceBackend`] itself has no `Sync` supertrait either. This is
 //!   a correction against this task's own brief, which specified `B:
 //!   InferenceBackend + Sync` here.
+//! - **[API BREAK] the engine's mutating surface is sealed to this crate**, an
+//!   unconditional and authorized break against `main` rather than a deviation
+//!   from Swift — Swift has no library surface here at all. It removes one
+//!   caller shape with no migration; the record, the reasoning and the design
+//!   for the verified contract that could restore it are in the next section.
+//!
 //! # The engine's mutating surface is `pub(crate)`
 //!
 //! [`LocalAgreement`] is `pub` and fully READABLE —
@@ -286,6 +292,22 @@
 //! [`LocalAgreementTranscriber`] produced. Removing it declines a promise that
 //! was never true rather than withdrawing a working mode; the issue's own
 //! impossibility argument is that no substitute oracle exists for it.
+//!
+//! **This is an AUTHORIZED, unconditional public API break** against `main`,
+//! recorded here rather than left incidental. On `main` `LocalAgreement`
+//! published `Default`, its constructor, count mutation, retargeting, `ingest`
+//! and `finalize`; code outside this crate that fed stored, remote or
+//! precomputed [`TranscriptionResult`]s into the engine no longer compiles, and
+//! [`InferenceBackend`] is NOT an equivalent seam for it — that trait exposes
+//! feature/encoder/decoder-step operations and cannot be handed an existing
+//! transcript. **Migration: there is none today.** A caller that has a
+//! transcript and wants confirmation over it has no supported path; the design
+//! for one is recorded on <https://github.com/findit-studio/coremlit/issues/94>
+//! and is a VERIFIED contract rather than a trusted one — the engine would check
+//! that the returned result BEGINS with the holdback, which is decidable in one
+//! pass, unlike the occurrence identity the impossibility result rules out. The
+//! crate is unpublished, so no semver ceremony applies; the break is deliberate
+//! and visible instead.
 //!
 //! `the_engine_exposes_no_public_mutator` in `tests/whisper/streaming.rs` is the
 //! falsifier: it greps this file and reds if any of those names is re-published.

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -635,19 +635,57 @@ mod tests;
 #[non_exhaustive]
 pub enum AgreementOutcome {
   /// The new result's hypothesis agreed with the previous one on at least
-  /// [`LocalAgreement::agreement_count_needed`] words: the confirmation
-  /// watermark advanced and the result was kept.
-  Advanced,
-  /// The watermark is unchanged. Two routes reach it: there is no previous
-  /// result to agree with yet (the first ingested result), or the new hypothesis
-  /// disagreed with the previous one, in which case the result was dropped
-  /// rather than kept.
+  /// [`LocalAgreement::agreement_count_needed`] words, so the result was KEPT
+  /// rather than dropped.
   ///
-  /// Two hypotheses that AGREE always advance the watermark. A third route --
-  /// an agreeing round that DEFERRED rather than advancing -- existed on this
-  /// branch between `6987bec` and `b3ec5c6` and was removed on measured evidence
-  /// (#94; see this module's doc, "Why there is no deferral"). What this value
-  /// reports is what it always reported: whether the watermark moved.
+  /// **It does NOT follow that the confirmation watermark moved**, and this doc
+  /// used to say it did. An advance confirms `common[..split]` and holds the
+  /// rest; where that split is ZERO it confirms nothing, the anchor is the first
+  /// held-back word's start, and that is the word the watermark already sat on
+  /// -- so [`LocalAgreement::last_agreed_seconds`] comes back BIT-identical and
+  /// [`LocalAgreement::confirmed_words_slice`] unchanged. That is the ordinary
+  /// steady state of a stream whose rounds re-agree on exactly
+  /// `agreement_count_needed` words and hold all of them, not an edge case:
+  /// strides 7 and 9 of the shipping
+  /// `jfk_simulated_stream_confirms_the_transcript` fixture do it on the real
+  /// tiny model (watermark stuck at `0x3fb5c28f` and `0x3fb851ec`, three
+  /// confirmed words either side), and instrumenting the same 512-trial shape
+  /// `the_split_never_cuts_at_a_tied_start` sweeps finds 1281 such rounds out of
+  /// 4233 -- every one bit-identical, none of them a rounding artifact.
+  /// Characterized in
+  /// `characterization_an_agreeing_round_returns_advanced_without_moving_the_watermark`.
+  ///
+  /// So a caller may read this as "agreed, and kept" and may NOT read it as
+  /// "something progressed". Nothing in this enum carries the second question;
+  /// answering it is tracked separately, since giving this value that meaning
+  /// changes what the JFK regression trace records.
+  ///
+  /// The EXHAUSTED-BUDGET arm is not this condition and is worth telling apart:
+  /// where no split at or above the prefill-budget floor is legal, the split
+  /// runs off the end of `common` and confirms ALL of it, and the watermark
+  /// necessarily does move -- Rule W's first postcondition puts it strictly past
+  /// the settled high
+  /// (`a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant`).
+  /// A stuck watermark is the ZERO split, not the full one.
+  Advanced,
+  /// The round did not agree. Two routes reach it: there is no previous result
+  /// to agree with yet (the first ingested result), or the new hypothesis
+  /// disagreed with the previous one, in which case the result was dropped
+  /// rather than kept. The watermark is unchanged on both.
+  ///
+  /// **What separates this from [`Self::Advanced`] is agreed-and-kept versus
+  /// NOT agreed -- not whether the watermark moved.** An unchanged watermark
+  /// does not tell the two apart, because `Advanced` leaves it bit-identical
+  /// too whenever its split confirms nothing (see there for the measurement).
+  /// This doc asserted the opposite -- "two hypotheses that AGREE always advance
+  /// the watermark" -- and the shipping JFK fixture falsifies it on 2 of its 9
+  /// agreeing strides.
+  ///
+  /// A third route -- an agreeing round that DEFERRED rather than advancing --
+  /// existed on this branch between `6987bec` and `b3ec5c6` and was removed on
+  /// measured evidence (#94; see this module's doc, "Why there is no
+  /// deferral"). That removal is why every agreeing round now reaches
+  /// `Advanced`; it was never what would have made `Advanced` mean progress.
   AwaitingAgreement,
   /// The result carried no word timings to agree over; it was still kept
   /// (Swift `:403-409` falls through to the unconditional append).

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -625,7 +625,7 @@ mod tests;
 // ---------------------------------------------------------------------
 
 /// One `LocalAgreement::ingest` call's outcome — whether the new result
-/// advanced the confirmation watermark, merely awaits a future result to
+/// AGREED with the previous one and was kept, merely awaits a future result to
 /// agree with, or carried no word timings to agree over at all. Swift
 /// expresses these same three outcomes as local bookkeeping (`skipAppend`,
 /// the no-words `else` branch) rather than a value
@@ -857,9 +857,11 @@ impl LocalAgreement {
   }
 
   // -- last_agreed_words (Vec<WordTiming>) -----------------------------------
-  /// The most recent agreement's trailing [`Self::agreement_count_needed`]
-  /// words — held back from [`Self::confirmed_words_slice`] since a
-  /// still-later hypothesis could yet revise them.
+  /// The most recent agreement's holdback, `common[split..]` — held back from
+  /// [`Self::confirmed_words_slice`] since a still-later hypothesis could yet
+  /// revise them. [`Self::agreement_count_needed`] words is what it TARGETS,
+  /// not what it has: Rule W can leave it longer and the prefill budget
+  /// shorter, down to empty (`split_at_a_strict_boundary`).
   #[inline(always)]
   pub const fn last_agreed_words_slice(&self) -> &[WordTiming] {
     self.last_agreed_words.as_slice()
@@ -867,7 +869,7 @@ impl LocalAgreement {
 
   // -- confirmed_words (Vec<WordTiming>) -------------------------------------
   /// Word timings settled so far: every agreement's leading remainder, ahead of
-  /// that agreement's own [`Self::agreement_count_needed`]-word holdback.
+  /// that agreement's own [`Self::last_agreed_words_slice`] holdback.
   ///
   /// Append-only across the life of the engine: nothing here is ever rewritten,
   /// reordered, or taken back, which is why the trailing words of an agreement
@@ -1031,16 +1033,26 @@ impl LocalAgreement {
   /// - With a previous result, its own `all_words()` (filtered the same
   ///   way, `:375`) and the new hypothesis feed
   ///   [`crate::audio::whisper::text::find_longest_common_prefix`] (`:376`). A common
-  ///   prefix at least [`Self::agreement_count_needed`] words long
-  ///   advances the watermark: its trailing `agreement_count_needed`
-  ///   words become the new [`Self::last_agreed_words_slice`] (whose
-  ///   first word's start is the new [`Self::last_agreed_seconds`]), its
-  ///   leading remainder is folded into [`Self::confirmed_words_slice`],
-  ///   `result` is kept, and this returns [`AgreementOutcome::Advanced`]
-  ///   (`:383-394`). Otherwise the hypotheses disagree: the watermark is
-  ///   unchanged, `result` is **dropped** rather than kept (`:395-400`,
-  ///   `skipAppend`), and this returns
+  ///   prefix at least [`Self::agreement_count_needed`] words long is an
+  ///   AGREEMENT: `common[..split]` is folded into
+  ///   [`Self::confirmed_words_slice`], `common[split..]` becomes the new
+  ///   [`Self::last_agreed_words_slice`], a new [`Self::last_agreed_seconds`]
+  ///   is drawn, `result` is kept, and this returns
+  ///   [`AgreementOutcome::Advanced`] (`:383-394`). Otherwise the hypotheses
+  ///   disagree: the watermark is unchanged, `result` is **dropped** rather
+  ///   than kept (`:395-400`, `skipAppend`), and this returns
   ///   [`AgreementOutcome::AwaitingAgreement`].
+  ///
+  ///   **Both quantities are RULE W's rather than Swift's** (#94). Swift fixes
+  ///   them: the holdback is `commonPrefix.suffix(agreementCountNeeded)` and
+  ///   the watermark is `lastAgreedWords.first!.start` (`:385`). Here
+  ///   `split_at_a_strict_boundary` moves the boundary later OR earlier than
+  ///   that count, and `sparing_watermark` lowers that first held start to
+  ///   spare every word this round left unconfirmed — over an anchor
+  ///   `empty_holdback_anchor` supplies where the split empties the holdback.
+  ///   That is why [`AgreementOutcome::Advanced`] reports agreed-and-kept and
+  ///   NOT a moved watermark: a `split` of `0` confirms nothing and leaves
+  ///   [`Self::last_agreed_seconds`] bit-identical — measured there.
   ///
   /// Either way — agreeing, disagreeing, or no previous result — `result`
   /// becomes the new previous result for the next call (`:402`, outside
@@ -1098,7 +1110,7 @@ impl LocalAgreement {
       self.prev_words = Self::watermark_filtered(previous, self.last_agreed_seconds);
       let common = find_longest_common_prefix(&self.prev_words, &self.hypothesis_words);
       if common.len() >= self.agreement_count_needed {
-        // :383-394 — advance the watermark.
+        // :383-394 — the advance.
         let requested = common.len() - self.agreement_count_needed;
         let split = split_at_a_strict_boundary(
           common,

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -626,9 +626,14 @@ mod tests;
 
 /// One `LocalAgreement::ingest` call's outcome. It answers TWO questions, not
 /// one: whether the new result AGREED with the previous one and was kept, and —
-/// where it did — whether anything a caller can observe actually MOVED. The
-/// second question is why there are two agreeing variants, [`Self::Progressed`]
-/// and [`Self::Stationary`]; the remaining two are the round that did not agree
+/// where it did — whether either of the two SETTLED channels actually MOVED.
+/// Those two are [`LocalAgreement::last_agreed_seconds`] and
+/// [`LocalAgreement::confirmed_words_slice`], and they are the whole of what
+/// progress means here — NOT everything a caller can observe, since the
+/// holdback is observable too and is deliberately excluded (see
+/// [`Self::Stationary`], "What is NOT a progress channel"). The second question
+/// is why there are two agreeing variants, [`Self::Progressed`] and
+/// [`Self::Stationary`]; the remaining two are the round that did not agree
 /// ([`Self::AwaitingAgreement`]) and the result with no word timings to agree
 /// over at all ([`Self::NoWordTimings`]).
 ///
@@ -645,7 +650,7 @@ mod tests;
 pub enum AgreementOutcome {
   /// The round AGREED — the new hypothesis and the previous one shared at least
   /// [`LocalAgreement::agreement_count_needed`] words, so the result was KEPT
-  /// rather than dropped — AND something a caller can observe MOVED:
+  /// rather than dropped — AND one of the two SETTLED channels MOVED:
   /// [`LocalAgreement::last_agreed_seconds`] came back with different bits, or
   /// [`LocalAgreement::confirmed_words_slice`] grew, or both.
   ///
@@ -659,11 +664,16 @@ pub enum AgreementOutcome {
   /// [`Self::Stationary`] for why the split cannot be asked instead.
   Progressed,
   /// The round AGREED and its result was KEPT, exactly as [`Self::Progressed`],
-  /// but NOTHING a caller can observe moved:
+  /// but NEITHER of the two SETTLED channels moved:
   /// [`LocalAgreement::last_agreed_seconds`] came back BIT-identical and
   /// [`LocalAgreement::confirmed_words_slice`] is unchanged. A caller polling
-  /// the engine on this outcome reads back the same watermark and the same
-  /// words it read last round.
+  /// those two on this outcome reads back the same watermark and the same
+  /// confirmed words it read last round.
+  ///
+  /// Deliberately NOT "nothing observable moved". The holdback is observable
+  /// and DOES move here, routinely — see "What is NOT a progress channel"
+  /// below, which is why the two channels above are named rather than
+  /// generalized.
   ///
   /// Not an edge case: it is the ordinary steady state of a stream whose rounds
   /// re-agree on exactly `agreement_count_needed` words and hold all of them.
@@ -1593,8 +1603,12 @@ impl LocalAgreement {
 ///    backwards start reaches the same place the same way once the floor is
 ///    above it, which is the second half of residual 1 and the only route it
 ///    has left since codex round 8. `add_word_timestamps` produces the tied-run
-///    shape from an ALL-ZERO alignment matrix (113 ordinary one-token words at
-///    one instant, measured at 130), so it is the reachable one.
+///    shape from an ALL-ZERO alignment matrix -- DTW's tie-break walks the path
+///    down column 0, so every word lands at one instant, zero-duration and one
+///    token each -- so it is the reachable one. The width is whatever the
+///    gathered tokens supply; the fixtures that drive this residual build 113 of
+///    them (`a_tied_run_above_the_budget_floor_advances_instead_of_stalling`,
+///    `an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant`).
 ///
 ///    **What this costs, and why it is not a DEFERRAL** (#94, measured on this
 ///    branch; see this module's doc, "Why there is no deferral"). The empty

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -75,99 +75,22 @@
 //!   strictly earlier — searching forward from the requested split first, then
 //!   BACKING OFF when the forward search would run off the end of `common`,
 //!   because widening past a tied run that reaches that end would empty the
-//!   holdback and anchor the watermark on the run's own last word, and finally
-//!   DEFERRING the round outright — where the prefill budget floor sits at or
-//!   above every legal boundary, which is where the back-off has nowhere legal
-//!   to land, and where the budget FORCES the empty holdback but the watermark
-//!   that advance would set lies past a word the newer hypothesis produced
-//!   beyond `common`. And where the holdback is empty anyway — a single word the
-//!   prefill cannot carry WHOLE is the only thing that can still do that, and
-//!   only while it strands nothing — `LocalAgreement::ingest` anchors the
-//!   watermark at `empty_holdback_watermark`'s `end.max(start.next_up())` rather
-//!   than at `end`, since `end == start` for a zero-duration word. `next_up` is
-//!   the IMMEDIATE f32 successor: it refuses exactly the one instant the
-//!   confirmed word occupies and no span of instants, which an `end + epsilon`
-//!   tolerance would not have managed.
-//!
-//!   The DEFERRAL closes a DELETION rather than a re-confirmation (codex round 3
-//!   on PR #95). A tied run whose own tokens exceed
-//!   [`MAX_HOLDBACK_PREFILL_TOKENS`] — 113 ORDINARY one-token words sharing a
-//!   start, which `add_word_timestamps` produces from an ALL-ZERO alignment
-//!   matrix, measured at 130 such words — puts the budget floor strictly inside
-//!   the run, so every boundary the forward search and the back-off can reach
-//!   ties while split `0` is below the floor. Widening off the end there
-//!   confirmed the whole run, emptied the holdback and anchored the watermark
-//!   strictly PAST the run's instant: every word the newest hypothesis produced
-//!   at that same instant beyond `common` — words nothing had confirmed — was
-//!   then filtered out of both hypotheses on the next worded ingest and lost.
-//!   `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix` is the
-//!   falsifier. Deferring costs nothing on the round itself, since
-//!   `LocalAgreement::finalize` emits the same words either way, and TAIL growth
-//!   relieves it.
-//!
-//!   **The deferral is a WAIT, and the wait is BOUNDED TWICE** (codex rounds 4
-//!   and 5 on PR #95). Tail growth relieves it only where the tail GROWS
-//!   `common`, and two shapes stop it growing: hypotheses that ALTERNATE past
-//!   the agreed prefix pin `common` at the words they still share, and a
-//!   hypothesis that simply REPEATS pins it with no disagreement at all. Either
-//!   way the same round came back forever — nothing confirmed, the watermark
-//!   frozen, the caller reading `AwaitingAgreement`, and in the driver a clip
-//!   boundary that never advanced while the buffer grew past it.
-//!
-//!   So a deferral records a `DeferralSignature` — the floor, `common.len()`,
-//!   the terminal agreed start and the watermark an escape would anchor at,
-//!   which between them fix WHICH words an escape would strand — and a deferral
-//!   over a signature IDENTICAL to the round before's takes the empty holdback
-//!   instead: a MEASUREMENT of a wait that has already happened, not a
-//!   prediction about the next one.
-//!   `an_alternating_suffix_escapes_the_deferral_instead_of_stalling` and
-//!   `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`
-//!   are the falsifiers, one per deferral arm.
-//!
-//!   A signature bound alone is only half of it, and round 5 is both halves.
-//!   Recording `common.len()` alone (round 4's own predicate, compared with
-//!   `<=`) authorized an escape from a DIFFERENT deferral whenever two lengths
-//!   collided — the terminal timestamp may move while the normalized prefix does
-//!   not, and the escape's cost is a question about timings — which RETRACTS a
-//!   word a repeat would have kept
-//!   (`a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat`). And a
-//!   signature bound of any strength cannot end a wait whose state keeps MOVING:
-//!   an over-budget tied run gaining one tied word per stride defers with a
-//!   fresh signature every round, forever, retaining one result per round over a
-//!   clip window that never advances
-//!   (`a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`). The
-//!   two findings pull opposite ways — a stricter predicate lengthens the stall,
-//!   a looser bound widens the premature escape — so the answer is both:
-//!   [`MAX_CONSECUTIVE_DEFERRALS`] bounds the wait whatever it is waiting on,
-//!   and the signature ends a proven-repeat sooner. A caller therefore waits at
-//!   most that many consecutive deferred rounds between advances, and
-//!   `LocalAgreement::finalize` publishes the whole live transcript throughout.
-//!
-//!   What either escape can still lose is one thing and it is residual 1 below:
-//!   a word at the last confirmed word's own instant, where no watermark serves
-//!   both it and #94. Everything else `empty_holdback_watermark` now SPARES by
-//!   lowering the anchor to that word's own start
-//!   (`a_strand_starting_strictly_later_lowers_the_watermark_instead_of_deferring`),
-//!   which is what keeps the loss to the impossibility rather than to the
-//!   policy.
-//!
-//!   The FORCED empty holdback — the arm that first repair deliberately left
-//!   alone — strands the same way and needs the same guard (codex round 3 on
-//!   PR #95, second finding). Where the budget floor itself reaches
-//!   `common.len()` the split ran off the end unconditionally, deciding on
-//!   `common` alone and never looking at what the newer hypothesis produced past
-//!   it. What that costs is a RETRACTION rather than a deletion: the round's own
-//!   `LocalAgreement::finalize` PUBLISHES the stranded word through
-//!   `find_longest_different_suffix`, and only the NEXT hypothesis loses it, so
-//!   `confirmed_words`' append-only guarantee is intact throughout and cannot
-//!   see it. The forced advance is therefore taken exactly while it strands
-//!   nothing, which is also the whole of what keeps its original case alive: a
-//!   `common` with nothing beyond it has no anchor to wait for, and deferring
-//!   there would wait forever.
-//!   `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` is the
-//!   falsifier, and it needs both of its `finalize` points — the retraction is
-//!   only visible across two. It is the wait's FIRST round that this buys; the
-//!   bound above is what ends it.
+//!   holdback and anchor the watermark on the run's own last word — and widening
+//!   off the END only where the prefill budget floor sits at or above every
+//!   legal boundary, which is where the back-off has nowhere legal to land. And
+//!   where the holdback is empty, `LocalAgreement::ingest` anchors the watermark
+//!   at `empty_holdback_watermark`'s lowest sparing instant, never below
+//!   `end.max(start.next_up())`, rather than at `end` — since `end == start` for
+//!   a zero-duration word. `next_up` is the IMMEDIATE f32 successor: it refuses
+//!   exactly the one instant the confirmed word occupies and no span of
+//!   instants, which an `end + epsilon` tolerance would not have managed. The
+//!   SPARING fold is what keeps the empty holdback's cost to the impossibility
+//!   rather than to the policy: it lowers the anchor to the earliest word the
+//!   hypothesis already produced past `common`, so every such word at any start
+//!   strictly after the settled one stays offerable
+//!   (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`).
+//!   What no anchor can spare is a word at the settled start itself, and that is
+//!   residual 1.
 //!
 //!   The first shape of this rule widened unconditionally and left the empty
 //!   holdback anchored at `end`, which put the ORIGINAL duplicate-confirmation
@@ -264,13 +187,12 @@
 //!   That split runs all the way to `common.len()` when it has to, so **an
 //!   advance can leave the holdback EMPTY** and the watermark anchored past the
 //!   last confirmed word's own start instead of at the first held one's. Two
-//!   things reach it: a single word whose OWN tokens exceed the budget, on a
-//!   round where nothing the newer hypothesis produced beyond `common` would be
-//!   stranded by the watermark it would set; and a round that ESCAPES a
-//!   repeating deferral, which is the bound on that wait (see
+//!   things reach it: a single word whose OWN tokens exceed the budget, which
+//!   pushes the budget floor itself to `common.len()`; and a tied run whose own
+//!   tokens exceed the budget, which puts that floor strictly inside the run so
+//!   that no legal boundary is left at or above it (see
 //!   `split_at_a_strict_boundary`). Rule W's own widening backs off rather than
-//!   emptying, and DEFERS — once — both where the back-off has nowhere legal to
-//!   land and where the forced advance would strand such a word. The anchor is
+//!   emptying wherever a legal boundary remains above the floor. The anchor is
 //!   `empty_holdback_watermark`'s lowest sparing instant, never below
 //!   `start.next_up()`, so a zero-duration word there is still strictly behind
 //!   the watermark and a word the hypothesis already produced past `common` is
@@ -304,12 +226,8 @@
 //!   empty holdback the same expression fails the other way, dropping the
 //!   `commonPrefix.count` leading words both hypotheses actually produced.
 //!   `LocalAgreement::finalize` instead emits the final hypothesis's own
-//!   post-watermark words on that path (`holdback_superseded` is the flag), and
-//!   on the DEFERRED one too (`deferred`), where the hypotheses agreed but
-//!   the only split available was one Rule W refuses — nothing legal at or above
-//!   the prefill budget floor, or a forced empty holdback that would strand the
-//!   hypothesis's own suffix — so the holdback is an earlier agreement's and
-//!   Swift's sum would drop everything between it and `common`'s end. It keeps Swift's shape everywhere else — including when
+//!   post-watermark words on that path (`holdback_superseded` is the flag). It
+//!   keeps Swift's shape everywhere else — including when
 //!   the final hypothesis contributes nothing at or past the watermark, where
 //!   nothing supersedes the holdback. How much of the holdback that path actually replaces is the
 //!   window's question, below; what is NOT replaced is emitted ahead of the
@@ -361,6 +279,67 @@
 //!   from Swift — Swift has no library surface here at all. It removes one
 //!   caller shape with no migration; the record, the reasoning and the design
 //!   for the verified contract that could restore it are in the next section.
+//! - **[API BREAK] `MAX_CONSECUTIVE_DEFERRALS` is gone**, a `pub const` this
+//!   branch itself added at `4f2a3c9` and removed at the commit that removed the
+//!   deferral. It named the bound on a wait that no longer exists, so nothing
+//!   replaces it; the next section is why. It never reached `main`, so the break
+//!   is against this branch's own intermediate surface rather than against a
+//!   released one.
+//!
+//! # Why there is no deferral
+//!
+//! Between `6987bec` and `b3ec5c6` an agreeing round could decline to advance.
+//! Where `split_at_a_strict_boundary` found no legal boundary at or above the
+//! prefill budget floor — or where the floor forced the empty holdback and the
+//! watermark that advance would set lay past a word the hypothesis had already
+//! produced beyond `common` — the round DEFERRED, waiting for `common` to grow,
+//! under two bounds (a repeating `DeferralSignature` and a
+//! `MAX_CONSECUTIVE_DEFERRALS` count) that ended the wait. What it was protecting
+//! is real: the empty holdback strands a word at the settled instant, and on the
+//! forced arm this round's own `finalize` has already PUBLISHED that word, so
+//! losing it RETRACTS transcript rather than merely never emitting it — the
+//! direction `c6fc2e1` named as the non-preferred one.
+//!
+//! It was removed because it made that direction WORSE, measured rather than
+//! argued. Three trees — the deferral, this fallback, and `main` — were driven
+//! over the accumulated counterexample suite of this issue and over
+//! `the_split_never_cuts_at_a_tied_start`'s 512 fixed-seed trials, reading the
+//! published transcript after every round:
+//!
+//! | 512 fixed-seed trials | deferral | fallback |
+//! |---|---|---|
+//! | words ERASED from the published transcript | 26 | 10 |
+//! | strands, all at the settled instant | 29 | 38 |
+//! | rounds with no legal boundary that took the empty holdback | 43 | 141 |
+//! | rounds with no legal boundary that WAITED instead | 113 | — |
+//!
+//! The deferral produced 2.6x the published retractions. What it BOUGHT over the
+//! same suite was four words on the growing-tied-prefix row and one word each on
+//! two others — every one of them at the SETTLED instant, which is the class
+//! this module already accepts as residual 1 and already ships two
+//! characterization tests for. Over 141 fallback rounds and 38 strands the
+//! sweep's own oracle held every time: nothing unconfirmed fell below the
+//! watermark except at or before the settled start.
+//!
+//! And the wait had a liveness hole its own count bound could not close. A split
+//! at `0` is an ADVANCE that confirms nothing — legal whenever `common` opens on
+//! a boundary and the floor is `0` — yet it reset `deferrals_since_advance`. An
+//! `L, L, S` cycle (two long hypotheses, then a short one that agrees on two
+//! words) therefore held the engine at ZERO words confirmed for 30 rounds,
+//! `results` growing one per round, the published transcript oscillating between
+//! 2 and 113 words, while this fallback confirms 113 words on round 2 and is
+//! stable forever. The count bound was defeated by the very split it was meant
+//! to backstop.
+//!
+//! What the fallback keeps from that work, and what it does not. The SPARING
+//! FOLD in `empty_holdback_watermark` (`4f2a3c9`) is kept: it is separable from
+//! the deferral, it is what confines the loss to the settled instant, and
+//! dropping it reds
+//! `a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`.
+//! What is not kept is the wait, its two bounds, the deferred flag and
+//! `finalize`'s clause for it. `jfk_simulated_stream_confirms_the_transcript` is
+//! byte-identical across all three trees, so no measured stream in this repo
+//! distinguishes them at all.
 //!
 //! # The engine's mutating surface is `pub(crate)`
 //!
@@ -415,59 +394,42 @@
 //! W's postcondition IS total (see its entry above); the module claims no
 //! totality beyond it.
 //!
-//! 1. **A new word at an empty holdback's own instant is DROPPED.** With nothing
-//!    held back the watermark is the last confirmed word's `end`, raised to
-//!    `start.next_up()` where that word has no duration — so a word the stream
-//!    genuinely produces at that same instant fails the offered filter and never
-//!    reaches a hypothesis. It cannot be helped: to a timestamp filter that word
-//!    and a re-offer of the settled one are the same value, which is the issue's
-//!    impossibility result, and the alternative is the unbounded
-//!    re-confirmation #94 is about. A truncation is what the portable prefix
-//!    property tolerates; a rewrite is not. Needs the prefill budget to empty the
-//!    holdback — Rule W's own widening no longer does — over a ZERO-DURATION word,
-//!    which takes a single word at the end of `common` whose own tokens exceed
-//!    [`MAX_HOLDBACK_PREFILL_TOKENS`]. It does NOT additionally take a
-//!    non-default [`LocalAgreement::agreement_count_needed`]: an earlier form of
-//!    this entry listed one, and the default count reaches the same state
-//!    whenever that one word is the last of the agreed prefix (measured).
-//!    `add_word_timestamps` emitting a 112-token word is the whole of the gate —
-//!    and only since the deferral: an AGGREGATE tied run over budget used to
-//!    reach the same empty holdback with no oversized word anywhere, and what it
-//!    cost there was the DELETION of the words at the run's own instant rather
-//!    than this residual's single dropped word. That route now defers instead
-//!    (codex round 3 on PR #95;
-//!    `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix`), which
-//!    is what restores this sentence.
+//! 1. **A word at an empty holdback's own instant is DROPPED.** With nothing
+//!    held back the watermark is `empty_holdback_watermark`'s lowest sparing
+//!    instant — never below the last confirmed word's `end`, raised to
+//!    `start.next_up()` where that word has no duration — so a word at that same
+//!    start fails the offered filter and can never reach a hypothesis again. It
+//!    cannot be helped: to a timestamp filter that word and a re-offer of the
+//!    settled one are the same value, which is the issue's impossibility result,
+//!    and the alternative is the unbounded re-confirmation #94 is about. A
+//!    truncation is what the portable prefix property tolerates; a rewrite is
+//!    not. It needs the prefill budget to empty the holdback — Rule W's own
+//!    widening backs off wherever a legal boundary remains above the floor — and
+//!    two shapes do that: a single word at the end of `common` whose own tokens
+//!    exceed [`MAX_HOLDBACK_PREFILL_TOKENS`], and a TIED RUN whose tokens exceed
+//!    it in aggregate, which `add_word_timestamps` produces from an all-zero
+//!    alignment matrix. It does NOT additionally take a non-default
+//!    [`LocalAgreement::agreement_count_needed`]: an earlier form of this entry
+//!    listed one, and the default count reaches the same state whenever that one
+//!    word is the last of the agreed prefix (measured).
 //!
-//!    It is narrower again since round 3's second finding: the word this drops
-//!    must be one no hypothesis had produced YET at the moment of the advance.
-//!    A word already visible past `common` when the split runs is not dropped —
-//!    the forced arm defers rather than stranding it
-//!    (`a_forced_empty_holdback_defers_rather_than_retracting_its_suffix`). So
-//!    what remains is exactly the word the NEXT decode invents at an instant
-//!    already settled, which is the one case no watermark can tell from a
-//!    re-offer.
-//!    `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed` drives it
-//!    at count 1 — its dropped `" B"` arrives one hypothesis later, which is why
-//!    it is still dropped — and `the_split_never_cuts_at_a_tied_start` sweeps
-//!    both counts.
-//!
-//!    And it is WIDER again since round 4, by the length of a bounded wait and
-//!    only where that wait is OVER: an ESCAPE drops a word that WAS already
-//!    visible past `common`, if it starts at the settled instant. That is the
-//!    same impossibility from the same side — the alternative is the stall the
-//!    bound exists to leave, and the alternative to THAT is re-admitting the
-//!    settled word, which is #94 — so the residual's statement is unchanged and
-//!    only its route is wider. Everything at any OTHER instant is spared rather
-//!    than dropped, by `empty_holdback_watermark`'s fold. A wait is over on
-//!    either bound (see `DeferralWait::is_over`): its signature REPEATED, which
-//!    costs the escape one round after the state was first seen, or it ran to
-//!    [`MAX_CONSECUTIVE_DEFERRALS`] rounds without repeating, which costs it
-//!    that many. The escape's own falsifiers are
-//!    `an_alternating_suffix_escapes_the_deferral_instead_of_stalling`,
-//!    `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`
-//!    and `a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`,
-//!    and the sweep counts the strands so the residual cannot be reported as
+//!    It covers a word the hypothesis had ALREADY produced past `common` as well
+//!    as one a later decode invents. Between `6987bec` and `b3ec5c6` the first
+//!    kind was excluded — the round DEFERRED rather than stranding it — and
+//!    removing the deferral restores it, on measured evidence that the deferral
+//!    cost more published transcript than it saved (see "Why there is no
+//!    deferral" above). What is NOT covered is any other instant: the sparing
+//!    fold in `empty_holdback_watermark` lowers the anchor to the earliest word
+//!    beyond `common` it can, so a word starting strictly later stays offerable
+//!    (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`).
+//!    `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed` drives the
+//!    invented-later kind at count 1 — its dropped `" B"` arrives one hypothesis
+//!    later, which is why it is still dropped;
+//!    `an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant` and
+//!    `a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant` drive
+//!    the already-visible kind on each of the two shapes above; and
+//!    `the_split_never_cuts_at_a_tied_start` sweeps both counts and COUNTS the
+//!    strands and the erasures, so the residual cannot be reported as
 //!    unreachable.
 //! 2. **A repeat the engine's record cannot account for** is the stream's own,
 //!    on the untied input — and on a TIED one Rule W deletes it instead. Both
@@ -497,6 +459,35 @@
 //!    coverage. `task_facts().had_swallowed_error()` is a fact the PIPELINE
 //!    recorded rather than caller testimony and could preserve the record;
 //!    flagged, not taken.
+//! 6. **A whole hypothesis RE-TIMED past the watermark is confirmed twice, and
+//!    the shape cannot be built without also building a re-admission.** Offer a
+//!    113-word tied run at 2 s twice, then the SAME 113 words at 3 s: the first
+//!    pair advances and anchors just past 2 s, the second pair is entirely
+//!    strictly past that anchor, so it agrees with itself and is confirmed as
+//!    well — 226 confirmed words where the stream said 113 (measured; `main`
+//!    confirms 222 on the same input, so this is not new here).
+//!
+//!    It is AMBIGUOUS BY CONSTRUCTION, and the two readings give opposite
+//!    verdicts. Read as RE-TIMESTAMPING, the second confirmation is a duplicate
+//!    of the first and this is #94's own defect in another dress — the words are
+//!    the same words, moved. Read by this module's documented contract, a word
+//!    STRICTLY PAST the watermark is new speech (`watermark_filtered`, and
+//!    residual 2's "a repeat the engine's record cannot account for is the
+//!    stream's own"), so confirming it is exactly right and refusing it would be
+//!    the re-admission defence this issue's ledger already refuted. There is no
+//!    third reading available from the offered list: the two are byte-identical
+//!    there, which is the issue's impossibility result reached from the drift
+//!    side — residual 3's territory, and driver-unreachable for the same reason
+//!    it gives.
+//!
+//!    **Unconstrained by any current assertion.** No test in this file, and no
+//!    shape the 512-trial sweep draws, pins either verdict: the sweep's
+//!    `retiming` half drifts a whole offering by 0.03 s per round, which is
+//!    smaller than the gap in front of the watermark and so never jumps a
+//!    settled run past it. Neither the deferral tree nor this one flags it. The
+//!    deferral masked it on exactly this shape by declining the first advance,
+//!    which is not a fix and did not generalize. Recorded rather than decided,
+//!    because deciding it needs the identity oracle #94 proves does not exist.
 
 use crate::audio::whisper::{
   backend::InferenceBackend,
@@ -530,25 +521,16 @@ pub enum AgreementOutcome {
   /// [`LocalAgreement::agreement_count_needed`] words: the confirmation
   /// watermark advanced and the result was kept.
   Advanced,
-  /// The watermark is unchanged. Three routes reach it: there is no previous
-  /// result to agree with yet (the first ingested result); the new hypothesis
+  /// The watermark is unchanged. Two routes reach it: there is no previous
+  /// result to agree with yet (the first ingested result), or the new hypothesis
   /// disagreed with the previous one, in which case the result was dropped
-  /// rather than kept; or the two agreed and the round was DEFERRED because
-  /// every split Rule W would accept is one the prefill budget refuses, or the
-  /// one the budget forces would strand the hypothesis's own suffix (see
-  /// `split_at_a_strict_boundary`), in which case the result was kept like any
-  /// other agreeing one.
+  /// rather than kept.
   ///
-  /// The deferral is deliberately not its own variant, and codex rounds 4 and 5
-  /// on PR #95 are why that survives its strongest objection. The objection was
-  /// that a caller cannot escape a state it cannot see, which is true and was
-  /// the finding: the deferral used to repeat without bound. It is bounded now
-  /// -- at most [`MAX_CONSECUTIVE_DEFERRALS`] consecutive deferred rounds
-  /// between advances, and one round where the wait provably repeats
-  /// (`split_at_a_strict_boundary`'s arm 3) -- so there is no state left for a
-  /// caller to be told about that the engine does not leave by itself, and a
-  /// `Blocked` variant would report a wait that ends without it. What this value
-  /// reports stays what it always reported: whether the watermark moved.
+  /// Two hypotheses that AGREE always advance the watermark. A third route --
+  /// an agreeing round that DEFERRED rather than advancing -- existed on this
+  /// branch between `6987bec` and `b3ec5c6` and was removed on measured evidence
+  /// (#94; see this module's doc, "Why there is no deferral"). What this value
+  /// reports is what it always reported: whether the watermark moved.
   AwaitingAgreement,
   /// The result carried no word timings to agree over; it was still kept
   /// (Swift `:403-409` falls through to the unconditional append).
@@ -605,53 +587,6 @@ pub const DEFAULT_AGREEMENT_COUNT_NEEDED: usize = 2;
 /// (codex round 8, finding 1; codex round 12, finding 2).
 pub const MAX_HOLDBACK_PREFILL_TOKENS: usize = MAX_TOKEN_CONTEXT / 2;
 
-/// The most consecutive rounds Rule W's deferral may WAIT before it escapes,
-/// WHATEVER state it is waiting on — the liveness backstop beside the
-/// signature bound, and the second half of the answer to #94's codex round 5
-/// (finding 1).
-///
-/// `DeferralSignature` ends a wait that REPEATS, which is the only wait a
-/// measurement can prove bought nothing. It cannot end a wait whose state keeps
-/// MOVING, and one shape moves it every round: a tied run already over the
-/// prefill budget that gains one more tied word each stride defers with a longer
-/// `common`, a higher floor and a fresh signature every time, so every round's
-/// wait is a NEW one and nothing ever measures a repeat. `add_word_timestamps`
-/// produces exactly that run from an all-zero alignment matrix, one word per
-/// stride is the driver's own cadence, and the length is not bounded by
-/// anything: the stall is unbounded, and since an agreeing round is a KEPT
-/// round ([`LocalAgreement::results_slice`]) over a clip window that never
-/// advances, an unbounded stall is unbounded RETENTION as well as unbounded
-/// latency.
-///
-/// So a count bounds it, and the count is what the wait is FOR. A word that
-/// opens a legal boundary needs ONE round to appear in a hypothesis and ONE more
-/// to be corroborated into `common` — see the two-round relief in
-/// `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` — so a
-/// stream that is relieving itself is relieved within two rounds of the
-/// relieving word arriving, and `4` leaves room for that word to arrive two
-/// rounds late. Past that the wait is not waiting for anything a longer wait
-/// delivers. Rounds rather than seconds because the frozen quantity IS the
-/// watermark, so elapsed watermark cannot measure its own stall, and because the
-/// retained results this bounds accrue one per round.
-///
-/// **What a caller observes in the worst case.** At most this many consecutive
-/// DEFERRED rounds between advances; over them
-/// [`LocalAgreement::confirmed_words_slice`] does not grow, `Self::ingest`
-/// returns [`AgreementOutcome::AwaitingAgreement`],
-/// [`LocalAgreement::last_agreed_seconds`] does not move, and
-/// [`LocalAgreement::results_slice`] grows by one kept result per round —
-/// while `LocalAgreement::finalize` keeps publishing the whole live transcript
-/// (`confirmed ++ hypothesis_words`), so it is CONFIRMATION that stalls, not
-/// the transcript. When the count fires it costs this module's residual 1 on a
-/// state that has not repeated: the escape takes the empty holdback at
-/// `empty_holdback_watermark`'s lowest sparing instant, so the only word it can
-/// strand is one of the newest hypothesis's own AT the last confirmed word's
-/// instant — every other instant the sparing fold keeps offerable.
-///
-/// `a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals` is the
-/// falsifier and pins the number as a number.
-pub const MAX_CONSECUTIVE_DEFERRALS: usize = 4;
-
 /// The LocalAgreement-2 hypothesis-confirmation engine: consumes one
 /// [`TranscriptionResult`] per call and tracks the growing prefix two
 /// consecutive hypotheses agree on. Pure — no backend, no I/O, fully
@@ -682,56 +617,6 @@ pub struct LocalAgreement {
   /// four untouched, so this keeps describing the last hypothesis that actually
   /// had words to agree over — exactly the pair `finalize` reasons about.
   holdback_superseded: bool,
-  /// `Some(signature)` when the most recent WORDED hypothesis AGREED with
-  /// the previous one and the round still did not advance, because
-  /// `split_at_a_strict_boundary` had no acceptable boundary to advance to:
-  /// none legal at or above the prefill budget floor, or a forced empty
-  /// holdback whose watermark would have stranded a word this hypothesis
-  /// produced beyond `common` (#94, codex round 3 on PR #95, both findings).
-  /// `None` on every other worded round.
-  ///
-  /// `Self::finalize` needs the BOOLEAN for the same reason it needs
-  /// [`Self::holdback_superseded`]: on such a round the holdback belongs to an
-  /// EARLIER agreement while [`Self::hypothesis_words`] already re-covers that
-  /// whole span and more, so Swift's `lastAgreedWords + differentSuffix`
-  /// decomposition would drop everything between them.
-  ///
-  /// `Self::ingest` needs the SIGNATURE, which is half of the deferral's
-  /// liveness bound (#94, codex rounds 4 and 5 on PR #95). A deferral is a WAIT
-  /// for tail growth: `common` grows, and a boundary the split can legally take
-  /// appears above the budget floor. Deferring again on a state IDENTICAL to
-  /// the one that already deferred is therefore a wait that has already been
-  /// measured and found to buy nothing, which is a repeating state rather than
-  /// a wait — see `split_at_a_strict_boundary`'s escape. An earlier form of
-  /// this field held `common.len()` alone and compared it with `<=`; a LENGTH
-  /// does not establish that the previous wait covered the current state, which
-  /// is round 5's finding 2 and the whole reason `DeferralSignature` exists.
-  ///
-  /// Maintained on exactly the same schedule as `Self::holdback_superseded` —
-  /// only on the worded path, so the [`AgreementOutcome::NoWordTimings`] early
-  /// return leaves it describing the last hypothesis that had words, and a
-  /// wordless stride between two deferrals neither relieves nor repeats one. It
-  /// is a claim about the IMMEDIATELY preceding worded round: an advance or a
-  /// disagreement clears it, because either one moves the state the signature
-  /// describes.
-  deferred: Option<DeferralSignature>,
-  /// How many rounds have DEFERRED since the last advance —
-  /// `split_at_a_strict_boundary`'s other bound, the one that fires whatever
-  /// the signature says (#94, codex round 5 on PR #95, finding 1). See
-  /// [`MAX_CONSECUTIVE_DEFERRALS`] for what the number is and what firing it
-  /// costs.
-  ///
-  /// Reset by an ADVANCE only. A disagreement clears [`Self::deferred`] but not
-  /// this, deliberately: a stream that alternates defer/disagree/defer never
-  /// repeats a signature and never advances either, and a counter a
-  /// disagreement reset would let that shape stall exactly as far as the
-  /// unbounded wait did. A wordless stride touches neither, on the same
-  /// schedule as every other field of the worded path.
-  ///
-  /// Bounded by [`MAX_CONSECUTIVE_DEFERRALS`] and so incapable of overflowing:
-  /// it only ever increments on a round that DEFERRED, and a round only defers
-  /// while this is strictly below that cap.
-  deferrals_since_advance: usize,
   confirmed_words: Vec<WordTiming>,
   results: Vec<TranscriptionResult>,
   /// A sink for the reproducibility facts of EVERY ingested hypothesis —
@@ -761,8 +646,6 @@ impl LocalAgreement {
       hypothesis_words: Vec::new(),
       last_agreed_words: Vec::new(),
       holdback_superseded: false,
-      deferred: None,
-      deferrals_since_advance: 0,
       confirmed_words: Vec::new(),
       results: Vec::new(),
       ingested_facts: TaskFactsAccumulator::new(),
@@ -1037,7 +920,6 @@ impl LocalAgreement {
 
     let mut advanced = false;
     let mut skip_append = false;
-    let mut deferred: Option<DeferralSignature> = None;
     // :374 — absent on the first-ever call, so nothing below runs and
     // this falls through to the `AwaitingAgreement` append below.
     if let Some(previous) = &self.prev_result {
@@ -1051,117 +933,50 @@ impl LocalAgreement {
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
         let requested = common.len() - self.agreement_count_needed;
-        // RULE W'S DEFERRAL (#94, codex round 3 on PR #95, both findings).
-        // `None` is "the two hypotheses agreed, but every advance available is
-        // one Rule W refuses", and two states reach it. A tied run whose OWN
-        // tokens exceed the budget puts the floor strictly inside the run, so
-        // every boundary the forward search and the back-off can reach ties, and
-        // split 0, the one boundary a tied run always leaves legal, is below the
-        // floor. Or the budget FORCES the empty holdback and the watermark that
-        // advance would anchor lies past a word this hypothesis produced beyond
-        // `common` -- which is why `hypothesis_words` past `common` is passed
-        // in: on `common` alone that arm cannot see what it would strand.
-        //
-        // Advancing in either state empties the holdback and anchors the
-        // watermark strictly PAST the last confirmed instant. Every word the
-        // newest hypothesis produced at that same instant beyond `common` is
-        // then stranded: nothing confirmed it, the next worded ingest filters it
-        // out of BOTH hypotheses at once, and `finalize` has nothing left to
-        // recover it from -- after THIS round's `finalize` already published it
-        // through `find_longest_different_suffix`. A deletion, and on the forced
-        // arm a retraction, which is this module's non-preferred direction.
-        //
-        // So the round simply does not advance. It costs nothing that round --
-        // `finalize` emits `confirmed ++ hypothesis_words` either way, see
-        // `Self::finalize` -- and it is a WAIT for tail growth rather than the
-        // blocking policy this issue's ledger refuted for deadlock: one word
-        // starting strictly later opens a boundary above the floor and one word
-        // joining `common` gives an interior split something to hold.
-        //
-        // THE WAIT IS BOUNDED, TWICE (#94, codex rounds 4 and 5 on PR #95). A
-        // wait that is not waiting for anything is a stall, and `common`
-        // growing is the whole of what it waits for. Two bounds carry that, and
-        // they pull opposite ways on purpose -- see `DeferralWait::is_over`.
-        //
-        // The SIGNATURE bound is the correctness half: a deferral whose
-        // boundary-relevant state is IDENTICAL to the one the round before
-        // deferred over is the same round again, measured rather than
-        // predicted. Two shapes reach it and neither needs an exotic count:
-        // hypotheses that ALTERNATE past the agreed prefix keep `common` pinned
-        // at the words they still share, and a hypothesis that simply REPEATS
-        // with a tied run above the budget floor pins it with no disagreement at
-        // all.
-        //
-        // The COUNT bound is the liveness half, and it fires whatever the
-        // signature says: a state that keeps MOVING never repeats, so an
-        // over-budget tied run gaining one tied word per stride would defer
-        // forever under the signature alone (round 5, finding 1). Round 4's
-        // predicate -- `common.len()` no longer than the length already
-        // deferred over -- was neither: it missed the growing run (finding 1)
-        // and it authorized an escape from a DIFFERENT deferral whenever two
-        // lengths happened to match (finding 2).
-        let wait = DeferralWait {
-          previous: self.deferred.as_ref(),
-          taken: self.deferrals_since_advance,
-        };
-        let boundary = split_at_a_strict_boundary(
+        let split = split_at_a_strict_boundary(
           common,
-          &self.hypothesis_words[common.len()..],
           requested,
           self.confirmed_words.last().map(WordTiming::start),
-          wait,
         );
-        match boundary {
-          SplitDecision::At(split) => {
-            // `common` REPLACES the still-open record: it is the span two consecutive
-            // hypotheses have just re-agreed over it, and `last_agreed_words` is the
-            // one this hypothesis has superseded.
-            self.confirmed_words.extend_from_slice(&common[..split]);
-            self.last_agreed_words = common[split..].to_vec();
-            // RULE W'S WATERMARK (#94). The watermark is the first held-back word's
-            // start, which `split_at_a_strict_boundary` has already placed STRICTLY
-            // past the last confirmed word's start.
-            //
-            // With NOTHING held back -- which takes a single word whose OWN
-            // tokens exceed the prefill budget, the one thing that pushes the
-            // budget floor to `common.len()`, or a round that escaped a repeating
-            // deferral -- there is no held word to measure against, and
-            // `empty_holdback_watermark` is the answer. That is the SAME function,
-            // called with the SAME arguments, that the deferral decision above
-            // consults, deliberately: the guard and the value it guards may not
-            // drift apart, and the value is now the LOWEST instant that clears the
-            // last confirmed word's start rather than a fixed one.
-            //
-            // Monotone: every word of `common` starts at or past the old watermark,
-            // `end >= start` for any word the pipeline emits, `next_up` only
-            // increases, and the sparing minimum is taken only over words that
-            // themselves cleared the old watermark. A NaN start cannot break the
-            // postcondition either -- `max` returns the non-NaN side, and
-            // `start >= watermark` is false for a NaN start, so such a word is
-            // never offered back in the first place.
-            //
-            // `common` is non-empty here (its length is at least
-            // `agreement_count_needed`, clamped to at least one), so the final
-            // fallback is unreachable and only keeps this total.
-            self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
-              || {
-                common.last().map_or(self.last_agreed_seconds, |last| {
-                  empty_holdback_watermark(last, &self.hypothesis_words[common.len()..])
-                })
-              },
-              WordTiming::start,
-            );
-            advanced = true;
-          }
-          SplitDecision::Defer(signature) => {
-            // The hypotheses AGREED, so `result` is KEPT below (`:402`/`:408-410`,
-            // no `skipAppend`) and the next round compares against it -- that is
-            // what lets tail growth reach `common` and relieve this. The signature
-            // rides along as the state the NEXT deferral is judged against, and
-            // the counter below as the wait's own length.
-            deferred = Some(signature);
-          }
-        }
+        // `common` REPLACES the still-open record: it is the span two consecutive
+        // hypotheses have just re-agreed over it, and `last_agreed_words` is the
+        // one this hypothesis has superseded.
+        self.confirmed_words.extend_from_slice(&common[..split]);
+        self.last_agreed_words = common[split..].to_vec();
+        // RULE W'S WATERMARK (#94). The watermark is the first held-back word's
+        // start, which `split_at_a_strict_boundary` has already placed STRICTLY
+        // past the last confirmed word's start.
+        //
+        // With NOTHING held back -- the fallback, reached where neither the
+        // forward search nor the back-off found a legal boundary at or above the
+        // prefill budget floor, and where the floor itself reaches
+        // `common.len()` -- there is no held word to measure against, and
+        // `empty_holdback_watermark` is the answer: the LOWEST instant that
+        // still clears the last confirmed word's own start, which spares every
+        // word this hypothesis produced past `common` that any such instant
+        // could spare. What it cannot spare is a word at that exact start, and
+        // that is this module's residual 1.
+        //
+        // Monotone: every word of `common` starts at or past the old watermark,
+        // `end >= start` for any word the pipeline emits, `next_up` only
+        // increases, and the sparing minimum is taken only over words that
+        // themselves cleared the old watermark. A NaN start cannot break the
+        // postcondition either -- `max` returns the non-NaN side, and
+        // `start >= watermark` is false for a NaN start, so such a word is
+        // never offered back in the first place.
+        //
+        // `common` is non-empty here (its length is at least
+        // `agreement_count_needed`, clamped to at least one), so the final
+        // fallback is unreachable and only keeps this total.
+        self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
+          || {
+            common.last().map_or(self.last_agreed_seconds, |last| {
+              empty_holdback_watermark(last, &self.hypothesis_words[common.len()..])
+            })
+          },
+          WordTiming::start,
+        );
+        advanced = true;
       } else {
         // :395-400 — disagreement; `result` is dropped below.
         skip_append = true;
@@ -1175,21 +990,6 @@ impl LocalAgreement {
     // run at all) also lands on `false`: nothing has been held back yet, so
     // nothing can have been superseded.
     self.holdback_superseded = skip_append;
-    // Assigned on EVERY worded ingest for the same reason, so an advance or a
-    // disagreement clears a deferral the round before it -- which is also what
-    // keeps the signature comparison above a claim about the IMMEDIATELY
-    // preceding worded round rather than about some older one.
-    self.deferred = deferred;
-    // The COUNTER spans what the signature does not. An advance resets it: the
-    // watermark moved, the confirmed list grew, and whatever the wait was for is
-    // over. A DISAGREEMENT deliberately leaves it, so a stream that alternates
-    // deferral and disagreement -- never repeating a signature, never advancing
-    // -- is still bounded by it.
-    if advanced {
-      self.deferrals_since_advance = 0;
-    } else if self.deferred.is_some() {
-      self.deferrals_since_advance += 1;
-    }
 
     // :402 (unconditional) + :408-410 (`!skipAppend`).
     if skip_append {
@@ -1213,8 +1013,7 @@ impl LocalAgreement {
   /// ([`crate::audio::whisper::text::find_longest_different_suffix`] over the last
   /// ingested pair), both folded onto [`Self::confirmed_words_slice`] —
   /// **except when the holdback is not the final estimate of its own span** —
-  /// the final hypothesis DISAGREED with it, or the final round was DEFERRED so
-  /// the holdback belongs to an earlier agreement — where this port emits that
+  /// the final hypothesis DISAGREED with it — where this port emits that
   /// hypothesis's own post-watermark words instead
   /// (see this module's doc, "The final hypothesis's holdback");
   /// [`merge_transcription_results_with_words`] then merges every kept
@@ -1251,7 +1050,7 @@ impl LocalAgreement {
   /// settled instant; the last two findings on this branch both hid in exactly
   /// that gap, where `confirmed_words`' append-only guarantee cannot see.
   fn take_finalized_words(&mut self) -> Vec<WordTiming> {
-    if (self.holdback_superseded || self.deferred.is_some()) && !self.hypothesis_words.is_empty() {
+    if self.holdback_superseded && !self.hypothesis_words.is_empty() {
       // DIVERGENCE from `:418-419` — see this module's doc for the full
       // argument. Swift's `lastAgreedWords + differentSuffix(prevWords,
       // hypothesisWords)` is only a valid decomposition when the final round
@@ -1266,17 +1065,14 @@ impl LocalAgreement {
       // SUFFIX would instead drop the leading words both hypotheses produced,
       // which is the same defect's other face when the holdback is empty.
       //
-      // DEFERRED (`deferred`, codex round 3 on PR #95): the two hypotheses
-      // AGREED but no legal split existed at or above the prefill budget floor,
-      // so `last_agreed_words` is an EARLIER agreement's holdback and Swift's sum
-      // would drop everything between it and `common`'s end. `hypothesis_words`
-      // is the latest full reading of the whole post-watermark span and subsumes
-      // both. It is also byte-identical to what the widen-off-the-end fallback
-      // this replaced produced on the same round: that fallback confirmed
-      // `common`, left the holdback empty and finalized
-      // `confirmed ++ common ++ hypothesis-beyond-common`, which is
-      // `confirmed ++ hypothesis_words` written out. The whole divergence is in
-      // what LATER ingests can still see, not in this round's transcript.
+      // A DEFERRED round used to reach this branch too, between `6987bec` and
+      // `b3ec5c6`, and no longer exists: an agreeing round always advances (#94;
+      // see this module's doc, "Why there is no deferral"). It made no
+      // difference to the round's own transcript -- a deferred round finalized
+      // `confirmed ++ hypothesis_words` and the advance it refused finalizes
+      // `confirmed ++ common ++ hypothesis-beyond-common`, which is the same
+      // list -- so removing the clause moves no word out of any single round's
+      // `finalize`.
       //
       // The non-empty guard is load-bearing: a result whose every word falls
       // BEFORE the watermark still clears the `has_words` gate (`:371`) and
@@ -1324,127 +1120,6 @@ impl LocalAgreement {
 // ---------------------------------------------------------------------
 // The confirmed/holdback split
 // ---------------------------------------------------------------------
-
-/// The boundary-relevant state of a round that DEFERRED: everything that decides
-/// WHICH words an escape from that round would strand, and nothing else (#94,
-/// codex round 5 on PR #95, finding 2).
-///
-/// What this replaces was `common.len()` alone, compared with `<=`, and a LENGTH
-/// does not establish that the wait already taken covered the state now in front
-/// of the engine. Agreement compares NORMALIZED TEXT while the escape's cost is
-/// a question about TIMINGS, so the two come apart: defer over `[A, H@1]` with a
-/// tied strand `X@1`, then offer `[A, H@2, Y@2]`, and the common length is still
-/// two while the hazardous boundary has moved from 1 s to 2 s. Escaping there
-/// confirms `H@2`, anchors past 2 s, and strands `Y` — a word this round's own
-/// `LocalAgreement::finalize` had already published, retracted on the next
-/// ingest, and invisible to [`LocalAgreement::confirmed_words_slice`]'s
-/// append-only guarantee, which never held it. Repeating that hypothesis instead
-/// grows `common` to include `Y` and keeps it, which is what makes the escape a
-/// LOSS rather than an ordering.
-/// `a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat` is the
-/// falsifier.
-///
-/// **Why exactly these fields.** The escape splits at `common.len()` and anchors
-/// at `empty_holdback_watermark`, so what it strands is
-/// `{ w in beyond_common : w.start() < escape_watermark }` — which after that
-/// function's sparing fold is exactly the words TIED to `terminal_start`. Those
-/// two therefore fix the cost. `floor` and `common_len` fix which boundaries the
-/// forward search and the back-off could reach at all, and between them they
-/// also record the ARM: the budget forces the empty holdback exactly when
-/// `floor == common_len`. The last confirmed word's start is deliberately absent
-/// — nothing is confirmed between two deferrals, so it cannot move while this is
-/// being compared, and an advance clears the record anyway.
-///
-/// **What it deliberately does NOT record is TEXT**, so two deferrals whose
-/// strands differ only in what they say at the same instant count as the same
-/// wait. That is round 4's own adjudication rather than an oversight: a word
-/// that alternates at the settled instant is uncorroborable BY CONSTRUCTION —
-/// `find_longest_common_prefix` stops in front of it on every round it is
-/// offered — so no length of wait delivers it, and
-/// `an_alternating_suffix_escapes_the_deferral_instead_of_stalling` is the shape
-/// that would stall if this compared text.
-///
-/// The comparison is EQUALITY on every field, including the length. Round 4's
-/// `<=` is not merely widened here, it is dropped: escaping where `common`
-/// SHRANK is escaping from a state the previous wait did not cover either, and
-/// the safe direction for a doubt about whether a wait repeated is to wait
-/// again, which `MAX_CONSECUTIVE_DEFERRALS` bounds at four rounds. That choice
-/// is a recorded SUITE GAP rather than a proven one: relaxing the length back to
-/// `<=` reds nothing in this crate, since no shape here or in
-/// `the_split_never_cuts_at_a_tied_start` produces two consecutive deferrals
-/// whose `common` shrank at an otherwise identical state (measured: 0 in 512
-/// sweep trials), though a hypothesis that agrees with its predecessor on less
-/// makes one reachable.
-///
-/// Comparing `f32` by `==` is exact and total here: `terminal_start` reached this
-/// through `LocalAgreement::watermark_filtered`, whose `start >= watermark` is
-/// false for a NaN, and `empty_holdback_watermark` is documented never-NaN. Were
-/// one ever NaN the signature would simply never match, which defers one round
-/// longer and stays bounded by [`MAX_CONSECUTIVE_DEFERRALS`] — the safe
-/// direction.
-#[derive(Debug, Clone, Copy, PartialEq)]
-struct DeferralSignature {
-  /// `budgeted_split(common, 0)`: the earliest split whose holdback the prefill
-  /// can carry whole, and the floor neither search may cross.
-  floor: usize,
-  /// `common.len()`.
-  common_len: usize,
-  /// The last agreed word's start — the instant an escape must anchor strictly
-  /// past, and so the one instant no watermark can spare.
-  terminal_start: f32,
-  /// `empty_holdback_watermark(common.last(), beyond_common)`: the watermark an
-  /// escape would anchor at.
-  escape_watermark: f32,
-}
-
-/// What `split_at_a_strict_boundary` knows about the wait the current round
-/// would JOIN, and the one place the two bounds compose.
-///
-/// They pull opposite ways, which is the whole difficulty (#94, codex round 5 on
-/// PR #95). Tightening the predicate for finding 2 makes finding 1's stall
-/// LONGER; loosening it for finding 1 makes finding 2's premature escape MORE
-/// available. Neither is a predicate problem alone, so neither is fixed by one
-/// predicate: `previous` establishes that a wait is the SAME wait, which is a
-/// correctness claim about what an escape may cost, and `taken` bounds the wait
-/// whatever it is waiting on, which is a liveness claim about how long a caller
-/// may be made to wait. The first can only ever make the engine wait longer; the
-/// second is what stops that being forever.
-#[derive(Debug, Clone, Copy)]
-struct DeferralWait<'a> {
-  /// The signature of the IMMEDIATELY preceding worded round, if it deferred.
-  previous: Option<&'a DeferralSignature>,
-  /// How many rounds have already deferred since the last advance — never above
-  /// [`MAX_CONSECUTIVE_DEFERRALS`], since a round only defers while it is below.
-  taken: usize,
-}
-
-impl DeferralWait<'_> {
-  /// Whether a round in this state may ESCAPE — advance at `common.len()` with
-  /// an empty holdback — rather than wait again.
-  ///
-  /// The two bounds are a disjunction and each is complete on its own side. The
-  /// SIGNATURE fires on a wait that has provably already happened, so it can end
-  /// a repeat on the very next round without ever cutting a moving state short.
-  /// The COUNT fires on a wait that has gone on too long to be waiting for
-  /// anything, whatever it looks like, so it ends a state that keeps changing
-  /// shape. Neither subsumes the other, and dropping either re-opens one of
-  /// round 5's two findings.
-  fn is_over(self, signature: &DeferralSignature) -> bool {
-    self.previous == Some(signature) || self.taken >= MAX_CONSECUTIVE_DEFERRALS
-  }
-}
-
-/// What `split_at_a_strict_boundary` answered: where to split, or the state the
-/// round is waiting on instead.
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum SplitDecision {
-  /// Confirm `common[..at]` and hold `common[at..]` back — `at == common.len()`
-  /// being the empty holdback, which both the FORCED arm and the ESCAPE take.
-  At(usize),
-  /// Do not advance; this is the wait's own signature, which
-  /// `LocalAgreement::ingest` records for the round after it.
-  Defer(DeferralSignature),
-}
 
 /// RULE W (#94, at its source): where an advance splits `common`, moved off any
 /// boundary that would put the watermark AT a start already settled.
@@ -1504,108 +1179,48 @@ enum SplitDecision {
 ///    over the HEAD of the offered list, which only an advance can move, whereas
 ///    this defers a split position that TAIL growth relieves, and it advances
 ///    the holdback rather than refusing the round.
-/// 3. **`SplitDecision::At(common.len())` -- the ESCAPE**, where neither search
-///    found a legal boundary and `DeferralWait::is_over`. See arm 4 for the wait
-///    this bounds; the holdback goes empty and the watermark is
-///    `empty_holdback_watermark`'s lowest sparing instant, exactly as in arm 5.
-/// 4. **`SplitDecision::Defer` -- DEFER**, on either of two states, and each is
-///    a WAIT rather than a refusal: it costs nothing on the deferring round
-///    itself -- `finalize` emits `confirmed ++ hypothesis_words` either way (see
-///    `LocalAgreement::finalize`) -- and the divergence is entirely in what
-///    LATER ingests can still see. **The wait is BOUNDED** by
-///    `DeferralWait::is_over`, and that bound is the whole of arm 3; the two
-///    states below are what a wait is worth taking for at all.
-///
-///    The first is where the budget floor is `1` or more and no legal
-///    boundary sits at or above it. A tied run whose OWN tokens exceed
-///    `MAX_HOLDBACK_PREFILL_TOKENS` is the shape: the floor lands strictly
-///    inside the run, every boundary the search and the back-off can reach ties,
+/// 3. **`common.len()` -- the FALLBACK**, where neither search found a legal
+///    boundary at or above the budget floor. The floor is never crossed, because
+///    below it `prefill_tokens` silently truncates the prefill and the erased
+///    words are neither re-offered nor confirmed (codex round 7, finding 2), so
+///    the only position left is off the end: `common` is confirmed WHOLE, the
+///    holdback goes empty, and `LocalAgreement::ingest` anchors the watermark at
+///    `empty_holdback_watermark`'s lowest sparing instant rather than at
+///    `common.last().end()`. Two shapes reach it, and neither is exotic. The
+///    budget FLOOR itself can reach `common.len()`, which takes a LAST word
+///    whose own tokens exceed `MAX_HOLDBACK_PREFILL_TOKENS` -- nothing else runs
+///    `budgeted_split`'s loop off the end -- and there the empty holdback is
+///    forced outright, no split leaving one the prefill could carry. Or the
+///    floor lands strictly INSIDE a tied run whose own tokens exceed the budget,
+///    where every boundary the forward search and the back-off can reach ties
 ///    and split `0` -- the boundary a tied run always leaves legal -- is below
-///    the floor. Neither of the two positions that ARE available is acceptable.
-///    Crossing the floor issues a prefill `prefill_tokens` truncates at the
-///    head, and the head then exists in no hypothesis and in no confirmed list
-///    (codex round 7, finding 2, exactly). Widening off the end -- what this
-///    used to do -- confirms the whole run, empties the holdback and anchors the
-///    watermark strictly PAST the run's instant, stranding every word the newest
-///    hypothesis produced at that same instant beyond `common`: the next worded
-///    ingest filters them from both hypotheses at once and `LocalAgreement::
-///    finalize` cannot recover them (codex round 3 on PR #95).
+///    the floor. `add_word_timestamps` produces the second shape from an
+///    ALL-ZERO alignment matrix (113 ordinary one-token words at one instant,
+///    measured at 130), so it is the reachable one.
 ///
-///    So the round waits instead, and `LocalAgreement::ingest` records it for
-///    `LocalAgreement::finalize`. It is the same policy as the back-off
-///    above -- Rule W may not empty the holdback -- carried into the state where
-///    the back-off has nowhere legal to land, and TAIL growth relieves it: one
-///    word starting strictly later opens a boundary at or above the floor,
-///    because a single word's tokens raise the floor by at most that word's own
-///    cost.
+///    **What this costs, and why it is not a DEFERRAL** (#94, measured on this
+///    branch; see this module's doc, "Why there is no deferral"). The empty
+///    holdback anchors strictly past the last confirmed word's own start, so a
+///    word the newest hypothesis produced beyond `common` AT that same start is
+///    stranded: the next worded ingest filters it out of both hypotheses at
+///    once, and `LocalAgreement::finalize` cannot reach it afterwards -- after
+///    THIS round's `finalize` already published it through
+///    `find_longest_different_suffix`. That is this module's residual 1, and it
+///    is exactly that narrow: `empty_holdback_watermark`'s sparing fold lowers
+///    the anchor to spare every word at any OTHER instant
+///    (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`).
 ///
-///    The second state is arm 5's, refused: the budget FORCES the empty
-///    holdback, and the watermark that advance would set --
-///    `empty_holdback_watermark(common.last(), beyond_common)` -- still lies
-///    past a word of `beyond_common`, which after that function's sparing fold
-///    takes a word TIED to the last confirmed start. That word is stranded
-///    exactly as above, and what it costs is one step worse: this round's own
-///    `finalize` PUBLISHES it, through `find_longest_different_suffix`, so
-///    losing it on the next ingest RETRACTS transcript rather than merely never
-///    emitting it. `confirmed_words`' append-only guarantee never sees it -- the
-///    word was never confirmed. The same relief applies: tail growth either
-///    moves the strand into `common`, where an ordinary interior split can hold
-///    it, or opens a boundary above the floor.
-///
-///    **What relief actually requires, and why the wait needed a bound** (#94,
-///    codex round 4 on PR #95). Both reliefs are `common` GROWING, and nothing
-///    makes it grow. Two hypotheses that ALTERNATE past the agreed prefix pin
-///    `common` at the words they still share, round after round, and a
-///    hypothesis that simply REPEATS pins it with no disagreement at all -- so
-///    the deferral came back every round, the watermark never moved, the caller
-///    read `AwaitingAgreement` forever, and in the driver the clip kept
-///    re-decoding from a boundary that never advanced while the buffer grew past
-///    it. The earlier liveness argument -- "one word starting strictly later
-///    opens a boundary" -- is about a suffix that STABILIZES and reaches neither
-///    state. Both states are bounded by arm 3, and exempting either from its own
-///    bound is not a bound
-///    (`an_alternating_suffix_escapes_the_deferral_instead_of_stalling`,
-///    `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`).
-///
-///    **And `common` GROWING is not itself relief** (#94, codex round 5 on
-///    PR #95, finding 1) -- which is what a bound written as "`common` no longer
-///    than the length already deferred over", round 4's own, assumed. A tied run
-///    already over the budget that gains one more TIED word every stride grows
-///    `common` on every round while opening no boundary at all: the floor rises
-///    with it, every reachable position still ties, and the length predicate is
-///    false forever. That stall is unbounded in rounds AND in retention, since
-///    an agreeing round is a kept round. So the wait is bounded by
-///    `MAX_CONSECUTIVE_DEFERRALS` rounds as well, whatever its shape, and by a
-///    `DeferralSignature` rather than a length where it does repeat -- a length
-///    also cannot tell one deferral from a DIFFERENT one of the same length,
-///    which is round 5's finding 2 and the retraction on
-///    `a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat`.
-/// 5. **`SplitDecision::At(common.len())`** -- tested FIRST in the code, since its condition
-///    is a property of the budget alone and neither search runs on it. Only
-///    where the BUDGET FLOOR itself reaches `common.len()` is that length
-///    returned on the FIRST round and the holdback left empty. That takes a LAST
-///    word whose own tokens exceed the budget, since nothing else runs
-///    `budgeted_split`'s loop off the end, and it is the one state where the
-///    empty holdback is FORCED: no split leaves a holdback the prefill could
-///    carry, so there is no anchor to wait for and deferring would wait forever.
-///    Confirming is round 7 finding 2's own repair, and
-///    `LocalAgreement::ingest`'s watermark then anchors strictly past the last
-///    confirmed start rather than at its `end`. This arm and arm 3 are the whole
-///    of what reaches the empty holdback.
-///
-///    "There is no anchor to wait for" is a claim about `common` alone, and it
-///    is why this arm may not simply defer -- but the ADVANCE is not a property
-///    of `common` alone, which is what `beyond_common` is here to supply. Where
-///    a word past `common` would be stranded by this arm's own watermark, arm 4
-///    takes the round instead; where nothing is, this arm advances exactly as
-///    before. The guard is that narrow on purpose: widening it to "defer
-///    whenever the budget forces the empty holdback" re-opens round 7 finding
-///    2, which is the wait that never ends.
-///
-///    An EMPTY `common` reaches this arm too (`floor == 0 == common.len()`) and
-///    advances -- written out as its own early return above, so that everything
-///    after it has a terminal word to build a signature from. See that return
-///    for why it carries no falsifier.
+///    Between `6987bec` and `b3ec5c6` this arm did not advance at all: it
+///    DEFERRED, waiting for `common` to grow, under two bounds that ended the
+///    wait. Measured against exactly this fallback over the accumulated
+///    counterexample suite and the 512-trial sweep, the deferral erased 26 words
+///    from the published transcript where this erases 10, and its count bound
+///    was defeated by `At(0)` -- an advance that confirms nothing yet resets the
+///    counter -- so an `L, L, S` cycle held the engine at zero words confirmed
+///    for 30 rounds while `results` grew one per round. What the wait bought
+///    over the same suite was four words on one row and one word each on two
+///    others, every one of them at the settled instant. The trade is recorded in
+///    full in this module's doc; the fallback is what this returns.
 ///
 /// So `agreement_count_needed` is a target rather than an exact width in EITHER
 /// direction: the budget can shorten the holdback (see `budgeted_split`) and
@@ -1616,25 +1231,18 @@ enum SplitDecision {
 /// After every advance, `confirmed_words.last().start() < last_agreed_seconds`
 /// STRICTLY -- with no condition on the holdback. Where the split is interior
 /// the boundary above is exactly that inequality; where it is `common.len()`
-/// `LocalAgreement::ingest`'s `next_up` anchor is. So no confirmed word can pass
-/// the offered filter, and the re-admission question is unrepresentable rather
-/// than defended against.
+/// `LocalAgreement::ingest`'s `empty_holdback_watermark` anchor is, whose result
+/// is strictly greater than `common.last().start()` for every input -- the
+/// sparing fold skips exactly the starts that are not (see that function). So no
+/// confirmed word can pass the offered filter, and the re-admission question is
+/// unrepresentable rather than defended against.
 ///
-/// It stays TOTAL under both DEFER states rather than becoming conditional
-/// again: a deferred round is not an advance, so it moves neither side of the
-/// inequality and there is no state for the claim to be excluded from.
-/// `SplitDecision::Defer` REMOVES reachable advances rather than adding
-/// unguarded ones, and the second state removes a strict subset of arm 5's,
-/// which the `next_up` anchor already carried.
-///
-/// It stays total under the ESCAPE too, which ADDS advances rather than removing
-/// them, and under BOTH of the bounds that authorize one: every escape splits at
-/// `common.len()` whichever bound fired, and there `LocalAgreement::ingest`
-/// anchors at `empty_holdback_watermark`, whose result is strictly greater than
-/// `common.last().start()` for every input -- the sparing fold skips exactly the
-/// starts that are not (see that function). What `DeferralWait::is_over` decides
-/// is WHEN an escape may be taken, never where it splits or what it anchors at,
-/// so no bound can reach this inequality.
+/// The two arms above are the whole of the function, so there is no third state
+/// to exclude the claim from: every round with `common.len() >=
+/// agreement_count_needed` ADVANCES, and it advances to one of those two
+/// positions. That is what removing the deferral restores (#94) -- while it
+/// existed, totality had to be re-argued for a non-advancing state, and the
+/// argument was that a deferred round moves neither side of the inequality.
 ///
 /// # A second postcondition
 ///
@@ -1645,26 +1253,33 @@ enum SplitDecision {
 /// free -- the watermark is `common[split].start()` and word starts inside one
 /// hypothesis are non-decreasing, so everything from `split` on is at or past
 /// it. Where the split is `common.len()` the watermark is strictly PAST the last
-/// confirmed start, so it is not free, and two things buy it: the sparing fold
-/// in `empty_holdback_watermark`, which lowers the anchor to the earliest word
-/// of `beyond_common` it can, and the `beyond_common` test in arm 5, which waits
-/// where it cannot lower it far enough.
+/// confirmed start, so it is not free, and the sparing fold in
+/// `empty_holdback_watermark` is what buys it: the anchor drops to the earliest
+/// word of `beyond_common` it can.
 ///
-/// **It has ONE exception, and only since the deferral was bounded** (#94, codex
-/// round 4 on PR #95): a round that takes arm 3's ESCAPE may strand a word of
-/// `beyond_common` that starts at the last confirmed word's own instant. There
-/// no value serves both claims -- the first postcondition demands a watermark
-/// strictly past that start, and every such watermark filters the strand -- so
-/// this is the module's residual 1 reached earlier than the residual's own
-/// route, not a policy. It is exactly that narrow: at any other start the
-/// sparing fold spares the word, and only an escape may use it. Round 5's second
-/// bound does not widen the exception's SHAPE, only the set of rounds that may
-/// take it: an escape authorized by the round count strands the same tie an
-/// escape authorized by a repeating signature does, and nothing else.
-/// `the_split_never_cuts_at_a_tied_start` sweeps both postconditions and the
-/// exception, and counts the escapes and the strands so neither can pass by
-/// being unreachable -- and reads the published TRANSCRIPT across every round
-/// besides, which is where a retraction the confirmed list cannot see shows up.
+/// **It has ONE exception, and the exception is the arm rather than a policy**
+/// (#94). A round whose split runs to `common.len()` may strand a word of the
+/// hypothesis beyond `common` that starts at the last confirmed word's OWN
+/// instant. There no value serves both claims -- the first postcondition demands
+/// a watermark strictly past that start, and every such watermark filters the
+/// strand -- so this is this module's residual 1, reached wherever the empty
+/// holdback is reached. It is exactly that narrow: word starts inside one
+/// hypothesis are non-decreasing, so a word beyond `common` starts at or after
+/// `common.last()`, and at any start strictly after it the sparing fold spares
+/// the word.
+///
+/// The exception's GATE moved when the deferral was removed, and its SHAPE did
+/// not. While the deferral existed the gate was "this round escaped a repeating
+/// wait", and the rounds that would otherwise have stranded deferred instead;
+/// now every empty-holdback advance carries it. Measured over the 512-trial
+/// sweep the wider gate is 38 strands where the deferral had 29 -- and 10 words
+/// erased from the published transcript where the deferral erased 26, which is
+/// the direction that decided it (this module's doc, "Why there is no
+/// deferral"). `the_split_never_cuts_at_a_tied_start` sweeps both postconditions
+/// and the exception, and counts the empty-holdback rounds and the strands so
+/// neither can pass by being unreachable -- and reads the published TRANSCRIPT
+/// across every round besides, which is where a retraction the confirmed list
+/// cannot see shows up.
 ///
 /// It is a claim about the LAST confirmed word, and that is as strong as it needs
 /// to be exactly while word starts inside one hypothesis are non-decreasing --
@@ -1672,11 +1287,9 @@ enum SplitDecision {
 /// for the backwards-starts input the `pub(crate)` seal excludes.
 fn split_at_a_strict_boundary(
   common: &[WordTiming],
-  beyond_common: &[WordTiming],
   requested: usize,
   confirmed_last_start: Option<f32>,
-  wait: DeferralWait<'_>,
-) -> SplitDecision {
+) -> usize {
   let strictly_after_the_preceding_start = |at: usize| {
     let preceding = if at == 0 {
       confirmed_last_start
@@ -1688,108 +1301,15 @@ fn split_at_a_strict_boundary(
   // `budgeted_split` with nothing requested IS the budget's own floor: the
   // earliest split whose holdback fits `MAX_HOLDBACK_PREFILL_TOKENS`.
   let floor = budgeted_split(common, 0);
-  // An EMPTY `common` reaches the FORCED arm below (`floor == 0 ==
-  // common.len()`) and advances: there is no word to anchor a watermark on, so
-  // there is nothing to strand, and `LocalAgreement::ingest`'s own fallback
-  // leaves the watermark where it was. Taken here rather than inside that arm so
-  // everything below has a terminal word to speak about. Like the `at == 0`
-  // check above it carries NO falsifier -- `LocalAgreement::ingest` only calls
-  // this with `common.len() >= agreement_count_needed`, which is clamped to at
-  // least one -- and, like it, it is written out so this function is total on
-  // its own terms rather than on its caller's clamp. Flipping it to defer reds
-  // nothing in this crate.
-  let Some(last) = common.last() else {
-    return SplitDecision::At(common.len());
-  };
-  // The watermark an EMPTY holdback would anchor at, computed ONCE and shared by
-  // the strand test, the deferral's signature and (through `common.len()`)
-  // `LocalAgreement::ingest`'s own anchor -- the guard, the record and the value
-  // may not drift apart.
-  let escape_watermark = empty_holdback_watermark(last, beyond_common);
-  let signature = DeferralSignature {
-    floor,
-    common_len: common.len(),
-    terminal_start: last.start(),
-    escape_watermark,
-  };
-  // The EMPTY holdback strands a word exactly when `empty_holdback_watermark`
-  // cannot be lowered far enough to spare it, which takes a word of
-  // `beyond_common` starting at or before the last confirmed word's own start
-  // -- an exact tie, since starts inside one hypothesis do not run backwards.
-  // Everything else is spared by the watermark itself, which folds over exactly
-  // those starts.
-  //
-  // `start < watermark` is `watermark_filtered`'s own `start >= watermark`
-  // negated, and totally so: every word of `beyond_common` reached this call
-  // through that filter, so none of their starts is NaN.
-  let empty_holdback_strands = || {
-    beyond_common
-      .iter()
-      .any(|word| word.start() < escape_watermark)
-  };
-  if floor == common.len() {
-    // The budget FORCES the empty holdback: no split leaves a non-empty one the
-    // prefill could carry, which takes a LAST word whose own tokens exceed
-    // `MAX_HOLDBACK_PREFILL_TOKENS` (that is the only way the loop in
-    // `budgeted_split` runs off the end). Confirming it is always available and
-    // is round 7 finding 2's own repair; deferring where nothing would be
-    // stranded would wait for an anchor that can never arrive.
-    //
-    // But the advance anchors the watermark at
-    // `empty_holdback_watermark(common.last(), beyond_common)`, and a word the
-    // newer hypothesis produced beyond `common` at the last confirmed word's own
-    // instant is stranded by it (codex round 3 on PR #95, second finding): the
-    // next worded ingest filters it out of both hypotheses at once, and it is a
-    // word THIS round's `LocalAgreement::finalize` already published through
-    // `find_longest_different_suffix`. So the forced advance defers while it
-    // would strand -- and the strand is what `beyond_common` is here to see,
-    // since on `common` alone this arm cannot know what lies past it.
-    //
-    // Unless the WAIT IS OVER -- the same state has already been waited on, or
-    // the wait has run past `MAX_CONSECUTIVE_DEFERRALS` rounds -- in which case
-    // the round takes the advance anyway (codex rounds 4 and 5 on PR #95). What
-    // that costs is exactly this module's residual 1, one round earlier than the
-    // residual's own route: at an exact tie a word beyond `common` and a
-    // re-offer of the settled word in front of it are the same value to a
-    // timestamp filter, so no watermark serves both.
-    if empty_holdback_strands() && !wait.is_over(&signature) {
-      return SplitDecision::Defer(signature);
-    }
-    return SplitDecision::At(common.len());
-  }
   let widened = requested.max(floor);
-  match (widened..common.len())
+  (widened..common.len())
     .find(|&at| strictly_after_the_preceding_start(at))
     .or_else(|| {
       (floor..widened)
         .rev()
         .find(|&at| strictly_after_the_preceding_start(at))
-    }) {
-    Some(at) => SplitDecision::At(at),
-    // No INTERIOR boundary is legal, so this arm's deferral protects the
-    // holdback rather than a strand: the tied run stays revisable and the next
-    // stride keeps its prefill anchor (see
-    // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`).
-    // That is worth waiting for -- but only while the wait is still a wait. A
-    // state already waited on is not going to be relieved by waiting again -- a
-    // hypothesis REPEATING a tied run above the floor pins it with no
-    // disagreement anywhere, which is the shape an all-zero alignment matrix
-    // produces -- and a state that keeps CHANGING while never opening a boundary
-    // is a stall the signature can never catch, which is the same run gaining
-    // one tied word per stride. So the empty holdback is taken instead, still at
-    // the lowest watermark that clears the last confirmed start.
-    //
-    // `empty_holdback_strands()` is deliberately NOT consulted here, exactly as
-    // the forced arm stops consulting it once the wait is over: a bound that
-    // exempts the state it is there to escape is not a bound, and a tied run
-    // whose SUFFIX alternates at the run's own instant reaches this arm in
-    // precisely that state
-    // (`a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`'s
-    // second half). Both arms therefore strand the same thing on a wait that is
-    // over -- a word at the settled instant, residual 1 -- and nothing else.
-    None if wait.is_over(&signature) => SplitDecision::At(common.len()),
-    None => SplitDecision::Defer(signature),
-  }
+    })
+    .unwrap_or(common.len())
 }
 /// Where an advance splits `common` into the part that is CONFIRMED and the
 /// part that is HELD BACK, given the requested split — moved later until every
@@ -1864,10 +1384,9 @@ fn split_at_a_strict_boundary(
 /// line it may not cross: below it `prefill_tokens` silently truncates and the
 /// erased words are neither re-offered nor confirmed, which is the whole of
 /// round 7's finding 2. Where nothing legal sits at or above the floor, that
-/// rule DEFERS the round rather than crossing the floor — the one thing it never
-/// does, the floor being hard — and widens off the end only once that wait is
-/// OVER, either because its state repeated or because it ran to
-/// [`MAX_CONSECUTIVE_DEFERRALS`] rounds (its arm 3).
+/// rule widens off the END rather than crossing the floor — the one thing it
+/// never does, the floor being hard — and the empty holdback that leaves is its
+/// arm 3.
 ///
 /// **Documented deviation**: with `agreement_count_needed` at its
 /// [`DEFAULT_AGREEMENT_COUNT_NEEDED`] a two-word holdback of words

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -105,25 +105,48 @@
 //!   `LocalAgreement::finalize` emits the same words either way, and TAIL growth
 //!   relieves it.
 //!
-//!   **The deferral is a WAIT, and the wait is BOUNDED** (codex round 4 on
-//!   PR #95). Tail growth relieves it only where the tail GROWS `common`, and
-//!   two shapes stop it growing: hypotheses that ALTERNATE past the agreed
-//!   prefix pin `common` at the words they still share, and a hypothesis that
-//!   simply REPEATS pins it with no disagreement at all. Either way the same
-//!   round came back forever — nothing confirmed, the watermark frozen, the
-//!   caller reading `AwaitingAgreement`, and in the driver a clip boundary that
-//!   never advanced while the buffer grew past it. So a deferral over a `common`
-//!   no longer than the one the round before already deferred over takes the
-//!   empty holdback instead: that is a MEASUREMENT of a wait that has already
-//!   happened, not a prediction about the next one, and it costs at most one
-//!   round.
+//!   **The deferral is a WAIT, and the wait is BOUNDED TWICE** (codex rounds 4
+//!   and 5 on PR #95). Tail growth relieves it only where the tail GROWS
+//!   `common`, and two shapes stop it growing: hypotheses that ALTERNATE past
+//!   the agreed prefix pin `common` at the words they still share, and a
+//!   hypothesis that simply REPEATS pins it with no disagreement at all. Either
+//!   way the same round came back forever — nothing confirmed, the watermark
+//!   frozen, the caller reading `AwaitingAgreement`, and in the driver a clip
+//!   boundary that never advanced while the buffer grew past it.
+//!
+//!   So a deferral records a `DeferralSignature` — the floor, `common.len()`,
+//!   the terminal agreed start and the watermark an escape would anchor at,
+//!   which between them fix WHICH words an escape would strand — and a deferral
+//!   over a signature IDENTICAL to the round before's takes the empty holdback
+//!   instead: a MEASUREMENT of a wait that has already happened, not a
+//!   prediction about the next one.
 //!   `an_alternating_suffix_escapes_the_deferral_instead_of_stalling` and
 //!   `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`
-//!   are the falsifiers, one per deferral arm. What the escape can still lose is
-//!   one thing and it is residual 1 below: a word at the last confirmed word's
-//!   own instant, where no watermark serves both it and #94. Everything else
-//!   `empty_holdback_watermark` now SPARES by lowering the anchor to that word's
-//!   own start
+//!   are the falsifiers, one per deferral arm.
+//!
+//!   A signature bound alone is only half of it, and round 5 is both halves.
+//!   Recording `common.len()` alone (round 4's own predicate, compared with
+//!   `<=`) authorized an escape from a DIFFERENT deferral whenever two lengths
+//!   collided — the terminal timestamp may move while the normalized prefix does
+//!   not, and the escape's cost is a question about timings — which RETRACTS a
+//!   word a repeat would have kept
+//!   (`a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat`). And a
+//!   signature bound of any strength cannot end a wait whose state keeps MOVING:
+//!   an over-budget tied run gaining one tied word per stride defers with a
+//!   fresh signature every round, forever, retaining one result per round over a
+//!   clip window that never advances
+//!   (`a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`). The
+//!   two findings pull opposite ways — a stricter predicate lengthens the stall,
+//!   a looser bound widens the premature escape — so the answer is both:
+//!   [`MAX_CONSECUTIVE_DEFERRALS`] bounds the wait whatever it is waiting on,
+//!   and the signature ends a proven-repeat sooner. A caller therefore waits at
+//!   most that many consecutive deferred rounds between advances, and
+//!   `LocalAgreement::finalize` publishes the whole live transcript throughout.
+//!
+//!   What either escape can still lose is one thing and it is residual 1 below:
+//!   a word at the last confirmed word's own instant, where no watermark serves
+//!   both it and #94. Everything else `empty_holdback_watermark` now SPARES by
+//!   lowering the anchor to that word's own start
 //!   (`a_strand_starting_strictly_later_lowers_the_watermark_instead_of_deferring`),
 //!   which is what keeps the loss to the impossibility rather than to the
 //!   policy.
@@ -282,7 +305,7 @@
 //!   `commonPrefix.count` leading words both hypotheses actually produced.
 //!   `LocalAgreement::finalize` instead emits the final hypothesis's own
 //!   post-watermark words on that path (`holdback_superseded` is the flag), and
-//!   on the DEFERRED one too (`deferred_common_len`), where the hypotheses agreed but
+//!   on the DEFERRED one too (`deferred`), where the hypotheses agreed but
 //!   the only split available was one Rule W refuses — nothing legal at or above
 //!   the prefill budget floor, or a forced empty holdback that would strand the
 //!   hypothesis's own suffix — so the holdback is an earlier agreement's and
@@ -429,17 +452,21 @@
 //!    it is still dropped — and `the_split_never_cuts_at_a_tied_start` sweeps
 //!    both counts.
 //!
-//!    And it is WIDER again since round 4, by exactly one round and only where
-//!    the deferral has already been measured and found to buy nothing: an
-//!    ESCAPE drops a word that WAS already visible past `common`, if it starts
-//!    at the settled instant. That is the same impossibility from the same side
-//!    — the alternative is the stall the bound exists to leave, and the
-//!    alternative to THAT is re-admitting the settled word, which is #94 — so
-//!    the residual's statement is unchanged and only its route is one wider.
-//!    Everything at any OTHER instant is spared rather than dropped, by
-//!    `empty_holdback_watermark`'s fold. The escape's own falsifiers are
-//!    `an_alternating_suffix_escapes_the_deferral_instead_of_stalling` and
-//!    `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`,
+//!    And it is WIDER again since round 4, by the length of a bounded wait and
+//!    only where that wait is OVER: an ESCAPE drops a word that WAS already
+//!    visible past `common`, if it starts at the settled instant. That is the
+//!    same impossibility from the same side — the alternative is the stall the
+//!    bound exists to leave, and the alternative to THAT is re-admitting the
+//!    settled word, which is #94 — so the residual's statement is unchanged and
+//!    only its route is wider. Everything at any OTHER instant is spared rather
+//!    than dropped, by `empty_holdback_watermark`'s fold. A wait is over on
+//!    either bound (see `DeferralWait::is_over`): its signature REPEATED, which
+//!    costs the escape one round after the state was first seen, or it ran to
+//!    [`MAX_CONSECUTIVE_DEFERRALS`] rounds without repeating, which costs it
+//!    that many. The escape's own falsifiers are
+//!    `an_alternating_suffix_escapes_the_deferral_instead_of_stalling`,
+//!    `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`
+//!    and `a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`,
 //!    and the sweep counts the strands so the residual cannot be reported as
 //!    unreachable.
 //! 2. **A repeat the engine's record cannot account for** is the stream's own,
@@ -512,15 +539,16 @@ pub enum AgreementOutcome {
   /// `split_at_a_strict_boundary`), in which case the result was kept like any
   /// other agreeing one.
   ///
-  /// The deferral is deliberately not its own variant, and codex round 4 on
-  /// PR #95 is why that survives its strongest objection. The objection was
+  /// The deferral is deliberately not its own variant, and codex rounds 4 and 5
+  /// on PR #95 are why that survives its strongest objection. The objection was
   /// that a caller cannot escape a state it cannot see, which is true and was
   /// the finding: the deferral used to repeat without bound. It is bounded now
-  /// -- one round, measured (`split_at_a_strict_boundary`'s arm 3) -- so there
-  /// is no state left for a caller to be told about that the engine does not
-  /// leave by itself, and a `Blocked` variant would report a wait that has
-  /// already ended. What this value reports stays what it always reported:
-  /// whether the watermark moved.
+  /// -- at most [`MAX_CONSECUTIVE_DEFERRALS`] consecutive deferred rounds
+  /// between advances, and one round where the wait provably repeats
+  /// (`split_at_a_strict_boundary`'s arm 3) -- so there is no state left for a
+  /// caller to be told about that the engine does not leave by itself, and a
+  /// `Blocked` variant would report a wait that ends without it. What this value
+  /// reports stays what it always reported: whether the watermark moved.
   AwaitingAgreement,
   /// The result carried no word timings to agree over; it was still kept
   /// (Swift `:403-409` falls through to the unconditional append).
@@ -577,6 +605,53 @@ pub const DEFAULT_AGREEMENT_COUNT_NEEDED: usize = 2;
 /// (codex round 8, finding 1; codex round 12, finding 2).
 pub const MAX_HOLDBACK_PREFILL_TOKENS: usize = MAX_TOKEN_CONTEXT / 2;
 
+/// The most consecutive rounds Rule W's deferral may WAIT before it escapes,
+/// WHATEVER state it is waiting on — the liveness backstop beside the
+/// signature bound, and the second half of the answer to #94's codex round 5
+/// (finding 1).
+///
+/// `DeferralSignature` ends a wait that REPEATS, which is the only wait a
+/// measurement can prove bought nothing. It cannot end a wait whose state keeps
+/// MOVING, and one shape moves it every round: a tied run already over the
+/// prefill budget that gains one more tied word each stride defers with a longer
+/// `common`, a higher floor and a fresh signature every time, so every round's
+/// wait is a NEW one and nothing ever measures a repeat. `add_word_timestamps`
+/// produces exactly that run from an all-zero alignment matrix, one word per
+/// stride is the driver's own cadence, and the length is not bounded by
+/// anything: the stall is unbounded, and since an agreeing round is a KEPT
+/// round ([`LocalAgreement::results_slice`]) over a clip window that never
+/// advances, an unbounded stall is unbounded RETENTION as well as unbounded
+/// latency.
+///
+/// So a count bounds it, and the count is what the wait is FOR. A word that
+/// opens a legal boundary needs ONE round to appear in a hypothesis and ONE more
+/// to be corroborated into `common` — see the two-round relief in
+/// `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` — so a
+/// stream that is relieving itself is relieved within two rounds of the
+/// relieving word arriving, and `4` leaves room for that word to arrive two
+/// rounds late. Past that the wait is not waiting for anything a longer wait
+/// delivers. Rounds rather than seconds because the frozen quantity IS the
+/// watermark, so elapsed watermark cannot measure its own stall, and because the
+/// retained results this bounds accrue one per round.
+///
+/// **What a caller observes in the worst case.** At most this many consecutive
+/// DEFERRED rounds between advances; over them
+/// [`LocalAgreement::confirmed_words_slice`] does not grow, `Self::ingest`
+/// returns [`AgreementOutcome::AwaitingAgreement`],
+/// [`LocalAgreement::last_agreed_seconds`] does not move, and
+/// [`LocalAgreement::results_slice`] grows by one kept result per round —
+/// while `LocalAgreement::finalize` keeps publishing the whole live transcript
+/// (`confirmed ++ hypothesis_words`), so it is CONFIRMATION that stalls, not
+/// the transcript. When the count fires it costs this module's residual 1 on a
+/// state that has not repeated: the escape takes the empty holdback at
+/// `empty_holdback_watermark`'s lowest sparing instant, so the only word it can
+/// strand is one of the newest hypothesis's own AT the last confirmed word's
+/// instant — every other instant the sparing fold keeps offerable.
+///
+/// `a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals` is the
+/// falsifier and pins the number as a number.
+pub const MAX_CONSECUTIVE_DEFERRALS: usize = 4;
+
 /// The LocalAgreement-2 hypothesis-confirmation engine: consumes one
 /// [`TranscriptionResult`] per call and tracks the growing prefix two
 /// consecutive hypotheses agree on. Pure — no backend, no I/O, fully
@@ -607,7 +682,7 @@ pub struct LocalAgreement {
   /// four untouched, so this keeps describing the last hypothesis that actually
   /// had words to agree over — exactly the pair `finalize` reasons about.
   holdback_superseded: bool,
-  /// `Some(common.len())` when the most recent WORDED hypothesis AGREED with
+  /// `Some(signature)` when the most recent WORDED hypothesis AGREED with
   /// the previous one and the round still did not advance, because
   /// `split_at_a_strict_boundary` had no acceptable boundary to advance to:
   /// none legal at or above the prefill budget floor, or a forced empty
@@ -621,19 +696,42 @@ pub struct LocalAgreement {
   /// whole span and more, so Swift's `lastAgreedWords + differentSuffix`
   /// decomposition would drop everything between them.
   ///
-  /// `Self::ingest` needs the LENGTH, and that is the whole of the deferral's
-  /// liveness bound (#94, codex round 4 on PR #95). A deferral is a WAIT for
-  /// tail growth: `common` grows, and a boundary the split can legally take
-  /// appears above the budget floor. Deferring again over a `common` no LONGER
-  /// than the one that already deferred is therefore a wait that has already
-  /// been measured and found to buy nothing, which is a repeating state rather
-  /// than a wait — see `split_at_a_strict_boundary`'s escape.
+  /// `Self::ingest` needs the SIGNATURE, which is half of the deferral's
+  /// liveness bound (#94, codex rounds 4 and 5 on PR #95). A deferral is a WAIT
+  /// for tail growth: `common` grows, and a boundary the split can legally take
+  /// appears above the budget floor. Deferring again on a state IDENTICAL to
+  /// the one that already deferred is therefore a wait that has already been
+  /// measured and found to buy nothing, which is a repeating state rather than
+  /// a wait — see `split_at_a_strict_boundary`'s escape. An earlier form of
+  /// this field held `common.len()` alone and compared it with `<=`; a LENGTH
+  /// does not establish that the previous wait covered the current state, which
+  /// is round 5's finding 2 and the whole reason `DeferralSignature` exists.
   ///
   /// Maintained on exactly the same schedule as `Self::holdback_superseded` —
   /// only on the worded path, so the [`AgreementOutcome::NoWordTimings`] early
   /// return leaves it describing the last hypothesis that had words, and a
-  /// wordless stride between two deferrals neither relieves nor repeats one.
-  deferred_common_len: Option<usize>,
+  /// wordless stride between two deferrals neither relieves nor repeats one. It
+  /// is a claim about the IMMEDIATELY preceding worded round: an advance or a
+  /// disagreement clears it, because either one moves the state the signature
+  /// describes.
+  deferred: Option<DeferralSignature>,
+  /// How many rounds have DEFERRED since the last advance —
+  /// `split_at_a_strict_boundary`'s other bound, the one that fires whatever
+  /// the signature says (#94, codex round 5 on PR #95, finding 1). See
+  /// [`MAX_CONSECUTIVE_DEFERRALS`] for what the number is and what firing it
+  /// costs.
+  ///
+  /// Reset by an ADVANCE only. A disagreement clears [`Self::deferred`] but not
+  /// this, deliberately: a stream that alternates defer/disagree/defer never
+  /// repeats a signature and never advances either, and a counter a
+  /// disagreement reset would let that shape stall exactly as far as the
+  /// unbounded wait did. A wordless stride touches neither, on the same
+  /// schedule as every other field of the worded path.
+  ///
+  /// Bounded by [`MAX_CONSECUTIVE_DEFERRALS`] and so incapable of overflowing:
+  /// it only ever increments on a round that DEFERRED, and a round only defers
+  /// while this is strictly below that cap.
+  deferrals_since_advance: usize,
   confirmed_words: Vec<WordTiming>,
   results: Vec<TranscriptionResult>,
   /// A sink for the reproducibility facts of EVERY ingested hypothesis —
@@ -663,7 +761,8 @@ impl LocalAgreement {
       hypothesis_words: Vec::new(),
       last_agreed_words: Vec::new(),
       holdback_superseded: false,
-      deferred_common_len: None,
+      deferred: None,
+      deferrals_since_advance: 0,
       confirmed_words: Vec::new(),
       results: Vec::new(),
       ingested_facts: TaskFactsAccumulator::new(),
@@ -938,7 +1037,7 @@ impl LocalAgreement {
 
     let mut advanced = false;
     let mut skip_append = false;
-    let mut deferred: Option<usize> = None;
+    let mut deferred: Option<DeferralSignature> = None;
     // :374 — absent on the first-ever call, so nothing below runs and
     // this falls through to the `AwaitingAgreement` append below.
     if let Some(previous) = &self.prev_result {
@@ -979,74 +1078,89 @@ impl LocalAgreement {
         // starting strictly later opens a boundary above the floor and one word
         // joining `common` gives an interior split something to hold.
         //
-        // THE WAIT IS BOUNDED (#94, codex round 4 on PR #95). A wait that is
-        // not waiting for anything is a stall, and `common` growing is the
-        // whole of what it waits for -- so a deferral over a `common` no longer
-        // than the one that ALREADY deferred is the same round again, and
-        // repeating it is unbounded. Two shapes reach it and neither needs an
-        // exotic count: hypotheses that ALTERNATE past the agreed prefix keep
-        // `common` pinned at the words they still share, and a hypothesis that
-        // simply REPEATS with a tied run above the budget floor pins it with no
-        // disagreement at all. `deferral_gained_nothing` is that measurement,
-        // read off the round before rather than predicted, and
-        // `split_at_a_strict_boundary` takes the empty holdback instead of
-        // deferring again.
-        let deferral_gained_nothing = self
-          .deferred_common_len
-          .is_some_and(|already_deferred| common.len() <= already_deferred);
+        // THE WAIT IS BOUNDED, TWICE (#94, codex rounds 4 and 5 on PR #95). A
+        // wait that is not waiting for anything is a stall, and `common`
+        // growing is the whole of what it waits for. Two bounds carry that, and
+        // they pull opposite ways on purpose -- see `DeferralWait::is_over`.
+        //
+        // The SIGNATURE bound is the correctness half: a deferral whose
+        // boundary-relevant state is IDENTICAL to the one the round before
+        // deferred over is the same round again, measured rather than
+        // predicted. Two shapes reach it and neither needs an exotic count:
+        // hypotheses that ALTERNATE past the agreed prefix keep `common` pinned
+        // at the words they still share, and a hypothesis that simply REPEATS
+        // with a tied run above the budget floor pins it with no disagreement at
+        // all.
+        //
+        // The COUNT bound is the liveness half, and it fires whatever the
+        // signature says: a state that keeps MOVING never repeats, so an
+        // over-budget tied run gaining one tied word per stride would defer
+        // forever under the signature alone (round 5, finding 1). Round 4's
+        // predicate -- `common.len()` no longer than the length already
+        // deferred over -- was neither: it missed the growing run (finding 1)
+        // and it authorized an escape from a DIFFERENT deferral whenever two
+        // lengths happened to match (finding 2).
+        let wait = DeferralWait {
+          previous: self.deferred.as_ref(),
+          taken: self.deferrals_since_advance,
+        };
         let boundary = split_at_a_strict_boundary(
           common,
           &self.hypothesis_words[common.len()..],
           requested,
           self.confirmed_words.last().map(WordTiming::start),
-          deferral_gained_nothing,
+          wait,
         );
-        if let Some(split) = boundary {
-          // `common` REPLACES the still-open record: it is the span two consecutive
-          // hypotheses have just re-agreed over it, and `last_agreed_words` is the
-          // one this hypothesis has superseded.
-          self.confirmed_words.extend_from_slice(&common[..split]);
-          self.last_agreed_words = common[split..].to_vec();
-          // RULE W'S WATERMARK (#94). The watermark is the first held-back word's
-          // start, which `split_at_a_strict_boundary` has already placed STRICTLY
-          // past the last confirmed word's start.
-          //
-          // With NOTHING held back -- which takes a single word whose OWN
-          // tokens exceed the prefill budget, the one thing that pushes the
-          // budget floor to `common.len()`, or a round that escaped a repeating
-          // deferral -- there is no held word to measure against, and
-          // `empty_holdback_watermark` is the answer. That is the SAME function,
-          // called with the SAME arguments, that the deferral decision above
-          // consults, deliberately: the guard and the value it guards may not
-          // drift apart, and the value is now the LOWEST instant that clears the
-          // last confirmed word's start rather than a fixed one.
-          //
-          // Monotone: every word of `common` starts at or past the old watermark,
-          // `end >= start` for any word the pipeline emits, `next_up` only
-          // increases, and the sparing minimum is taken only over words that
-          // themselves cleared the old watermark. A NaN start cannot break the
-          // postcondition either -- `max` returns the non-NaN side, and
-          // `start >= watermark` is false for a NaN start, so such a word is
-          // never offered back in the first place.
-          //
-          // `common` is non-empty here (its length is at least
-          // `agreement_count_needed`, clamped to at least one), so the final
-          // fallback is unreachable and only keeps this total.
-          self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
-            || {
-              common.last().map_or(self.last_agreed_seconds, |last| {
-                empty_holdback_watermark(last, &self.hypothesis_words[common.len()..])
-              })
-            },
-            WordTiming::start,
-          );
-          advanced = true;
-        } else {
-          // The hypotheses AGREED, so `result` is KEPT below (`:402`/`:408-410`,
-          // no `skipAppend`) and the next round compares against it -- that is
-          // what lets tail growth reach `common` and relieve this. `common.len()`
-          // rides along as the measurement the NEXT deferral is judged against.
-          deferred = Some(common.len());
+        match boundary {
+          SplitDecision::At(split) => {
+            // `common` REPLACES the still-open record: it is the span two consecutive
+            // hypotheses have just re-agreed over it, and `last_agreed_words` is the
+            // one this hypothesis has superseded.
+            self.confirmed_words.extend_from_slice(&common[..split]);
+            self.last_agreed_words = common[split..].to_vec();
+            // RULE W'S WATERMARK (#94). The watermark is the first held-back word's
+            // start, which `split_at_a_strict_boundary` has already placed STRICTLY
+            // past the last confirmed word's start.
+            //
+            // With NOTHING held back -- which takes a single word whose OWN
+            // tokens exceed the prefill budget, the one thing that pushes the
+            // budget floor to `common.len()`, or a round that escaped a repeating
+            // deferral -- there is no held word to measure against, and
+            // `empty_holdback_watermark` is the answer. That is the SAME function,
+            // called with the SAME arguments, that the deferral decision above
+            // consults, deliberately: the guard and the value it guards may not
+            // drift apart, and the value is now the LOWEST instant that clears the
+            // last confirmed word's start rather than a fixed one.
+            //
+            // Monotone: every word of `common` starts at or past the old watermark,
+            // `end >= start` for any word the pipeline emits, `next_up` only
+            // increases, and the sparing minimum is taken only over words that
+            // themselves cleared the old watermark. A NaN start cannot break the
+            // postcondition either -- `max` returns the non-NaN side, and
+            // `start >= watermark` is false for a NaN start, so such a word is
+            // never offered back in the first place.
+            //
+            // `common` is non-empty here (its length is at least
+            // `agreement_count_needed`, clamped to at least one), so the final
+            // fallback is unreachable and only keeps this total.
+            self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
+              || {
+                common.last().map_or(self.last_agreed_seconds, |last| {
+                  empty_holdback_watermark(last, &self.hypothesis_words[common.len()..])
+                })
+              },
+              WordTiming::start,
+            );
+            advanced = true;
+          }
+          SplitDecision::Defer(signature) => {
+            // The hypotheses AGREED, so `result` is KEPT below (`:402`/`:408-410`,
+            // no `skipAppend`) and the next round compares against it -- that is
+            // what lets tail growth reach `common` and relieve this. The signature
+            // rides along as the state the NEXT deferral is judged against, and
+            // the counter below as the wait's own length.
+            deferred = Some(signature);
+          }
         }
       } else {
         // :395-400 — disagreement; `result` is dropped below.
@@ -1063,9 +1177,19 @@ impl LocalAgreement {
     self.holdback_superseded = skip_append;
     // Assigned on EVERY worded ingest for the same reason, so an advance or a
     // disagreement clears a deferral the round before it -- which is also what
-    // keeps `deferral_gained_nothing` above a claim about the IMMEDIATELY
+    // keeps the signature comparison above a claim about the IMMEDIATELY
     // preceding worded round rather than about some older one.
-    self.deferred_common_len = deferred;
+    self.deferred = deferred;
+    // The COUNTER spans what the signature does not. An advance resets it: the
+    // watermark moved, the confirmed list grew, and whatever the wait was for is
+    // over. A DISAGREEMENT deliberately leaves it, so a stream that alternates
+    // deferral and disagreement -- never repeating a signature, never advancing
+    // -- is still bounded by it.
+    if advanced {
+      self.deferrals_since_advance = 0;
+    } else if self.deferred.is_some() {
+      self.deferrals_since_advance += 1;
+    }
 
     // :402 (unconditional) + :408-410 (`!skipAppend`).
     if skip_append {
@@ -1112,10 +1236,22 @@ impl LocalAgreement {
   /// the decoded span is restored from the merged surviving result (round 10, F3;
   /// the ingest strip carries only the wholly-unknown span, so the fold cannot
   /// supply the exact count, round 12); see `Self::ingest`.
-  pub(crate) fn finalize(mut self, options: &DecodingOptions) -> TranscriptionResult {
-    if (self.holdback_superseded || self.deferred_common_len.is_some())
-      && !self.hypothesis_words.is_empty()
-    {
+  /// The exact word list `Self::finalize` publishes, taken out of the engine —
+  /// `Self::confirmed_words_slice` with the round's own provisional tail folded
+  /// on, under the two shapes described on `Self::finalize`.
+  ///
+  /// Split out of `Self::finalize` so the TRANSCRIPT can be observed with its
+  /// timings intact (#94, codex round 5 on PR #95, closing note).
+  /// `merge_transcription_results_with_words` keeps this list only as merged
+  /// TEXT, and the merged segments carry the decoders' own words instead — so
+  /// from `Self::finalize`'s return value alone there is no way to ask when a
+  /// published word started, which is the question a retraction is answered by.
+  /// `the_split_never_cuts_at_a_tied_start` reads this every round and asserts
+  /// that a word which LEAVES the transcript is either still offerable or at the
+  /// settled instant; the last two findings on this branch both hid in exactly
+  /// that gap, where `confirmed_words`' append-only guarantee cannot see.
+  fn take_finalized_words(&mut self) -> Vec<WordTiming> {
+    if (self.holdback_superseded || self.deferred.is_some()) && !self.hypothesis_words.is_empty() {
       // DIVERGENCE from `:418-419` — see this module's doc for the full
       // argument. Swift's `lastAgreedWords + differentSuffix(prevWords,
       // hypothesisWords)` is only a valid decomposition when the final round
@@ -1130,7 +1266,7 @@ impl LocalAgreement {
       // SUFFIX would instead drop the leading words both hypotheses produced,
       // which is the same defect's other face when the holdback is empty.
       //
-      // DEFERRED (`deferred_common_len`, codex round 3 on PR #95): the two hypotheses
+      // DEFERRED (`deferred`, codex round 3 on PR #95): the two hypotheses
       // AGREED but no legal split existed at or above the prefill budget floor,
       // so `last_agreed_words` is an EARLIER agreement's holdback and Swift's sum
       // would drop everything between it and `common`'s end. `hypothesis_words`
@@ -1154,8 +1290,12 @@ impl LocalAgreement {
       let suffix = find_longest_different_suffix(&self.prev_words, &self.hypothesis_words);
       self.confirmed_words.extend_from_slice(suffix);
     }
-    let mut merged =
-      merge_transcription_results_with_words(&self.results, &self.confirmed_words, options);
+    core::mem::take(&mut self.confirmed_words)
+  }
+
+  pub(crate) fn finalize(mut self, options: &DecodingOptions) -> TranscriptionResult {
+    let words = self.take_finalized_words();
+    let mut merged = merge_transcription_results_with_words(&self.results, &words, options);
     // Fold the merged (surviving-result) facts INTO the ingest-ordered sink, not
     // the other way round (codex round 9): the sink observed EVERY hypothesis in
     // ingest order — the disagreeing dropped ones included — so its FIRST-observed
@@ -1184,6 +1324,127 @@ impl LocalAgreement {
 // ---------------------------------------------------------------------
 // The confirmed/holdback split
 // ---------------------------------------------------------------------
+
+/// The boundary-relevant state of a round that DEFERRED: everything that decides
+/// WHICH words an escape from that round would strand, and nothing else (#94,
+/// codex round 5 on PR #95, finding 2).
+///
+/// What this replaces was `common.len()` alone, compared with `<=`, and a LENGTH
+/// does not establish that the wait already taken covered the state now in front
+/// of the engine. Agreement compares NORMALIZED TEXT while the escape's cost is
+/// a question about TIMINGS, so the two come apart: defer over `[A, H@1]` with a
+/// tied strand `X@1`, then offer `[A, H@2, Y@2]`, and the common length is still
+/// two while the hazardous boundary has moved from 1 s to 2 s. Escaping there
+/// confirms `H@2`, anchors past 2 s, and strands `Y` — a word this round's own
+/// `LocalAgreement::finalize` had already published, retracted on the next
+/// ingest, and invisible to [`LocalAgreement::confirmed_words_slice`]'s
+/// append-only guarantee, which never held it. Repeating that hypothesis instead
+/// grows `common` to include `Y` and keeps it, which is what makes the escape a
+/// LOSS rather than an ordering.
+/// `a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat` is the
+/// falsifier.
+///
+/// **Why exactly these fields.** The escape splits at `common.len()` and anchors
+/// at `empty_holdback_watermark`, so what it strands is
+/// `{ w in beyond_common : w.start() < escape_watermark }` — which after that
+/// function's sparing fold is exactly the words TIED to `terminal_start`. Those
+/// two therefore fix the cost. `floor` and `common_len` fix which boundaries the
+/// forward search and the back-off could reach at all, and between them they
+/// also record the ARM: the budget forces the empty holdback exactly when
+/// `floor == common_len`. The last confirmed word's start is deliberately absent
+/// — nothing is confirmed between two deferrals, so it cannot move while this is
+/// being compared, and an advance clears the record anyway.
+///
+/// **What it deliberately does NOT record is TEXT**, so two deferrals whose
+/// strands differ only in what they say at the same instant count as the same
+/// wait. That is round 4's own adjudication rather than an oversight: a word
+/// that alternates at the settled instant is uncorroborable BY CONSTRUCTION —
+/// `find_longest_common_prefix` stops in front of it on every round it is
+/// offered — so no length of wait delivers it, and
+/// `an_alternating_suffix_escapes_the_deferral_instead_of_stalling` is the shape
+/// that would stall if this compared text.
+///
+/// The comparison is EQUALITY on every field, including the length. Round 4's
+/// `<=` is not merely widened here, it is dropped: escaping where `common`
+/// SHRANK is escaping from a state the previous wait did not cover either, and
+/// the safe direction for a doubt about whether a wait repeated is to wait
+/// again, which `MAX_CONSECUTIVE_DEFERRALS` bounds at four rounds. That choice
+/// is a recorded SUITE GAP rather than a proven one: relaxing the length back to
+/// `<=` reds nothing in this crate, since no shape here or in
+/// `the_split_never_cuts_at_a_tied_start` produces two consecutive deferrals
+/// whose `common` shrank at an otherwise identical state (measured: 0 in 512
+/// sweep trials), though a hypothesis that agrees with its predecessor on less
+/// makes one reachable.
+///
+/// Comparing `f32` by `==` is exact and total here: `terminal_start` reached this
+/// through `LocalAgreement::watermark_filtered`, whose `start >= watermark` is
+/// false for a NaN, and `empty_holdback_watermark` is documented never-NaN. Were
+/// one ever NaN the signature would simply never match, which defers one round
+/// longer and stays bounded by [`MAX_CONSECUTIVE_DEFERRALS`] — the safe
+/// direction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct DeferralSignature {
+  /// `budgeted_split(common, 0)`: the earliest split whose holdback the prefill
+  /// can carry whole, and the floor neither search may cross.
+  floor: usize,
+  /// `common.len()`.
+  common_len: usize,
+  /// The last agreed word's start — the instant an escape must anchor strictly
+  /// past, and so the one instant no watermark can spare.
+  terminal_start: f32,
+  /// `empty_holdback_watermark(common.last(), beyond_common)`: the watermark an
+  /// escape would anchor at.
+  escape_watermark: f32,
+}
+
+/// What `split_at_a_strict_boundary` knows about the wait the current round
+/// would JOIN, and the one place the two bounds compose.
+///
+/// They pull opposite ways, which is the whole difficulty (#94, codex round 5 on
+/// PR #95). Tightening the predicate for finding 2 makes finding 1's stall
+/// LONGER; loosening it for finding 1 makes finding 2's premature escape MORE
+/// available. Neither is a predicate problem alone, so neither is fixed by one
+/// predicate: `previous` establishes that a wait is the SAME wait, which is a
+/// correctness claim about what an escape may cost, and `taken` bounds the wait
+/// whatever it is waiting on, which is a liveness claim about how long a caller
+/// may be made to wait. The first can only ever make the engine wait longer; the
+/// second is what stops that being forever.
+#[derive(Debug, Clone, Copy)]
+struct DeferralWait<'a> {
+  /// The signature of the IMMEDIATELY preceding worded round, if it deferred.
+  previous: Option<&'a DeferralSignature>,
+  /// How many rounds have already deferred since the last advance — never above
+  /// [`MAX_CONSECUTIVE_DEFERRALS`], since a round only defers while it is below.
+  taken: usize,
+}
+
+impl DeferralWait<'_> {
+  /// Whether a round in this state may ESCAPE — advance at `common.len()` with
+  /// an empty holdback — rather than wait again.
+  ///
+  /// The two bounds are a disjunction and each is complete on its own side. The
+  /// SIGNATURE fires on a wait that has provably already happened, so it can end
+  /// a repeat on the very next round without ever cutting a moving state short.
+  /// The COUNT fires on a wait that has gone on too long to be waiting for
+  /// anything, whatever it looks like, so it ends a state that keeps changing
+  /// shape. Neither subsumes the other, and dropping either re-opens one of
+  /// round 5's two findings.
+  fn is_over(self, signature: &DeferralSignature) -> bool {
+    self.previous == Some(signature) || self.taken >= MAX_CONSECUTIVE_DEFERRALS
+  }
+}
+
+/// What `split_at_a_strict_boundary` answered: where to split, or the state the
+/// round is waiting on instead.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum SplitDecision {
+  /// Confirm `common[..at]` and hold `common[at..]` back — `at == common.len()`
+  /// being the empty holdback, which both the FORCED arm and the ESCAPE take.
+  At(usize),
+  /// Do not advance; this is the wait's own signature, which
+  /// `LocalAgreement::ingest` records for the round after it.
+  Defer(DeferralSignature),
+}
 
 /// RULE W (#94, at its source): where an advance splits `common`, moved off any
 /// boundary that would put the watermark AT a start already settled.
@@ -1243,17 +1504,17 @@ impl LocalAgreement {
 ///    over the HEAD of the offered list, which only an advance can move, whereas
 ///    this defers a split position that TAIL growth relieves, and it advances
 ///    the holdback rather than refusing the round.
-/// 3. **`Some(common.len())` -- the ESCAPE**, where neither search found a legal
-///    boundary and `deferral_gained_nothing`. See arm 4 for the wait this
-///    bounds; the holdback goes empty and the watermark is
+/// 3. **`SplitDecision::At(common.len())` -- the ESCAPE**, where neither search
+///    found a legal boundary and `DeferralWait::is_over`. See arm 4 for the wait
+///    this bounds; the holdback goes empty and the watermark is
 ///    `empty_holdback_watermark`'s lowest sparing instant, exactly as in arm 5.
-/// 4. **`None` -- DEFER**, on either of two states, and each is a WAIT rather
-///    than a refusal: it costs nothing on the deferring round itself --
-///    `finalize` emits `confirmed ++ hypothesis_words` either way (see
+/// 4. **`SplitDecision::Defer` -- DEFER**, on either of two states, and each is
+///    a WAIT rather than a refusal: it costs nothing on the deferring round
+///    itself -- `finalize` emits `confirmed ++ hypothesis_words` either way (see
 ///    `LocalAgreement::finalize`) -- and the divergence is entirely in what
 ///    LATER ingests can still see. **The wait is BOUNDED** by
-///    `deferral_gained_nothing`, and that bound is the whole of arm 3; the two
-///    states below are what the FIRST wait is worth taking for.
+///    `DeferralWait::is_over`, and that bound is the whole of arm 3; the two
+///    states below are what a wait is worth taking for at all.
 ///
 ///    The first is where the budget floor is `1` or more and no legal
 ///    boundary sits at or above it. A tied run whose OWN tokens exceed
@@ -1296,19 +1557,30 @@ impl LocalAgreement {
 ///    makes it grow. Two hypotheses that ALTERNATE past the agreed prefix pin
 ///    `common` at the words they still share, round after round, and a
 ///    hypothesis that simply REPEATS pins it with no disagreement at all -- so
-///    `None` came back every round, the watermark never moved, the caller read
-///    `AwaitingAgreement` forever, and in the driver the clip kept re-decoding
-///    from a boundary that never advanced while the buffer grew past it. The
-///    earlier liveness argument -- "one word starting strictly later opens a
-///    boundary" -- is about a suffix that STABILIZES and reaches neither state.
-///    `deferral_gained_nothing` is the bound: a deferral over a `common` no
-///    longer than the one the round before already deferred over is that round
-///    again, measured rather than predicted, so arm 3 takes the empty holdback
-///    instead. It costs at most one round, and BOTH states are bounded by it --
-///    exempting either from its own bound is not a bound
+///    the deferral came back every round, the watermark never moved, the caller
+///    read `AwaitingAgreement` forever, and in the driver the clip kept
+///    re-decoding from a boundary that never advanced while the buffer grew past
+///    it. The earlier liveness argument -- "one word starting strictly later
+///    opens a boundary" -- is about a suffix that STABILIZES and reaches neither
+///    state. Both states are bounded by arm 3, and exempting either from its own
+///    bound is not a bound
 ///    (`an_alternating_suffix_escapes_the_deferral_instead_of_stalling`,
 ///    `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`).
-/// 5. **`Some(common.len())`** -- tested FIRST in the code, since its condition
+///
+///    **And `common` GROWING is not itself relief** (#94, codex round 5 on
+///    PR #95, finding 1) -- which is what a bound written as "`common` no longer
+///    than the length already deferred over", round 4's own, assumed. A tied run
+///    already over the budget that gains one more TIED word every stride grows
+///    `common` on every round while opening no boundary at all: the floor rises
+///    with it, every reachable position still ties, and the length predicate is
+///    false forever. That stall is unbounded in rounds AND in retention, since
+///    an agreeing round is a kept round. So the wait is bounded by
+///    `MAX_CONSECUTIVE_DEFERRALS` rounds as well, whatever its shape, and by a
+///    `DeferralSignature` rather than a length where it does repeat -- a length
+///    also cannot tell one deferral from a DIFFERENT one of the same length,
+///    which is round 5's finding 2 and the retraction on
+///    `a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat`.
+/// 5. **`SplitDecision::At(common.len())`** -- tested FIRST in the code, since its condition
 ///    is a property of the budget alone and neither search runs on it. Only
 ///    where the BUDGET FLOOR itself reaches `common.len()` is that length
 ///    returned on the FIRST round and the holdback left empty. That takes a LAST
@@ -1331,14 +1603,9 @@ impl LocalAgreement {
 ///    2, which is the wait that never ends.
 ///
 ///    An EMPTY `common` reaches this arm too (`floor == 0 == common.len()`) and
-///    advances: there is no word to anchor a watermark on, so there is nothing
-///    to strand, and `LocalAgreement::ingest`'s own fallback leaves the
-///    watermark where it was. Like the `at == 0` check above it carries NO
-///    falsifier -- `LocalAgreement::ingest` only calls this with
-///    `common.len() >= agreement_count_needed`, which is clamped to at least one
-///    -- and, like it, it is written out so this function is total on its own
-///    terms rather than on its caller's clamp. Flipping it to defer reds nothing
-///    in this crate.
+///    advances -- written out as its own early return above, so that everything
+///    after it has a terminal word to build a signature from. See that return
+///    for why it carries no falsifier.
 ///
 /// So `agreement_count_needed` is a target rather than an exact width in EITHER
 /// direction: the budget can shorten the holdback (see `budgeted_split`) and
@@ -1353,18 +1620,21 @@ impl LocalAgreement {
 /// the offered filter, and the re-admission question is unrepresentable rather
 /// than defended against.
 ///
-/// It stays TOTAL under both `None` states rather than becoming conditional
+/// It stays TOTAL under both DEFER states rather than becoming conditional
 /// again: a deferred round is not an advance, so it moves neither side of the
-/// inequality and there is no state for the claim to be excluded from. `None`
-/// REMOVES reachable advances rather than adding unguarded ones, and the second
-/// state removes a strict subset of arm 5's, which the `next_up` anchor already
-/// carried.
+/// inequality and there is no state for the claim to be excluded from.
+/// `SplitDecision::Defer` REMOVES reachable advances rather than adding
+/// unguarded ones, and the second state removes a strict subset of arm 5's,
+/// which the `next_up` anchor already carried.
 ///
 /// It stays total under the ESCAPE too, which ADDS advances rather than removing
-/// them: every escape splits at `common.len()`, and there
-/// `LocalAgreement::ingest` anchors at `empty_holdback_watermark`, whose result
-/// is strictly greater than `common.last().start()` for every input -- the
-/// sparing fold skips exactly the starts that are not (see that function).
+/// them, and under BOTH of the bounds that authorize one: every escape splits at
+/// `common.len()` whichever bound fired, and there `LocalAgreement::ingest`
+/// anchors at `empty_holdback_watermark`, whose result is strictly greater than
+/// `common.last().start()` for every input -- the sparing fold skips exactly the
+/// starts that are not (see that function). What `DeferralWait::is_over` decides
+/// is WHEN an escape may be taken, never where it splits or what it anchors at,
+/// so no bound can reach this inequality.
 ///
 /// # A second postcondition
 ///
@@ -1385,12 +1655,16 @@ impl LocalAgreement {
 /// `beyond_common` that starts at the last confirmed word's own instant. There
 /// no value serves both claims -- the first postcondition demands a watermark
 /// strictly past that start, and every such watermark filters the strand -- so
-/// this is the module's residual 1 reached one round earlier than the residual's
-/// own route, not a policy. It is exactly that narrow: at any other start the
-/// sparing fold spares the word, and only an escape may use it.
+/// this is the module's residual 1 reached earlier than the residual's own
+/// route, not a policy. It is exactly that narrow: at any other start the
+/// sparing fold spares the word, and only an escape may use it. Round 5's second
+/// bound does not widen the exception's SHAPE, only the set of rounds that may
+/// take it: an escape authorized by the round count strands the same tie an
+/// escape authorized by a repeating signature does, and nothing else.
 /// `the_split_never_cuts_at_a_tied_start` sweeps both postconditions and the
 /// exception, and counts the escapes and the strands so neither can pass by
-/// being unreachable.
+/// being unreachable -- and reads the published TRANSCRIPT across every round
+/// besides, which is where a retraction the confirmed list cannot see shows up.
 ///
 /// It is a claim about the LAST confirmed word, and that is as strong as it needs
 /// to be exactly while word starts inside one hypothesis are non-decreasing --
@@ -1401,8 +1675,8 @@ fn split_at_a_strict_boundary(
   beyond_common: &[WordTiming],
   requested: usize,
   confirmed_last_start: Option<f32>,
-  deferral_gained_nothing: bool,
-) -> Option<usize> {
+  wait: DeferralWait<'_>,
+) -> SplitDecision {
   let strictly_after_the_preceding_start = |at: usize| {
     let preceding = if at == 0 {
       confirmed_last_start
@@ -1410,6 +1684,33 @@ fn split_at_a_strict_boundary(
       Some(common[at - 1].start())
     };
     preceding.is_none_or(|preceding| preceding < common[at].start())
+  };
+  // `budgeted_split` with nothing requested IS the budget's own floor: the
+  // earliest split whose holdback fits `MAX_HOLDBACK_PREFILL_TOKENS`.
+  let floor = budgeted_split(common, 0);
+  // An EMPTY `common` reaches the FORCED arm below (`floor == 0 ==
+  // common.len()`) and advances: there is no word to anchor a watermark on, so
+  // there is nothing to strand, and `LocalAgreement::ingest`'s own fallback
+  // leaves the watermark where it was. Taken here rather than inside that arm so
+  // everything below has a terminal word to speak about. Like the `at == 0`
+  // check above it carries NO falsifier -- `LocalAgreement::ingest` only calls
+  // this with `common.len() >= agreement_count_needed`, which is clamped to at
+  // least one -- and, like it, it is written out so this function is total on
+  // its own terms rather than on its caller's clamp. Flipping it to defer reds
+  // nothing in this crate.
+  let Some(last) = common.last() else {
+    return SplitDecision::At(common.len());
+  };
+  // The watermark an EMPTY holdback would anchor at, computed ONCE and shared by
+  // the strand test, the deferral's signature and (through `common.len()`)
+  // `LocalAgreement::ingest`'s own anchor -- the guard, the record and the value
+  // may not drift apart.
+  let escape_watermark = empty_holdback_watermark(last, beyond_common);
+  let signature = DeferralSignature {
+    floor,
+    common_len: common.len(),
+    terminal_start: last.start(),
+    escape_watermark,
   };
   // The EMPTY holdback strands a word exactly when `empty_holdback_watermark`
   // cannot be lowered far enough to spare it, which takes a word of
@@ -1422,14 +1723,10 @@ fn split_at_a_strict_boundary(
   // negated, and totally so: every word of `beyond_common` reached this call
   // through that filter, so none of their starts is NaN.
   let empty_holdback_strands = || {
-    common.last().is_some_and(|last| {
-      let watermark = empty_holdback_watermark(last, beyond_common);
-      beyond_common.iter().any(|word| word.start() < watermark)
-    })
+    beyond_common
+      .iter()
+      .any(|word| word.start() < escape_watermark)
   };
-  // `budgeted_split` with nothing requested IS the budget's own floor: the
-  // earliest split whose holdback fits `MAX_HOLDBACK_PREFILL_TOKENS`.
-  let floor = budgeted_split(common, 0);
   if floor == common.len() {
     // The budget FORCES the empty holdback: no split leaves a non-empty one the
     // prefill could carry, which takes a LAST word whose own tokens exceed
@@ -1448,47 +1745,52 @@ fn split_at_a_strict_boundary(
     // would strand -- and the strand is what `beyond_common` is here to see,
     // since on `common` alone this arm cannot know what lies past it.
     //
-    // Unless deferring has already been measured and bought nothing, in which
-    // case the wait is a stall and the round takes the advance anyway (codex
-    // round 4 on PR #95). What that costs is exactly this module's residual 1,
-    // one round earlier than the residual's own route: at an exact tie a word
-    // beyond `common` and a re-offer of the settled word in front of it are the
-    // same value to a timestamp filter, so no watermark serves both.
-    if empty_holdback_strands() && !deferral_gained_nothing {
-      return None;
+    // Unless the WAIT IS OVER -- the same state has already been waited on, or
+    // the wait has run past `MAX_CONSECUTIVE_DEFERRALS` rounds -- in which case
+    // the round takes the advance anyway (codex rounds 4 and 5 on PR #95). What
+    // that costs is exactly this module's residual 1, one round earlier than the
+    // residual's own route: at an exact tie a word beyond `common` and a
+    // re-offer of the settled word in front of it are the same value to a
+    // timestamp filter, so no watermark serves both.
+    if empty_holdback_strands() && !wait.is_over(&signature) {
+      return SplitDecision::Defer(signature);
     }
-    return Some(common.len());
+    return SplitDecision::At(common.len());
   }
   let widened = requested.max(floor);
-  (widened..common.len())
+  match (widened..common.len())
     .find(|&at| strictly_after_the_preceding_start(at))
     .or_else(|| {
       (floor..widened)
         .rev()
         .find(|&at| strictly_after_the_preceding_start(at))
-    })
+    }) {
+    Some(at) => SplitDecision::At(at),
     // No INTERIOR boundary is legal, so this arm's deferral protects the
     // holdback rather than a strand: the tied run stays revisable and the next
     // stride keeps its prefill anchor (see
     // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`).
-    // That is worth exactly one wait. A `common` that did not grow since the
-    // deferral before it is not going to be relieved by waiting again -- a
+    // That is worth waiting for -- but only while the wait is still a wait. A
+    // state already waited on is not going to be relieved by waiting again -- a
     // hypothesis REPEATING a tied run above the floor pins it with no
     // disagreement anywhere, which is the shape an all-zero alignment matrix
-    // produces -- so the empty holdback is taken instead, still at the lowest
-    // watermark that clears the last confirmed start.
+    // produces -- and a state that keeps CHANGING while never opening a boundary
+    // is a stall the signature can never catch, which is the same run gaining
+    // one tied word per stride. So the empty holdback is taken instead, still at
+    // the lowest watermark that clears the last confirmed start.
     //
     // `empty_holdback_strands()` is deliberately NOT consulted here, exactly as
-    // the forced arm stops consulting it once the wait has repeated: a bound
-    // that exempts the state it is there to escape is not a bound, and a tied
-    // run whose SUFFIX alternates at the run's own instant reaches this arm in
+    // the forced arm stops consulting it once the wait is over: a bound that
+    // exempts the state it is there to escape is not a bound, and a tied run
+    // whose SUFFIX alternates at the run's own instant reaches this arm in
     // precisely that state
     // (`a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`'s
-    // second half). Both arms therefore strand the same thing on a repeating
-    // wait -- a word at the settled instant, residual 1 -- and nothing else.
-    .or_else(|| deferral_gained_nothing.then_some(common.len()))
+    // second half). Both arms therefore strand the same thing on a wait that is
+    // over -- a word at the settled instant, residual 1 -- and nothing else.
+    None if wait.is_over(&signature) => SplitDecision::At(common.len()),
+    None => SplitDecision::Defer(signature),
+  }
 }
-
 /// Where an advance splits `common` into the part that is CONFIRMED and the
 /// part that is HELD BACK, given the requested split — moved later until every
 /// word still held is one [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens)
@@ -1563,8 +1865,9 @@ fn split_at_a_strict_boundary(
 /// erased words are neither re-offered nor confirmed, which is the whole of
 /// round 7's finding 2. Where nothing legal sits at or above the floor, that
 /// rule DEFERS the round rather than crossing the floor — the one thing it never
-/// does, the floor being hard — and widens off the end only once that wait has
-/// been measured and found to buy nothing (its arm 3).
+/// does, the floor being hard — and widens off the end only once that wait is
+/// OVER, either because its state repeated or because it ran to
+/// [`MAX_CONSECUTIVE_DEFERRALS`] rounds (its arm 3).
 ///
 /// **Documented deviation**: with `agreement_count_needed` at its
 /// [`DEFAULT_AGREEMENT_COUNT_NEEDED`] a two-word holdback of words

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -51,74 +51,50 @@
 //!   [`STRIDE_SAMPLES`]-sized thresholds as samples are pushed in — a
 //!   deliberate regularization for that push-based shape, not a
 //!   byte-for-byte port of Swift's off-by-one starting point.
-//! - **A word already confirmed is not re-confirmed by a re-decode** (Swift
-//!   `:372`/`:375`). Swift's hypothesis view is a bare timestamp filter,
-//!   `start >= lastAgreedSeconds`, and the watermark is the first held-back
-//!   word's start — so a word confirmed in the previous round that shares that
-//!   exact start (DTW row steps without a column advance, then centisecond
-//!   rounding; ties are pipeline-reachable) is pulled back in and confirmed
-//!   AGAIN. This port instead locates the FRONTIER between the settled span and
-//!   the still-open one, by aligning the engine's own record of that span (the
-//!   confirmed tail whose extent reaches the watermark, then the holdback)
-//!   against the offered words and refusing the offered prefix that every
-//!   optimal alignment attributes to the settled half — see
-//!   `LocalAgreement::watermark_filtered` for the algorithm, its ambiguity rule,
-//!   and the four things it deliberately leaves. Adjudicated: Swift shares the
-//!   bug, and "confirmed once and stable" wins over parity.
+//! - **The split may not cut at a tied start (Rule W), so a confirmed word is
+//!   never re-offered** (Swift `:372`/`:375`). Swift's hypothesis view is a bare
+//!   timestamp filter, `start >= lastAgreedSeconds`, and the watermark is the
+//!   first held-back word's start — so a word confirmed in the previous round
+//!   that shares that exact start (DTW row steps without a column advance, then
+//!   centisecond rounding; ties are pipeline-reachable) is pulled back in and
+//!   confirmed AGAIN. This port keeps Swift's filter verbatim and closes the
+//!   hole at its SOURCE instead: an advance refuses to put the watermark at a
+//!   word whose start ties the confirmed one in front of it, widening past the
+//!   tie rather than cutting the clip boundary INSIDE a span already settled
+//!   (see the Rule W comment at [`LocalAgreement::ingest`]'s advance).
 //!
-//!   **This changes what [`LocalAgreement::ingest`] returns on some inputs**,
-//!   against Swift and against this port's own previous leading-run strip. That
-//!   strip caught only a reproduction the hypothesis put at offset 0; a
-//!   reproduction behind an insertion, one missing the confirmed tail's head,
-//!   one behind a shorter false match, and one shifted a hair past the watermark
-//!   all rode through into `hypothesis_words`, where they either disagreed with
-//!   the previous hypothesis ([`AgreementOutcome::AwaitingAgreement`], the
-//!   result dropped from [`LocalAgreement::results_slice`]) or agreed and
-//!   confirmed a settled word a second time ([`AgreementOutcome::Advanced`]).
-//!   They now reach the same view a clean reproduction does, so those sequences
-//!   can return `Advanced` where they returned `AwaitingAgreement` and keep the
-//!   result where they dropped it. [`LocalAgreement::finalize`]'s own contract
-//!   is unchanged — it composes `confirmed_words`, `last_agreed_words`,
-//!   `prev_words` and `hypothesis_words` exactly as before — but the words those
-//!   now hold are the corrected ones, so its text changes on the same
-//!   sequences. <https://github.com/findit-studio/coremlit/issues/94> is the
-//!   record of the ten that move; each is a named property test in this
-//!   module's `tests`, alongside the constraints that bound the rule.
-//! - **`ingest` takes the options the result was decoded under, and the frontier
-//!   rule has TWO readings selected by them.** Swift's loop has no equivalent
-//!   parameter; its filter is the bare timestamp comparison and needs no premise.
-//!   The frontier's ambiguity tie-break here is not a preference, it is the
-//!   reading the PREFILL forces — and [`LocalAgreement::ingest`] is public and
-//!   takes an unmarked [`TranscriptionResult`], which carries no record of how it
-//!   was decoded (codex round 6, finding 1). So the premise is now supplied and
-//!   CHECKED rather than assumed: `ingest(result, decoded_under)` compares
-//!   `decoded_under` against the retarget it would have issued for its current
-//!   state (see `LocalAgreement::prefill_reproduces_holdback`) and reads the
-//!   smallest optimal seam only when that holds. A result decoded any other way
-//!   gets the largest match-supported optimal seam instead — refuse everything
-//!   any optimal alignment could read as a settled word coming back, because with
-//!   no prefill to appeal to a disputed head is unattributable and confirmation is
-//!   append-only. Two paths, two policies, each with its own standing
-//!   justification. See `LocalAgreement::watermark_filtered`, "Ambiguity rule",
-//!   for why the unmarked path does not instead BLOCK on the ambiguity.
+//!   **Postcondition** — whenever [`LocalAgreement::last_agreed_words_slice`] is
+//!   non-empty, `confirmed_words.last().start() < last_agreed_seconds`
+//!   STRICTLY. No confirmed word can satisfy the offered filter's own
+//!   `start >= watermark`, so none can ever head a hypothesis and the
+//!   re-admission question is unrepresentable rather than defended against.
+//!   Adjudicated: Swift shares the bug, and "confirmed once and stable" wins
+//!   over parity here.
 //!
-//!   **The premise belongs to the RESULT, not to the call that reads it** (codex
-//!   round 7, finding 1). `ingest` keeps the previous result raw and re-filters
-//!   it on every later call, so a premise derived from the current call and
-//!   reused for the stored one gives an unmarked result the marked frontier one
-//!   call later — undoing its refusal with no caller lying, and confirming words
-//!   on an agreement neither hypothesis offered. Each result is therefore paired
-//!   with its own premise the moment it arrives (`ProvenancedResult`), and
-//!   `watermark_filtered_with` takes only the pair; no signature in the engine
-//!   can carry a foreign one. **This changes what
-//!   [`LocalAgreement::ingest`] returns on a mixed-provenance sequence**, in the
-//!   opposite direction to the re-admission fix above: where an unmarked result
-//!   is followed by a marked one that repeats it, the pair no longer agrees, so
-//!   `ingest` returns [`AgreementOutcome::AwaitingAgreement`] where it returned
-//!   [`AgreementOutcome::Advanced`], the result is dropped rather than kept, and
-//!   the words that advance would have confirmed stay provisional — revisable by
-//!   the hypothesis after them. A single-provenance stream, which is every
-//!   stream [`LocalAgreementTranscriber`] can produce, is unaffected.
+//!   **[BEHAVIOUR CHANGE]** the rule confirms one word EARLIER on a tied input,
+//!   trading one round of revisability for a clip boundary that does not bisect
+//!   a settled span — the same trade `budgeted_split` already makes, and
+//!   [`LocalAgreement::agreement_count_needed`] becomes a maximum slightly more
+//!   often. **Trigger:** two adjacent agreed words with equal `start`. On words
+//!   this crate's own pipeline produces that requires a ZERO-DURATION word:
+//!   `find_alignment` guarantees `w[i].end() <= w[i + 1].start() + 1e-4`
+//!   (pinned in `crate::audio::whisper::segment`'s tests), so
+//!   `w[i].start() >= w[i + 1].start()` forces `w[i].end() <= w[i].start() +
+//!   1e-4`. The committed jfk golden carries no start tie at all and is
+//!   byte-identical under the rule. Two hermetic sequences DO move, both
+//!   LOSING a word, and both are pinned as characterization rather than
+//!   repaired: `rule_w_deletes_a_tied_insertion_that_reproduces_nothing_
+//!   confirmed` (finalized `" A X B C D"` becomes `" A B C D"`) and
+//!   `rule_w_deletes_an_unaccounted_repeat_of_a_settled_word` (`" A A B C"`
+//!   becomes `" A B C"`). Deletion is this module's non-preferred direction and
+//!   the cost was weighed rather than missed: the alignment frontier Rule W
+//!   replaces deleted words on PHRASE RECURRENCE — a shape real transcripts
+//!   produce, present at two watermark positions of this crate's own canonical
+//!   jfk phrase — while Rule W deletes only in a degenerate tie the driver
+//!   cannot reach. Each test names
+//!   <https://github.com/findit-studio/coremlit/issues/94> and carries the
+//!   CORRECT behaviour in its failure message, so the day the trade is
+//!   revisited the suite hands the next author the expectation.
 //! - **The holdback holds only what the prefill carries WHOLE, with no
 //!   residual.** Swift's `agreementCountNeeded` is a hardcoded `2` it never
 //!   exposes, so the length case cannot arise there. Here
@@ -133,8 +109,8 @@
 //!   8, finding 1): `prefill_tokens` drops every id at or above the vocabulary's
 //!   `special_token_begin`, and a word with no tokens contributes nothing to the
 //!   prefix at all, so either kind of held word leaves the engine reasoning
-//!   about text the decoder was never given — the exact premise the frontier's
-//!   marked reading rests on. It was recorded as a residual for as long as the
+//!   about text the decoder was never given — the exact premise the pending
+//!   head's promotion rests on. It was recorded as a residual for as long as the
 //!   argument was "`add_word_timestamps` strips those ids from everything this
 //!   crate emits", which is true and does not reach
 //!   [`LocalAgreement::ingest`]'s public hand-built path. **[BEHAVIOUR CHANGE]**
@@ -190,14 +166,9 @@
 //!   are non-monotone
 //!   (`an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too`). It is
 //!   the LocalAgreement-2 contract itself — confirmation follows agreement
-//!   between two consecutive hypotheses and is append-only — and whether an
-//!   offered word is a settled one coming BACK is the FRONTIER's question, which
-//!   `settled_seams` answers by alignment. Requiring a non-vacuous anchor
-//!   instead reinstates the indefinite hold, and also breaks
-//!   `with_nothing_held_back_both_frontiers_are_the_same_column`: leaving a word
-//!   pending beside an empty holdback makes `watermark_filtered_with`'s
-//!   `revisable` non-empty, so `settled_seams`' `after` row is no longer
-//!   identically zero and the vacuous premise stops being harmless. **[BEHAVIOUR CHANGE]** [`LocalAgreement::confirmed_words_slice`]
+//!   between two consecutive hypotheses and is append-only. Requiring a
+//!   non-vacuous anchor instead reinstates the indefinite hold.
+//!   **[BEHAVIOUR CHANGE]** [`LocalAgreement::confirmed_words_slice`]
 //!   therefore gains a word that waits one `ingest` later than it did, and on a
 //!   MIXED-provenance stream an
 //!   unmarked hypothesis that revises one now replaces it instead of landing
@@ -335,15 +306,14 @@
 //!   and the stream re-decodes each span with no anchor at all. Both this port
 //!   and Swift default the flag on, so this only diverges for a caller that
 //!   turned it off; it is forced for the same reason
-//!   [`LocalAgreementTranscriber::new`] forces `word_timestamps`, and because the
-//!   frontier rule's ambiguity tie-break is DECIDED by the prefill (see
-//!   `LocalAgreement::watermark_filtered`, "Ambiguity rule").
+//!   [`LocalAgreementTranscriber::new`] forces `word_timestamps`, and because
+//!   the promotion of a pending word is DECIDED by the prefill (see
+//!   `LocalAgreement::prefill_reproduces_holdback`).
 //!
 //!   It is forced only while [`LocalAgreement::last_agreed_words_slice`] is
 //!   NON-EMPTY (codex round 6, finding 3). Before the first advance there is no
-//!   holdback, the prefix is empty, `settled` is empty too, and
-//!   `watermark_filtered` takes its `settled_len == 0` fast path — no frontier is
-//!   read, so no premise needs enforcing. Forcing the flag on those strides would
+//!   holdback, the prefix is empty, and nothing is pending — so no premise needs
+//!   enforcing. Forcing the flag on those strides would
 //!   change the caller's prompt from a bare `<|startoftranscript|>` to the full
 //!   multilingual language/task/timestamp prefill for nothing, and a streaming
 //!   caller would get different decoding behaviour before LocalAgreement had
@@ -366,7 +336,7 @@ use crate::audio::whisper::{
   options::DecodingOptions,
   result::{TranscriptionResult, WordTiming, merge_transcription_results_with_words},
   task_facts::{SpanKnowledge, TaskFactsAccumulator},
-  text::{find_longest_common_prefix, find_longest_different_suffix, normalized},
+  text::{find_longest_common_prefix, find_longest_different_suffix},
   tokenizer::MIN_SPECIAL_TOKEN_BEGIN,
   transcribe::WhisperKit,
 };
@@ -431,11 +401,12 @@ pub const DEFAULT_AGREEMENT_COUNT_NEEDED: usize = 2;
 /// dropped before the initial prompt is even assembled, so it never enters
 /// `decode_text`'s `current_tokens` and never appears in the hypothesis.
 ///
-/// That trim is silent, and the frontier rule in
-/// `LocalAgreement::watermark_filtered` is justified by the WHOLE holdback
-/// being forced into the next hypothesis — so a holdback that cannot survive
-/// this budget would leave the rule reasoning about text the decoder was never
-/// given. [`LocalAgreement::ingest`] therefore holds back only what fits, and
+/// That trim is silent, and the holdback is what
+/// [`LocalAgreement::decoding_options_for_next`] promises the next hypothesis
+/// will be WRITTEN with — so a holdback that cannot survive this budget is one
+/// the decoder is never given, and the words the trim erases would be neither
+/// re-offered nor confirmed. [`LocalAgreement::ingest`] therefore holds back
+/// only what fits, and
 /// `budgeted_split` guarantees that for EVERY input rather than for every input
 /// but one: where nothing can be held it holds nothing, and the advance confirms
 /// the whole agreed prefix.
@@ -465,31 +436,25 @@ pub const MAX_HOLDBACK_PREFILL_TOKENS: usize = MAX_TOKEN_CONTEXT / 2;
 
 /// A result and the provenance it ARRIVED with, inseparable by construction.
 ///
-/// `LocalAgreement::watermark_filtered_with` reads a result's frontier under one
-/// of two policies, and which one is right is a fact about how THAT result was
-/// decoded — not about the engine's state at the moment the frontier happens to
-/// be read. Those two moments are not the same moment:
-/// [`LocalAgreement::ingest`] keeps `prev_result` RAW and re-filters it on every
-/// later call, so a premise derived from the CURRENT call and reused for the
-/// stored one hands an unmarked result the MARKED frontier one call later. That
-/// undoes the unmarked refusal without any caller lying, and manufactures an
-/// agreement neither hypothesis offered: `find_longest_common_prefix` returns
-/// elements of the current hypothesis, but its LENGTH is set by both sides, and
-/// a `prev_words` read more permissively than its own provenance allows makes
-/// that length LONGER — which is what decides whether the watermark advances and
-/// how much lands in the append-only `LocalAgreement::confirmed_words_slice`
-/// (codex round 7, finding 1).
+/// Two of the engine's decisions are facts about how a PARTICULAR result was
+/// decoded rather than about the engine's state at the moment they are asked:
+/// whether that result could have re-read the still-open record at all
+/// ([`ProvenancedResult::decoded`]) and whether it can settle the pending head
+/// of it ([`ProvenancedResult::prefilled`]). Those two moments are not the same
+/// moment: [`LocalAgreement::ingest`] keeps `prev_result` RAW and re-reads it on
+/// every later call, so a premise derived from the CURRENT call and reused for
+/// the stored one answers a question about one result with another result's
+/// options — with no caller lying (codex round 7, finding 1).
 ///
 /// The pairing is the fix, and it is structural rather than a rule to remember.
-/// The fields are private to this module, [`ProvenancedResult::arriving`] is the
-/// only constructor and the only caller of
-/// [`LocalAgreement::prefill_reproduces_holdback`], and
-/// `watermark_filtered_with` takes the PAIR — so no signature anywhere in the
-/// engine has a channel through which a foreign premise could arrive, and the
-/// answer is immutable for as long as the engine keeps the result. Recorded once
-/// and read back, exactly as `LocalAgreement::holdback_superseded` is and for
-/// the same reason: a value a later call could re-derive differently is a value
-/// a later call WILL re-derive differently.
+/// The fields are private to this module and
+/// [`ProvenancedResult::arriving`] is the only constructor and the only caller
+/// of [`LocalAgreement::prefill_reproduces_holdback`] — so no signature anywhere
+/// in the engine has a channel through which a foreign premise could arrive, and
+/// the answer is immutable for as long as the engine keeps the result. Recorded
+/// once and read back, exactly as `LocalAgreement::holdback_superseded` is and
+/// for the same reason: a value a later call could re-derive differently is a
+/// value a later call WILL re-derive differently.
 mod provenance {
   use super::{DecodingOptions, LocalAgreement, TranscriptionResult, WordTiming, chunker};
 
@@ -620,8 +585,8 @@ pub struct LocalAgreement {
   last_agreed_seconds: f32,
   /// The previous hypothesis, kept RAW so each ingest can re-filter it against
   /// the watermark that is current then — paired with the provenance it arrived
-  /// with, so that re-filter can only ever read the frontier THAT result's own
-  /// premise supports (see [`ProvenancedResult`]).
+  /// with, so the two replacement decisions this engine makes about it read THAT
+  /// result's own premise and never a later call's (see [`ProvenancedResult`]).
   prev_result: Option<ProvenancedResult>,
   prev_words: Vec<WordTiming>,
   hypothesis_words: Vec<WordTiming>,
@@ -667,8 +632,7 @@ pub struct LocalAgreement {
   /// the advance's own second split.
   ///
   /// Until then they are the head of the holdback in every respect except the
-  /// prefill: they align in `settled_seams`' revisable half, an advance replaces
-  /// them along with the rest of the holdback, and
+  /// prefill: an advance replaces them along with the rest of the holdback, and
   /// [`Self::finalize`]'s `holdback_superseded` path drops them with it.
   pending_words: Vec<WordTiming>,
   results: Vec<TranscriptionResult>,
@@ -897,10 +861,11 @@ impl LocalAgreement {
   /// `prefixTokens` exactly as described. It defaults `true` on both sides, so
   /// this only diverges for a caller that turned it off.
   ///
-  /// What the prefill buys is the reason
-  /// `LocalAgreement::watermark_filtered`'s frontier can be read off an ambiguous
-  /// alignment at all. `prefill_tokens` appends these tokens to the initial
-  /// prompt, and `decode_text` FORCES every prompt position
+  /// What the prefill buys is the reason a hypothesis decoded from these options
+  /// cannot put anything in front of the holdback — the premise
+  /// [`Self::pending_words_slice`]'s promotion rests on. `prefill_tokens`
+  /// appends these tokens to the initial prompt, and `decode_text` FORCES every
+  /// prompt position
   /// (`next_token = current_tokens[token_index]` for `token_index <
   /// initial_prompt_index`) before `finalize_decoding_result` keeps the whole
   /// `SOT..=EOT` span — so the holdback is not something the next hypothesis
@@ -908,25 +873,22 @@ impl LocalAgreement {
   /// with `clip_timestamps`, which puts the audio before the watermark outside
   /// the decoded window entirely, a hypothesis produced from these options
   /// BEGINS with a reproduction of the holdback, and nothing already confirmed
-  /// can precede it. See `LocalAgreement::watermark_filtered`, "Ambiguity rule".
+  /// can precede it. See `LocalAgreement::prefill_reproduces_holdback`.
   ///
   /// Hand the returned value back to [`Self::ingest`] alongside the result it
   /// decoded: that is how the premise above becomes something the engine has
   /// CHECKED rather than assumed. `ingest` compares what it is given against
-  /// what this method would issue for the same state, and falls back to the
-  /// unattributable frontier when they differ.
+  /// what this method would issue for the same state, and leaves the pending
+  /// head unsettled when they differ.
   ///
   /// # Before the first advance
   ///
   /// With an empty [`Self::last_agreed_words_slice`] there is nothing to
   /// reproduce: the prefix is empty, `clip_timestamps` is at the watermark, and
   /// [`DecodingOptions::use_prefill_prompt`] is left exactly as `base` had it.
-  /// The forcing above exists to make the frontier's tie-break sound, and with
-  /// no holdback there is no tie-break to make sound — before the first advance
-  /// [`Self::confirmed_words_slice`] is empty too, so `settled` is empty and
-  /// `watermark_filtered` takes its `settled_len == 0` fast path; after an
-  /// advance that could hold nothing (`budgeted_split`) a frontier IS read, but
-  /// the two policies name the same column when the holdback is empty (see
+  /// The forcing above exists to make the pending promotion sound, and with no
+  /// holdback nothing is ever pending — the advance settles such a word on the
+  /// spot, precisely because no anchor could ever clear it (see
   /// `Self::prefill_reproduces_holdback`). Overriding the caller's flag here
   /// would change the initial prompt from a bare `<|startoftranscript|>` to the
   /// full multilingual language/task/timestamp prefill for no reason the engine's
@@ -939,13 +901,10 @@ impl LocalAgreement {
       .with_prefix_tokens(self.holdback_prefill_tokens());
     if self.last_agreed_words.is_empty() {
       // NOTHING IS HELD BACK, so there is no premise to enforce and the caller's
-      // own flag stands. Before the first advance `confirmed_words` is empty for
-      // exactly as long as `last_agreed_words` is, so `watermark_filtered`'s
-      // `settled_len` is zero and the frontier question never arises; after an
-      // advance whose budget could hold nothing (`budgeted_split`) it does
-      // arise, and the two policies answer it identically with an empty holdback
-      // (see `prefill_reproduces_holdback`). Either way the tie-break the prefill
-      // DECIDES is not being asked. Forcing the flag here would change the prompt
+      // own flag stands: `pending_words` is empty for exactly as long as
+      // `last_agreed_words` is (the advance's own second split), so the
+      // promotion the prefill DECIDES is not being asked for. Forcing the flag
+      // here would change the prompt
       // from whatever the caller asked for to the full multilingual
       // language/task/timestamp prefill, on strides where the engine holds no
       // state that needs the deviation (codex round 6, finding 3). The prefix
@@ -972,32 +931,26 @@ impl LocalAgreement {
 
   /// Whether `decoded_under` — the options a caller says the offered result was
   /// decoded with — actually establishes the premise
-  /// `LocalAgreement::watermark_filtered`'s ambiguity rule is decided by: that
-  /// the offered hypothesis was written to BEGIN with this engine's whole
-  /// holdback, with nothing already confirmed able to precede it.
+  /// [`Self::pending_words_slice`]'s promotion is decided by: that the offered
+  /// hypothesis was written to BEGIN with this engine's whole holdback, so
+  /// nothing it produces can precede that reproduction and the pending words,
+  /// which sit in front of it, are past revising.
   ///
   /// Every clause is a thing that, if false, breaks that premise outright:
   ///
-  /// - **An empty holdback** makes it vacuous — and harmlessly so, on both of the
-  ///   two ways it arises. Before the first advance `settled` is empty too, so
-  ///   `watermark_filtered` takes its fast path and no frontier is read at all.
-  ///   After an advance the budget could hold nothing (`budgeted_split`),
-  ///   `settled` is NOT empty and a frontier IS read — but with an empty holdback
-  ///   `settled_seams`' `after` row is identically zero, so `score(j)` is the
-  ///   non-decreasing `before[j]`, no column past the smallest optimal one is
-  ///   match-supported, and the two policies name the same frontier. The answer
-  ///   here cannot change any word either way
-  ///   (`with_nothing_held_back_both_frontiers_are_the_same_column`).
+  /// - **An empty holdback** makes it vacuous, and harmlessly so: nothing is
+  ///   ever pending beside an empty holdback (the advance's own second split
+  ///   confirms such a word on the spot, because no anchor could ever clear
+  ///   it), so the only consumer of this answer has nothing to read it for.
   /// - **[`DecodingOptions::use_prefill_prompt`] off** means
   ///   [`crate::audio::whisper::transcribe::WhisperKit::transcribe`] never calls
   ///   [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens), so the
   ///   prefix is inert and the hypothesis PREDICTED its head rather than being
   ///   fed it.
   /// - **A different [`DecodingOptions::clip_timestamps`](DecodingOptions::clip_timestamps_slice)**
-  ///   means the audio the settled words were recognized in was NOT excluded from
-  ///   the decoded window, so a settled word can precede the holdback in the
-  ///   offered list after all — which is precisely the reading the tie-break
-  ///   rules out.
+  ///   means the audio the pending words were recognized in was NOT excluded
+  ///   from the decoded window, so this hypothesis DID re-read them and may be
+  ///   revising them — precisely what the promotion rules out.
   /// - **A prefix that is not the holdback** is not a reproduction of it — and
   ///   the test is equality, not "ends with". A prefix over
   ///   [`MAX_HOLDBACK_PREFILL_TOKENS`] whose TAIL reproduces the holdback is
@@ -1106,10 +1059,9 @@ impl LocalAgreement {
   /// `confirmed`, and DROPS the rest, leaving both record buckets empty for the
   /// caller to refill. The two replacement sites' shared tail.
   ///
-  /// By field rather than through `&mut self` for the same reason
-  /// [`Self::watermark_filtered_with`] is: the advance calls it while `common`
-  /// still borrows `hypothesis_words`, and these three buckets are disjoint from
-  /// that one.
+  /// By field rather than through `&mut self`: the advance calls it while
+  /// `common` still borrows `hypothesis_words`, and these three buckets are
+  /// disjoint from that one.
   fn confirm_the_unread_prefix_and_drop_the_rest(
     confirmed: &mut Vec<WordTiming>,
     pending: &mut Vec<WordTiming>,
@@ -1124,285 +1076,31 @@ impl LocalAgreement {
   }
 
   /// The agreement view of a result's words: everything at or past the
-  /// watermark, MINUS the leading words that only re-offer words already
-  /// settled. The watermark is the first held-back word's start, and the
-  /// confirmed word in front of it is its immediate neighbour in one
-  /// hypothesis's word list, with no audio between them — so it can share that
-  /// exact start (DTW row steps without a column advance, then centisecond
-  /// rounding — ties are pipeline-reachable) or simply end on it, and a
-  /// re-decode can put it on either side of the cut. A bare timestamp filter
-  /// pulls it back in and confirms it AGAIN (phase-gate round-1 finding; Swift
-  /// shares the bug at `:372`/`:375`, and "confirmed once and stable" wins over
-  /// parity here).
+  /// watermark — `TranscribeCLI.swift:372`/`:375` verbatim,
+  /// `result.allWords.filter { $0.start >= lastAgreedSeconds }`, with no strip,
+  /// no scope and no alignment behind it.
   ///
-  /// # The frontier is an alignment boundary, not a prefix match
+  /// It needs none. The watermark is the first held-back word's start, and
+  /// RULE W (see [`Self::ingest`]'s advance) refuses to put it at a word whose
+  /// start ties the confirmed one in front of it — so whenever there is a
+  /// holdback at all, `confirmed_words.last().start() < last_agreed_seconds`
+  /// STRICTLY and no confirmed word can pass this filter. The re-admission the
+  /// issue is about is unrepresentable rather than detected, which is why this
+  /// is the Swift line and not a rule.
   ///
-  /// What the engine already knows about the span `[watermark, ..)` is
-  /// `settled ++ holdback`, in that order: `settled` is the trailing run of
-  /// [`Self::confirmed_words_slice`] whose extent REACHES the watermark — the
-  /// confirmed words a re-decode of that span could hand back — and `holdback` is
-  /// [`Self::last_agreed_words_slice`], still provisional, and the very text
-  /// [`Self::decoding_options_for_next`] prefills the next decode with. A fresh
-  /// hypothesis re-decodes that same span and continues past it, so the question
-  /// is not "does the offered list BEGIN with the confirmed tail" but "WHERE in
-  /// the offered list does the settled part stop and the still-open part start".
-  ///
-  /// `settled`'s scope is a SPAN question, and it is settled on the edge of each
-  /// word that faces the span: `offered` keeps a word whose start is at or past
-  /// the watermark, `settled` keeps a confirmed word whose END is. Testing
-  /// `start` on both sides — which this did until it was found to re-admit —
-  /// asks whether a confirmed word BEGINS inside the span, and every word that
-  /// straddles the boundary answers no while still being reachable from inside
-  /// it. See the scope comment in `watermark_filtered_with` for why the last
-  /// confirmed word straddles it on essentially every advance.
-  ///
-  /// This aligns the whole of `settled ++ holdback` against the offered list —
-  /// a longest-common-subsequence alignment over
-  /// [`normalized`](crate::audio::whisper::text::normalized) text, the same
-  /// equality [`find_longest_common_prefix`] agrees by — and reads the frontier
-  /// off where the alignment crosses the seam between the two halves. Insertions
-  /// and deletions on either side cost nothing beyond the matches they forgo, so
-  /// an insertion ahead of the reproduction, an omission of the confirmed tail's
-  /// head, a partial front match, and a re-decode that nudges every timestamp a
-  /// hair past the watermark all land on the same frontier as the clean case.
-  /// Deciding every position JOINTLY is also what makes "which occurrence is
-  /// this" a well-posed question at all: the two runs of the issue's
-  /// impossibility argument differ only in their HOLDBACK, and the holdback is
-  /// invisible to any rule that scans the offered list for one text match.
-  ///
-  /// # Ambiguity rule: two premises, two readings
-  ///
-  /// An LCS alignment is rarely unique, and the seam can fall at several columns
-  /// of the offered list. Which column is the frontier depends on something no
-  /// alignment can see — how the offered list was PRODUCED — so `prefilled`
-  /// carries the answer in, and [`Self::ingest`] does not assume it: it checks
-  /// the options the caller says the result was decoded under against the
-  /// retarget this engine would have issued (`Self::prefill_reproduces_holdback`).
-  ///
-  /// **With the premise established**, the frontier is the SMALLEST column any
-  /// optimal alignment puts the seam at — equivalently, the longest offered
-  /// prefix that *every* optimal alignment attributes to `settled`. Everything
-  /// the optimal alignments disagree about is attributed to the HOLDBACK.
-  ///
-  /// That direction is not a coin-flip dressed as a tie-break: it is the one the
-  /// engine itself forced. [`Self::decoding_options_for_next`] hands the next
-  /// decode `clip_timestamps = [watermark]` and `prefix_tokens =
-  /// holdback`, and a prefilled decode does not PREDICT its prefix, it is fed it
-  /// — `decode_text` overwrites the sampled token with the prompt token at every
-  /// prompt position, and the finalized `SOT..=EOT` token span keeps them. So a
-  /// hypothesis decoded from those options BEGINS with the holdback, and the
-  /// audio the settled words were recognized in is outside its window entirely.
-  /// When the seam is ambiguous because the offered head could be read either as
-  /// a settled word coming back or as the holdback's own first word, the second
-  /// reading is the one that matches how the list was produced — the first would
-  /// need the decoder to have DROPPED a token it was forced to emit. The
-  /// smallest optimal seam is exactly that reading, and it is why
-  /// `watermark_filtered` is the identity on every stride of
-  /// `jfk_simulated_stream_confirms_the_transcript`. Taking the LARGEST instead
-  /// would refuse the engine's own prefill.
-  ///
-  /// **Without it**, none of that argument is available: the engine wrote nothing
-  /// into this hypothesis, so a disputed head is UNATTRIBUTABLE. The frontier is
-  /// then the largest match-supported optimal seam — refuse every offered word
-  /// that *some* optimal alignment reads as a settled word coming back, because
-  /// [`Self::confirmed_words_slice`] is append-only and irrevocable and a second
-  /// confirmation cannot be taken back. That is a standing justification of its
-  /// own, not a bias: each policy is the reading its own premise supports, and
-  /// the two coincide wherever the optimal seam is unique. See
-  /// [`SettledSeams::unattributed`] for why the seam must be match-SUPPORTED
-  /// (the plain maximum refuses the whole hypothesis whenever `settled` matches
-  /// nothing) and for the proof that it is never smaller than the prefilled one.
-  ///
-  /// Kept also means OFFERED to the agreement comparison, not confirmed:
-  /// LocalAgreement-2 still needs a second hypothesis to corroborate a word
-  /// before it reaches [`Self::confirmed_words_slice`]. That is where "wait for
-  /// corroboration" lives on both paths.
-  ///
-  /// Refusing to ADVANCE on an ambiguous frontier — the other reading of "treat
-  /// an ambiguous boundary as disagreement", which trades liveness for safety on
-  /// purpose — would deadlock rather than stall, and would do it on the driver's
-  /// own steady state. The ambiguity is a function of `(settled, holdback,
-  /// offered)`; `settled` and `holdback` move only on an advance; and the
-  /// prefill makes the offered list BEGIN with the holdback on every stride
-  /// after one. So whenever a settled word's text matches the holdback's head — a
-  /// stutter at the watermark is exactly that — every stride reproduces the same
-  /// two optimal seams, the block re-arms itself, and the prefill it keeps
-  /// re-issuing is what re-creates it. Growing the offered list at the tail does
-  /// not clear it either: `before[j]` is unchanged for the disputed columns and
-  /// the extra words raise `after[j]` uniformly, so the tie survives every new
-  /// stride. The stall would be permanent in the literal sense, not eventual.
-  ///
-  /// **Blocking is not the right policy on the UNMARKED path either**, though the
-  /// argument above appeals to the prefill. Its load-bearing half does not: the
-  /// ambiguity persists under tail growth for reasons that are entirely a
-  /// property of the LCS scores, and a caller re-decoding a growing window off
-  /// unchanged audio reproduces the same head every stride whether or not it
-  /// prefills — a deterministic decoder does not need to be forced to repeat
-  /// itself. Blocking would then convert a bounded, visible cost (one repetition
-  /// of a settled word forgone) into an unbounded, silent one (the rest of the
-  /// stream never confirmed), and it would do it non-deterministically, which is
-  /// worse than doing it always. `a_recurring_ambiguity_would_never_clear_on_the_
-  /// unmarked_path` is that claim as a test, not an argument: it grows the offered
-  /// list stride after stride and shows both seams staying apart at every one.
-  ///
-  /// # What this deliberately leaves
-  ///
-  /// - **A repetition the engine's record cannot account for is read as the
-  ///   stream's own, not the decoder's.** When the offered list carries one more
-  ///   copy of a settled word than `settled ++ holdback` does, nothing the
-  ///   engine holds says whether the clip stuttered or the decode duplicated, so
-  ///   the extra copy is kept and can be confirmed a second time. That is the
-  ///   issue's two-run construction with the HOLDBACKS equal too, which the
-  ///   holdback therefore cannot separate. Pinned by
-  ///   `an_unaccounted_repeat_of_a_settled_word_is_kept_as_the_streams_own`.
-  /// - **Words offered AHEAD of a reproduced settled word are refused with
-  ///   it.** The settled word is already in the caller's hands and
-  ///   [`Self::confirmed_words_slice`] is append-only, so a word the hypothesis
-  ///   puts before a reproduction of it can go neither before it (the list is
-  ///   closed) nor after it (that would rewrite the confirmed prefix). Take the
-  ///   reproduction away and the choice disappears, which is why the two are
-  ///   pinned as a pair:
-  ///   `an_insertion_before_a_reproduced_confirmed_word_is_refused_with_it` and
-  ///   `an_insertion_that_reproduces_nothing_confirmed_keeps_its_word`.
-  /// - **Timestamps decide nothing beyond which words are in the span.** The
-  ///   alignment itself is over normalized TEXT only. Drawing a match window
-  ///   from the watermark instead was defeated by a reproduction shifted a hair
-  ///   past it (`a_reproduction_shifted_off_the_watermark_is_still_refused` is
-  ///   that sequence, now green), and a re-decode is free to move every
-  ///   timestamp it emits, so timings are evidence about the SPAN, not about
-  ///   occurrence identity within it. Both timestamp reads here are span reads:
-  ///   `offered`'s `start >= watermark` and `settled`'s `end >= watermark`.
-  /// - **A drift wider than the gap in front of the watermark still gets
-  ///   through.** `settled` reaches back through the confirmed words whose
-  ///   extent touches the watermark and stops at the first one that ends before
-  ///   it. A re-decode that moves such a word ACROSS the whole gap — past the
-  ///   silence or the intervening word that separated it from the span — offers
-  ///   it into a `settled` that does not hold it, and it can be confirmed a
-  ///   second time. No threshold closes this: widening the scope by a tolerance
-  ///   only moves the same cliff, and widening it to the whole confirmed list
-  ///   deletes a genuine later re-use instead
-  ///   (`a_confirmed_word_from_before_the_watermark_is_out_of_the_alignment` is
-  ///   that cost, and its gaps are load-bearing). What DOES close it is the
-  ///   contract above: under [`Self::decoding_options_for_next`] such a word is
-  ///   outside the clip window and behind the forced prefill, so no re-decode of
-  ///   the span can offer it at all. The residual is a result decoded some other
-  ///   way — which is exactly the path whose frontier is the unattributable
-  ///   reading, so the residual is a word offered from outside `settled`'s scope
-  ///   entirely, not a disputed seam.
-  /// - **Every word of `holdback` is one the prefill carries whole**, so this
-  ///   rule never reasons about text the decoder was not given.
-  ///   `budgeted_split` enforces BOTH of `prefill_tokens`'s reductions — the
-  ///   [`MAX_HOLDBACK_PREFILL_TOKENS`] trim and the `id < special_token_begin`
-  ///   filter, the latter against the vocabulary-independent floor
-  ///   [`MIN_SPECIAL_TOKEN_BEGIN`]
-  ///   — by CONFIRMING what it cannot hold rather than holding it. It was a
-  ///   residual until codex round 8, finding 1: `add_word_timestamps` really
-  ///   does strip those ids from everything this crate's pipeline emits, but
-  ///   [`Self::ingest`] is public and takes a hand-built
-  ///   [`TranscriptionResult`], so a caller could establish such a holdback,
-  ///   use [`Self::decoding_options_for_next`] honestly, and have the premise
-  ///   below recorded true for a hypothesis the decoder was given only part of.
-  ///
-  /// Issue <https://github.com/findit-studio/coremlit/issues/94> carries the
-  /// four defeated predecessors of this rule and the counterexample that killed
-  /// each; every one of them is a named test in this module's `tests`.
-  fn watermark_filtered(&self, hypothesis: &ProvenancedResult) -> Vec<WordTiming> {
-    Self::watermark_filtered_with(
-      hypothesis,
-      self.last_agreed_seconds,
-      &self.confirmed_words,
-      &self.pending_words,
-      &self.last_agreed_words,
-    )
-  }
-
-  /// `hypothesis` carries its OWN premise (see [`ProvenancedResult`]) — there is
-  /// deliberately no separate `prefilled` parameter, so a result's frontier
-  /// cannot be read under another result's provenance.
-  ///
-  /// `pending` is the STILL-OPEN head of the holdback (see
-  /// [`Self::pending_words_slice`]) and joins the revisable half here rather
-  /// than the settled one. That is not a per-result reading: pending words leave
-  /// this state the instant a hypothesis arrives that cannot revise them (one
-  /// that arrives under this engine's own prefill promotes them into `confirmed`
-  /// before either list is filtered; one whose window never reached them is
-  /// handled at the advance, after both lists are filtered), so both sides of
-  /// the agreement comparison always see the same partition, and no premise from
-  /// one result can widen what another one settles.
-  fn watermark_filtered_with(
-    hypothesis: &ProvenancedResult,
-    watermark: f32,
-    confirmed: &[WordTiming],
-    pending: &[WordTiming],
-    holdback: &[WordTiming],
-  ) -> Vec<WordTiming> {
-    let offered: Vec<WordTiming> = hypothesis
-      .result()
+  /// What it deliberately leaves is the same short list the postcondition
+  /// bounds, recorded in this module's doc and each with a named test:
+  /// a repeat the engine's record cannot account for is read as the stream's
+  /// own; an empty holdback anchors the watermark at the last confirmed word's
+  /// END, so a zero-duration word there can still tie it; and a re-decode free
+  /// to move every timestamp it emits can push a settled word past the
+  /// watermark, where it reads as new speech.
+  fn watermark_filtered(result: &TranscriptionResult, watermark: f32) -> Vec<WordTiming> {
+    result
       .all_words()
       .into_iter()
       .filter(|word| word.start() >= watermark)
-      .collect();
-    // The settled words that REACH the re-decoded span, and so could come back
-    // out of it: confirmed words are time-ordered, so those are the trailing run
-    // whose extent touches the watermark. Note the endpoint -- `end`, not
-    // `start`. Each list is tested against the watermark on the edge that FACES
-    // the span: `offered` above keeps a word whose LEADING edge is at or past it,
-    // and this keeps a confirmed word whose TRAILING edge is. A word is in the
-    // span when any part of it is, and testing `start` here asked instead
-    // whether the word BEGINS inside the span -- which is false for every word
-    // that straddles the boundary, and the last confirmed word straddles it on
-    // essentially every advance: DTW word timings abut (in
-    // `jfk_tiny_words_golden.json`, 20 of 21 consecutive pairs share an instant
-    // exactly), so `confirmed.last().end() == holdback[0].start() ==
-    // watermark`. Under `start` that word was in scope only in the degenerate
-    // tie where it also had a zero-length overlap with the holdback, and a
-    // re-decode that nudged it a hundredth of a second past the watermark
-    // re-offered it into an EMPTY settled set -- confirming it a second time
-    // (`a_word_whose_extent_reaches_the_watermark_is_in_the_alignment`).
-    // `end >= watermark` is a strict widening (`end >= start`), so the scope can
-    // only ever grow against the old rule, never shrink.
-    //
-    // A confirmed word that ends BEFORE the watermark is still out of the
-    // alignment: another word's audio, or silence, lies between it and the span,
-    // and letting it match a genuinely later re-use of the same text is how a
-    // scan-based rule eats the provisional words in front of it
-    // (`a_confirmed_word_from_before_the_watermark_is_out_of_the_alignment`,
-    // whose gaps are load-bearing for exactly this reason). That leaves a
-    // residual, stated in `watermark_filtered`'s doc: a re-decode free to move
-    // every timestamp it emits can move one further than that gap.
-    let settled_len = confirmed
-      .iter()
-      .rev()
-      .take_while(|word| word.end() >= watermark)
-      .count();
-    if settled_len == 0 {
-      // No confirmed word's extent reaches this span, so nothing offered can be
-      // a re-admission of one. The alignment agrees (an empty `settled` scores
-      // zero against every prefix, so every seam is optimal and the smallest --
-      // and the smallest match-supported -- is 0); this is the fast path,
-      // not a special case. It is a no-op GIVEN the scope above is right --
-      // which is the load it carries, and why the endpoint it tests is
-      // pinned by a test rather than left to the reader.
-      return offered;
-    }
-    // `pending ++ holdback` is the engine's whole still-open record of the span:
-    // the head the prefill could not carry, then the part it did. Both halves
-    // are revisable, so both belong to `after` -- putting `pending` in `before`
-    // instead would refuse an offered head that re-covers it, which is the right
-    // treatment for a CONFIRMED word and the wrong one for a word that is not
-    // confirmed yet.
-    let revisable: Vec<WordTiming> = pending.iter().chain(holdback).cloned().collect();
-    let seams = settled_seams(
-      &confirmed[confirmed.len() - settled_len..],
-      &revisable,
-      &offered,
-    );
-    let frontier = if hypothesis.prefilled() {
-      seams.prefilled
-    } else {
-      seams.unattributed
-    };
-    offered[frontier..].to_vec()
+      .collect()
   }
 
   /// Folds one freshly-decoded `result` into the engine. Ports
@@ -1446,22 +1144,11 @@ impl LocalAgreement {
     // PROVENANCE IS BOUND HERE, ONCE, BEFORE ANY STATE MOVES -- `decoded_under`
     // is checked against the watermark and holdback the caller decoded with,
     // which are still the current ones at this point, and the answer then
-    // travels WITH the result for as long as the engine keeps it.
-    //
-    // Each of the two filtered views below reads its own result's premise, and
-    // there is no way for it to read the other's: `watermark_filtered_with`
-    // takes the PAIR. Deriving one flag here and reusing it for `prev_result`
-    // was round 7's finding 1 -- the previous result is stored RAW and
-    // re-filtered on every later call, so reusing this call's premise gives an
-    // unmarked result the marked frontier one call later, undoing its refusal
-    // with no caller lying. The old justification for sharing the flag ("a
-    // `prev_words` filtered more permissively can only make the two agree on
-    // FEWER words") had the direction backwards: `find_longest_common_prefix`
-    // returns elements of its SECOND argument, but its LENGTH is set by both,
-    // and a permissively-filtered `prev_words` keeps a leading word the
-    // conservative one dropped -- so the prefix gets LONGER, and length is what
-    // decides whether the watermark advances and how much reaches the
-    // append-only `confirmed_words`.
+    // travels WITH the result for as long as the engine keeps it. What it buys
+    // is no longer a reading of the offered list (Rule W removed that question)
+    // but the two REPLACEMENT decisions below: whether this hypothesis could
+    // have revised the still-open record at all, and whether it can settle the
+    // pending head of it.
     let hypothesis = ProvenancedResult::arriving(result, self, decoded_under);
 
     // Accumulate THIS hypothesis's reproducibility facts BEFORE any gate or
@@ -1538,8 +1225,9 @@ impl LocalAgreement {
     // boundary at the moment it drops it.
     let open_record_split = self.open_record_split(&hypothesis);
 
-    // :372 — plus the readmit skip (see `watermark_filtered`).
-    self.hypothesis_words = self.watermark_filtered(&hypothesis);
+    // :372 verbatim — see `watermark_filtered`, and Rule W below for why the
+    // bare filter is sound.
+    self.hypothesis_words = Self::watermark_filtered(hypothesis.result(), self.last_agreed_seconds);
 
     let mut advanced = false;
     let mut skip_append = false;
@@ -1548,15 +1236,10 @@ impl LocalAgreement {
     if let Some(previous) = &self.prev_result {
       // :375-376 — the same filter as the hypothesis, against the CURRENT
       // watermark, so the two sides stay index-aligned for the prefix
-      // comparison. Under its OWN premise, though: `previous` carries the
-      // provenance it arrived with, and this call cannot supply another.
-      self.prev_words = Self::watermark_filtered_with(
-        previous,
-        self.last_agreed_seconds,
-        &self.confirmed_words,
-        &self.pending_words,
-        &self.last_agreed_words,
-      );
+      // comparison. `prev_result` is kept RAW for exactly this: the watermark it
+      // is re-read against is the one current NOW, not the one current when it
+      // arrived.
+      self.prev_words = Self::watermark_filtered(previous.result(), self.last_agreed_seconds);
       let common = find_longest_common_prefix(&self.prev_words, &self.hypothesis_words);
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
@@ -1590,11 +1273,11 @@ impl LocalAgreement {
         // `common[split - 1]` is the last word this advance CONFIRMS only when
         // every word `budgeted_split` widened past also ends at or before the
         // new watermark; one that ends past it lands in `pending_words` instead
-        // -- the revisable half of `watermark_filtered_with`, where a tie
-        // creates no re-admission to defend against -- and this widens past it
-        // all the same. The postcondition holds either way, so the cost is
-        // conservatism: on a holdback whose tail ties, the split can run to the
-        // end of `common` and leave nothing held and nothing pending.
+        // -- not confirmed, so a tie against it creates no re-admission to
+        // defend against -- and this widens past it all the same. The
+        // postcondition holds either way, so the cost is conservatism: on a
+        // holdback whose tail ties, the split can run to the end of `common` and
+        // leave nothing held and nothing pending.
         //
         // Composes with `budgeted_split` in one direction only, which is why it
         // runs after it: widening can only SHRINK the holdback `common[split..]`,
@@ -1675,14 +1358,11 @@ impl LocalAgreement {
         // - **Nothing can overlap it.** Every word the engine will ever be
         //   offered again is filtered to `start >= watermark`, so a word whose
         //   extent ENDS at or before the watermark shares no instant with any of
-        //   them. Note the STRICT `>`, against the non-strict `end >= watermark`
-        //   `watermark_filtered_with` scopes `settled` by: the two answer
-        //   different questions and err in opposite directions on the abutting
-        //   word. There, erring wide costs one repetition of a settled word and
-        //   erring narrow confirms it twice; here, erring wide DELETES a word the
-        //   stream produced and nothing revised. Interval overlap is the exact
-        //   notion this one needs, and `[p.start, p.end)` overlaps
-        //   `[watermark, ..)` exactly when `p.end > watermark`.
+        //   them. The `>` is STRICT: erring wide here DELETES a word the stream
+        //   produced and nothing revised, while erring narrow only leaves a word
+        //   pending one call longer. Interval overlap is the exact notion this
+        //   one needs, and `[p.start, p.end)` overlaps `[watermark, ..)` exactly
+        //   when `p.end > watermark`.
         // - **Nothing could ever clear it.** A pending word waits for a
         //   hypothesis that provably cannot revise it, and the only such
         //   hypothesis is one this engine ANCHORED -- prefilled with a holdback
@@ -1892,7 +1572,7 @@ impl LocalAgreement {
 }
 
 // ---------------------------------------------------------------------
-// The settled/holdback frontier
+// The confirmed/holdback split
 // ---------------------------------------------------------------------
 
 /// Where an advance splits `common` into the part that is CONFIRMED and the
@@ -1945,7 +1625,7 @@ impl LocalAgreement {
 /// [`LocalAgreement::decoding_options_for_next`] just issued, and have
 /// `ProvenancedResult` record `prefilled = true` for a hypothesis the decoder
 /// was fed only PART of the holdback for — the one premise
-/// `LocalAgreement::watermark_filtered`'s ambiguity rule rests on.
+/// [`LocalAgreement::pending_words_slice`]'s promotion rests on.
 ///
 /// Widening the split instead takes that head OUT of the holdback. It is not a
 /// weaker claim than any other agreed word carries: `common` is the prefix two
@@ -1974,29 +1654,15 @@ impl LocalAgreement {
 /// hypothesis arrives that the engine itself anchored. Deferring the
 /// DESTINATION is available; deferring the SPLIT is not.
 ///
-/// Widening is also the only one of the two repairs that repairs anything.
-/// REFUSING the marked reading for such a holdback — reading the unattributable
-/// frontier instead — leaves the unreproducible word in the holdback, where the
-/// next unanchored hypothesis disagrees with it and
-/// [`LocalAgreement::finalize`]'s `holdback_superseded` path deletes it: the
-/// same data loss round 7's finding 2 established for the budget, reached by the
-/// same route. On the frontier itself the refusal is not even conservative — it
-/// cuts the offered head as well, so the word the engine dropped AND the word it
-/// refused both leave the transcript
-/// (`a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held`
-/// carries the arithmetic). Neither seam is the repair, because the defect is
-/// the STATE, not the reading of it. The pending bucket does not reopen that
-/// choice: the seam a pending word is read under is still the one its own
-/// premise supports, and a marked continuation still finds the word out of the
-/// holdback and out of its way.
+/// Widening is the repair because the defect is the STATE, not any reading of
+/// it. Leaving the unreproducible word IN the holdback is what round 7's
+/// finding 2 recorded: the next unanchored hypothesis disagrees with it and
+/// [`LocalAgreement::finalize`]'s `holdback_superseded` path deletes it.
 ///
 /// The split runs all the way to `common.len()` when it has to, so the holdback
 /// this leaves can be EMPTY. It has to (codex round 7, finding 2): stopping while
 /// one word remained still held a single word whose OWN tokens exceed the budget,
-/// and the cap silently did not cap. Refusing the prefill READING for it, which
-/// is what used to catch that residual, is the wrong instrument — the unmarked
-/// frontier is the right answer for a hypothesis the engine did not write, and it
-/// cannot put back a token the engine itself dropped. What followed was data
+/// and the cap silently did not cap. What followed was data
 /// loss, not a stall: the next hypothesis came back with the truncated word
 /// rather than the held one, disagreed, and
 /// [`LocalAgreement::finalize`]'s `holdback_superseded` path replaced the intact
@@ -2065,143 +1731,6 @@ fn budgeted_split(common: &[WordTiming], requested: usize, special_token_begin: 
 fn prefill_carries_whole(word: &WordTiming, special_token_begin: u32) -> bool {
   let tokens = word.tokens_slice();
   !tokens.is_empty() && tokens.iter().all(|&id| id < special_token_begin)
-}
-
-/// The two frontiers an optimal alignment of `settled ++ holdback` against
-/// `offered` admits: where `offered` stops re-covering `settled` and starts
-/// re-covering `holdback`, read once under each of the two premises
-/// [`LocalAgreement::ingest`] can be in. See `LocalAgreement::watermark_filtered`
-/// for what a frontier means and for the standing justification of each.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct SettledSeams {
-  /// The number of leading `offered` words EVERY optimal alignment attributes
-  /// to `settled` — the smallest optimal seam. Everything the optimal
-  /// alignments disagree about goes to the HOLDBACK, which is the reading a
-  /// verified prefill forces: the engine WROTE the holdback into this
-  /// hypothesis, so a disputed head is the holdback's own reproduction.
-  prefilled: usize,
-  /// The number of leading `offered` words SOME optimal alignment attributes to
-  /// `settled`, counting only seams a settled MATCH actually supports — the
-  /// largest such optimal seam. This is the reading with no prefill to appeal
-  /// to: a disputed head is unattributable, and confirmation is append-only, so
-  /// it must not become a second confirmation of a word already handed to the
-  /// caller.
-  ///
-  /// The match-supported restriction (`before[j] > before[j - 1]`) is what keeps
-  /// this from degenerating. Take the plain maximum and a `settled` that matches
-  /// NOTHING makes every seam optimal at score zero, so the maximum is
-  /// `offered.len()` and the whole hypothesis is refused — a permanent stall
-  /// dressed as caution. Requiring the word immediately before the seam to be
-  /// matched to a settled word excludes exactly that padding, and the
-  /// restriction never empties the set: if `j` is optimal and
-  /// `before[j] == before[j - 1]` then `j - 1` is optimal too (`after` is
-  /// non-increasing, so `score(j - 1) >= score(j)`), so every optimal seam walks
-  /// down to a supported one — [`Self::prefilled`] itself is supported, being
-  /// the smallest. Hence `unattributed >= prefilled` always.
-  ///
-  /// With an EMPTY holdback the two are equal, which is what lets
-  /// [`LocalAgreement::prefill_reproduces_holdback`] answer such a state
-  /// vacuously: `after` is then identically zero, so `score(j)` is the
-  /// non-decreasing `before[j]`, and every column past the smallest optimal one
-  /// has `before[j] == before[j - 1]` and so is unsupported
-  /// (`with_nothing_held_back_both_frontiers_are_the_same_column`).
-  unattributed: usize,
-}
-
-/// Both seams of [`SettledSeams`], from one pair of LCS reads. See
-/// `LocalAgreement::watermark_filtered` for what the frontier means and why the
-/// tie breaks toward the HOLDBACK under a verified prefill — which is not a
-/// preference but the reading that matches how the offered list was produced,
-/// the engine having prefilled the decoder with that holdback itself.
-///
-/// The alignment is a longest-common-subsequence one over
-/// [`normalized`](crate::audio::whisper::text::normalized) text — the same
-/// equality [`find_longest_common_prefix`] agrees by. Insertion and deletion are
-/// the only edits (there is no "substitution": a revised word is a deletion and
-/// an insertion, and this equality admits no partial similarity to price one
-/// against the other), so minimizing edits is exactly maximizing matches and the
-/// whole rule reduces to two LCS reads:
-///
-/// - `before[j] == LCS(settled, offered[..j])` — how much of the settled half
-///   an alignment can still account for if the frontier is put at `j`;
-/// - `after[j] == LCS(holdback, offered[j..])` — the same for the holdback.
-///   Both come from one prefix DP: the second runs it over the two sequences
-///   REVERSED, which turns a suffix read into a prefix read.
-///
-/// Every alignment splits at the seam into one of each, and every such pair
-/// composes back into an alignment, so `max_j (before[j] + after[j])` IS the
-/// alignment's total and `{ j : before[j] + after[j] == max }` is exactly the
-/// set of columns an optimal alignment can put the seam at. Its MINIMUM refuses
-/// the offered prefix every optimal alignment settles and leaves everything they
-/// disagree about in the agreement game; its largest match-supported member
-/// refuses everything any of them could settle. Which one is the frontier is
-/// [`LocalAgreement::ingest`]'s call, on the premise it could verify.
-fn settled_seams(
-  settled: &[WordTiming],
-  holdback: &[WordTiming],
-  offered: &[WordTiming],
-) -> SettledSeams {
-  fn normalize(words: &[WordTiming]) -> Vec<String> {
-    words.iter().map(|word| normalized(word.word())).collect()
-  }
-  let settled_text = normalize(settled);
-  let holdback_text = normalize(holdback);
-  let offered_text = normalize(offered);
-
-  let settled: Vec<&str> = settled_text.iter().map(String::as_str).collect();
-  let offered: Vec<&str> = offered_text.iter().map(String::as_str).collect();
-  let holdback_reversed: Vec<&str> = holdback_text.iter().rev().map(String::as_str).collect();
-  let offered_reversed: Vec<&str> = offered.iter().rev().copied().collect();
-
-  let before = common_subsequence_with_every_prefix(&settled, &offered);
-  // Reversing both sides turns the suffix read into a prefix read:
-  // `after_reversed[m] == LCS(holdback, offered[len - m..])`, so the score for a
-  // frontier at `j` reads it at `len - j`.
-  let after_reversed = common_subsequence_with_every_prefix(&holdback_reversed, &offered_reversed);
-
-  let len = offered.len();
-  let score = |frontier: usize| before[frontier] + after_reversed[len - frontier];
-  // `0..=len` is never empty, so the `max` and the `find` always land; the
-  // defaults keep this total rather than panicking on an impossible state.
-  let best = (0..=len).map(score).max().unwrap_or(0);
-  let prefilled = (0..=len)
-    .find(|&frontier| score(frontier) == best)
-    .unwrap_or(0);
-  // The largest optimal seam a settled MATCH supports -- see
-  // `SettledSeams::unattributed` for why the plain maximum refuses the whole
-  // hypothesis whenever `settled` matches nothing, and for the proof that
-  // `prefilled` is always in this set (so the fallback below never fires).
-  let unattributed = (0..=len)
-    .rfind(|&frontier| {
-      score(frontier) == best && (frontier == 0 || before[frontier] > before[frontier - 1])
-    })
-    .unwrap_or(prefilled);
-  SettledSeams {
-    prefilled,
-    unattributed,
-  }
-}
-
-/// `out[j]` is the length of the longest common subsequence of `pattern` and
-/// `text[..j]`, for every `j` in `0..=text.len()` — the last row of the
-/// standard LCS table, computed with two rolling rows.
-///
-/// `out[0]` stays `0` on every row (nothing has a common subsequence with the
-/// empty prefix), which is why the row buffers are never re-zeroed.
-fn common_subsequence_with_every_prefix(pattern: &[&str], text: &[&str]) -> Vec<usize> {
-  let mut previous = vec![0usize; text.len() + 1];
-  let mut current = vec![0usize; text.len() + 1];
-  for pattern_word in pattern {
-    for (index, text_word) in text.iter().enumerate() {
-      current[index + 1] = if pattern_word == text_word {
-        previous[index] + 1
-      } else {
-        current[index].max(previous[index + 1])
-      };
-    }
-    core::mem::swap(&mut previous, &mut current);
-  }
-  previous
 }
 
 // ---------------------------------------------------------------------

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -1561,7 +1561,58 @@ impl LocalAgreement {
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
         let requested = common.len() - self.agreement_count_needed;
-        let split = budgeted_split(common, requested, self.special_token_begin);
+        let mut split = budgeted_split(common, requested, self.special_token_begin);
+        // RULE W -- THE SPLIT MAY NOT CUT AT A TIED START (#94, at its source).
+        //
+        // The watermark is the first held-back word's start, and it is also the
+        // CLIP this engine hands its own next decoder. Cutting at a word whose
+        // start TIES the last confirmed one puts that boundary INSIDE a span
+        // already settled: the confirmed word then satisfies the offered filter's
+        // own `start >= watermark`, and the next hypothesis can re-offer it at
+        // the head of its word list. That is the state every re-admission defence
+        // in this issue's history was built to survive -- and the one that cannot
+        // be decided from the offered list, because a re-offered settled word and
+        // the stream's own second occurrence of the same text are byte-identical
+        // there. Refuse to CREATE it: widen past the tie instead.
+        //
+        // Postcondition: whenever `last_agreed_words` is non-empty,
+        // `confirmed_words.last().start() < last_agreed_seconds` strictly, so no
+        // confirmed word can ever pass the offered filter again.
+        //
+        // The anchor is the word the watermark would be measured against: the
+        // last word the split has already moved past (`common[split - 1]`) when
+        // it has moved past anything, and otherwise the engine's own last
+        // confirmed word, which is what the watermark would then sit beside. It
+        // is carried forward through the loop, so a RUN of tied starts is
+        // cleared in one pass rather than one word of it.
+        //
+        // Against `pending_words` this OVER-FIRES, deliberately.
+        // `common[split - 1]` is the last word this advance CONFIRMS only when
+        // every word `budgeted_split` widened past also ends at or before the
+        // new watermark; one that ends past it lands in `pending_words` instead
+        // -- the revisable half of `watermark_filtered_with`, where a tie
+        // creates no re-admission to defend against -- and this widens past it
+        // all the same. The postcondition holds either way, so the cost is
+        // conservatism: on a holdback whose tail ties, the split can run to the
+        // end of `common` and leave nothing held and nothing pending.
+        //
+        // Composes with `budgeted_split` in one direction only, which is why it
+        // runs after it: widening can only SHRINK the holdback `common[split..]`,
+        // so the token budget it just established still holds, and its id-filter
+        // floor is likewise never re-crossed (see `budgeted_split`). Where the
+        // tie runs to the end of `common` the holdback empties and the watermark
+        // falls back to `common.last().end()`, which is at or past every start in
+        // it -- the postcondition is then vacuous, and the next advance re-seeds
+        // the anchor from the confirmed list.
+        let mut anchor = if split > 0 {
+          Some(common[split - 1].start())
+        } else {
+          self.confirmed_words.last().map(WordTiming::start)
+        };
+        while split < common.len() && anchor.is_some_and(|tied| tied >= common[split].start()) {
+          anchor = Some(common[split].start());
+          split += 1;
+        }
         // The still-open record is REPLACED here -- `pending_words` dropped and
         // `last_agreed_words` overwritten -- because `common` is the span two
         // hypotheses have just re-agreed over it. That is a claim about this

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -565,8 +565,8 @@
 //!    flagged, not taken.
 //! 6. **A whole hypothesis RE-TIMED past the watermark is confirmed twice, and
 //!    the shape cannot be built without also building a re-admission.** Offer a
-//!    113-word tied run at 2 s twice, then the SAME 113 words at 3 s: the first
-//!    pair advances and anchors just past 2 s, the second pair is entirely
+//!    113-word tied run at 2 s twice, then the SAME 113 words at 3 s twice: the
+//!    first pair advances and anchors just past 2 s, the second pair is entirely
 //!    strictly past that anchor, so it agrees with itself and is confirmed as
 //!    well, which double-counts those words: the stream is credited with more
 //!    confirmed words than it actually offered. Not new here — `main` shows the
@@ -784,9 +784,9 @@ impl AgreementOutcome {
   /// This is the question the single `Advanced` variant used to answer, and it
   /// is kept as a predicate rather than dropped because it is a real and
   /// separate question from progress: `finalize` folds in every kept result, so
-  /// a `Stationary` round contributed to the transcript even though it moved
-  /// nothing. What it must NOT be used for is deciding that something advanced —
-  /// that is `is_progressed()`.
+  /// a `Stationary` round contributed to the transcript even though NEITHER of
+  /// the two SETTLED channels moved. What it must NOT be used for is deciding
+  /// that something advanced — that is `is_progressed()`.
   ///
   /// It is not the KEPT predicate. [`Self::AwaitingAgreement`] covers two
   /// routes, and the first-ever result reaches it and IS kept

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -59,16 +59,40 @@
 //!   centisecond rounding; ties are pipeline-reachable) is pulled back in and
 //!   confirmed AGAIN. This port keeps Swift's filter verbatim and closes the
 //!   hole at its SOURCE instead: an advance refuses to put the watermark at a
-//!   word whose start ties the confirmed one in front of it, widening past the
-//!   tie rather than cutting the clip boundary INSIDE a span already settled
-//!   (see the Rule W comment at `LocalAgreement::ingest`'s advance).
+//!   word whose start ties the confirmed one in front of it, cutting the clip
+//!   boundary INSIDE a span already settled (see `split_at_a_strict_boundary`).
 //!
-//!   **Postcondition** — whenever [`LocalAgreement::last_agreed_words_slice`] is
-//!   non-empty, `confirmed_words.last().start() < last_agreed_seconds`
-//!   STRICTLY, so the LAST confirmed word cannot satisfy the offered filter's
-//!   own `start >= watermark` and cannot head a hypothesis. The re-admission
-//!   question is then unrepresentable rather than defended against. Adjudicated:
-//!   Swift shares the bug, and "confirmed once and stable" wins over parity here.
+//!   **Postcondition (TOTAL)** — after every advance,
+//!   `confirmed_words.last().start() < last_agreed_seconds` STRICTLY, with no
+//!   condition on the holdback, so the LAST confirmed word cannot satisfy the
+//!   offered filter's own `start >= watermark` and cannot head a hypothesis. The
+//!   re-admission question is unrepresentable rather than defended against.
+//!   Adjudicated: Swift shares the bug, and "confirmed once and stable" wins
+//!   over parity here.
+//!
+//!   Two things carry it, and they are separable. `split_at_a_strict_boundary`
+//!   puts an INTERIOR split only on a boundary whose preceding word starts
+//!   strictly earlier — searching forward from the requested split first, then
+//!   BACKING OFF when the forward search would run off the end of `common`,
+//!   because widening past a tied run that reaches that end would empty the
+//!   holdback and anchor the watermark on the run's own last word. And where the
+//!   holdback is empty anyway — the prefill budget is the only thing that can
+//!   still do that — `LocalAgreement::ingest` anchors the watermark at
+//!   `end.max(start.next_up())` rather than at `end`, since `end == start` for a
+//!   zero-duration word. `next_up` is the IMMEDIATE f32 successor: it refuses
+//!   exactly the one instant the confirmed word occupies and no span of
+//!   instants, which an `end + epsilon` tolerance would not have managed.
+//!
+//!   The first shape of this rule widened unconditionally and left the empty
+//!   holdback anchored at `end`, which put the ORIGINAL duplicate-confirmation
+//!   defect back on the DEFAULT driver path: two ingests of one hypothesis whose
+//!   agreed prefix ends in a zero-duration tied run confirmed that whole run,
+//!   emptied the holdback, and re-confirmed the run on every later stride
+//!   without bound (codex round 1 on PR #95;
+//!   `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`).
+//!   The lesson is recorded with it: the patch had covered the ROUTE to that
+//!   state (an over-budget word) and not the STATE, and the property test's own
+//!   shape skipped the state, which read as coverage.
 //!
 //!   It is a claim about the LAST confirmed word, and that is as strong as it
 //!   needs to be exactly while word starts inside one hypothesis are
@@ -83,11 +107,14 @@
 //!   words come from `add_word_timestamps`. It is one more thing the seal below
 //!   is holding up, and one more reason the grep gate exists.
 //!
-//!   **[BEHAVIOUR CHANGE]** the rule confirms one word EARLIER on a tied input,
-//!   trading one round of revisability for a clip boundary that does not bisect
-//!   a settled span — the same trade `budgeted_split` already makes, and
-//!   [`LocalAgreement::agreement_count_needed`] becomes a maximum slightly more
-//!   often. **Trigger:** two adjacent agreed words with equal `start`. On words
+//!   **[BEHAVIOUR CHANGE]** the rule confirms one word EARLIER on a tied input
+//!   the forward search clears, trading one round of revisability for a clip
+//!   boundary that does not bisect a settled span — the same trade
+//!   `budgeted_split` already makes — and holds one word LONGER where it has to
+//!   back off instead. So [`LocalAgreement::agreement_count_needed`] is a target
+//!   rather than an exact width in either direction: the budget can shorten the
+//!   holdback and the back-off can lengthen it. **Trigger:** two adjacent agreed
+//!   words with equal `start`. On words
 //!   this crate's own pipeline produces that requires a ZERO-DURATION word:
 //!   `find_alignment` guarantees `w[i].end() <= w[i + 1].start() + 1e-4`
 //!   (pinned in `crate::audio::whisper::segment`'s tests), so
@@ -149,8 +176,12 @@
 //!   between two consecutive hypotheses and is append-only.
 //!
 //!   That split runs all the way to `common.len()` when it has to, so **an
-//!   advance can leave the holdback EMPTY** and the watermark anchored at the
-//!   last confirmed word's end instead of the first held one's start. It has to:
+//!   advance can leave the holdback EMPTY** and the watermark anchored on the
+//!   last confirmed word's own far edge instead of the first held one's start.
+//!   The BUDGET is now the only thing that can do that — Rule W's own widening
+//!   backs off rather than empties (see `split_at_a_strict_boundary`) — and the
+//!   anchor is `end.max(start.next_up())`, so a zero-duration word there is
+//!   still strictly behind the watermark. It has to:
 //!   stopping while one word remained left a single word whose OWN tokens exceed
 //!   the budget held anyway, and the cap silently did not cap (codex round 7,
 //!   finding 2). What followed was data loss rather than a stall — the next
@@ -161,9 +192,10 @@
 //!   possible and is no weaker a claim: `common` is the prefix two hypotheses
 //!   agreed on, and a word outside the prefill budget is one no third hypothesis
 //!   decoded from that prefill could revise — see the widened-past entry above
-//!   for the qualifier that carries. Unreachable through
-//!   [`LocalAgreementTranscriber`], which never leaves
-//!   [`DEFAULT_AGREEMENT_COUNT_NEEDED`].
+//!   for the qualifier that carries. It costs one thing, recorded as this
+//!   module's residual 1: a genuinely NEW word beginning at the same instant a
+//!   zero-duration confirmed word occupies is filtered out with the
+//!   re-offer it cannot be told apart from.
 //! - **The final hypothesis's holdback** (Swift `:418-419`, `let final =
 //!   lastAgreedWords + findLongestDifferentSuffix(prevWords,
 //!   hypothesisWords)`). That decomposition is only valid when the LAST
@@ -227,7 +259,6 @@
 //!   [`InferenceBackend`] itself has no `Sync` supertrait either. This is
 //!   a correction against this task's own brief, which specified `B:
 //!   InferenceBackend + Sync` here.
-//!
 //! # The engine's mutating surface is `pub(crate)`
 //!
 //! [`LocalAgreement`] is `pub` and fully READABLE —
@@ -261,19 +292,23 @@
 //!
 //! # Residuals
 //!
-//! Stated with the sequence that reaches each, rather than claimed closed. The
-//! module makes no totality claim.
+//! Stated with the sequence that reaches each, rather than claimed closed. Rule
+//! W's postcondition IS total (see its entry above); the module claims no
+//! totality beyond it.
 //!
-//! 1. **An empty holdback leaves a zero-duration word AT the watermark.** With
-//!    nothing held back the watermark anchors at `common.last().end()` instead
-//!    of the first held word's start, and Rule W has no `common[split]` to
-//!    anchor against — so a word with `start == end` there satisfies the offered
-//!    filter and a re-decode can confirm it twice. Needs a non-default
+//! 1. **A new word at an empty holdback's own instant is DROPPED.** With nothing
+//!    held back the watermark is the last confirmed word's `end`, raised to
+//!    `start.next_up()` where that word has no duration — so a word the stream
+//!    genuinely produces at that same instant fails the offered filter and never
+//!    reaches a hypothesis. It cannot be helped: to a timestamp filter that word
+//!    and a re-offer of the settled one are the same value, which is the issue's
+//!    impossibility result, and the alternative is the unbounded
+//!    re-confirmation #94 is about. A truncation is what the portable prefix
+//!    property tolerates; a rewrite is not. Needs a non-default
 //!    [`LocalAgreement::agreement_count_needed`], a word whose own tokens exceed
-//!    [`MAX_HOLDBACK_PREFILL_TOKENS`], and a zero-duration word, simultaneously.
-//!    `an_empty_holdback_leaves_a_zero_duration_word_at_the_watermark`; the very
-//!    next advance repairs it
-//!    (`the_split_widens_past_a_tie_with_the_confirmed_list_itself`).
+//!    [`MAX_HOLDBACK_PREFILL_TOKENS`] (Rule W's own widening no longer empties
+//!    the holdback), and a zero-duration word, simultaneously.
+//!    `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed`.
 //! 2. **A repeat the engine's record cannot account for** is the stream's own,
 //!    on the untied input — and on a TIED one Rule W deletes it instead. Both
 //!    directions are pinned:
@@ -525,8 +560,8 @@ impl LocalAgreement {
   /// Append-only across the life of the engine: nothing here is ever rewritten,
   /// reordered, or taken back, which is why the trailing words of an agreement
   /// wait in [`Self::last_agreed_words_slice`] instead. RULE W (see
-  /// `Self::ingest`'s advance) additionally guarantees that while that
-  /// holdback is non-empty, this list's last word starts STRICTLY before
+  /// `split_at_a_strict_boundary`) additionally guarantees, with no condition on
+  /// that holdback, that this list's last word starts STRICTLY before
   /// [`Self::last_agreed_seconds`] — so nothing here can be re-offered to the
   /// agreement comparison and confirmed a second time.
   #[inline(always)]
@@ -631,21 +666,20 @@ impl LocalAgreement {
   /// `result.allWords.filter { $0.start >= lastAgreedSeconds }`, with no strip,
   /// no scope and no alignment behind it.
   ///
-  /// It needs none. The watermark is the first held-back word's start, and
-  /// RULE W (see `Self::ingest`'s advance) refuses to put it at a word whose
-  /// start ties the confirmed one in front of it — so whenever there is a
-  /// holdback at all, `confirmed_words.last().start() < last_agreed_seconds`
-  /// STRICTLY and no confirmed word can pass this filter. The re-admission the
+  /// It needs none. RULE W (see `split_at_a_strict_boundary`) refuses to put the
+  /// watermark at a start already settled — so `confirmed_words.last().start() <
+  /// last_agreed_seconds` STRICTLY after every advance, with no condition on the
+  /// holdback, and no confirmed word can pass this filter. The re-admission the
   /// issue is about is unrepresentable rather than detected, which is why this
   /// is the Swift line and not a rule.
   ///
   /// What it deliberately leaves is the same short list the postcondition
-  /// bounds, recorded in this module's doc and each with a named test:
-  /// a repeat the engine's record cannot account for is read as the stream's
-  /// own; an empty holdback anchors the watermark at the last confirmed word's
-  /// END, so a zero-duration word there can still tie it; and a re-decode free
-  /// to move every timestamp it emits can push a settled word past the
-  /// watermark, where it reads as new speech.
+  /// bounds, recorded in this module's doc and each with a named test: a repeat
+  /// the engine's record cannot account for is read as the stream's own; a word
+  /// the stream genuinely produces at an empty holdback's own instant is
+  /// filtered out with the re-offer it cannot be told apart from; and a
+  /// re-decode free to move every timestamp it emits can push a settled word
+  /// past the watermark, where it reads as new speech.
   fn watermark_filtered(result: &TranscriptionResult, watermark: f32) -> Vec<WordTiming> {
     result
       .all_words()
@@ -742,74 +776,47 @@ impl LocalAgreement {
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
         let requested = common.len() - self.agreement_count_needed;
-        let mut split = budgeted_split(common, requested);
-        // RULE W -- THE SPLIT MAY NOT CUT AT A TIED START (#94, at its source).
-        //
-        // The watermark is the first held-back word's start, and it is also the
-        // CLIP this engine hands its own next decoder. Cutting at a word whose
-        // start TIES the last confirmed one puts that boundary INSIDE a span
-        // already settled: the confirmed word then satisfies the offered filter's
-        // own `start >= watermark`, and the next hypothesis can re-offer it at
-        // the head of its word list. That is the state every re-admission defence
-        // in this issue's history was built to survive -- and the one that cannot
-        // be decided from the offered list, because a re-offered settled word and
-        // the stream's own second occurrence of the same text are byte-identical
-        // there. Refuse to CREATE it: widen past the tie instead.
-        //
-        // Postcondition: whenever `last_agreed_words` is non-empty,
-        // `confirmed_words.last().start() < last_agreed_seconds` strictly, so no
-        // confirmed word can ever pass the offered filter again.
-        //
-        // The anchor is the word the watermark would be measured against: the
-        // last word the split has already moved past (`common[split - 1]`) when
-        // it has moved past anything, and otherwise the engine's own last
-        // confirmed word, which is what the watermark would then sit beside. It
-        // is carried forward through the loop, so a RUN of tied starts is
-        // cleared in one pass rather than one word of it.
-        //
-        // Composes with `budgeted_split` in one direction only, which is why it
-        // runs after it: widening can only SHRINK the holdback `common[split..]`,
-        // so the token budget it just established still holds, and its id-filter
-        // floor is likewise never re-crossed (see `budgeted_split`). Where the
-        // tie runs to the end of `common` the holdback empties and the watermark
-        // falls back to `common.last().end()`, which is at or past every start
-        // in it -- the postcondition is then vacuous, and the next advance
-        // re-seeds the anchor from the confirmed list.
-        let mut anchor = if split > 0 {
-          Some(common[split - 1].start())
-        } else {
-          self.confirmed_words.last().map(WordTiming::start)
-        };
-        while split < common.len() && anchor.is_some_and(|tied| tied >= common[split].start()) {
-          anchor = Some(common[split].start());
-          split += 1;
-        }
+        let split = split_at_a_strict_boundary(
+          common,
+          requested,
+          self.confirmed_words.last().map(WordTiming::start),
+        );
         // `common` REPLACES the still-open record: it is the span two consecutive
         // hypotheses have just re-agreed over it, and `last_agreed_words` is the
         // one this hypothesis has superseded.
         self.confirmed_words.extend_from_slice(&common[..split]);
         self.last_agreed_words = common[split..].to_vec();
-        // The watermark is the first held-back word's start -- except when the
-        // budget could hold NOTHING (see `budgeted_split`), where the still-open
-        // span begins where the confirmed one ends. `common` is non-empty here
-        // (its length is at least `agreement_count_needed`, clamped to at least
-        // one), so the final fallback is unreachable and only keeps this total.
-        // Monotone either way: every word of `common` starts at or past the old
-        // watermark, and `end >= start`.
+        // RULE W'S WATERMARK (#94). The watermark is the first held-back word's
+        // start, which `split_at_a_strict_boundary` has already placed STRICTLY
+        // past the last confirmed word's start.
         //
-        // That empty-holdback anchor is Rule W's one gap, and it is recorded as
-        // a residual rather than closed: `common.last().end()` can EQUAL
-        // `common.last().start()` for a zero-duration word, and the
-        // postcondition is then vacuous because there is no held-back word for
-        // it to speak about. Reaching it needs a non-default
-        // `agreement_count_needed`, a word whose own tokens exceed
-        // `MAX_HOLDBACK_PREFILL_TOKENS`, and a zero-duration word, all at once
-        // (`an_empty_holdback_leaves_a_zero_duration_word_at_the_watermark`).
+        // With NOTHING held back -- which only the prefill budget can now cause
+        // (see `split_at_a_strict_boundary`) -- there is no held word to measure
+        // against and the still-open span begins where the confirmed one ends.
+        // `end` is the answer whenever the last confirmed word has any duration
+        // at all; where it does NOT, `end == start` and the word would satisfy
+        // `watermark_filtered`'s own `start >= watermark` against its own
+        // confirmation, which is the whole of #94. The watermark is therefore the
+        // first instant that is strictly past that start: `next_up` is the
+        // IMMEDIATE f32 successor, so nothing representable lies between it and
+        // the start it excludes, and it is a successor rather than a tolerance --
+        // no span of instants is moved, only the single instant the confirmed
+        // word already occupies is refused.
+        //
+        // Monotone: every word of `common` starts at or past the old watermark,
+        // `end >= start` for any word the pipeline emits, and `next_up` only
+        // increases. A NaN start cannot break the postcondition either -- `max`
+        // returns the non-NaN side, and `start >= watermark` is false for a NaN
+        // start, so such a word is never offered back in the first place.
+        //
+        // `common` is non-empty here (its length is at least
+        // `agreement_count_needed`, clamped to at least one), so the final
+        // fallback is unreachable and only keeps this total.
         self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
           || {
-            common
-              .last()
-              .map_or(self.last_agreed_seconds, WordTiming::end)
+            common.last().map_or(self.last_agreed_seconds, |last| {
+              last.end().max(last.start().next_up())
+            })
           },
           WordTiming::start,
         );
@@ -927,6 +934,115 @@ impl LocalAgreement {
 // The confirmed/holdback split
 // ---------------------------------------------------------------------
 
+/// RULE W (#94, at its source): where an advance splits `common`, moved off any
+/// boundary that would put the watermark AT a start already settled.
+///
+/// The watermark is the first held-back word's start, and it is also the CLIP
+/// this engine hands its own next decoder. Cutting at a word whose start TIES
+/// the last confirmed one puts that boundary INSIDE a span already settled: the
+/// confirmed word then satisfies `LocalAgreement::watermark_filtered`'s own
+/// `start >= watermark`, and the next hypothesis can re-offer it at the head of
+/// its word list. That is the state every re-admission defence in this issue's
+/// history was built to survive -- and the one that cannot be DECIDED from the
+/// offered list, because a re-offered settled word and the stream's own second
+/// occurrence of the same text are byte-identical there. Refuse to CREATE it.
+///
+/// A split at `at` is legal exactly when the word that would then END the
+/// confirmed list starts STRICTLY before the word that would HEAD the holdback.
+/// At `at == 0` nothing of `common` is confirmed, so the preceding word is the
+/// engine's own last confirmed one -- the word the watermark would sit beside.
+/// That arm is provably never the blocking one: the postcondition below gives
+/// `confirmed.last().start() < last_agreed_seconds`, and every word of `common`
+/// cleared `start >= last_agreed_seconds` to be offered at all, so
+/// `confirmed.last().start() < common[0].start()` already. It is written as a
+/// CHECK rather than assumed so this function is correct on its own terms rather
+/// than on its caller's induction — but the proof is why it carries NO
+/// falsifier: replacing `confirmed_last_start` with `None` reds nothing in this
+/// crate, and no sequence through `LocalAgreement::ingest` can construct the
+/// state it guards, because that state IS the postcondition's negation. It was
+/// testable while the postcondition was conditional (through the empty-holdback
+/// residual, which the `next_up` anchor has since closed) and its test went with
+/// that state.
+///
+/// # Which legal boundary
+///
+/// `requested` (`common.len() - agreement_count_needed`) is where the split
+/// WANTS to be, and `budgeted_split`'s floor is where the prefill budget lets it
+/// be at the earliest. From `max(requested, floor)`:
+///
+/// 1. **Forward** to the first legal boundary. This confirms one word earlier
+///    than Swift on a tied input -- the [BEHAVIOUR CHANGE] recorded in this
+///    module's doc.
+/// 2. **Backward**, if there is no legal boundary at or after that point, to the
+///    LAST legal one still at or above the budget floor. Rule W may not empty
+///    the holdback: widening past a run that reaches the END of `common` would
+///    leave the watermark anchored at that run's own last word, which for a
+///    zero-duration word is that word's own start -- the very state this rule
+///    exists to refuse, re-entered from the other side (codex round 1 on PR #95;
+///    `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`,
+///    where two ingests of ONE default-count hypothesis re-confirmed its whole
+///    tied tail on every later stride, without bound).
+///
+///    Backing off never fails for want of a boundary while the budget floor is
+///    `0`: `at == 0` is legal by the argument above, so a `common` that is one
+///    tied run from end to end is held WHOLE rather than confirmed, and the next
+///    stride -- which grows the hypothesis at its TAIL -- opens a boundary as
+///    soon as one word starts strictly later. This is NOT the blocking policy
+///    this issue's ledger refuted for deadlock: that one blocked on a predicate
+///    over the HEAD of the offered list, which only an advance can move, whereas
+///    this defers a split position that TAIL growth relieves, and it advances
+///    the holdback rather than refusing the round.
+/// 3. Only where the BUDGET FLOOR itself sits at or above every legal boundary
+///    is `common.len()` returned and the holdback left empty -- the floor is
+///    never crossed, because below it `prefill_tokens` silently truncates the
+///    prefill and the erased words are neither re-offered nor confirmed (codex
+///    round 7, finding 2). `LocalAgreement::ingest`'s watermark then anchors
+///    strictly past the last confirmed start rather than at its `end`.
+///
+/// So `agreement_count_needed` is a target rather than an exact width in EITHER
+/// direction: the budget can shorten the holdback (see `budgeted_split`) and
+/// this can lengthen it.
+///
+/// # Postcondition (TOTAL)
+///
+/// After every advance, `confirmed_words.last().start() < last_agreed_seconds`
+/// STRICTLY -- with no condition on the holdback. Where the split is interior
+/// the boundary above is exactly that inequality; where it is `common.len()`
+/// `LocalAgreement::ingest`'s `next_up` anchor is. So no confirmed word can pass
+/// the offered filter, and the re-admission question is unrepresentable rather
+/// than defended against.
+///
+/// It is a claim about the LAST confirmed word, and that is as strong as it needs
+/// to be exactly while word starts inside one hypothesis are non-decreasing --
+/// see this module's doc for the `find_alignment` guarantee that supplies it and
+/// for the backwards-starts input the `pub(crate)` seal excludes.
+fn split_at_a_strict_boundary(
+  common: &[WordTiming],
+  requested: usize,
+  confirmed_last_start: Option<f32>,
+) -> usize {
+  let strictly_after_the_preceding_start = |at: usize| {
+    let preceding = if at == 0 {
+      confirmed_last_start
+    } else {
+      Some(common[at - 1].start())
+    };
+    preceding.is_none_or(|preceding| preceding < common[at].start())
+  };
+  // `budgeted_split` with nothing requested IS the budget's own floor: the
+  // earliest split whose holdback fits `MAX_HOLDBACK_PREFILL_TOKENS`.
+  let floor = budgeted_split(common, 0);
+  let widened = requested.max(floor);
+  (widened..common.len())
+    .find(|&at| strictly_after_the_preceding_start(at))
+    .or_else(|| {
+      (floor..widened)
+        .rev()
+        .find(|&at| strictly_after_the_preceding_start(at))
+    })
+    .unwrap_or(common.len())
+}
+
 /// Where an advance splits `common` into the part that is CONFIRMED and the
 /// part that is HELD BACK, given the requested split — moved later until every
 /// word still held is one [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens)
@@ -987,11 +1103,19 @@ impl LocalAgreement {
 /// available and is exactly the argument above.
 ///
 /// Where the holdback comes back empty, `LocalAgreement::ingest` anchors the
-/// watermark at the last confirmed word's END rather than the first held word's
-/// start — see the anchor at its advance branch.
+/// watermark on the last confirmed word's own far edge — `end`, raised to
+/// `start.next_up()` where that word has no duration — rather than at the first
+/// held word's start; see the anchor at its advance branch.
 /// [`LocalAgreement::agreement_count_needed`] is then a maximum that reached
 /// zero for that round, the same way it becomes a maximum for any holdback the
 /// budget shortens.
+///
+/// Called with `requested == 0` this IS the budget's own FLOOR — the earliest
+/// split whose holdback fits at all. `split_at_a_strict_boundary` needs that
+/// value because its back-off moves the split EARLIER, and the floor is the one
+/// line it may not cross: below it `prefill_tokens` silently truncates and the
+/// erased words are neither re-offered nor confirmed, which is the whole of
+/// round 7's finding 2.
 ///
 /// **Documented deviation**: with `agreement_count_needed` at its
 /// [`DEFAULT_AGREEMENT_COUNT_NEEDED`] — the only value
@@ -1000,7 +1124,8 @@ impl LocalAgreement {
 /// two-word holdback is nowhere near 112 tokens and this is the identity. It
 /// bites only for a direct caller that raised
 /// [`LocalAgreement::agreement_count_needed`] far enough, and for that caller
-/// the count becomes a maximum rather than an exact width.
+/// the count becomes a maximum rather than an exact width. (Rule W's back-off
+/// moves it the other way for any caller — see `split_at_a_strict_boundary`.)
 fn budgeted_split(common: &[WordTiming], requested: usize) -> usize {
   let mut split = requested;
   let mut tokens: usize = common[split..]
@@ -1076,8 +1201,11 @@ impl<'ctx, B> LocalAgreementTranscriber<'ctx, B> {
   /// wholesale. Swift hardcodes `2` and never exposes the knob
   /// (`TranscribeCLI.swift:349`).
   ///
-  /// Raising it far enough makes [`MAX_HOLDBACK_PREFILL_TOKENS`] bite, and the
-  /// count becomes a MAXIMUM rather than an exact width — see `budgeted_split`.
+  /// It is a TARGET rather than an exact width in either direction: raising it
+  /// far enough makes [`MAX_HOLDBACK_PREFILL_TOKENS`] bite and the holdback
+  /// comes back SHORTER (see `budgeted_split`), while a tied run at the end of
+  /// an agreed prefix makes Rule W back its split off and the holdback comes
+  /// back LONGER (see `split_at_a_strict_boundary`).
   #[must_use]
   #[inline(always)]
   pub fn with_agreement_count_needed(mut self, agreement_count_needed: usize) -> Self {

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -568,8 +568,9 @@
 //!    113-word tied run at 2 s twice, then the SAME 113 words at 3 s: the first
 //!    pair advances and anchors just past 2 s, the second pair is entirely
 //!    strictly past that anchor, so it agrees with itself and is confirmed as
-//!    well — 226 confirmed words where the stream said 113 (measured; `main`
-//!    confirms 222 on the same input, so this is not new here).
+//!    well, which double-counts those words: the stream is credited with more
+//!    confirmed words than it actually offered. Not new here — `main` shows the
+//!    same double-count on this input.
 //!
 //!    It is AMBIGUOUS BY CONSTRUCTION, and the two readings give opposite
 //!    verdicts. Read as RE-TIMESTAMPING, the second confirmation is a duplicate
@@ -681,7 +682,7 @@ pub enum AgreementOutcome {
   /// `jfk_simulated_stream_confirms_the_transcript` fixture land here on the
   /// real tiny model, and `the_split_never_cuts_at_a_tied_start`'s 512-trial
   /// sweep asserts a live count over its 4233 rounds — 1281 of the 2965
-  /// agreeing ones at this commit.
+  /// agreeing ones, at `1508e76`.
   ///
   /// **Reporting this as progress is what a caller cannot recover from**, which
   /// is why it is a value rather than a footnote. On the worst shape this module

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -624,71 +624,133 @@ mod tests;
 // AgreementOutcome
 // ---------------------------------------------------------------------
 
-/// One `LocalAgreement::ingest` call's outcome — whether the new result
-/// AGREED with the previous one and was kept, merely awaits a future result to
-/// agree with, or carried no word timings to agree over at all. Swift
-/// expresses these same three outcomes as local bookkeeping (`skipAppend`,
-/// the no-words `else` branch) rather than a value
-/// (`TranscribeCLI.swift:370-410`).
+/// One `LocalAgreement::ingest` call's outcome. It answers TWO questions, not
+/// one: whether the new result AGREED with the previous one and was kept, and —
+/// where it did — whether anything a caller can observe actually MOVED. The
+/// second question is why there are two agreeing variants, [`Self::Progressed`]
+/// and [`Self::Stationary`]; the remaining two are the round that did not agree
+/// ([`Self::AwaitingAgreement`]) and the result with no word timings to agree
+/// over at all ([`Self::NoWordTimings`]).
+///
+/// Swift expresses only the first question, and as local bookkeeping
+/// (`skipAppend`, the no-words `else` branch) rather than as a value
+/// (`TranscribeCLI.swift:370-410`). It has no answer to the second, and neither
+/// did this enum until the two agreeing cases were split apart: a single
+/// `Advanced` reported agreed-and-kept and was routinely read as progress, so a
+/// stalled stream was indistinguishable from a moving one. See
+/// [`Self::Stationary`] for what that cost.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, derive_more::IsVariant)]
 #[display("{}", self.as_str())]
 #[non_exhaustive]
 pub enum AgreementOutcome {
-  /// The new result's hypothesis agreed with the previous one on at least
+  /// The round AGREED — the new hypothesis and the previous one shared at least
   /// [`LocalAgreement::agreement_count_needed`] words, so the result was KEPT
-  /// rather than dropped.
+  /// rather than dropped — AND something a caller can observe MOVED:
+  /// [`LocalAgreement::last_agreed_seconds`] came back with different bits, or
+  /// [`LocalAgreement::confirmed_words_slice`] grew, or both.
   ///
-  /// **It does NOT follow that the confirmation watermark moved**, and this doc
-  /// used to say it did. An advance confirms `common[..split]` and holds the
-  /// rest; where that split is ZERO it confirms nothing, the anchor is the first
-  /// held-back word's start, and that is the word the watermark already sat on
-  /// -- so [`LocalAgreement::last_agreed_seconds`] comes back BIT-identical and
-  /// [`LocalAgreement::confirmed_words_slice`] unchanged. That is the ordinary
-  /// steady state of a stream whose rounds re-agree on exactly
-  /// `agreement_count_needed` words and hold all of them, not an edge case:
-  /// strides 7 and 9 of the shipping
-  /// `jfk_simulated_stream_confirms_the_transcript` fixture do it on the real
-  /// tiny model (watermark stuck at `0x3fb5c28f` and `0x3fb851ec`, three
-  /// confirmed words either side), and instrumenting the same 512-trial shape
-  /// `the_split_never_cuts_at_a_tied_start` sweeps finds 1281 such rounds out of
-  /// 4233 -- every one bit-identical, none of them a rounding artifact.
-  /// Characterized in
-  /// `characterization_an_agreeing_round_returns_advanced_without_moving_the_watermark`.
+  /// This is the value a progress indicator may drive, a stall watchdog may
+  /// reset, and a decision to stop re-offering audio may rest on.
+  /// [`Self::Stationary`] is the SAME agreement with neither of those two things
+  /// moving; nothing else separates them.
   ///
-  /// So a caller may read this as "agreed, and kept" and may NOT read it as
-  /// "something progressed". Nothing in this enum carries the second question;
-  /// answering it is tracked separately, since giving this value that meaning
-  /// changes what the JFK regression trace records.
+  /// Which of the two a round lands on is decided by COMPARING the watermark's
+  /// bits and the confirmed length across the update — see
+  /// [`Self::Stationary`] for why the split cannot be asked instead.
+  Progressed,
+  /// The round AGREED and its result was KEPT, exactly as [`Self::Progressed`],
+  /// but NOTHING a caller can observe moved:
+  /// [`LocalAgreement::last_agreed_seconds`] came back BIT-identical and
+  /// [`LocalAgreement::confirmed_words_slice`] is unchanged. A caller polling
+  /// the engine on this outcome reads back the same watermark and the same
+  /// words it read last round.
   ///
-  /// The EXHAUSTED-BUDGET arm is not this condition and is worth telling apart:
-  /// where no split at or above the prefill-budget floor is legal, the split
-  /// runs off the end of `common` and confirms ALL of it, and the watermark
-  /// necessarily does move -- Rule W's first postcondition puts it strictly past
-  /// the settled high
+  /// Not an edge case: it is the ordinary steady state of a stream whose rounds
+  /// re-agree on exactly `agreement_count_needed` words and hold all of them.
+  /// Strides 7 and 9 of the shipping
+  /// `jfk_simulated_stream_confirms_the_transcript` fixture land here on the
+  /// real tiny model, and `the_split_never_cuts_at_a_tied_start`'s 512-trial
+  /// sweep asserts a live count over its 4233 rounds — 1281 of the 2965
+  /// agreeing ones at this commit.
+  ///
+  /// **Reporting this as progress is what a caller cannot recover from**, which
+  /// is why it is a value rather than a footnote. On the worst shape this module
+  /// documents — the permanently-backwards tail whose confirmation the prefill
+  /// budget alone bounds — 110 of 120 rounds are this one
+  /// (`a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forever`),
+  /// and a stall watchdog keyed on a single agreed-and-kept outcome sees 110
+  /// consecutive reports of progress across a stream that made none.
+  ///
+  /// # What is NOT a progress channel
+  ///
+  /// [`LocalAgreement::last_agreed_words_slice`] — the holdback — may change on
+  /// a `Stationary` round, and does so routinely: every advance replaces it
+  /// wholesale with `common[split..]` carrying THIS hypothesis's timings, so a
+  /// stream re-agreeing on the same two words forever churns it every round.
+  /// Counting that as progress is exactly how the stall stays invisible, so it
+  /// is deliberately excluded. The two channels this variant is decided by are
+  /// the SETTLED ones — the watermark a caller's next clip is cut at, and the
+  /// append-only confirmed prefix it has already been handed. The holdback is
+  /// provisional by construction.
+  ///
+  /// # A zero split is necessary for this, and NOT sufficient
+  ///
+  /// An advance confirms `common[..split]` and holds the rest, so a split of
+  /// ZERO confirms nothing and leaves
+  /// [`LocalAgreement::confirmed_words_slice`] unchanged. That half is a
+  /// property of the split alone. **The watermark half is not, and a doc on this
+  /// enum claimed it was.** The watermark is RECOMPUTED on every advance from
+  /// THIS round's own timings:
+  /// [`find_longest_common_prefix`] matches on normalized TEXT and returns a
+  /// slice of the NEW hypothesis, so with a zero split the anchor is the new
+  /// hypothesis's start for the first held-back word — not the previous round's
+  /// — and `sparing_watermark` folds it against that same hypothesis's other
+  /// unconfirmed starts. A re-decode that shifts those timings moves the
+  /// watermark with the split still at zero.
+  ///
+  /// The shipping JFK fixture is the disproof: `confirmed` sits at 3 from stride
+  /// 3 through stride 9, so every advance from stride 4 on splits at zero — yet
+  /// the watermark walks 1.36 → 1.38 → 1.40 → 1.42 and later 1.42 → 1.44. Only
+  /// strides 7 and 9 hold still.
+  /// `an_agreeing_round_with_a_zero_split_and_drifting_timings_progresses` pins
+  /// the moving case hermetically, against
+  /// `an_agreeing_round_that_moves_nothing_reports_stationary` for the still one
+  /// — the two differ by one word's start and by nothing else.
+  ///
+  /// So this variant is reached where the recomputed watermark is bit-identical
+  /// to its prior value, which is a fact about the RESULT of the advance and not
+  /// about its split. The other direction does hold, and is what bounds the
+  /// state: a split ABOVE zero always moves the watermark, because every word of
+  /// `common` cleared the old watermark (`watermark_filtered`), so confirming
+  /// one raises `highest_start(confirmed_words)` to at least it, and Rule W's
+  /// first postcondition then puts the new watermark strictly past that. The
+  /// EXHAUSTED-BUDGET arm is the far end of the same statement: the split runs
+  /// off the end of `common` and confirms ALL of it, and the watermark
+  /// necessarily moves
   /// (`a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant`).
-  /// A stuck watermark is the ZERO split, not the full one.
-  Advanced,
+  Stationary,
   /// The round did not agree. Two routes reach it: there is no previous result
   /// to agree with yet (the first ingested result), or the new hypothesis
   /// disagreed with the previous one, in which case the result was dropped
-  /// rather than kept. The watermark is unchanged on both.
+  /// rather than kept. The watermark is unchanged on both, and so is the
+  /// confirmed prefix — no advance ran.
   ///
-  /// **What separates this from [`Self::Advanced`] is agreed-and-kept versus
-  /// NOT agreed -- not whether the watermark moved.** An unchanged watermark
-  /// does not tell the two apart, because `Advanced` leaves it bit-identical
-  /// too whenever its split confirms nothing (see there for the measurement).
-  /// This doc asserted the opposite -- "two hypotheses that AGREE always advance
-  /// the watermark" -- and the shipping JFK fixture falsifies it on 2 of its 9
-  /// agreeing strides.
+  /// **What separates this from [`Self::Progressed`] and [`Self::Stationary`] is
+  /// agreed-and-kept versus NOT agreed.** An unchanged watermark does not tell
+  /// it from `Stationary`, which leaves the watermark bit-identical too; what
+  /// tells them apart is that a `Stationary` round's result was KEPT and fed
+  /// `LocalAgreement::finalize`, and a disagreeing round's was dropped.
   ///
-  /// A third route -- an agreeing round that DEFERRED rather than advancing --
+  /// A third route — an agreeing round that DEFERRED rather than advancing —
   /// existed on this branch between `6987bec` and `b3ec5c6` and was removed on
   /// measured evidence (#94; see this module's doc, "Why there is no
   /// deferral"). That removal is why every agreeing round now reaches
-  /// `Advanced`; it was never what would have made `Advanced` mean progress.
+  /// `Progressed` or `Stationary`; it was never what would have made an
+  /// agreeing outcome mean progress.
   AwaitingAgreement,
   /// The result carried no word timings to agree over; it was still kept
-  /// (Swift `:403-409` falls through to the unconditional append).
+  /// (Swift `:403-409` falls through to the unconditional append). No advance
+  /// ran, so the watermark and the confirmed prefix are both unchanged.
   NoWordTimings,
 }
 
@@ -697,10 +759,32 @@ impl AgreementOutcome {
   #[inline(always)]
   pub const fn as_str(&self) -> &'static str {
     match self {
-      Self::Advanced => "advanced",
+      Self::Progressed => "progressed",
+      Self::Stationary => "stationary",
       Self::AwaitingAgreement => "awaiting_agreement",
       Self::NoWordTimings => "no_word_timings",
     }
+  }
+
+  /// Whether the round AGREED and its result was therefore KEPT — true for
+  /// [`Self::Progressed`] and [`Self::Stationary`] alike, false for the other
+  /// two.
+  ///
+  /// This is the question the single `Advanced` variant used to answer, and it
+  /// is kept as a predicate rather than dropped because it is a real and
+  /// separate question from progress: `finalize` folds in every kept result, so
+  /// a `Stationary` round contributed to the transcript even though it moved
+  /// nothing. What it must NOT be used for is deciding that something advanced —
+  /// that is `is_progressed()`.
+  ///
+  /// It is not the KEPT predicate. [`Self::AwaitingAgreement`] covers two
+  /// routes, and the first-ever result reaches it and IS kept
+  /// (`TranscribeCLI.swift:408-410`, `!skipAppend`); only the disagreeing route
+  /// drops one. Whether a result was kept is therefore not a function of this
+  /// value, and reading `!agreed()` as "dropped" is wrong on the first round.
+  #[inline(always)]
+  pub const fn agreed(&self) -> bool {
+    matches!(self, Self::Progressed | Self::Stationary)
   }
 }
 
@@ -1038,7 +1122,8 @@ impl LocalAgreement {
   ///   [`Self::confirmed_words_slice`], `common[split..]` becomes the new
   ///   [`Self::last_agreed_words_slice`], a new [`Self::last_agreed_seconds`]
   ///   is drawn, `result` is kept, and this returns
-  ///   [`AgreementOutcome::Advanced`] (`:383-394`). Otherwise the hypotheses
+  ///   [`AgreementOutcome::Progressed`] or [`AgreementOutcome::Stationary`]
+  ///   (`:383-394`) — see below for which. Otherwise the hypotheses
   ///   disagree: the watermark is unchanged, `result` is **dropped** rather
   ///   than kept (`:395-400`, `skipAppend`), and this returns
   ///   [`AgreementOutcome::AwaitingAgreement`].
@@ -1050,9 +1135,14 @@ impl LocalAgreement {
   ///   that count, and `sparing_watermark` lowers that first held start to
   ///   spare every word this round left unconfirmed — over an anchor
   ///   `empty_holdback_anchor` supplies where the split empties the holdback.
-  ///   That is why [`AgreementOutcome::Advanced`] reports agreed-and-kept and
-  ///   NOT a moved watermark: a `split` of `0` confirms nothing and leaves
-  ///   [`Self::last_agreed_seconds`] bit-identical — measured there.
+  ///
+  ///   Which of the two agreeing outcomes an advance reports is decided by
+  ///   COMPARING observed state across it — [`Self::last_agreed_seconds`] by
+  ///   bits and [`Self::confirmed_words_slice`] by length, read before and after
+  ///   — and never by testing the split. A zero split confirms nothing, but the
+  ///   watermark is redrawn from THIS hypothesis's timings and moves whenever
+  ///   they drift, so `split == 0` does not decide it either way; see
+  ///   [`AgreementOutcome::Stationary`].
   ///
   /// Either way — agreeing, disagreeing, or no previous result — `result`
   /// becomes the new previous result for the next call (`:402`, outside
@@ -1093,11 +1183,33 @@ impl LocalAgreement {
       return AgreementOutcome::NoWordTimings;
     }
 
+    // THE PROGRESS BASELINE, read before anything below can move it. What
+    // separates `Progressed` from `Stationary` is measured against these two
+    // and nothing else.
+    //
+    // NOT `split != 0`, which is the reading this replaced and the one that made
+    // the signal dishonest in the other direction as well. A zero split confirms
+    // nothing, but the watermark is REDRAWN from this hypothesis's own timings
+    // every advance -- `find_longest_common_prefix` agrees on normalized text
+    // and hands back a slice of the NEW hypothesis -- so a re-decode that shifts
+    // them moves the watermark at split 0. Strides 4, 5, 6 and 8 of the shipping
+    // `jfk_simulated_stream_confirms_the_transcript` fixture do exactly that:
+    // three confirmed words either side, and a watermark that moves anyway.
+    // Comparing the state the caller reads is the only formulation that is right
+    // on both zero-split cases.
+    //
+    // `to_bits` rather than `==`: the seconds a caller sees are the whole of the
+    // watermark, and two starts 0.02 s apart round to the same two decimals in a
+    // log while being different f32s. A comparison that rounds would report a
+    // stall that is not one.
+    let watermark_before = self.last_agreed_seconds.to_bits();
+    let confirmed_before = self.confirmed_words.len();
+
     // :372 verbatim — see `watermark_filtered`, and Rule W below for why the
     // bare filter is sound.
     self.hypothesis_words = Self::watermark_filtered(&result, self.last_agreed_seconds);
 
-    let mut advanced = false;
+    let mut agreed = false;
     let mut skip_append = false;
     // :374 — absent on the first-ever call, so nothing below runs and
     // this falls through to the `AwaitingAgreement` append below.
@@ -1182,7 +1294,7 @@ impl LocalAgreement {
           settled_high.unwrap_or(f32::NEG_INFINITY),
           &self.hypothesis_words[split..],
         );
-        advanced = true;
+        agreed = true;
       } else {
         // :395-400 — disagreement; `result` is dropped below.
         skip_append = true;
@@ -1205,10 +1317,19 @@ impl LocalAgreement {
       self.results.push(result);
     }
 
-    if advanced {
-      AgreementOutcome::Advanced
+    if !agreed {
+      return AgreementOutcome::AwaitingAgreement;
+    }
+    // `!=` rather than `>` on the length: `confirmed_words` is only ever
+    // extended, so the two are the same test here, and "changed" is the question
+    // being asked. Bits rather than value on the watermark, for the reason
+    // recorded at the baseline above.
+    if self.last_agreed_seconds.to_bits() == watermark_before
+      && self.confirmed_words.len() == confirmed_before
+    {
+      AgreementOutcome::Stationary
     } else {
-      AgreementOutcome::AwaitingAgreement
+      AgreementOutcome::Progressed
     }
   }
 

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -78,16 +78,24 @@
 //!   high-water settled start, rather than against the last word.
 //!
 //!   Two things carry it, and they are separable. `split_at_a_strict_boundary`
-//!   puts an INTERIOR split only on a boundary whose start is strictly past
-//!   every settled start behind it — searching forward from the requested split
-//!   first, then BACKING OFF when the forward search would run off the end of
-//!   `common`, because widening past a tied run that reaches that end would
-//!   empty the holdback and anchor the watermark on the run's own last word —
-//!   and widening off the END only where the prefill budget floor sits at or
-//!   above every legal boundary, which is where the back-off has nowhere legal
-//!   to land. And where the holdback is empty, `LocalAgreement::ingest` anchors
-//!   at `empty_holdback_anchor`: the last confirmed word's own far edge, raised
-//!   to `past_the_settled_instant` where that word has no duration — since
+//!   puts an INTERIOR split only where a SPARING WATERMARK EXISTS for it: the
+//!   maximum start it would settle strictly below the minimum start it would
+//!   leave unconfirmed. Both sides are folds and each was completed by its own
+//!   round — the settled side a running maximum (round 7's finding 1), the
+//!   unsettled side a suffix minimum over `hypothesis_words[split..]` (round 8's
+//!   HIGH finding, which found the second half still being read as
+//!   `common[split]` alone, the one comparand the first half had just made
+//!   unsound). It searches forward from the requested split first, then BACKS
+//!   OFF when the forward search finds nothing legal — because widening past a
+//!   tied run that reaches the end of `common` would empty the holdback and
+//!   anchor the watermark on the run's own last word, and widening past a
+//!   backwards word would settle a start no watermark can then clear without
+//!   filtering that word out — and widens off the END only where the prefill
+//!   budget floor sits at or above every legal boundary, which is where the
+//!   back-off has nowhere legal to land. And where the holdback is empty,
+//!   `LocalAgreement::ingest` anchors at `empty_holdback_anchor`: the last
+//!   confirmed word's own far edge, raised to `past_the_settled_instant` where
+//!   that word has no duration — since
 //!   `end == start` for a zero-duration word.
 //!
 //!   `past_the_settled_instant` is a SAMPLE-domain step, and it used to be
@@ -115,7 +123,10 @@
 //!   (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`).
 //!   On an interior split with non-decreasing starts it is the identity; it
 //!   bites where the starts run backwards. What no watermark can spare is a word
-//!   at or below the settled high-water start itself, and that is residual 1.
+//!   at or below the settled high-water start of the split that was TAKEN — and
+//!   since round 8 an interior split is taken only where nothing has to be
+//!   skipped, so the fold meets an unsparable word only on the forced arm. That
+//!   is residual 1, and it is now exactly that narrow.
 //!
 //!   **Word starts run backwards, and the pipeline is where they come from.**
 //!   `segment::update_segments_with_word_timings` prefers a SEGMENT's own start
@@ -126,10 +137,15 @@
 //!   `a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word`
 //!   (`[0.50, 0.80, 0.99, 0.81]`). `find_alignment`'s
 //!   `w[i].end() <= w[i + 1].start() + 1e-4` is a guarantee about its OWN
-//!   output, and the post-processing that follows it is not bound by it. Two
-//!   claims used to rest on the premise and neither does now: the postcondition
-//!   above reads the high-water start, and the second postcondition's exception
-//!   is stated at `<=` that start rather than at the tie.
+//!   output, and the post-processing that follows it is not bound by it. THREE
+//!   claims used to rest on the premise and none does now: the postcondition
+//!   above reads the high-water start; the second postcondition's exception is
+//!   stated at `<=` that start rather than at the tie; and the split's legality
+//!   predicate reads the MINIMUM start it leaves unconfirmed rather than the
+//!   first one. The third took a round longer than the other two (codex round 8
+//!   on PR #95), and the shape is worth naming: removing a premise from one side
+//!   of a comparison and leaving it on the other reads as complete from either
+//!   side alone.
 //!
 //!   The first shape of this rule widened unconditionally and left the empty
 //!   holdback anchored at `end`, which put the ORIGINAL duplicate-confirmation
@@ -442,35 +458,55 @@
 //! W's postcondition IS total (see its entry above); the module claims no
 //! totality beyond it.
 //!
-//! 1. **A word at or below the settled high-water start is DROPPED.** The
+//! 1. **A word the budget floor leaves no way to spare is DROPPED.** The
 //!    watermark is strictly past every confirmed start (postcondition 1), so a
 //!    word this round did not confirm that starts at or below the highest
 //!    confirmed one fails the offered filter and can never reach a hypothesis
-//!    again. It cannot be helped: to a timestamp filter that word and a re-offer
-//!    of the settled one are the same value, which is the issue's impossibility
-//!    result, and the alternative is the unbounded re-confirmation #94 is about.
-//!    A truncation is what the portable prefix property tolerates; a rewrite is
-//!    not.
+//!    again. It cannot be helped THERE: to a timestamp filter that word and a
+//!    re-offer of the settled one are the same value, which is the issue's
+//!    impossibility result, and the alternative is the unbounded re-confirmation
+//!    #94 is about. A truncation is what the portable prefix property tolerates;
+//!    a rewrite is not.
+//!
+//!    It is stated against the FLOOR rather than against the settled start
+//!    alone, because the settled start is ENDOGENOUS to the split (codex round 8
+//!    on PR #95). An earlier form of this entry read "a word at or below the
+//!    settled high-water start is dropped", full stop, and that claim was too
+//!    broad: a split one word earlier settles less, so a word unsparable under
+//!    the requested split can be spared under an earlier one, and
+//!    `split_at_a_strict_boundary` now takes the earlier one. What remains
+//!    unsparable is only what NO split at or above the budget floor avoids —
+//!    the floor being the line the back-off may not cross, because below it
+//!    `prefill_tokens` silently truncates.
+//!    `the_split_never_cuts_at_a_tied_start` asks an independent brute-force
+//!    oracle for exactly that and asserts the AVOIDABLE count at zero.
 //!
 //!    TWO shapes reach it, and they are the two halves of the second
-//!    postcondition's exception. AT the settled start is the TIE, which needs an
-//!    empty holdback: the prefill budget must run the split off the end of
-//!    `common` — Rule W's own widening backs off wherever a legal boundary
-//!    remains above the floor — and two things do that, a single word at the end
-//!    of `common` whose own tokens exceed [`MAX_HOLDBACK_PREFILL_TOKENS`], and a
-//!    TIED RUN whose tokens exceed it in aggregate, which `add_word_timestamps`
-//!    produces from an all-zero alignment matrix. It does NOT additionally take
-//!    a non-default [`LocalAgreement::agreement_count_needed`]: an earlier form
-//!    of this entry listed one, and the default count reaches the same state
+//!    postcondition's exception. BOTH need an empty holdback: the prefill budget
+//!    must run the split off the end of `common` — Rule W's own widening backs
+//!    off wherever a legal boundary remains above the floor — and two things do
+//!    that, a single word at the end of `common` whose own tokens exceed
+//!    [`MAX_HOLDBACK_PREFILL_TOKENS`], and a TIED RUN whose tokens exceed it in
+//!    aggregate, which `add_word_timestamps` produces from an all-zero alignment
+//!    matrix. AT the settled start is the TIE. It does NOT additionally take a
+//!    non-default [`LocalAgreement::agreement_count_needed`]: an earlier form of
+//!    this entry listed one, and the default count reaches the same state
 //!    whenever that one word is the last of the agreed prefix (measured).
 //!
-//!    BELOW the settled start is a BACKWARDS start, and it needs no empty
-//!    holdback at all: `segment::update_segments_with_word_timings` can put a
-//!    later word behind an earlier one (see "Word starts run backwards" above),
-//!    and an INTERIOR split that confirms past it strands it. This half was
+//!    BELOW the settled start is a BACKWARDS start:
+//!    `segment::update_segments_with_word_timings` can put a later word behind
+//!    an earlier one (see "Word starts run backwards" above). This half was
 //!    invisible while the postcondition assumed non-decreasing starts (codex
-//!    round 7 on PR #95, finding 1); `the_split_never_cuts_at_a_tied_start`
-//!    counts it as `backward_strands` and reached it 4 times in 512 trials.
+//!    round 7 on PR #95, finding 1), and between that round and round 8 it
+//!    reached an INTERIOR split as well — which was a DEFECT rather than a
+//!    residual, a split one word earlier having lost nothing. Round 8 closed
+//!    that route in the legality predicate, so this half now takes the forced
+//!    arm too. `the_split_never_cuts_at_a_tied_start` counts it as
+//!    `backward_strands` and reaches it 2 times in 512 trials, down from 4 on
+//!    the identical draw before the predicate was completed — the 2 that went
+//!    are the 2 its avoidability oracle flagged, the published transcript's
+//!    erasures went from 13 to 11 with them, and the forced arm did not move at
+//!    all (140 fallback rounds and 410 empty holdbacks either way).
 //!
 //!    It covers a word the hypothesis had ALREADY produced past `common` as well
 //!    as one a later decode invents. Between `6987bec` and `b3ec5c6` the first
@@ -1026,8 +1062,12 @@ impl LocalAgreement {
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
         let requested = common.len() - self.agreement_count_needed;
-        let split =
-          split_at_a_strict_boundary(common, requested, highest_start(&self.confirmed_words));
+        let split = split_at_a_strict_boundary(
+          common,
+          &self.hypothesis_words[common.len()..],
+          requested,
+          highest_start(&self.confirmed_words),
+        );
         // `common` REPLACES the still-open record: it is the span two consecutive
         // hypotheses have just re-agreed over it, and `last_agreed_words` is the
         // one this hypothesis has superseded.
@@ -1039,7 +1079,10 @@ impl LocalAgreement {
         // The ANCHOR is where the advance would like to put the clip boundary.
         // With a holdback it is the first held-back word's start, which
         // `split_at_a_strict_boundary` has already placed strictly past every
-        // settled start. With NOTHING held back -- the fallback, reached where
+        // settled start -- and, since codex round 8 on PR #95, so is every OTHER
+        // start this round leaves unconfirmed, that function's legality
+        // predicate now ranging over the same set the fold below does. With
+        // NOTHING held back -- the fallback, reached where
         // neither the forward search nor the back-off found a legal boundary at
         // or above the prefill budget floor, and where the floor itself reaches
         // `common.len()` -- there is no held word to measure against and
@@ -1056,6 +1099,12 @@ impl LocalAgreement {
         // which `update_segments_with_word_timings` can produce (codex round 7
         // on PR #95, finding 1): there the adjacent boundary is not the latest
         // settled start, and an unconfirmed word can sit below the anchor.
+        //
+        // On the INTERIOR arm the fold never SKIPS a word now: the split was
+        // taken only where every unconfirmed start clears the settled high, so
+        // the filter passes all of them and the minimum is over the whole set.
+        // A skip means a word was lost, and reaching one is the forced arm's
+        // business (codex round 8 on PR #95).
         //
         // `settled_high` is read AFTER the append, so it covers what this very
         // round confirmed. Postcondition 1 follows: the anchor is strictly past
@@ -1241,26 +1290,69 @@ impl LocalAgreement {
 /// offered list, because a re-offered settled word and the stream's own second
 /// occurrence of the same text are byte-identical there. Refuse to CREATE it.
 ///
-/// A split at `at` is legal exactly when `common[at]` starts STRICTLY after
-/// every start a split there would settle -- everything already confirmed, plus
-/// `common[..at]`. That is a running MAXIMUM, not the adjacent predecessor:
-/// word starts inside one hypothesis are not non-decreasing (see the
-/// postconditions below), so the word immediately in front of the boundary is
-/// not necessarily the latest one behind it.
+/// A split at `at` is legal exactly when the MAXIMUM start among everything it
+/// SETTLES is strictly below the MINIMUM start among everything it leaves
+/// UNCONFIRMED. Settled is everything already confirmed plus `common[..at]`;
+/// unconfirmed is `hypothesis_words[at..]` -- `common[at..]` plus whatever the
+/// driving hypothesis produced beyond the agreed prefix.
+///
+/// Equivalently, and this is the reading that makes it CHECKABLE: **a split is
+/// legal iff a sparing watermark exists for it**, some instant strictly greater
+/// than every settled start and at or below every unconfirmed one.
+/// `sparing_watermark` folds over that same `hypothesis_words[at..]`, so where
+/// this predicate holds the fold spares the WHOLE of it and the second
+/// postcondition below is free; where it fails, the fold must skip a word and
+/// something is stranded.
+///
+/// BOTH SIDES ARE FOLDS, and each was completed by a different round.
+///
+/// - The SETTLED side is a running MAXIMUM, not the adjacent predecessor: word
+///   starts inside one hypothesis are not non-decreasing (see the
+///   postconditions below), so the word immediately in front of the boundary is
+///   not necessarily the latest one behind it (codex round 7 on PR #95,
+///   finding 1).
+/// - The UNSETTLED side is a suffix MINIMUM, not `common[at]` alone. Reading the
+///   FIRST unconfirmed word is right only where unconfirmed starts are
+///   non-decreasing -- the very premise the settled side had just been fixed to
+///   stop assuming, so the predicate was one statement read in halves (codex
+///   round 8 on PR #95, the HIGH finding;
+///   `a_backward_start_past_the_requested_split_backs_off_instead_of_stranding_it`).
+///   What the half-predicate did: on a pipeline-emittable `[0.00, 0.70, 1.50,
+///   2.20, 2.30, 2.19]` it accepted the requested split 4, confirmed up to
+///   2.20, and no watermark could then clear 2.20 while sparing 2.19 -- while
+///   split 3 loses nothing at all. The highest confirmed start is ENDOGENOUS to
+///   the split, so it cannot be treated as a fixed bound the way the old
+///   exception below treated it.
+///
+/// The unconfirmed set includes the words BEYOND `common` because
+/// `sparing_watermark`'s does, and that fold is the authority: a predicate over
+/// a smaller set would call a split legal that the fold cannot then spare. A
+/// beyond-`common` word is unconfirmed in the sense that matters -- this round's
+/// own `LocalAgreement::finalize` publishes it through
+/// `find_longest_different_suffix`, so a watermark above it RETRACTS transcript
+/// (`a_backward_start_beyond_common_backs_the_split_off_too`).
 ///
 /// At `at == 0` nothing of `common` is confirmed, so the maximum is the engine's
 /// own `confirmed_start_high` -- the latest start the watermark would sit
-/// beside. That arm is provably never the blocking one: the postcondition below
-/// gives `high < last_agreed_seconds`, and every word of `common` cleared
-/// `start >= last_agreed_seconds` to be offered at all, so
-/// `high < common[0].start()` already. It is written as a CHECK rather than
-/// assumed so this function is correct on its own terms rather than on its
-/// caller's induction — but the proof is why it carries NO falsifier: replacing
-/// `confirmed_start_high` with `None` reds nothing in this crate, and no
-/// sequence through `LocalAgreement::ingest` can construct the state it guards,
-/// because that state IS the postcondition's negation. It was testable while the
-/// postcondition was conditional (through the empty-holdback residual, which the
-/// anchor has since closed) and its test went with that state.
+/// beside. That arm is provably never the blocking one, and the proof now
+/// carries the completed predicate as well: the postcondition below gives
+/// `high < last_agreed_seconds`, and every word of `hypothesis_words` cleared
+/// `start >= last_agreed_seconds` to be offered at all, so `high` is strictly
+/// below the minimum over the WHOLE offered list, not merely below
+/// `common[0].start()`. **Split 0 is therefore always legal**, which is what
+/// bounds the back-off: it can only run out of legal boundaries when the budget
+/// floor is above 0, and the floor rises only as `common` outgrows
+/// `MAX_HOLDBACK_PREFILL_TOKENS`. That is the whole of this rule's liveness
+/// (`a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forever`).
+///
+/// It is written as a CHECK rather than assumed so this function is correct on
+/// its own terms rather than on its caller's induction — but the proof is why it
+/// carries NO falsifier: replacing `confirmed_start_high` with `None` reds
+/// nothing in this crate, and no sequence through `LocalAgreement::ingest` can
+/// construct the state it guards, because that state IS the postcondition's
+/// negation. It was testable while the postcondition was conditional (through
+/// the empty-holdback residual, which the anchor has since closed) and its test
+/// went with that state.
 ///
 /// # Which legal boundary
 ///
@@ -1281,15 +1373,38 @@ impl LocalAgreement {
 ///    where two ingests of ONE default-count hypothesis re-confirmed its whole
 ///    tied tail on every later stride, without bound).
 ///
+///    It runs for a BACKWARDS start as well as for a tie, and that is what codex
+///    round 8 on PR #95 added: a boundary above a word the hypothesis has
+///    already put BEHIND it settles a start the watermark can then not clear
+///    without filtering that word out, so the completed predicate refuses it and
+///    the search comes back here.
+///
 ///    Backing off never fails for want of a boundary while the budget floor is
-///    `0`: `at == 0` is legal by the argument above, so a `common` that is one
-///    tied run from end to end is held WHOLE rather than confirmed, and the next
-///    stride -- which grows the hypothesis at its TAIL -- opens a boundary as
-///    soon as one word starts strictly later. This is NOT the blocking policy
-///    this issue's ledger refuted for deadlock: that one blocked on a predicate
-///    over the HEAD of the offered list, which only an advance can move, whereas
-///    this defers a split position that TAIL growth relieves, and it advances
-///    the holdback rather than refusing the round.
+///    `0`: `at == 0` is legal by the argument above -- which the completed
+///    predicate keeps, every offered word being at or past the watermark that is
+///    itself strictly past the settled high -- so a `common` that is one tied
+///    run from end to end, or one whose tail runs backwards, is held WHOLE
+///    rather than confirmed, and the next stride -- which grows the hypothesis
+///    at its TAIL -- opens a boundary as soon as one word starts strictly later.
+///    This is NOT the blocking policy this issue's ledger refuted for deadlock:
+///    that one blocked on a predicate over the HEAD of the offered list, which
+///    only an advance can move, whereas this defers a split position that TAIL
+///    growth relieves, and it advances the holdback rather than refusing the
+///    round.
+///
+///    **LIVENESS**, which the back-off owes and the budget pays. Confirming
+///    fewer words per round is not a stall while it cannot go on forever, and it
+///    cannot: `split == 0` requires `floor == 0`, `floor == 0` requires the
+///    whole of `common` to fit `MAX_HOLDBACK_PREFILL_TOKENS`, and `common` grows
+///    with the stream. The first round it no longer fits, the floor is above
+///    every legal boundary and arm 3 confirms `common` whole. So the number of
+///    consecutive zero-confirming rounds is bounded by the prefill budget, on
+///    ANY input including a word permanently behind everything else -- and
+///    nothing is lost meanwhile, the held words being exactly what
+///    `LocalAgreement::finalize` publishes. Both halves are driven in
+///    `a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forever`,
+///    which pins the bound at the budget rather than merely asserting that some
+///    round eventually confirms.
 /// 3. **`common.len()` -- the FALLBACK**, where neither search found a legal
 ///    boundary at or above the budget floor. The floor is never crossed, because
 ///    below it `prefill_tokens` silently truncates the prefill and the erased
@@ -1303,21 +1418,26 @@ impl LocalAgreement {
 ///    forced outright, no split leaving one the prefill could carry. Or the
 ///    floor lands strictly INSIDE a tied run whose own tokens exceed the budget,
 ///    where every boundary the forward search and the back-off can reach ties
-///    and split `0` -- the boundary a tied run always leaves legal -- is below
-///    the floor. `add_word_timestamps` produces the second shape from an
-///    ALL-ZERO alignment matrix (113 ordinary one-token words at one instant,
-///    measured at 130), so it is the reachable one.
+///    and split `0` -- the boundary always left legal -- is below the floor. A
+///    backwards start reaches the same place the same way once the floor is
+///    above it, which is the second half of residual 1 and the only route it
+///    has left since codex round 8. `add_word_timestamps` produces the tied-run
+///    shape from an ALL-ZERO alignment matrix (113 ordinary one-token words at
+///    one instant, measured at 130), so it is the reachable one.
 ///
 ///    **What this costs, and why it is not a DEFERRAL** (#94, measured on this
 ///    branch; see this module's doc, "Why there is no deferral"). The empty
 ///    holdback anchors strictly past the settled high-water start, so a word the
-///    newest hypothesis produced beyond `common` AT that same start is stranded:
-///    the next worded ingest filters it out of both hypotheses at once, and
-///    `LocalAgreement::finalize` cannot reach it afterwards -- after THIS
-///    round's `finalize` already published it through
-///    `find_longest_different_suffix`. That is the TIE half of this module's
-///    residual 1, and it is exactly that narrow: `sparing_watermark` lowers the
-///    anchor to spare every word at any HIGHER instant
+///    newest hypothesis produced beyond `common` at or below that start is
+///    stranded: the next worded ingest filters it out of both hypotheses at
+///    once, and `LocalAgreement::finalize` cannot reach it afterwards -- after
+///    THIS round's `finalize` already published it through
+///    `find_longest_different_suffix`. That is the WHOLE of this module's
+///    residual 1, both halves of it, and this arm is now the ONLY place it can
+///    happen: the two interior arms take a boundary only where a sparing
+///    watermark exists for it, and where one exists nothing is stranded at all
+///    (codex round 8 on PR #95). It is exactly that narrow: `sparing_watermark`
+///    lowers the anchor to spare every word at any HIGHER instant
 ///    (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`).
 ///
 ///    Between `6987bec` and `b3ec5c6` this arm did not advance at all: it
@@ -1371,34 +1491,48 @@ impl LocalAgreement {
 /// round did not confirm that any legal watermark could still spare.
 ///
 /// **It has ONE exception, and the exception is the impossibility rather than a
-/// policy** (#94). A stranded word starts AT OR BELOW the highest confirmed
-/// start. There no value serves both claims -- the first postcondition demands a
-/// watermark strictly past that start, and every such watermark filters the
-/// strand -- so this is this module's residual 1.
+/// policy** (#94). A stranded word starts at or below the highest confirmed
+/// start AND no split at or above the budget floor avoids it. The first clause
+/// is why no value serves both claims for THAT split -- the first postcondition
+/// demands a watermark strictly past the settled high, and every such watermark
+/// filters the strand. The second clause is what makes it an impossibility
+/// rather than a choice, and it was MISSING until codex round 8 on PR #95: the
+/// settled high is ENDOGENOUS to the split, so "at or below it" is a fact about
+/// one boundary rather than about the word. A split one word earlier settles
+/// less and can spare what a later one cannot.
 ///
-/// Both halves of `<=` are reachable and they are reached differently. AT is the
-/// TIE, and it takes an empty holdback: a zero-duration word the fallback arm
-/// settles last, with something the same hypothesis produced beyond `common` at
-/// that same instant. BELOW is a BACKWARDS start, and it takes no empty holdback
-/// at all -- an INTERIOR split can confirm a word that starts later than one it
-/// leaves unconfirmed, and then no watermark can clear the first while sparing
-/// the second. The exception was written at `==` and gated on the arm until
-/// codex round 7 on PR #95, finding 1; the gate was never what bounded this.
+/// So the ARM GATE is back, in the only form that was ever true of it: a strand
+/// takes the `common.len()` FALLBACK, on both halves of the `<=`. AT the settled
+/// high is the TIE, and it takes an empty holdback: a zero-duration word the
+/// fallback arm settles last, with something the same hypothesis produced beyond
+/// `common` at that same instant. BELOW it is a BACKWARDS start. Between codex
+/// rounds 7 and 8 the BELOW half also reached an INTERIOR split, and that was
+/// the defect rather than the exception -- the interior arms now take a boundary
+/// only where a sparing watermark exists for it, and where one exists nothing is
+/// stranded. The exception was written at `==` and gated on the arm until codex
+/// round 7 on PR #95, finding 1; that gate was not what bounded this, and this
+/// one is.
 ///
-/// The exception's GATE moved twice. While the deferral existed it read "this
-/// round escaped a repeating wait"; removing the deferral made it "this round's
-/// split ran off the END of `common`" (measured over the 512-trial sweep at
-/// `4b259ef`: 38 strands where the deferral had 29, and 10 words erased from the
-/// published transcript where the deferral erased 26 -- the direction that
-/// decided it, this module's doc, "Why there is no deferral"). The ARM gate is
-/// now gone, because a backwards start strands from an interior split too.
+/// The exception's GATE has moved three times, and each move was a finding, so
+/// the history is kept rather than overwritten. While the deferral existed it
+/// read "this round escaped a repeating wait"; removing the deferral made it
+/// "this round's split ran off the END of `common`" (measured over the
+/// 512-trial sweep at `4b259ef`: 38 strands where the deferral had 29, and 10
+/// words erased from the published transcript where the deferral erased 26 --
+/// the direction that decided it, this module's doc, "Why there is no
+/// deferral"). Codex round 7's finding 1 removed the arm gate, a backwards start
+/// having reached an interior split; round 8 closed that route in the PREDICATE
+/// instead, and the gate returns with the budget floor written into it.
 /// `the_split_never_cuts_at_a_tied_start` sweeps both postconditions and both
 /// halves of the exception, counts the empty-holdback rounds, the tie strands
-/// and the backwards strands so none can pass by being unreachable -- and reads
-/// the published TRANSCRIPT across every round besides, which is where a
-/// retraction the confirmed list cannot see shows up.
+/// and the backwards strands so none can pass by being unreachable, asks an
+/// INDEPENDENT brute-force oracle whether any split at or above the floor would
+/// have lost nothing and asserts that count at ZERO -- and reads the published
+/// TRANSCRIPT across every round besides, which is where a retraction the
+/// confirmed list cannot see shows up.
 fn split_at_a_strict_boundary(
   common: &[WordTiming],
+  beyond_common: &[WordTiming],
   requested: usize,
   confirmed_start_high: Option<f32>,
 ) -> usize {
@@ -1415,24 +1549,59 @@ fn split_at_a_strict_boundary(
   // legal; `f32::max` returns the non-NaN side, so a NaN start neither poisons
   // the running maximum nor makes a boundary look legal (`high < start` is false
   // for a NaN `start`).
-  let mut running = confirmed_start_high.unwrap_or(f32::NEG_INFINITY);
+  let mut settled = confirmed_start_high.unwrap_or(f32::NEG_INFINITY);
   let mut settled_before: Vec<f32> = Vec::with_capacity(common.len() + 1);
-  settled_before.push(running);
+  settled_before.push(settled);
   for word in common {
-    running = running.max(word.start());
-    settled_before.push(running);
+    settled = settled.max(word.start());
+    settled_before.push(settled);
   }
-  let strictly_after_every_settled_start = |at: usize| settled_before[at] < common[at].start();
+  // The LOW-WATER UNSETTLED start at each candidate boundary: the minimum over
+  // every word a split at `at` leaves unconfirmed. That is `common[at..]` plus
+  // `beyond_common`, which is `hypothesis_words[at..]` -- exactly the set
+  // `sparing_watermark` folds over, so the two agree by construction rather than
+  // by coincidence.
+  //
+  // The suffix minimum is the OTHER HALF of the same statement the running
+  // maximum above is one half of, and it was missing until codex round 8 on PR
+  // #95. Reading `common[at]` alone -- the FIRST unconfirmed word -- is the
+  // right comparand only where unconfirmed starts are non-decreasing, which is
+  // the premise round 7 destroyed.
+  //
+  // One backward pass, so this stays linear. `INFINITY` is the nothing-left
+  // base, where the settled side is unconstrained; `f32::min` returns the
+  // non-NaN side, so a NaN start is skipped rather than absorbing the fold --
+  // the same treatment `sparing_watermark`'s own `*start > settled_high` gives
+  // it, NaN failing that test too. A NaN start is unsparable at EVERY split, so
+  // letting it constrain this would refuse every boundary and force the empty
+  // holdback for a word no split could have saved.
+  let mut unsettled = beyond_common
+    .iter()
+    .map(WordTiming::start)
+    .fold(f32::INFINITY, f32::min);
+  let mut unsettled_from: Vec<f32> = vec![unsettled; common.len() + 1];
+  for at in (0..common.len()).rev() {
+    unsettled = unsettled.min(common[at].start());
+    unsettled_from[at] = unsettled;
+  }
+  // A SPARING WATERMARK EXISTS FOR THIS SPLIT: some instant is strictly past
+  // every start it settles and at or below every start it does not. The second
+  // conjunct is the whole of it wherever `common[at].start()` is a number, since
+  // that word is itself in the minimum; the first is what keeps a NaN there --
+  // which `sparing_watermark` would carry through to the anchor, and from there
+  // to a watermark no word can clear -- from reading as legal.
+  let a_sparing_watermark_exists =
+    |at: usize| settled_before[at] < common[at].start() && settled_before[at] < unsettled_from[at];
   // `budgeted_split` with nothing requested IS the budget's own floor: the
   // earliest split whose holdback fits `MAX_HOLDBACK_PREFILL_TOKENS`.
   let floor = budgeted_split(common, 0);
   let widened = requested.max(floor);
   (widened..common.len())
-    .find(|&at| strictly_after_every_settled_start(at))
+    .find(|&at| a_sparing_watermark_exists(at))
     .or_else(|| {
       (floor..widened)
         .rev()
-        .find(|&at| strictly_after_every_settled_start(at))
+        .find(|&at| a_sparing_watermark_exists(at))
     })
     .unwrap_or(common.len())
 }
@@ -1678,10 +1847,19 @@ fn past_the_settled_instant(settled: f32) -> f32 {
 ///
 /// SKIPPING rather than abandoning on an unsparable word is deliberate and
 /// predates this generalization: a word at or below `settled_high` cannot be
-/// spared by ANY watermark the first postcondition permits, but the words
-/// BEHIND it can, and an anchor that gave up on all of them because one was
-/// unsparable stranded them as collateral (measured on the sweep: a strand at
-/// 2.5 s lost to a tie at 2.0 s).
+/// spared by ANY watermark the first postcondition permits FOR THIS SPLIT, but
+/// the words BEHIND it can, and an anchor that gave up on all of them because
+/// one was unsparable stranded them as collateral (measured on the sweep: a
+/// strand at 2.5 s lost to a tie at 2.0 s).
+///
+/// The skip is not a licence to CREATE the state it survives, and reading it as
+/// one is what codex round 8 on PR #95 found. `settled_high` is whatever the
+/// split settled, so a skip here means the split lost a word --
+/// `split_at_a_strict_boundary` therefore refuses any interior boundary this
+/// fold would have to skip on, over exactly this `unconfirmed` set, and reaches
+/// a skip only on the fallback arm where the budget floor left it no choice.
+/// The two range over the SAME set for that reason: a predicate over a smaller
+/// one would call a split legal that this cannot then spare.
 fn sparing_watermark(anchor: f32, settled_high: f32, unconfirmed: &[WordTiming]) -> f32 {
   unconfirmed
     .iter()

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -21,7 +21,7 @@
 //!   [`crate::audio::whisper::result::TranscriptionSegment::words_slice`] is never
 //!   optional (empty-means-absent, that module's own doc), so nil and
 //!   `[]` already collapse to the same representation before
-//!   [`LocalAgreement::ingest`] ever sees it — "any segment has a
+//!   `LocalAgreement::ingest` ever sees it — "any segment has a
 //!   non-empty `words_slice`" is the closest faithful gate reachable
 //!   from that representation, checking every segment rather than only
 //!   the first since there is no cheaper-but-still-correct equivalent of
@@ -61,7 +61,7 @@
 //!   hole at its SOURCE instead: an advance refuses to put the watermark at a
 //!   word whose start ties the confirmed one in front of it, widening past the
 //!   tie rather than cutting the clip boundary INSIDE a span already settled
-//!   (see the Rule W comment at [`LocalAgreement::ingest`]'s advance).
+//!   (see the Rule W comment at `LocalAgreement::ingest`'s advance).
 //!
 //!   **Postcondition** — whenever [`LocalAgreement::last_agreed_words_slice`] is
 //!   non-empty, `confirmed_words.last().start() < last_agreed_seconds`
@@ -113,7 +113,7 @@
 //!   `segment::update_segments_with_word_timings` strips exactly those ids from
 //!   every [`WordTiming`] this crate emits and emits no word at all for an
 //!   all-special alignment entry, so the pipeline cannot produce such a word,
-//!   and [`LocalAgreement::new`]/[`LocalAgreement::ingest`] are `pub(crate)`
+//!   and `LocalAgreement::new`/`LocalAgreement::ingest` are `pub(crate)`
 //!   (see the seal), so no caller outside this crate can hand one in either.
 //!   The residual the id filter used to carry is closed by the API surface
 //!   rather than by a vocabulary threshold the hermetic engine cannot know.
@@ -121,11 +121,11 @@
 //!   **A widened-past word is CONFIRMED on the spot.** The argument is round 8's:
 //!   a word the prefill cannot carry is neither corroborable nor revisable by a
 //!   continuation decoded under
-//!   [`LocalAgreement::decoding_options_for_next`], being behind both the clip
+//!   `LocalAgreement::decoding_options_for_next`, being behind both the clip
 //!   and the forced prefill, and the watermark passes it on the very next line,
 //!   so no future result can ever be offered over its span. Holding it instead
 //!   would be an indefinite wait ending in the deletion codex round 7 finding 2
-//!   removed. A caller driving [`LocalAgreement::ingest`] with a result decoded
+//!   removed. A caller driving `LocalAgreement::ingest` with a result decoded
 //!   some OTHER way could have re-read that audio, and for that caller the word
 //!   is confirmed while a revision of it is still possible — the transcript then
 //!   carries both readings. That is not a property of this arm:
@@ -144,7 +144,7 @@
 //!   finding 2). What followed was data loss rather than a stall — the next
 //!   hypothesis was decoded from a prefix `prefill_tokens` trims, came back with
 //!   a word that is not the held one, disagreed, and
-//!   [`LocalAgreement::finalize`]'s `holdback_superseded` path replaced the
+//!   `LocalAgreement::finalize`'s `holdback_superseded` path replaced the
 //!   intact held word with that truncation. Confirming such a word is always
 //!   possible and is no weaker a claim: `common` is the prefix two hypotheses
 //!   agreed on, and a word outside the prefill budget is one no third hypothesis
@@ -166,7 +166,7 @@
 //!   it replaced, and every word the two share is transcribed twice. With an
 //!   empty holdback the same expression fails the other way, dropping the
 //!   `commonPrefix.count` leading words both hypotheses actually produced.
-//!   [`LocalAgreement::finalize`] instead emits the final hypothesis's own
+//!   `LocalAgreement::finalize` instead emits the final hypothesis's own
 //!   post-watermark words on that path (`holdback_superseded` is the flag), and
 //!   keeps Swift's shape everywhere else — including when the final hypothesis
 //!   contributes nothing at or past the watermark, where nothing supersedes the
@@ -189,7 +189,7 @@
 //!   [`crate::audio::whisper::transcribe::WhisperKit::transcribe`] makes only when
 //!   [`DecodingOptions::use_prefill_prompt`](crate::audio::whisper::options::DecodingOptions::use_prefill_prompt)
 //!   is set — so on a base with the prompt off, the prefix
-//!   [`LocalAgreement::decoding_options_for_next`] attaches is silently dropped
+//!   `LocalAgreement::decoding_options_for_next` attaches is silently dropped
 //!   and the stream re-decodes each span with no anchor at all. Both this port
 //!   and Swift default the flag on, so this only diverges for a caller that
 //!   turned it off; it is forced for the same reason
@@ -215,6 +215,37 @@
 //!   [`InferenceBackend`] itself has no `Sync` supertrait either. This is
 //!   a correction against this task's own brief, which specified `B:
 //!   InferenceBackend + Sync` here.
+//!
+//! # The engine's mutating surface is `pub(crate)`
+//!
+//! [`LocalAgreement`] is `pub` and fully READABLE —
+//! [`LocalAgreement::confirmed_words_slice`],
+//! [`LocalAgreement::last_agreed_words_slice`],
+//! [`LocalAgreement::last_agreed_seconds`], [`LocalAgreement::results_slice`],
+//! [`LocalAgreement::agreement_count_needed`] — and everything that MOVES its
+//! state is crate-internal: its constructor, `ingest`, `finalize`,
+//! `decoding_options_for_next`, and the count knob (rehomed to
+//! [`LocalAgreementTranscriber::with_agreement_count_needed`], the only side
+//! that can order the engine's calls correctly). `impl Default` is deliberately
+//! ABSENT: a public trait impl is a public constructor.
+//!
+//! What that removes is one shape and one shape only: **bring your own
+//! TRANSCRIPT.** A caller can still bring its own DECODER — the extension seam
+//! is [`InferenceBackend`], which is public, unsealed, and has two impls in this
+//! crate, and
+//! [`WhisperKit::local_agreement_transcriber`](crate::audio::whisper::transcribe::WhisperKit::local_agreement_transcriber)
+//! sits on `impl<B> WhisperKit<B>` with no bound at all, so a custom backend
+//! inherits this entire stack, Rule W included. Only the caller that wanted to
+//! hand `ingest` hypotheses this crate did not decode loses anything, and that
+//! is the one shape which inherits NONE of the correctness above: the holdback
+//! reproduction that makes an advance a re-agreement, the budget that keeps the
+//! prefill whole, and Rule W's postcondition are all facts about hypotheses
+//! [`LocalAgreementTranscriber`] produced. Removing it declines a promise that
+//! was never true rather than withdrawing a working mode; the issue's own
+//! impossibility argument is that no substitute oracle exists for it.
+//!
+//! `the_engine_exposes_no_public_mutator` in `tests/whisper/streaming.rs` is the
+//! falsifier: it greps this file and reds if any of those names is re-published.
 
 use crate::audio::whisper::{
   backend::InferenceBackend,
@@ -234,7 +265,7 @@ mod tests;
 // AgreementOutcome
 // ---------------------------------------------------------------------
 
-/// One [`LocalAgreement::ingest`] call's outcome — whether the new result
+/// One `LocalAgreement::ingest` call's outcome — whether the new result
 /// advanced the confirmation watermark, merely awaits a future result to
 /// agree with, or carried no word timings to agree over at all. Swift
 /// expresses these same three outcomes as local bookkeeping (`skipAppend`,
@@ -288,10 +319,10 @@ pub const DEFAULT_AGREEMENT_COUNT_NEEDED: usize = 2;
 /// `decode_text`'s `current_tokens` and never appears in the hypothesis.
 ///
 /// That trim is silent, and the holdback is what
-/// [`LocalAgreement::decoding_options_for_next`] promises the next hypothesis
+/// `LocalAgreement::decoding_options_for_next` promises the next hypothesis
 /// will be WRITTEN with — so a holdback that cannot survive this budget is one
 /// the decoder is never given, and the words the trim erases would be neither
-/// re-offered nor confirmed. [`LocalAgreement::ingest`] therefore holds back
+/// re-offered nor confirmed. `LocalAgreement::ingest` therefore holds back
 /// only what fits, and
 /// `budgeted_split` guarantees that for EVERY input rather than for every input
 /// but one: where nothing can be held it holds nothing, and the advance confirms
@@ -328,11 +359,11 @@ pub struct LocalAgreement {
   last_agreed_words: Vec<WordTiming>,
   /// Whether the most recent WORDED hypothesis failed to corroborate
   /// [`Self::last_agreed_words`] — i.e. that holdback belongs to a hypothesis
-  /// the latest one has since superseded. [`Self::finalize`] needs this and
+  /// the latest one has since superseded. `Self::finalize` needs this and
   /// cannot recover it from the word lists alone; see the divergence recorded
   /// there and in this module's doc.
   ///
-  /// Maintained ONLY on the worded path of [`Self::ingest`], alongside
+  /// Maintained ONLY on the worded path of `Self::ingest`, alongside
   /// [`Self::prev_words`]/[`Self::hypothesis_words`]/[`Self::last_agreed_words`]
   /// themselves: the [`AgreementOutcome::NoWordTimings`] early return leaves all
   /// four untouched, so this keeps describing the last hypothesis that actually
@@ -346,25 +377,19 @@ pub struct LocalAgreement {
   /// round 8, F1). The same error-drop-sink pattern the VAD branch uses: a
   /// dropped hypothesis's unseeded draw (or callback truncation) still decided
   /// which words the surviving hypotheses agreed on, so it must reach
-  /// [`Self::finalize`]'s reproducibility answer even though its segments never
+  /// `Self::finalize`'s reproducibility answer even though its segments never
   /// survive into the merge. Only the draw/early-stop/language facts are folded;
   /// the worker schedule and id span are stripped to `None` (see the strip in
-  /// [`Self::ingest`]) — the finalized schedule is the adjudicated `None` and the
+  /// `Self::ingest`) — the finalized schedule is the adjudicated `None` and the
   /// finalized span is restored from the merged surviving result (round 10).
   ingested_facts: TaskFactsAccumulator,
-}
-
-impl Default for LocalAgreement {
-  fn default() -> Self {
-    Self::new()
-  }
 }
 
 impl LocalAgreement {
   /// A fresh engine: no prior result, a zero watermark, every collection
   /// empty, [`DEFAULT_AGREEMENT_COUNT_NEEDED`] words required to confirm
   /// (Swift's all-default locals, `TranscribeCLI.swift:346-353`).
-  pub const fn new() -> Self {
+  pub(crate) const fn new() -> Self {
     Self {
       agreement_count_needed: DEFAULT_AGREEMENT_COUNT_NEEDED,
       last_agreed_seconds: 0.0,
@@ -386,10 +411,10 @@ impl LocalAgreement {
   pub const fn agreement_count_needed(&self) -> usize {
     self.agreement_count_needed
   }
-  /// Builder form of [`Self::set_agreement_count_needed`].
+  /// Builder form of `Self::set_agreement_count_needed`.
   #[must_use]
   #[inline(always)]
-  pub const fn with_agreement_count_needed(mut self, agreement_count_needed: usize) -> Self {
+  pub(crate) const fn with_agreement_count_needed(mut self, agreement_count_needed: usize) -> Self {
     self.set_agreement_count_needed(agreement_count_needed);
     self
   }
@@ -408,7 +433,10 @@ impl LocalAgreement {
   /// the watermark anchor covers it), so the clamp is about keeping the
   /// ALGORITHM meaningful rather than about keeping it from panicking.
   #[inline(always)]
-  pub const fn set_agreement_count_needed(&mut self, agreement_count_needed: usize) -> &mut Self {
+  pub(crate) const fn set_agreement_count_needed(
+    &mut self,
+    agreement_count_needed: usize,
+  ) -> &mut Self {
     self.agreement_count_needed = if agreement_count_needed == 0 {
       1
     } else {
@@ -441,7 +469,7 @@ impl LocalAgreement {
   /// Append-only across the life of the engine: nothing here is ever rewritten,
   /// reordered, or taken back, which is why the trailing words of an agreement
   /// wait in [`Self::last_agreed_words_slice`] instead. RULE W (see
-  /// [`Self::ingest`]'s advance) additionally guarantees that while that
+  /// `Self::ingest`'s advance) additionally guarantees that while that
   /// holdback is non-empty, this list's last word starts STRICTLY before
   /// [`Self::last_agreed_seconds`] — so nothing here can be re-offered to the
   /// agreement comparison and confirmed a second time.
@@ -451,7 +479,7 @@ impl LocalAgreement {
   }
 
   // -- results (Vec<TranscriptionResult>) ------------------------------------
-  /// Every ingested result kept for the eventual [`Self::finalize`] merge
+  /// Every ingested result kept for the eventual `Self::finalize` merge
   /// — every result except the ones a disagreeing hypothesis caused to be
   /// dropped (`TranscribeCLI.swift:395-400`, `skipAppend`).
   #[inline(always)]
@@ -512,7 +540,7 @@ impl LocalAgreement {
   /// full multilingual language/task/timestamp prefill for no reason the engine's
   /// own state can point at (codex round 6, finding 3), and there would be no
   /// prefix for it to carry in any case.
-  pub fn decoding_options_for_next(&self, base: &DecodingOptions) -> DecodingOptions {
+  pub(crate) fn decoding_options_for_next(&self, base: &DecodingOptions) -> DecodingOptions {
     let retargeted = base
       .clone()
       .with_clip_timestamps(vec![self.last_agreed_seconds])
@@ -532,7 +560,7 @@ impl LocalAgreement {
   }
 
   /// The holdback as one token sequence — the exact value
-  /// [`Self::decoding_options_for_next`] attaches as
+  /// `Self::decoding_options_for_next` attaches as
   /// [`DecodingOptions::prefix_tokens`](DecodingOptions::prefix_tokens_slice).
   fn holdback_prefill_tokens(&self) -> Vec<u32> {
     self
@@ -548,7 +576,7 @@ impl LocalAgreement {
   /// no scope and no alignment behind it.
   ///
   /// It needs none. The watermark is the first held-back word's start, and
-  /// RULE W (see [`Self::ingest`]'s advance) refuses to put it at a word whose
+  /// RULE W (see `Self::ingest`'s advance) refuses to put it at a word whose
   /// start ties the confirmed one in front of it — so whenever there is a
   /// holdback at all, `confirmed_words.last().start() < last_agreed_seconds`
   /// STRICTLY and no confirmed word can pass this filter. The re-admission the
@@ -582,7 +610,7 @@ impl LocalAgreement {
   /// - Otherwise, `result.all_words()` filtered to `start >=
   ///   last_agreed_seconds()` becomes the new hypothesis (`:372`). With no
   ///   previous result yet (the first call ever, or the first call after
-  ///   [`Self::new`]), there is nothing to compare against: `result` is
+  ///   `Self::new`), there is nothing to compare against: `result` is
   ///   kept and this returns [`AgreementOutcome::AwaitingAgreement`] —
   ///   Swift runs no agreement logic on this path either (`:374`'s `if
   ///   let prevResult = prevResult` is simply not entered).
@@ -603,7 +631,7 @@ impl LocalAgreement {
   /// Either way — agreeing, disagreeing, or no previous result — `result`
   /// becomes the new previous result for the next call (`:402`, outside
   /// the agreement `if`/`else` but still inside the has-words branch).
-  pub fn ingest(&mut self, result: TranscriptionResult) -> AgreementOutcome {
+  pub(crate) fn ingest(&mut self, result: TranscriptionResult) -> AgreementOutcome {
     // Accumulate THIS hypothesis's reproducibility facts BEFORE any gate or
     // branch, so a hypothesis dropped from `results` on disagreement (:395-400,
     // `skipAppend`) still contributes them to `finalize` (codex round 8, F1). It
@@ -786,8 +814,8 @@ impl LocalAgreement {
   /// the adjudicated `None` (agreement attribution is unknown, round 10, F2) and
   /// the decoded span is restored from the merged surviving result (round 10, F3;
   /// the ingest strip carries only the wholly-unknown span, so the fold cannot
-  /// supply the exact count, round 12); see [`Self::ingest`].
-  pub fn finalize(mut self, options: &DecodingOptions) -> TranscriptionResult {
+  /// supply the exact count, round 12); see `Self::ingest`.
+  pub(crate) fn finalize(mut self, options: &DecodingOptions) -> TranscriptionResult {
     if self.holdback_superseded && !self.hypothesis_words.is_empty() {
       // DIVERGENCE from `:418-419` — see this module's doc for the full
       // argument. Swift's `lastAgreedWords + differentSuffix(prevWords,
@@ -830,7 +858,7 @@ impl LocalAgreement {
     // deliberately left at the `None` the strip and the absorbing merge produce —
     // ADJUDICATED (round 10, F2): agreement-confirmed text interleaves multiple
     // hypotheses, so no single ordered worker attribution is knowable. See the
-    // strip site in [`Self::ingest`].
+    // strip site in `Self::ingest`.
     let merged_span = merged.task_facts().decoded_span();
     let mut facts = self.ingested_facts.into_facts();
     facts.merge(merged.task_facts());
@@ -849,7 +877,7 @@ impl LocalAgreement {
 /// carries into the initial prompt WHOLE.
 ///
 /// The holdback is not merely "the last few agreed words": it is the text
-/// [`LocalAgreement::decoding_options_for_next`] forces into the next
+/// `LocalAgreement::decoding_options_for_next` forces into the next
 /// hypothesis, and
 /// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens) keeps only
 /// the last [`MAX_HOLDBACK_PREFILL_TOKENS`] ids of it. A holdback the decoder
@@ -864,14 +892,14 @@ impl LocalAgreement {
 /// total rather than partial: `segment::update_segments_with_word_timings`
 /// strips exactly those ids from every [`WordTiming`] this crate emits and emits
 /// no word at all for an all-special alignment entry, so the pipeline cannot
-/// produce such a word, and [`LocalAgreement::new`]/[`LocalAgreement::ingest`]
+/// produce such a word, and `LocalAgreement::new`/`LocalAgreement::ingest`
 /// are `pub(crate)`, so no caller outside this crate can hand one in. See this
 /// module's doc.
 ///
 /// Widening the split instead takes that head OUT of the holdback and CONFIRMS
 /// it. That is not a weaker claim than any other agreed word carries: `common`
 /// is the prefix two consecutive hypotheses agreed on, which is the whole of
-/// LocalAgreement-2's criterion, and [`LocalAgreement::finalize`] already
+/// LocalAgreement-2's criterion, and `LocalAgreement::finalize` already
 /// appends the entire holdback to
 /// [`LocalAgreement::confirmed_words_slice`] unconditionally on its Swift-shaped
 /// path. What the holdback buys on top of that is one more round in which a
@@ -879,7 +907,7 @@ impl LocalAgreement {
 /// be revised by one *that was decoded from the prefill*, because whatever such
 /// a hypothesis produces over that extent came from a DIFFERENT prefix and from
 /// audio the clip excludes, and is therefore neither a corroboration of the held
-/// word nor a revision of it. A caller driving [`LocalAgreement::ingest`] with a
+/// word nor a revision of it. A caller driving `LocalAgreement::ingest` with a
 /// result decoded some OTHER way is subject to neither reduction, so for it the
 /// word is revisable after all and the confirmation lands beside the revision —
 /// the same append-only cost `common[..split]` already carries on every path
@@ -888,7 +916,7 @@ impl LocalAgreement {
 /// Widening is the repair because the defect is the STATE, not any reading of
 /// it. Leaving the unreproducible word IN the holdback is what round 7's
 /// finding 2 recorded: the next unanchored hypothesis disagrees with it and
-/// [`LocalAgreement::finalize`]'s `holdback_superseded` path deletes it.
+/// `LocalAgreement::finalize`'s `holdback_superseded` path deletes it.
 ///
 /// The split runs all the way to `common.len()` when it has to, so the holdback
 /// this leaves can be EMPTY. It has to (codex round 7, finding 2): stopping while
@@ -896,13 +924,13 @@ impl LocalAgreement {
 /// and the cap silently did not cap. What followed was data
 /// loss, not a stall: the next hypothesis came back with the truncated word
 /// rather than the held one, disagreed, and
-/// [`LocalAgreement::finalize`]'s `holdback_superseded` path replaced the intact
+/// `LocalAgreement::finalize`'s `holdback_superseded` path replaced the intact
 /// held word with that truncation. Made impossible here rather than refused
 /// downstream, because a refusal on a public, infallible `ingest` has no path to
 /// report on, and this needs none: taking the word out of the holdback is always
 /// available and is exactly the argument above.
 ///
-/// Where the holdback comes back empty, [`LocalAgreement::ingest`] anchors the
+/// Where the holdback comes back empty, `LocalAgreement::ingest` anchors the
 /// watermark at the last confirmed word's END rather than the first held word's
 /// start — see the anchor at its advance branch.
 /// [`LocalAgreement::agreement_count_needed`] is then a maximum that reached
@@ -950,7 +978,7 @@ pub const STRIDE_SAMPLES: usize = SAMPLE_RATE as usize;
 /// Ports the loop shell of `transcribeStreamSimulated`
 /// (`TranscribeCLI.swift:357-369`) — see this module's doc for the
 /// `word_timestamps`-forcing and error-propagation deviations, and
-/// [`LocalAgreement::ingest`] for the per-result confirmation logic this
+/// `LocalAgreement::ingest` for the per-result confirmation logic this
 /// driver doesn't itself implement.
 ///
 /// Bare struct, no bounds — bounds live on the `impl` blocks below,
@@ -982,6 +1010,27 @@ impl<'ctx, B> LocalAgreementTranscriber<'ctx, B> {
     }
   }
 
+  /// How many consecutive agreeing words this driver's engine needs before it
+  /// confirms — [`LocalAgreement::agreement_count_needed`], set from the only
+  /// side that can order the engine's calls correctly.
+  ///
+  /// Clamped up to at least `1`: zero would hold back no words at all on every
+  /// advance, so no hypothesis would ever be given an anchor to re-decode from
+  /// and LocalAgreement-2's second round of corroboration would be switched off
+  /// wholesale. Swift hardcodes `2` and never exposes the knob
+  /// (`TranscribeCLI.swift:349`).
+  ///
+  /// Raising it far enough makes [`MAX_HOLDBACK_PREFILL_TOKENS`] bite, and the
+  /// count becomes a MAXIMUM rather than an exact width — see `budgeted_split`.
+  #[must_use]
+  #[inline(always)]
+  pub fn with_agreement_count_needed(mut self, agreement_count_needed: usize) -> Self {
+    self.agreement = self
+      .agreement
+      .with_agreement_count_needed(agreement_count_needed);
+    self
+  }
+
   /// The live confirmation engine — read
   /// [`LocalAgreement::confirmed_words_slice`] for the settled transcript
   /// so far without waiting for [`Self::finalize`].
@@ -997,7 +1046,7 @@ impl<'ctx, B> LocalAgreementTranscriber<'ctx, B> {
   }
 
   /// Consumes the driver and produces the final merged transcript.
-  /// Delegates to [`LocalAgreement::finalize`], passing this driver's own
+  /// Delegates to `LocalAgreement::finalize`, passing this driver's own
   /// (word-timestamp-forced) [`DecodingOptions`] so the merge honors the
   /// same [`DecodingOptions::drop_blank_audio`] the streamed results decoded
   /// under.
@@ -1017,8 +1066,8 @@ where
   /// fixed cadence). Each pass transcribes the buffer from the start
   /// through that stride's end
   /// ([`crate::audio::whisper::transcribe::WhisperKit::transcribe`], with options
-  /// retargeted per [`LocalAgreement::decoding_options_for_next`]) and
-  /// folds the result through [`LocalAgreement::ingest`]. Ports
+  /// retargeted per `LocalAgreement::decoding_options_for_next`) and
+  /// folds the result through `LocalAgreement::ingest`. Ports
   /// `TranscribeCLI.swift:357-369`.
   ///
   /// # Errors

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -109,8 +109,9 @@
 //!   8, finding 1): `prefill_tokens` drops every id at or above the vocabulary's
 //!   `special_token_begin`, and a word with no tokens contributes nothing to the
 //!   prefix at all, so either kind of held word leaves the engine reasoning
-//!   about text the decoder was never given — the exact premise the pending
-//!   head's promotion rests on. It was recorded as a residual for as long as the
+//!   about text the decoder was never given — the premise
+//!   [`LocalAgreement::decoding_options_for_next`]'s retarget makes. It was
+//!   recorded as a residual for as long as the
 //!   argument was "`add_word_timestamps` strips those ids from everything this
 //!   crate emits", which is true and does not reach
 //!   [`LocalAgreement::ingest`]'s public hand-built path. **[BEHAVIOUR CHANGE]**
@@ -138,42 +139,23 @@
 //!   this module has a stake in, so the loader is left alone. The default is
 //!   today's constant, so no existing caller moves.
 //!
-//!   **A widened-past word is not confirmed on the spot** (codex round 12,
-//!   finding 1). The argument for confirming it — neither corroborable nor
-//!   revisable, being behind both the clip and the forced prefill — is an
-//!   argument about the hypothesis that comes NEXT, and the split runs before it
-//!   exists. It holds for a continuation decoded under
-//!   [`LocalAgreement::decoding_options_for_next`] and for no other, and
-//!   confirming into the append-only list cannot be taken back. So the split
-//!   still widens (its retarget is the only coherent one either way) and the
-//!   widened-past words wait in [`LocalAgreement::pending_words_slice`] **[new
-//!   public accessor]** — settled by the first hypothesis this engine anchored
-//!   (one written to begin with the whole holdback, which they sit in front of),
-//!   revisable by any other, and dropped with the holdback they head when one
-//!   supersedes them. Two kinds of word skip the wait entirely: one the
-//!   still-open span can never reach (`end` at or before the watermark), since
-//!   nothing offered could ever overlap it; and every one of them when the
-//!   holdback comes back EMPTY, since with no anchor no later result could ever
-//!   clear the wait and the hold would end in the deletion round 7 finding 2
-//!   removed.
-//!
-//!   That second kind therefore CAN be confirmed while a later unanchored decode
-//!   still re-reads its audio, and the transcript then carries both readings
-//!   (codex round 13, finding 1, refuted rather than fixed). That is not a
-//!   property of this arm: `common[..requested]`, the mainline confirmation
-//!   Swift has and this port has never touched, appends with no overlap test of
-//!   any kind and lands in the same place whenever word ends inside a hypothesis
-//!   are non-monotone
+//!   **A widened-past word is CONFIRMED on the spot.** The argument is round 8's:
+//!   a word the prefill cannot carry is neither corroborable nor revisable by a
+//!   continuation decoded under
+//!   [`LocalAgreement::decoding_options_for_next`], being behind both the clip
+//!   and the forced prefill, and the watermark passes it on the very next line,
+//!   so no future result can ever be offered over its span. Holding it instead
+//!   would be an indefinite wait ending in the deletion codex round 7 finding 2
+//!   removed. A caller driving [`LocalAgreement::ingest`] with a result decoded
+//!   some OTHER way could have re-read that audio, and for that caller the word
+//!   is confirmed while a revision of it is still possible — the transcript then
+//!   carries both readings. That is not a property of this arm:
+//!   `common[..split]`, the mainline confirmation Swift has and this port has
+//!   never touched, appends with no overlap test of any kind and lands in the
+//!   same place whenever word ends inside a hypothesis are non-monotone
 //!   (`an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too`). It is
 //!   the LocalAgreement-2 contract itself — confirmation follows agreement
-//!   between two consecutive hypotheses and is append-only. Requiring a
-//!   non-vacuous anchor instead reinstates the indefinite hold.
-//!   **[BEHAVIOUR CHANGE]** [`LocalAgreement::confirmed_words_slice`]
-//!   therefore gains a word that waits one `ingest` later than it did, and on a
-//!   MIXED-provenance stream an
-//!   unmarked hypothesis that revises one now replaces it instead of landing
-//!   beside it. Unreachable through [`LocalAgreementTranscriber`], which never
-//!   widens the split at all.
+//!   between two consecutive hypotheses and is append-only.
 //!
 //!   That split runs all the way to `common.len()` when it has to, so **an
 //!   advance can leave the holdback EMPTY** and the watermark anchored at the
@@ -187,7 +169,7 @@
 //!   intact held word with that truncation. Confirming such a word is always
 //!   possible and is no weaker a claim: `common` is the prefix two hypotheses
 //!   agreed on, and a word outside the prefill budget is one no third hypothesis
-//!   decoded from that prefill could revise — see the pending-word entry above
+//!   decoded from that prefill could revise — see the widened-past entry above
 //!   for the qualifier that carries. Unreachable through
 //!   [`LocalAgreementTranscriber`], which never leaves
 //!   [`DEFAULT_AGREEMENT_COUNT_NEEDED`].
@@ -219,80 +201,6 @@
 //!   against a Swift capture (`tests/whisper/streaming.rs` "owns no golden"; the
 //!   token-for-token goldens are the BATCH decode's), so the divergence costs no
 //!   oracle comparison.
-//! - **A result only replaces the PART of the span its own window DECODED**
-//!   (codex round 13, finding 2; intervals and the split, codex round 14). Two
-//!   places install a hypothesis's words over the engine's still-open record of
-//!   the still-open span — [`LocalAgreement::pending_words_slice`] then
-//!   [`LocalAgreement::last_agreed_words_slice`]: the advance in
-//!   [`LocalAgreement::ingest`], and the `holdback_superseded` branch above.
-//!   Both justify it by calling the replacement a REVISION of what it replaces,
-//!   and both inferred that from `prefilled` being false — "decoded some other
-//!   way, so its decoder saw that audio". Nothing made it so. `ingest` is public
-//!   and states no requirement that an unmarked result's window reach the
-//!   watermark, and a caller resuming a stream at a clip point of its own
-//!   legitimately hands over one that does not. Such a decode produced no
-//!   revision of that record, because it produced nothing over its span at all —
-//!   so replacing the record with its words deletes text two hypotheses agreed
-//!   on and nothing contradicted.
-//!
-//!   The deciding fact was already in hand and merely unused:
-//!   [`DecodingOptions::clip_timestamps`](crate::audio::whisper::options::DecodingOptions::clip_timestamps_slice)
-//!   is the window the decode actually covered, and `ProvenancedResult` already
-//!   pairs a result with what was known when it arrived. The window now travels
-//!   with the result exactly as its prefill premise does
-//!   (`ProvenancedResult::decoded`, scanned by
-//!   `LocalAgreement::open_record_split`), and both replacement sites ask it
-//!   first.
-//!
-//!   THE WINDOW IS A SET OF INTERVALS. `clip_timestamps` is a list of
-//!   `(start, end)` PAIRS that splits the audio into segments — its own doc says
-//!   so, and [`crate::audio::whisper::transcribe::WhisperKit::transcribe`] hands
-//!   it to `chunker::prepare_seek_clips`, which decodes each pair as its own
-//!   clip. `[0.0, 0.5, 3.0]` therefore decodes `[0.0, 0.5)` and `[3.0, end)` and
-//!   NOTHING between, so a first-timestamp-plus-half-line reading called a
-//!   two-clip schedule a window over the whole audio and let a word from the
-//!   second range supersede a record inside the gap (round 14, finding 1). Both
-//!   readings come out of one derivation, `chunker::seek_clip_ranges`, which
-//!   `prepare_seek_clips` is also built on; only the sentinels differ, since a
-//!   hermetic engine has no content length and leaves an odd final point's tail
-//!   unbounded. The leading comparison is NON-STRICT and has to be:
-//!   [`LocalAgreement::decoding_options_for_next`] clips exactly AT the
-//!   watermark, which is exactly where the holdback begins, so a strict test
-//!   would fail the engine's own retarget on every stride.
-//!
-//!   THE ANSWER IS A BOUNDARY, NOT A VERDICT. One verdict for a whole record is
-//!   wrong in both directions (round 14, finding 2): a window that opens BETWEEN
-//!   two held words re-read only the second, and deciding at the record's head
-//!   confirms that second word irrevocably at the very moment a hypothesis that
-//!   did re-read it says it is something else — then emits the stale reading
-//!   beside its own revision. `open_record_split` returns the index where the
-//!   longest wholly-re-read SUFFIX begins; the prefix in front of it is
-//!   preserved (finalized) or confirmed (advanced), and only the suffix is
-//!   replaced. Word-level CONTAINMENT in ONE clip, so a word the window only
-//!   partly reaches, or that straddles two adjacent clips, is preserved: erring
-//!   wide costs a repetition, erring narrow deletes a word. Same direction, for
-//!   the same reason, as the advance's own `position` split.
-//!
-//!   **[BEHAVIOUR CHANGE]** on both sites. An advance whose hypothesis could not
-//!   re-read part of the record now CONFIRMS that part instead of dropping it —
-//!   the watermark passes it on the very next line, so nothing can ever be
-//!   offered over its span again and there is no third option that terminates;
-//!   it is the pending bucket's own terminating rule applied where the bucket's
-//!   anchor also runs out. And `finalize` emits that part ahead of the revision
-//!   rather than deleting it for a revision that does not exist. Conversely, the
-//!   part a window DID re-read is no longer confirmed or emitted beside its
-//!   replacement; and the divergence's tail is `hypothesis_words` on every
-//!   disagreeing path rather than only on the ones that re-read something, which
-//!   stops Swift's prefix subtraction from dropping a word both hypotheses
-//!   produced whenever the holdback it subtracts against is being kept. All of
-//!   it is unreachable through [`LocalAgreementTranscriber`], whose every stride
-//!   clips at the watermark and contains its own holdback whole.
-//!
-//!   Swift cannot have the defect and cannot have the fix: it has no
-//!   `decoded_under` to check, and on this path its `:418-419` emits
-//!   `lastAgreedWords` beside the final hypothesis anyway — the duplication the
-//!   `holdback_superseded` branch exists to remove, and, when the final
-//!   hypothesis re-covered nothing, the answer that happens to be right.
 //! - **`use_prefill_prompt` is forced on the retargeted options, but only once
 //!   there is a holdback to reproduce** (Swift `:364-367` sets only
 //!   `clipTimestamps` and `prefixTokens`).
@@ -306,14 +214,15 @@
 //!   and the stream re-decodes each span with no anchor at all. Both this port
 //!   and Swift default the flag on, so this only diverges for a caller that
 //!   turned it off; it is forced for the same reason
-//!   [`LocalAgreementTranscriber::new`] forces `word_timestamps`, and because
-//!   the promotion of a pending word is DECIDED by the prefill (see
-//!   `LocalAgreement::prefill_reproduces_holdback`).
+//!   [`LocalAgreementTranscriber::new`] forces `word_timestamps`: a prefix the
+//!   decoder is never given makes `budgeted_split`'s whole budget argument
+//!   vacuous, and leaves the next hypothesis with no anchor over the span the
+//!   holdback covers.
 //!
 //!   It is forced only while [`LocalAgreement::last_agreed_words_slice`] is
 //!   NON-EMPTY (codex round 6, finding 3). Before the first advance there is no
-//!   holdback, the prefix is empty, and nothing is pending — so no premise needs
-//!   enforcing. Forcing the flag on those strides would
+//!   holdback and the prefix is empty, so there is nothing for the flag to
+//!   carry. Forcing the flag on those strides would
 //!   change the caller's prompt from a bare `<|startoftranscript|>` to the full
 //!   multilingual language/task/timestamp prefill for nothing, and a streaming
 //!   caller would get different decoding behaviour before LocalAgreement had
@@ -329,7 +238,6 @@
 //!   InferenceBackend + Sync` here.
 
 use crate::audio::whisper::{
-  audio::chunker,
   backend::InferenceBackend,
   constants::{MAX_TOKEN_CONTEXT, SAMPLE_RATE},
   error::TranscribeError,
@@ -418,10 +326,7 @@ pub const DEFAULT_AGREEMENT_COUNT_NEEDED: usize = 2;
 /// [`LocalAgreement::special_token_begin`] — the loaded vocabulary's own value
 /// where the engine was told it, and [`MIN_SPECIAL_TOKEN_BEGIN`] otherwise — and
 /// widens past every word that fails, exactly as it widens past an over-budget
-/// one. So no prefill this engine issues is ever trimmed OR filtered, and
-/// `LocalAgreement::prefill_reproduces_holdback` needs a clause for neither: a
-/// prefix EQUAL to the holdback is within budget and carried whole because the
-/// holdback is.
+/// one. So no prefill this engine issues is ever trimmed OR filtered.
 ///
 /// That id filter used to be recorded here as a residual, on the evidence that
 /// `add_word_timestamps` strips exactly those ids from every [`WordTiming`] it
@@ -433,144 +338,6 @@ pub const DEFAULT_AGREEMENT_COUNT_NEEDED: usize = 2;
 /// word, honestly pass the retarget, and still be recorded `prefilled`
 /// (codex round 8, finding 1); see `budgeted_split`.
 pub const MAX_HOLDBACK_PREFILL_TOKENS: usize = MAX_TOKEN_CONTEXT / 2;
-
-/// A result and the provenance it ARRIVED with, inseparable by construction.
-///
-/// Two of the engine's decisions are facts about how a PARTICULAR result was
-/// decoded rather than about the engine's state at the moment they are asked:
-/// whether that result could have re-read the still-open record at all
-/// ([`ProvenancedResult::decoded`]) and whether it can settle the pending head
-/// of it ([`ProvenancedResult::prefilled`]). Those two moments are not the same
-/// moment: [`LocalAgreement::ingest`] keeps `prev_result` RAW and re-reads it on
-/// every later call, so a premise derived from the CURRENT call and reused for
-/// the stored one answers a question about one result with another result's
-/// options — with no caller lying (codex round 7, finding 1).
-///
-/// The pairing is the fix, and it is structural rather than a rule to remember.
-/// The fields are private to this module and
-/// [`ProvenancedResult::arriving`] is the only constructor and the only caller
-/// of [`LocalAgreement::prefill_reproduces_holdback`] — so no signature anywhere
-/// in the engine has a channel through which a foreign premise could arrive, and
-/// the answer is immutable for as long as the engine keeps the result. Recorded
-/// once and read back, exactly as `LocalAgreement::holdback_superseded` is and
-/// for the same reason: a value a later call could re-derive differently is a
-/// value a later call WILL re-derive differently.
-mod provenance {
-  use super::{DecodingOptions, LocalAgreement, TranscriptionResult, WordTiming, chunker};
-
-  /// One ingested result, bound to the premise it arrived under. See the module
-  /// comment above for why the two travel together.
-  #[derive(Debug, Clone, PartialEq)]
-  pub(super) struct ProvenancedResult {
-    result: TranscriptionResult,
-    prefilled: bool,
-    window: Vec<(f32, f32)>,
-  }
-
-  impl ProvenancedResult {
-    /// Binds `result` to the premise `decoded_under` establishes against
-    /// `engine`'s state RIGHT NOW — which is the state the caller decoded
-    /// under, since [`LocalAgreement::ingest`] calls this before any of that
-    /// state moves — and to the WINDOW `decoded_under` says it was decoded in,
-    /// which needs no state at all (see [`Self::decoded`]).
-    pub(super) fn arriving(
-      result: TranscriptionResult,
-      engine: &LocalAgreement,
-      decoded_under: &DecodingOptions,
-    ) -> Self {
-      Self {
-        prefilled: engine.prefill_reproduces_holdback(decoded_under),
-        // `clip_timestamps` is a list of `(start, end)` PAIRS that splits the
-        // audio into segments, not a start (codex round 14, finding 1): its own
-        // doc says so, and `WhisperKit::transcribe` hands it straight to
-        // `chunker::prepare_seek_clips`, which pairs the points and decodes each
-        // pair as its own clip. So `[0.0, 0.5, 3.0]` decodes `[0.0, 0.5)` and
-        // `[3.0, end)` and nothing between — a schedule the round-13 reading
-        // (`first()`, then `[decoded_from, ..)`) called a window over the whole
-        // audio.
-        //
-        // Derived by `chunker::seek_clip_ranges`, which
-        // `prepare_seek_clips` is also built on, so the two cannot drift into
-        // two readings of one option. Both sentinels differ here: the seconds
-        // domain rather than samples, and an UNBOUNDED tail for an odd final
-        // point, because a hermetic engine holds no audio and so has no content
-        // length. That is the only place this reading is wider than the
-        // chunker's, and it is unreachable: every instant the two disagree about
-        // is past the end of the audio, and every word this window is ever asked
-        // about came out of a decode OF that audio.
-        window: chunker::seek_clip_ranges(
-          decoded_under.clip_timestamps_slice(),
-          0.0,
-          f32::INFINITY,
-        ),
-        result,
-      }
-    }
-
-    /// Whether this result's decoder saw the WHOLE of `word`'s audio — that is,
-    /// whether one clip of its schedule contains `[word.start(), word.end())`
-    /// entirely (codex round 13, finding 2; intervals per codex round 14,
-    /// finding 1).
-    ///
-    /// The engine reads this before letting a result's words REPLACE its own
-    /// still-open record of a span: `finalize`'s `holdback_superseded` branch
-    /// prefers the final hypothesis's words over that record because they are a
-    /// revision of it, and the advance replaces it with `common` for the same
-    /// reason — neither is true of a hypothesis whose window excluded the span.
-    /// Nothing checked it: `prefilled()` false was read as "decoded some other
-    /// way, so it saw that audio", and
-    /// [`LocalAgreement::ingest`] states no requirement that an unmarked
-    /// result's window reach the watermark at all.
-    ///
-    /// The leading comparison is NON-STRICT, and it has to be: the window
-    /// [`LocalAgreement::decoding_options_for_next`] issues begins exactly at
-    /// the watermark, which is exactly where the holdback begins, so a strict
-    /// test would fail the engine's own retarget on every stride. The two
-    /// values are the same `f32` — `last_agreed_seconds` is assigned from a
-    /// [`WordTiming::start`] — so the boundary compares exactly, the same
-    /// exactness [`LocalAgreement::prefill_reproduces_holdback`]'s own clip
-    /// clause already rests on. The trailing one is non-strict for the ordinary
-    /// half-open reason: a word that ENDS where the clip does was decoded whole
-    /// inside it.
-    ///
-    /// CONTAINMENT, not overlap, and containment in ONE clip rather than in the
-    /// union of several — "authorised only by real continuous coverage". A word
-    /// the window only partly reaches was only partly re-read, and a word that
-    /// straddles two adjacent clips was decoded in two pieces, neither of which
-    /// saw it whole; in both cases the decoder's reading of it is not a revision
-    /// of the whole word. Erring wide here (calling such a word uncovered)
-    /// leaves the record beside the partial re-reading, which costs a
-    /// repetition; erring narrow would delete it. Same direction the advance's
-    /// overlap split is drawn in, and for the same reason. A `NaN` or reversed
-    /// clip errs the same way for free: every comparison against it is false, so
-    /// it contains nothing.
-    pub(super) fn decoded(&self, word: &WordTiming) -> bool {
-      self
-        .window
-        .iter()
-        .any(|&(start, end)| start <= word.start() && word.end() <= end)
-    }
-
-    /// The hypothesis itself.
-    pub(super) const fn result(&self) -> &TranscriptionResult {
-      &self.result
-    }
-
-    /// Whether THIS result's own options established the prefill premise —
-    /// never any other result's.
-    pub(super) const fn prefilled(&self) -> bool {
-      self.prefilled
-    }
-
-    /// Unbinds the result, for the two places that need to OWN it (the
-    /// wordless-result append, and the kept-result clone).
-    pub(super) fn into_result(self) -> TranscriptionResult {
-      self.result
-    }
-  }
-}
-
-use provenance::ProvenancedResult;
 
 /// The LocalAgreement-2 hypothesis-confirmation engine: consumes one
 /// [`TranscriptionResult`] per call and tracks the growing prefix two
@@ -584,10 +351,9 @@ pub struct LocalAgreement {
   agreement_count_needed: usize,
   last_agreed_seconds: f32,
   /// The previous hypothesis, kept RAW so each ingest can re-filter it against
-  /// the watermark that is current then — paired with the provenance it arrived
-  /// with, so the two replacement decisions this engine makes about it read THAT
-  /// result's own premise and never a later call's (see [`ProvenancedResult`]).
-  prev_result: Option<ProvenancedResult>,
+  /// the watermark that is current then rather than the one current when it
+  /// arrived.
+  prev_result: Option<TranscriptionResult>,
   prev_words: Vec<WordTiming>,
   hypothesis_words: Vec<WordTiming>,
   last_agreed_words: Vec<WordTiming>,
@@ -604,37 +370,6 @@ pub struct LocalAgreement {
   /// had words to agree over — exactly the pair `finalize` reasons about.
   holdback_superseded: bool,
   confirmed_words: Vec<WordTiming>,
-  /// The head of the last advance's holdback that `budgeted_split` widened past
-  /// — words two consecutive hypotheses agreed on that
-  /// [`Self::decoding_options_for_next`]'s prefill cannot re-offer, and which
-  /// are therefore NOT YET in the append-only [`Self::confirmed_words`].
-  ///
-  /// The split has to widen: the retarget it produces (clip and prefill both
-  /// past these words) is the only coherent one, and leaving such a word IN the
-  /// holdback makes every marked continuation disagree with a prefill that
-  /// cannot reproduce it. What the split cannot know at the moment it runs is
-  /// whether the NEXT result will be one of those continuations — and confirming
-  /// on the spot is only sound if it is (codex round 12, finding 1). So the
-  /// split's WIDTH is decided at the advance and these words' DESTINATION is
-  /// decided one call later, by the premise that decides it — whether the next
-  /// result was written to BEGIN with the whole holdback, which every pending
-  /// word sits in front of ([`Self::prefill_reproduces_holdback`]).
-  ///
-  /// A result that could not have SEEN their audio settles them too, and for the
-  /// mirror-image reason (`Self::open_record_split`, codex round 13, finding 2):
-  /// a window that never reached these words revised nothing over their span, so
-  /// neither the advance nor [`Self::finalize`]'s superseded path may replace
-  /// them with it.
-  ///
-  /// Non-empty only while [`Self::last_agreed_words`] is: with nothing held back
-  /// there is no anchor a later result could be checked against, so a word left
-  /// here could never be cleared and is confirmed at the advance instead. See
-  /// the advance's own second split.
-  ///
-  /// Until then they are the head of the holdback in every respect except the
-  /// prefill: an advance replaces them along with the rest of the holdback, and
-  /// [`Self::finalize`]'s `holdback_superseded` path drops them with it.
-  pending_words: Vec<WordTiming>,
   results: Vec<TranscriptionResult>,
   /// A sink for the reproducibility facts of EVERY ingested hypothesis —
   /// including the disagreeing ones dropped from [`Self::results`] but retained
@@ -673,7 +408,6 @@ impl LocalAgreement {
       last_agreed_words: Vec::new(),
       holdback_superseded: false,
       confirmed_words: Vec::new(),
-      pending_words: Vec::new(),
       results: Vec::new(),
       ingested_facts: TaskFactsAccumulator::new(),
       special_token_begin: MIN_SPECIAL_TOKEN_BEGIN,
@@ -733,9 +467,9 @@ impl LocalAgreement {
   /// any parseable `tokenizer.json` and probes `<|endoftext|>` for its own
   /// threshold, so an artifact whose threshold is LOWER makes the default an
   /// over-estimate — the engine would hold a word whose ids that artifact's
-  /// `prefill_tokens` erases, and the equality
-  /// `Self::prefill_reproduces_holdback` checks would be satisfied by a prefix
-  /// the decoder is given only part of (codex round 12, finding 2).
+  /// `prefill_tokens` erases, so the prefill the engine promises the next
+  /// hypothesis is one the decoder is given only part of (codex round 12,
+  /// finding 2).
   ///
   /// So it is a value rather than a constant. [`LocalAgreementTranscriber::new`]
   /// sets it from the pipeline's own loaded vocabulary, which is exact and needs
@@ -757,9 +491,8 @@ impl LocalAgreement {
   /// a value ABOVE the deciding vocabulary's own threshold makes the engine hold
   /// a word the decoder never receives, and a value below it only confirms a
   /// word a round earlier than it had to. The caller owns the artifact, so the
-  /// caller supplies the fact — the same trust model as
-  /// [`Self::ingest`]'s `decoded_under`, and checked the same way where it can
-  /// be: [`LocalAgreementTranscriber`] reads it off the vocabulary itself.
+  /// caller supplies the fact, and it is checked where it can be:
+  /// [`LocalAgreementTranscriber`] reads it off the vocabulary itself.
   #[inline(always)]
   pub const fn set_special_token_begin(&mut self, special_token_begin: u32) -> &mut Self {
     self.special_token_begin = special_token_begin;
@@ -783,44 +516,17 @@ impl LocalAgreement {
     self.last_agreed_words.as_slice()
   }
 
-  // -- pending_words (Vec<WordTiming>) ---------------------------------------
-  /// The words the last advance agreed on but could not hold back — the ones
-  /// `budgeted_split` widened the split past because
-  /// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens) cannot
-  /// carry them into the next hypothesis whole.
-  ///
-  /// They sit BETWEEN [`Self::confirmed_words_slice`] and
-  /// [`Self::last_agreed_words_slice`], so the transcript a streaming caller can
-  /// read between pushes is the three concatenated in that order. They are not
-  /// confirmed: a hypothesis decoded some way OTHER than
-  /// [`Self::decoding_options_for_next`] MAY have seen their audio and revised
-  /// them, and [`Self::confirmed_words_slice`] is append-only and cannot take a
-  /// word back. The first hypothesis written to begin with this engine's own
-  /// holdback settles them — nothing it produces can precede that reproduction,
-  /// and these words are in front of it (see the field's own comment, and codex
-  /// round 12, finding 1). So does one whose own
-  /// [`DecodingOptions::clip_timestamps`](crate::audio::whisper::options::DecodingOptions::clip_timestamps_slice)
-  /// begin after them, for the opposite reason — it never decoded their audio at
-  /// all, so it revised nothing and the engine's record is all their span will
-  /// ever have (codex round 13, finding 2).
-  ///
-  /// Always empty for [`LocalAgreementTranscriber`], whose words come from
-  /// `add_word_timestamps` and whose holdback is two words wide.
-  #[inline(always)]
-  pub const fn pending_words_slice(&self) -> &[WordTiming] {
-    self.pending_words.as_slice()
-  }
-
   // -- confirmed_words (Vec<WordTiming>) -------------------------------------
-  /// Word timings settled so far: every agreement's leading remainder,
-  /// ahead of that agreement's own [`Self::agreement_count_needed`]-word
-  /// holdback — and ahead of [`Self::pending_words_slice`], the part of that
-  /// holdback the prefill could not carry, which reaches this list one ingest
-  /// later than the rest of the remainder does.
+  /// Word timings settled so far: every agreement's leading remainder, ahead of
+  /// that agreement's own [`Self::agreement_count_needed`]-word holdback.
   ///
   /// Append-only across the life of the engine: nothing here is ever rewritten,
-  /// reordered, or taken back, which is why a word the next hypothesis might
-  /// still revise waits in [`Self::pending_words_slice`] instead.
+  /// reordered, or taken back, which is why the trailing words of an agreement
+  /// wait in [`Self::last_agreed_words_slice`] instead. RULE W (see
+  /// [`Self::ingest`]'s advance) additionally guarantees that while that
+  /// holdback is non-empty, this list's last word starts STRICTLY before
+  /// [`Self::last_agreed_seconds`] — so nothing here can be re-offered to the
+  /// agreement comparison and confirmed a second time.
   #[inline(always)]
   pub const fn confirmed_words_slice(&self) -> &[WordTiming] {
     self.confirmed_words.as_slice()
@@ -861,9 +567,10 @@ impl LocalAgreement {
   /// `prefixTokens` exactly as described. It defaults `true` on both sides, so
   /// this only diverges for a caller that turned it off.
   ///
-  /// What the prefill buys is the reason a hypothesis decoded from these options
-  /// cannot put anything in front of the holdback — the premise
-  /// [`Self::pending_words_slice`]'s promotion rests on. `prefill_tokens`
+  /// What the prefill buys is that the next hypothesis REPRODUCES the holdback
+  /// rather than predicting it — which is what makes an advance's `common` a
+  /// re-agreement over the same span rather than a fresh reading of it, and what
+  /// `budgeted_split`'s budget argument is about. `prefill_tokens`
   /// appends these tokens to the initial prompt, and `decode_text` FORCES every
   /// prompt position
   /// (`next_token = current_tokens[token_index]` for `token_index <
@@ -873,23 +580,16 @@ impl LocalAgreement {
   /// with `clip_timestamps`, which puts the audio before the watermark outside
   /// the decoded window entirely, a hypothesis produced from these options
   /// BEGINS with a reproduction of the holdback, and nothing already confirmed
-  /// can precede it. See `LocalAgreement::prefill_reproduces_holdback`.
-  ///
-  /// Hand the returned value back to [`Self::ingest`] alongside the result it
-  /// decoded: that is how the premise above becomes something the engine has
-  /// CHECKED rather than assumed. `ingest` compares what it is given against
-  /// what this method would issue for the same state, and leaves the pending
-  /// head unsettled when they differ.
+  /// can precede it.
   ///
   /// # Before the first advance
   ///
   /// With an empty [`Self::last_agreed_words_slice`] there is nothing to
   /// reproduce: the prefix is empty, `clip_timestamps` is at the watermark, and
   /// [`DecodingOptions::use_prefill_prompt`] is left exactly as `base` had it.
-  /// The forcing above exists to make the pending promotion sound, and with no
-  /// holdback nothing is ever pending — the advance settles such a word on the
-  /// spot, precisely because no anchor could ever clear it (see
-  /// `Self::prefill_reproduces_holdback`). Overriding the caller's flag here
+  /// The forcing above exists so the prefix the engine attaches actually
+  /// reaches the decoder, and there is no prefix on this path. Overriding the
+  /// caller's flag here
   /// would change the initial prompt from a bare `<|startoftranscript|>` to the
   /// full multilingual language/task/timestamp prefill for no reason the engine's
   /// own state can point at (codex round 6, finding 3), and there would be no
@@ -900,11 +600,8 @@ impl LocalAgreement {
       .with_clip_timestamps(vec![self.last_agreed_seconds])
       .with_prefix_tokens(self.holdback_prefill_tokens());
     if self.last_agreed_words.is_empty() {
-      // NOTHING IS HELD BACK, so there is no premise to enforce and the caller's
-      // own flag stands: `pending_words` is empty for exactly as long as
-      // `last_agreed_words` is (the advance's own second split), so the
-      // promotion the prefill DECIDES is not being asked for. Forcing the flag
-      // here would change the prompt
+      // NOTHING IS HELD BACK, so the prefix is empty and the caller's own flag
+      // stands. Forcing the flag here would change the prompt
       // from whatever the caller asked for to the full multilingual
       // language/task/timestamp prefill, on strides where the engine holds no
       // state that needs the deviation (codex round 6, finding 3). The prefix
@@ -918,161 +615,13 @@ impl LocalAgreement {
 
   /// The holdback as one token sequence — the exact value
   /// [`Self::decoding_options_for_next`] attaches as
-  /// [`DecodingOptions::prefix_tokens`](DecodingOptions::prefix_tokens_slice),
-  /// and the value [`Self::prefill_reproduces_holdback`] compares a caller's
-  /// options against.
+  /// [`DecodingOptions::prefix_tokens`](DecodingOptions::prefix_tokens_slice).
   fn holdback_prefill_tokens(&self) -> Vec<u32> {
     self
       .last_agreed_words
       .iter()
       .flat_map(|word| word.tokens_slice().iter().copied())
       .collect()
-  }
-
-  /// Whether `decoded_under` — the options a caller says the offered result was
-  /// decoded with — actually establishes the premise
-  /// [`Self::pending_words_slice`]'s promotion is decided by: that the offered
-  /// hypothesis was written to BEGIN with this engine's whole holdback, so
-  /// nothing it produces can precede that reproduction and the pending words,
-  /// which sit in front of it, are past revising.
-  ///
-  /// Every clause is a thing that, if false, breaks that premise outright:
-  ///
-  /// - **An empty holdback** makes it vacuous, and harmlessly so: nothing is
-  ///   ever pending beside an empty holdback (the advance's own second split
-  ///   confirms such a word on the spot, because no anchor could ever clear
-  ///   it), so the only consumer of this answer has nothing to read it for.
-  /// - **[`DecodingOptions::use_prefill_prompt`] off** means
-  ///   [`crate::audio::whisper::transcribe::WhisperKit::transcribe`] never calls
-  ///   [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens), so the
-  ///   prefix is inert and the hypothesis PREDICTED its head rather than being
-  ///   fed it.
-  /// - **A different [`DecodingOptions::clip_timestamps`](DecodingOptions::clip_timestamps_slice)**
-  ///   means the audio the pending words were recognized in was NOT excluded
-  ///   from the decoded window, so this hypothesis DID re-read them and may be
-  ///   revising them — precisely what the promotion rules out.
-  /// - **A prefix that is not the holdback** is not a reproduction of it — and
-  ///   the test is equality, not "ends with". A prefix over
-  ///   [`MAX_HOLDBACK_PREFILL_TOKENS`] whose TAIL reproduces the holdback is
-  ///   refused by that same clause, and must be: `prefill_tokens` trims such a
-  ///   prefix to its last [`MAX_HOLDBACK_PREFILL_TOKENS`] tokens, which still
-  ///   carries the padding ahead of the holdback into the initial prompt, so the
-  ///   hypothesis does not BEGIN with the holdback. Equality also subsumes both
-  ///   of `prefill_tokens`'s reductions outright: `budgeted_split` leaves a
-  ///   holdback that is inside the budget AND carried whole by the id filter
-  ///   after every advance, so anything equal to that holdback is too — which is
-  ///   why neither reduction gets a clause of its own here. A clause for either
-  ///   would be a conjunct no input can falsify, the shape round 7 removed the
-  ///   length clause for.
-  ///
-  /// What it cannot check is that the caller actually DECODED with the options
-  /// it handed over; `TranscriptionResult` carries no provenance, and the
-  /// issue's impossibility argument already established that no predicate over
-  /// the word lists can recover it (two runs reach byte-identical
-  /// `(confirmed, offered, watermark, holdback)` and need opposite answers).
-  /// This is therefore the strongest premise the engine can hold: an explicit,
-  /// typed assertion by the caller, checked against what the engine itself would
-  /// have issued — not an unstated assumption about how `ingest` is called.
-  fn prefill_reproduces_holdback(&self, decoded_under: &DecodingOptions) -> bool {
-    if self.last_agreed_words.is_empty() {
-      return true;
-    }
-    if !decoded_under.use_prefill_prompt() {
-      return false;
-    }
-    if decoded_under.clip_timestamps_slice() != [self.last_agreed_seconds] {
-      return false;
-    }
-    // Equality, not `ends_with`: a prefix whose head is something else is not a
-    // reproduction of the holdback, however faithfully its TAIL reproduces one
-    // (`prefill_tokens` would force the head into the hypothesis too). Equality
-    // also subsumes both of `prefill_tokens`'s reductions: after every advance
-    // `budgeted_split` leaves a holdback inside `MAX_HOLDBACK_PREFILL_TOKENS`
-    // whose every word the id filter carries whole, so anything equal to it is
-    // within budget and unfiltered as well.
-    decoded_under.prefix_tokens_slice() == self.holdback_prefill_tokens()
-  }
-
-  /// The engine's own STILL-OPEN record of the span, in time order:
-  /// `pending_words` — the agreed-but-not-yet-irrevocable head — then
-  /// `last_agreed_words`, the holdback proper. The two places that would
-  /// REPLACE it read it through here so neither can forget half of it.
-  fn open_record(&self) -> impl DoubleEndedIterator<Item = &WordTiming> {
-    self
-      .pending_words
-      .iter()
-      .chain(self.last_agreed_words.iter())
-  }
-
-  /// How many words are in [`Self::open_record`].
-  fn open_record_len(&self) -> usize {
-    self.pending_words.len() + self.last_agreed_words.len()
-  }
-
-  /// WHERE `hypothesis`'s own decode window cuts the still-open record: the
-  /// index at which the record stops being the only estimate its span will ever
-  /// have and becomes something this hypothesis re-read and may replace (codex
-  /// round 13 finding 2, split per codex round 14 finding 2).
-  ///
-  /// Both places that replace the record ask this, and it is the same question
-  /// in both: the advance, which drops the record and installs `common` over
-  /// it, and [`Self::finalize`]'s `holdback_superseded` branch, which drops it
-  /// and installs the final hypothesis's own post-watermark words. Each
-  /// justifies itself by calling the replacement a REVISION of what it
-  /// replaces, and a decode whose window never reached a word produced no
-  /// revision of it — it produced nothing over its span at all, and the record
-  /// is then the only estimate that span will ever have.
-  ///
-  /// ONE VERDICT FOR THE WHOLE RECORD IS WRONG IN BOTH DIRECTIONS, which is why
-  /// this returns a boundary rather than a `bool`. Deciding it at the record's
-  /// first word alone lets a window that opens BETWEEN two held words confirm
-  /// the second one at the very moment a hypothesis that did re-read it says it
-  /// is something else — irrevocably, on the streaming face, with the stale
-  /// reading then emitted beside its own revision. That is the exact mirror of
-  /// round 13's defect, reached from the conservative side.
-  ///
-  /// The replaceable part is the longest SUFFIX every word of which
-  /// `ProvenancedResult::decoded` accepts, so this is `open_record_len()` minus
-  /// that suffix's length. A suffix rather than a per-word verdict because the
-  /// record is emitted as a prefix and word extents within a hypothesis are not
-  /// guaranteed monotone: an uncovered word anywhere pushes the boundary past
-  /// it, so a later word is never replaced out from behind a preserved one. That
-  /// is the erring-wide direction — a repetition at worst — and it is the same
-  /// direction, for the same reason, as the advance's own `position` split over
-  /// `common[requested..split]`.
-  ///
-  /// `0` when the record is empty, which is exactly "all of it is replaceable"
-  /// and harmlessly so: with nothing held and nothing pending there is nothing
-  /// to protect. `finalize` still has to spell that case out, because there
-  /// "replaceable" and "empty" have to reach the same branch — see the guard
-  /// there.
-  fn open_record_split(&self, hypothesis: &ProvenancedResult) -> usize {
-    self.open_record_len()
-      - self
-        .open_record()
-        .rev()
-        .take_while(|word| hypothesis.decoded(word))
-        .count()
-  }
-
-  /// Moves the record's first `keep` words — the part no window re-read — into
-  /// `confirmed`, and DROPS the rest, leaving both record buckets empty for the
-  /// caller to refill. The two replacement sites' shared tail.
-  ///
-  /// By field rather than through `&mut self`: the advance calls it while
-  /// `common` still borrows `hypothesis_words`, and these three buckets are
-  /// disjoint from that one.
-  fn confirm_the_unread_prefix_and_drop_the_rest(
-    confirmed: &mut Vec<WordTiming>,
-    pending: &mut Vec<WordTiming>,
-    holdback: &mut Vec<WordTiming>,
-    keep: usize,
-  ) {
-    let from_pending = keep.min(pending.len());
-    confirmed.extend_from_slice(&pending[..from_pending]);
-    confirmed.extend_from_slice(&holdback[..keep - from_pending]);
-    pending.clear();
-    holdback.clear();
   }
 
   /// The agreement view of a result's words: everything at or past the
@@ -1136,21 +685,7 @@ impl LocalAgreement {
   /// Either way — agreeing, disagreeing, or no previous result — `result`
   /// becomes the new previous result for the next call (`:402`, outside
   /// the agreement `if`/`else` but still inside the has-words branch).
-  pub fn ingest(
-    &mut self,
-    result: TranscriptionResult,
-    decoded_under: &DecodingOptions,
-  ) -> AgreementOutcome {
-    // PROVENANCE IS BOUND HERE, ONCE, BEFORE ANY STATE MOVES -- `decoded_under`
-    // is checked against the watermark and holdback the caller decoded with,
-    // which are still the current ones at this point, and the answer then
-    // travels WITH the result for as long as the engine keeps it. What it buys
-    // is no longer a reading of the offered list (Rule W removed that question)
-    // but the two REPLACEMENT decisions below: whether this hypothesis could
-    // have revised the still-open record at all, and whether it can settle the
-    // pending head of it.
-    let hypothesis = ProvenancedResult::arriving(result, self, decoded_under);
-
+  pub fn ingest(&mut self, result: TranscriptionResult) -> AgreementOutcome {
     // Accumulate THIS hypothesis's reproducibility facts BEFORE any gate or
     // branch, so a hypothesis dropped from `results` on disagreement (:395-400,
     // `skipAppend`) still contributes them to `finalize` (codex round 8, F1). It
@@ -1168,8 +703,7 @@ impl LocalAgreement {
     // ordinals; `finalize` overwrites it with the merged surviving result's own
     // span, the authoritative id-ordinal count.
     self.ingested_facts.merge(
-      &hypothesis
-        .result()
+      &result
         .task_facts()
         .clone()
         .with_worker_schedule(None)
@@ -1178,56 +712,18 @@ impl LocalAgreement {
 
     // :371 gate — see this module's doc for "any segment" vs. Swift's
     // first-segment-only nil check.
-    let has_words = hypothesis
-      .result()
+    let has_words = result
       .segments_slice()
       .iter()
       .any(|segment| !segment.words_slice().is_empty());
     if !has_words {
-      self.results.push(hypothesis.into_result());
+      self.results.push(result);
       return AgreementOutcome::NoWordTimings;
     }
 
-    // THE PENDING WORDS' DESTINATION, decided here because here is the first
-    // moment the provenance that decides it exists (codex round 12, finding 1).
-    // `budgeted_split` widened past them at the last advance so the retarget
-    // could be coherent, and round 8's argument for confirming them on the spot
-    // -- neither corroborable nor revisable, being behind both the clip and the
-    // prefill -- is an argument about the hypothesis that comes NEXT, which the
-    // advance had not seen. THIS hypothesis's own premise is that argument's
-    // missing clause: a result written to begin with the whole holdback cannot
-    // put anything in front of that reproduction, and every pending word is in
-    // front of it, so such a result can neither corroborate nor revise one and
-    // they settle here. A result decoded any other way saw their audio and could,
-    // so they stay where they are.
-    //
-    // The premise is never the VACUOUS one: `prefill_reproduces_holdback`
-    // answers TRUE for anything when the holdback is empty, and the advance below
-    // leaves nothing pending in that state precisely so this consumer can never
-    // read it (see the anchor argument there). `pending_words` non-empty implies
-    // `last_agreed_words` non-empty, because only an advance sets either and an
-    // advance sets both together.
-    //
-    // Before the `has_words` gate this would also fire for a wordless result,
-    // which the gate above documents as leaving every agreement bookkeeping
-    // field untouched. Deferring past one costs nothing -- the next worded
-    // hypothesis makes the same call -- so the gate keeps its meaning.
-    if hypothesis.prefilled() {
-      self.confirmed_words.append(&mut self.pending_words);
-    }
-
-    // THE OTHER FACT `decoded_under` CARRIES, read here because here is where
-    // the state it is read against stops moving for this call (codex round 13,
-    // finding 2). The promotion above is the last thing to touch
-    // `pending_words` before the advance, and nothing below touches
-    // `last_agreed_words` until the advance replaces it -- so this is the record
-    // whose span the advance would drop, and the boundary computed now is the
-    // boundary at the moment it drops it.
-    let open_record_split = self.open_record_split(&hypothesis);
-
     // :372 verbatim — see `watermark_filtered`, and Rule W below for why the
     // bare filter is sound.
-    self.hypothesis_words = Self::watermark_filtered(hypothesis.result(), self.last_agreed_seconds);
+    self.hypothesis_words = Self::watermark_filtered(&result, self.last_agreed_seconds);
 
     let mut advanced = false;
     let mut skip_append = false;
@@ -1239,7 +735,7 @@ impl LocalAgreement {
       // comparison. `prev_result` is kept RAW for exactly this: the watermark it
       // is re-read against is the one current NOW, not the one current when it
       // arrived.
-      self.prev_words = Self::watermark_filtered(previous.result(), self.last_agreed_seconds);
+      self.prev_words = Self::watermark_filtered(previous, self.last_agreed_seconds);
       let common = find_longest_common_prefix(&self.prev_words, &self.hypothesis_words);
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
@@ -1269,24 +765,14 @@ impl LocalAgreement {
         // is carried forward through the loop, so a RUN of tied starts is
         // cleared in one pass rather than one word of it.
         //
-        // Against `pending_words` this OVER-FIRES, deliberately.
-        // `common[split - 1]` is the last word this advance CONFIRMS only when
-        // every word `budgeted_split` widened past also ends at or before the
-        // new watermark; one that ends past it lands in `pending_words` instead
-        // -- not confirmed, so a tie against it creates no re-admission to
-        // defend against -- and this widens past it all the same. The
-        // postcondition holds either way, so the cost is conservatism: on a
-        // holdback whose tail ties, the split can run to the end of `common` and
-        // leave nothing held and nothing pending.
-        //
         // Composes with `budgeted_split` in one direction only, which is why it
         // runs after it: widening can only SHRINK the holdback `common[split..]`,
         // so the token budget it just established still holds, and its id-filter
         // floor is likewise never re-crossed (see `budgeted_split`). Where the
         // tie runs to the end of `common` the holdback empties and the watermark
-        // falls back to `common.last().end()`, which is at or past every start in
-        // it -- the postcondition is then vacuous, and the next advance re-seeds
-        // the anchor from the confirmed list.
+        // falls back to `common.last().end()`, which is at or past every start
+        // in it -- the postcondition is then vacuous, and the next advance
+        // re-seeds the anchor from the confirmed list.
         let mut anchor = if split > 0 {
           Some(common[split - 1].start())
         } else {
@@ -1296,43 +782,10 @@ impl LocalAgreement {
           anchor = Some(common[split].start());
           split += 1;
         }
-        // The still-open record is REPLACED here -- `pending_words` dropped and
-        // `last_agreed_words` overwritten -- because `common` is the span two
-        // hypotheses have just re-agreed over it. That is a claim about this
-        // hypothesis's WINDOW, and it used to be assumed: whatever was still
-        // pending had not been settled by the promotion above, from which the
-        // code concluded "so this hypothesis saw its audio". An unmarked result
-        // may legitimately clip LATER than the watermark, or skip the span
-        // between two clips of its schedule entirely, and then it saw none of
-        // it (codex round 13, finding 2; codex round 14, finding 1).
-        //
-        // What it could not re-read, it cannot revise, so THAT PART of the
-        // record is CONFIRMED instead of dropped -- the same claim every other
-        // confirmed word carries (two consecutive hypotheses agreed on it, and
-        // nothing that could see its audio has contradicted it), and the only
-        // alternative to deleting it: the watermark moves past these words on
-        // the very next line, so no future result can ever be offered over
-        // their span and holding them would be an indefinite wait ending in the
-        // deletion round 7 finding 2 removed. Time-ordered, too: they start at
-        // or before the old watermark and every word of `common` starts at or
-        // past it.
-        //
-        // The rest -- the suffix this hypothesis re-read -- is dropped, because
-        // `common` IS its revision and confirming it would make the superseded
-        // reading irrevocable beside its replacement (codex round 14, finding
-        // 2).
-        //
-        // On the promoted path the drain already emptied `pending_words`, and
-        // on every marked stride the retarget's own window begins exactly at
-        // the watermark and runs unbounded from there, so the whole record is
-        // inside it, `open_record_split` is 0, and this is the unchanged
-        // replacement.
-        Self::confirm_the_unread_prefix_and_drop_the_rest(
-          &mut self.confirmed_words,
-          &mut self.pending_words,
-          &mut self.last_agreed_words,
-          open_record_split,
-        );
+        // `common` REPLACES the still-open record: it is the span two consecutive
+        // hypotheses have just re-agreed over it, and `last_agreed_words` is the
+        // one this hypothesis has superseded.
+        self.confirmed_words.extend_from_slice(&common[..split]);
         self.last_agreed_words = common[split..].to_vec();
         // The watermark is the first held-back word's start -- except when the
         // budget could hold NOTHING (see `budgeted_split`), where the still-open
@@ -1341,6 +794,15 @@ impl LocalAgreement {
         // one), so the final fallback is unreachable and only keeps this total.
         // Monotone either way: every word of `common` starts at or past the old
         // watermark, and `end >= start`.
+        //
+        // That empty-holdback anchor is Rule W's one gap, and it is recorded as
+        // a residual rather than closed: `common.last().end()` can EQUAL
+        // `common.last().start()` for a zero-duration word, and the
+        // postcondition is then vacuous because there is no held-back word for
+        // it to speak about. Reaching it needs a non-default
+        // `agreement_count_needed`, a word whose own tokens exceed
+        // `MAX_HOLDBACK_PREFILL_TOKENS`, and a zero-duration word, all at once
+        // (`an_empty_holdback_leaves_a_zero_duration_word_at_the_watermark`).
         self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
           || {
             common
@@ -1349,54 +811,6 @@ impl LocalAgreement {
           },
           WordTiming::start,
         );
-        // `common[requested..split]` is what the split had to widen past, and it
-        // splits ONE more time -- on whether anything could still speak to the
-        // word (codex round 12, finding 1). Two ways the answer is no, and a
-        // word that gets either is settled here and now on round 8's own
-        // argument rather than deferred:
-        //
-        // - **Nothing can overlap it.** Every word the engine will ever be
-        //   offered again is filtered to `start >= watermark`, so a word whose
-        //   extent ENDS at or before the watermark shares no instant with any of
-        //   them. The `>` is STRICT: erring wide here DELETES a word the stream
-        //   produced and nothing revised, while erring narrow only leaves a word
-        //   pending one call longer. Interval overlap is the exact notion this
-        //   one needs, and `[p.start, p.end)` overlaps `[watermark, ..)` exactly
-        //   when `p.end > watermark`.
-        // - **Nothing could ever clear it.** A pending word waits for a
-        //   hypothesis that provably cannot revise it, and the only such
-        //   hypothesis is one this engine ANCHORED -- prefilled with a holdback
-        //   that occupies the span in front of the word, so nothing it produces
-        //   can precede that reproduction. With the holdback EMPTY there is no
-        //   anchor and no future result can ever supply one, so waiting is not
-        //   deferral but an indefinite hold, ending in exactly the deletion round
-        //   7 finding 2 removed. Confirming instead is what that finding
-        //   requires, and this is where it keeps requiring it.
-        //
-        // Together they also keep this module's one cross-call invariant:
-        // `pending_words` non-empty implies `last_agreed_words` non-empty, which
-        // is what stops the promotion above from ever reading the vacuous
-        // premise.
-        //
-        // `position`, so what is confirmed is a PREFIX: word ends within a
-        // hypothesis are not guaranteed monotone, and a later short word must
-        // not be confirmed out from behind an overlapping earlier one.
-        let widened = &common[requested..split];
-        let overlapping = if self.last_agreed_words.is_empty() {
-          widened.len()
-        } else {
-          widened
-            .iter()
-            .position(|word| word.end() > self.last_agreed_seconds)
-            .unwrap_or(widened.len())
-        };
-        self.confirmed_words.extend_from_slice(&common[..requested]);
-        self
-          .confirmed_words
-          .extend_from_slice(&widened[..overlapping]);
-        self
-          .pending_words
-          .extend_from_slice(&widened[overlapping..]);
         advanced = true;
       } else {
         // :395-400 — disagreement; `result` is dropped below.
@@ -1412,13 +826,12 @@ impl LocalAgreement {
     // nothing can have been superseded.
     self.holdback_superseded = skip_append;
 
-    // :402 (unconditional) + :408-410 (`!skipAppend`). The premise goes into
-    // `prev_result` with the result, never re-derived when it is read back.
+    // :402 (unconditional) + :408-410 (`!skipAppend`).
     if skip_append {
-      self.prev_result = Some(hypothesis);
+      self.prev_result = Some(result);
     } else {
-      self.results.push(hypothesis.result().clone());
-      self.prev_result = Some(hypothesis);
+      self.prev_result = Some(result.clone());
+      self.results.push(result);
     }
 
     if advanced {
@@ -1435,11 +848,8 @@ impl LocalAgreement {
   /// ([`crate::audio::whisper::text::find_longest_different_suffix`] over the last
   /// ingested pair), both folded onto [`Self::confirmed_words_slice`] —
   /// **except when the final hypothesis DISAGREED**, where this port emits that
-  /// hypothesis's own post-watermark words instead — behind whatever part of the
-  /// record its own decode window never reached, which it does not supersede and
-  /// which is emitted ahead of them (see this module's doc, "The final
-  /// hypothesis's holdback", and "A result only replaces the PART of the span
-  /// its own window DECODED" for the window clause);
+  /// hypothesis's own post-watermark words instead of the superseded holdback
+  /// (see this module's doc, "The final hypothesis's holdback");
   /// [`merge_transcription_results_with_words`] then merges every kept
   /// [`Self::results_slice`] result with that word list as the merged
   /// text, under `options` — the same options the kept results were decoded
@@ -1460,29 +870,6 @@ impl LocalAgreement {
   /// the ingest strip carries only the wholly-unknown span, so the fold cannot
   /// supply the exact count, round 12); see [`Self::ingest`].
   pub fn finalize(mut self, options: &DecodingOptions) -> TranscriptionResult {
-    // The third conjunct is `ProvenancedResult::decoded` read off the FINAL
-    // hypothesis -- which is what `prev_result` holds here, since `ingest` sets
-    // it on every worded path and the wordless gate returns before it (codex
-    // round 13, finding 2). `holdback_superseded` is only ever set inside `if
-    // let Some(previous) = &self.prev_result`, so the `None` arm is unreachable
-    // while the branch below is live and is `0` only to keep this total.
-    let open_record_split = match self.prev_result.as_ref() {
-      Some(previous) => self.open_record_split(previous),
-      None => 0,
-    };
-    // AND NOTHING MORE. Round 13 made "this hypothesis re-read the record" a
-    // third conjunct here; the SPLIT above subsumes it, because a record nothing
-    // re-read gets `open_record_split == len` and is kept WHOLE by the branch
-    // itself. What a surviving conjunct would still decide is the tail --
-    // `hypothesis_words` here against `find_longest_different_suffix`'s
-    // remainder below -- and that subtraction is only sound when
-    // `last_agreed_words` holds the prefix it subtracts. On this path it does
-    // not: the record is the OLD holdback, unrelated to whatever prefix the last
-    // two hypotheses happen to share, so the conjunct's false arm dropped words
-    // both of them produced and nothing put back --
-    // `a_disagreeing_final_pair_keeps_the_words_both_hypotheses_agreed_on`'s
-    // defect with a non-empty holdback (codex round 14; the conjunct redded no
-    // test, and every shape that made it observable made it wrong).
     if self.holdback_superseded && !self.hypothesis_words.is_empty() {
       // DIVERGENCE from `:418-419` — see this module's doc for the full
       // argument. Swift's `lastAgreedWords + differentSuffix(prevWords,
@@ -1500,46 +887,9 @@ impl LocalAgreement {
       // disagrees, but it re-covers nothing, so there is no revision to prefer
       // and the provisional holdback remains the only estimate for that span.
       // That case stays on the Swift shape below, byte-identical.
-      //
-      // COVERAGE is the same argument reached from the other end (codex round
-      // 13, finding 2), and it is spent HERE rather than on the branch
-      // condition. "Already re-covers that exact span" is a claim about the
-      // final hypothesis's decode WINDOW, and it was assumed of every unmarked
-      // result rather than checked. A result whose clip schedule never reaches
-      // the holdback shares no instant with it: its words are not a revision of
-      // anything held, so dropping the record for them deletes words the stream
-      // agreed on and nothing contradicted. `open_record_split` is `len` for
-      // such a result, so the call below keeps the record WHOLE and only the
-      // hypothesis's own words follow it.
-      //
-      // And it is a BOUNDARY, not a verdict on the whole record (codex round 14,
-      // finding 2). A window that opens between two held words re-read only the
-      // second, so only the second is superseded; the first is kept, ahead of
-      // the revision, exactly where it sits in time. Reading the record's head
-      // alone got both halves wrong at once -- it emitted the re-read word
-      // beside its own revision, and it did so on the strength of a word the
-      // hypothesis never saw.
-      //
-      // `pending_words` is dropped with the part of the holdback it heads, and
-      // for the same reason: `hypothesis_words` re-covers that span carrying the
-      // revision, and emitting both would strand the superseded reading beside
-      // its replacement — the very defect this branch exists to prevent, reached
-      // one word earlier (codex round 12, finding 1). It is empty on every
-      // marked stream: a hypothesis that clips at the watermark settles the
-      // pending words on arrival, so only a hypothesis that could actually see
-      // their audio ever gets to supersede them.
-      Self::confirm_the_unread_prefix_and_drop_the_rest(
-        &mut self.confirmed_words,
-        &mut self.pending_words,
-        &mut self.last_agreed_words,
-        open_record_split,
-      );
       self.confirmed_words.append(&mut self.hypothesis_words);
     } else {
-      // `:418-419` verbatim, with `pending_words` ahead of the holdback because
-      // that is where they sit in time. Nothing superseded them, so they are
-      // still the only estimate for their span.
-      self.confirmed_words.append(&mut self.pending_words);
+      // `:418-419` verbatim.
       self.confirmed_words.append(&mut self.last_agreed_words);
       let suffix = find_longest_different_suffix(&self.prev_words, &self.hypothesis_words);
       self.confirmed_words.extend_from_slice(suffix);
@@ -1619,40 +969,27 @@ impl LocalAgreement {
 /// from every [`WordTiming`] it emits (and emits no word at all for an
 /// all-special alignment entry). The evidence is correct and the pipeline really
 /// is clean. What it does not cover is [`LocalAgreement::ingest`] itself, which
-/// is public and takes a hand-built [`TranscriptionResult`] — the very call
-/// shape `decoded_under` exists to make safe. Such a caller can hold back a word
-/// carrying filtered ids, honestly pass the options
-/// [`LocalAgreement::decoding_options_for_next`] just issued, and have
-/// `ProvenancedResult` record `prefilled = true` for a hypothesis the decoder
-/// was fed only PART of the holdback for — the one premise
-/// [`LocalAgreement::pending_words_slice`]'s promotion rests on.
+/// is public and takes a hand-built [`TranscriptionResult`], so a caller can
+/// hold back a word carrying filtered ids and then use
+/// [`LocalAgreement::decoding_options_for_next`] honestly, leaving the engine
+/// promising the decoder text it will never be given.
 ///
-/// Widening the split instead takes that head OUT of the holdback. It is not a
-/// weaker claim than any other agreed word carries: `common` is the prefix two
-/// consecutive hypotheses agreed on, which is the whole of LocalAgreement-2's
-/// criterion, and [`LocalAgreement::finalize`] already appends the entire
-/// holdback to [`LocalAgreement::confirmed_words_slice`] unconditionally on its
-/// Swift-shaped path. What the holdback buys on top of that is one more round in
-/// which a third hypothesis could revise it — and a word the prefill cannot
-/// carry cannot be revised by one *that was decoded from the prefill*, because
-/// whatever such a hypothesis produces over that extent came from a DIFFERENT
-/// prefix and from audio the clip excludes, and is therefore neither a
-/// corroboration of the held word nor a revision of it.
-///
-/// **That qualifier is the whole of codex round 12, finding 1.** The argument
-/// above is about the hypothesis that comes NEXT, and the split runs before it
-/// exists. A caller who does not use
-/// [`LocalAgreement::decoding_options_for_next`] is subject to neither reduction
-/// — its decoder never sees a truncated prefix and its window is its own — so
-/// for it the held word is revisable after all, and confirming here would strand
-/// the stale reading beside the revision. So the split still widens (the
-/// retarget it produces is the only coherent one either way: a word the prefill
-/// cannot re-offer must not be the thing the next hypothesis is asked to
-/// reproduce), but the widened-past words land in
-/// [`LocalAgreement::pending_words_slice`] rather than in the append-only
-/// confirmed list, and [`LocalAgreement::ingest`] settles them the moment a
-/// hypothesis arrives that the engine itself anchored. Deferring the
-/// DESTINATION is available; deferring the SPLIT is not.
+/// Widening the split instead takes that head OUT of the holdback and CONFIRMS
+/// it. That is not a weaker claim than any other agreed word carries: `common`
+/// is the prefix two consecutive hypotheses agreed on, which is the whole of
+/// LocalAgreement-2's criterion, and [`LocalAgreement::finalize`] already
+/// appends the entire holdback to
+/// [`LocalAgreement::confirmed_words_slice`] unconditionally on its Swift-shaped
+/// path. What the holdback buys on top of that is one more round in which a
+/// third hypothesis could revise it — and a word the prefill cannot carry cannot
+/// be revised by one *that was decoded from the prefill*, because whatever such
+/// a hypothesis produces over that extent came from a DIFFERENT prefix and from
+/// audio the clip excludes, and is therefore neither a corroboration of the held
+/// word nor a revision of it. A caller driving [`LocalAgreement::ingest`] with a
+/// result decoded some OTHER way is subject to neither reduction, so for it the
+/// word is revisable after all and the confirmation lands beside the revision —
+/// the same append-only cost `common[..split]` already carries on every path
+/// (`an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too`).
 ///
 /// Widening is the repair because the defect is the STATE, not any reading of
 /// it. Leaving the unreproducible word IN the holdback is what round 7's
@@ -1717,8 +1054,9 @@ fn budgeted_split(common: &[WordTiming], requested: usize, special_token_begin: 
 
 /// Whether [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens)
 /// carries this word's tokens into the initial prompt WHOLE — the property every
-/// held-back word has to have for `LocalAgreement::prefill_reproduces_holdback`'s
-/// equality to mean what it says.
+/// held-back word has to have for
+/// [`LocalAgreement::decoding_options_for_next`]'s retarget to promise the
+/// decoder text it will actually be given.
 ///
 /// Two ways to fail, and the empty one needs no vocabulary knowledge at all: a
 /// word with NO tokens contributes nothing to `prefix_tokens`, so a prefix equal
@@ -1857,9 +1195,7 @@ where
       let end = (self.transcribed_samples + STRIDE_SAMPLES).min(self.buffer.len());
       let options = self.agreement.decoding_options_for_next(&self.options);
       let result = self.kit.transcribe(&self.buffer[..end], &options)?;
-      // The same `options` the result was decoded with, handed back so
-      // `ingest` can VERIFY the prefill premise rather than assume it.
-      outcomes.push(self.agreement.ingest(result, &options));
+      outcomes.push(self.agreement.ingest(result));
       self.transcribed_samples = end;
     }
     Ok(outcomes)

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -326,11 +326,16 @@
 //!    and a re-offer of the settled one are the same value, which is the issue's
 //!    impossibility result, and the alternative is the unbounded
 //!    re-confirmation #94 is about. A truncation is what the portable prefix
-//!    property tolerates; a rewrite is not. Needs a non-default
-//!    [`LocalAgreement::agreement_count_needed`], a word whose own tokens exceed
-//!    [`MAX_HOLDBACK_PREFILL_TOKENS`] (Rule W's own widening no longer empties
-//!    the holdback), and a zero-duration word, simultaneously.
-//!    `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed`.
+//!    property tolerates; a rewrite is not. Needs the prefill budget to empty the
+//!    holdback — Rule W's own widening no longer does — over a ZERO-DURATION word,
+//!    which takes a single word at the end of `common` whose own tokens exceed
+//!    [`MAX_HOLDBACK_PREFILL_TOKENS`]. It does NOT additionally take a
+//!    non-default [`LocalAgreement::agreement_count_needed`]: an earlier form of
+//!    this entry listed one, and the default count reaches the same state
+//!    whenever that one word is the last of the agreed prefix (measured).
+//!    `add_word_timestamps` emitting a 112-token word is the whole of the gate.
+//!    `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed` drives it
+//!    at count 1, and `the_split_never_cuts_at_a_tied_start` sweeps both counts.
 //! 2. **A repeat the engine's record cannot account for** is the stream's own,
 //!    on the untied input — and on a TIED one Rule W deletes it instead. Both
 //!    directions are pinned:
@@ -1140,14 +1145,21 @@ fn split_at_a_strict_boundary(
 /// round 7's finding 2.
 ///
 /// **Documented deviation**: with `agreement_count_needed` at its
-/// [`DEFAULT_AGREEMENT_COUNT_NEEDED`] — the only value
-/// [`LocalAgreementTranscriber`] can reach, since it exposes
-/// [`LocalAgreementTranscriber::agreement`] by shared reference only — a
-/// two-word holdback is nowhere near 112 tokens and this is the identity. It
-/// bites only for a direct caller that raised
-/// [`LocalAgreement::agreement_count_needed`] far enough, and for that caller
-/// the count becomes a maximum rather than an exact width. (Rule W's back-off
-/// moves it the other way for any caller — see `split_at_a_strict_boundary`.)
+/// [`DEFAULT_AGREEMENT_COUNT_NEEDED`] a two-word holdback of words
+/// `add_word_timestamps` emits is nowhere near 112 tokens, and this is the
+/// identity. What makes it bite is a HOLDBACK too expensive for the prefill, and
+/// the count is only one of the two ways to get one: raise the count far enough,
+/// or leave the count alone and have a SINGLE word at the end of `common` whose
+/// own tokens exceed the budget — the split then runs to `common.len()` at the
+/// default count too (measured). Either way the count becomes a maximum rather
+/// than an exact width. (Rule W's back-off moves it the other way for any
+/// caller — see `split_at_a_strict_boundary`.)
+///
+/// The count is NOT out of a public caller's reach, and an earlier form of this
+/// note said it was: [`LocalAgreementTranscriber::with_agreement_count_needed`]
+/// is `pub`, having been rehomed there when the engine's own knob was sealed. It
+/// is `LocalAgreement::set_agreement_count_needed` that a caller outside this
+/// crate cannot call, and the driver's builder does the same job.
 fn budgeted_split(common: &[WordTiming], requested: usize) -> usize {
   let mut split = requested;
   let mut tokens: usize = common[split..]

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -105,6 +105,29 @@
 //!   `LocalAgreement::finalize` emits the same words either way, and TAIL growth
 //!   relieves it.
 //!
+//!   **The deferral is a WAIT, and the wait is BOUNDED** (codex round 4 on
+//!   PR #95). Tail growth relieves it only where the tail GROWS `common`, and
+//!   two shapes stop it growing: hypotheses that ALTERNATE past the agreed
+//!   prefix pin `common` at the words they still share, and a hypothesis that
+//!   simply REPEATS pins it with no disagreement at all. Either way the same
+//!   round came back forever — nothing confirmed, the watermark frozen, the
+//!   caller reading `AwaitingAgreement`, and in the driver a clip boundary that
+//!   never advanced while the buffer grew past it. So a deferral over a `common`
+//!   no longer than the one the round before already deferred over takes the
+//!   empty holdback instead: that is a MEASUREMENT of a wait that has already
+//!   happened, not a prediction about the next one, and it costs at most one
+//!   round.
+//!   `an_alternating_suffix_escapes_the_deferral_instead_of_stalling` and
+//!   `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`
+//!   are the falsifiers, one per deferral arm. What the escape can still lose is
+//!   one thing and it is residual 1 below: a word at the last confirmed word's
+//!   own instant, where no watermark serves both it and #94. Everything else
+//!   `empty_holdback_watermark` now SPARES by lowering the anchor to that word's
+//!   own start
+//!   (`a_strand_starting_strictly_later_lowers_the_watermark_instead_of_deferring`),
+//!   which is what keeps the loss to the impossibility rather than to the
+//!   policy.
+//!
 //!   The FORCED empty holdback — the arm that first repair deliberately left
 //!   alone — strands the same way and needs the same guard (codex round 3 on
 //!   PR #95, second finding). Where the budget floor itself reaches
@@ -120,7 +143,8 @@
 //!   there would wait forever.
 //!   `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` is the
 //!   falsifier, and it needs both of its `finalize` points — the retraction is
-//!   only visible across two.
+//!   only visible across two. It is the wait's FIRST round that this buys; the
+//!   bound above is what ends it.
 //!
 //!   The first shape of this rule widened unconditionally and left the empty
 //!   holdback anchored at `end`, which put the ORIGINAL duplicate-confirmation
@@ -215,16 +239,19 @@
 //!   between two consecutive hypotheses and is append-only.
 //!
 //!   That split runs all the way to `common.len()` when it has to, so **an
-//!   advance can leave the holdback EMPTY** and the watermark anchored on the
-//!   last confirmed word's own far edge instead of the first held one's start.
-//!   A single word whose OWN tokens exceed the budget is now the only thing that
-//!   can do that, and only on a round where nothing the newer hypothesis
-//!   produced beyond `common` starts before the watermark it would set — Rule
-//!   W's own widening backs off, and DEFERS both where the back-off has nowhere
-//!   legal to land and where the forced advance would strand such a word, rather
-//!   than emptying (see `split_at_a_strict_boundary`) — and the
-//!   anchor is `empty_holdback_watermark`'s `end.max(start.next_up())`, so a
-//!   zero-duration word there is still strictly behind the watermark. It has to:
+//!   advance can leave the holdback EMPTY** and the watermark anchored past the
+//!   last confirmed word's own start instead of at the first held one's. Two
+//!   things reach it: a single word whose OWN tokens exceed the budget, on a
+//!   round where nothing the newer hypothesis produced beyond `common` would be
+//!   stranded by the watermark it would set; and a round that ESCAPES a
+//!   repeating deferral, which is the bound on that wait (see
+//!   `split_at_a_strict_boundary`). Rule W's own widening backs off rather than
+//!   emptying, and DEFERS — once — both where the back-off has nowhere legal to
+//!   land and where the forced advance would strand such a word. The anchor is
+//!   `empty_holdback_watermark`'s lowest sparing instant, never below
+//!   `start.next_up()`, so a zero-duration word there is still strictly behind
+//!   the watermark and a word the hypothesis already produced past `common` is
+//!   spared wherever any instant could spare it. It has to:
 //!   stopping while one word remained left a single word whose OWN tokens exceed
 //!   the budget held anyway, and the cap silently did not cap (codex round 7,
 //!   finding 2). What followed was data loss rather than a stall — the next
@@ -255,7 +282,7 @@
 //!   `commonPrefix.count` leading words both hypotheses actually produced.
 //!   `LocalAgreement::finalize` instead emits the final hypothesis's own
 //!   post-watermark words on that path (`holdback_superseded` is the flag), and
-//!   on the DEFERRED one too (`split_deferred`), where the hypotheses agreed but
+//!   on the DEFERRED one too (`deferred_common_len`), where the hypotheses agreed but
 //!   the only split available was one Rule W refuses — nothing legal at or above
 //!   the prefill budget floor, or a forced empty holdback that would strand the
 //!   hypothesis's own suffix — so the holdback is an earlier agreement's and
@@ -401,6 +428,20 @@
 //!    at count 1 — its dropped `" B"` arrives one hypothesis later, which is why
 //!    it is still dropped — and `the_split_never_cuts_at_a_tied_start` sweeps
 //!    both counts.
+//!
+//!    And it is WIDER again since round 4, by exactly one round and only where
+//!    the deferral has already been measured and found to buy nothing: an
+//!    ESCAPE drops a word that WAS already visible past `common`, if it starts
+//!    at the settled instant. That is the same impossibility from the same side
+//!    — the alternative is the stall the bound exists to leave, and the
+//!    alternative to THAT is re-admitting the settled word, which is #94 — so
+//!    the residual's statement is unchanged and only its route is one wider.
+//!    Everything at any OTHER instant is spared rather than dropped, by
+//!    `empty_holdback_watermark`'s fold. The escape's own falsifiers are
+//!    `an_alternating_suffix_escapes_the_deferral_instead_of_stalling` and
+//!    `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`,
+//!    and the sweep counts the strands so the residual cannot be reported as
+//!    unreachable.
 //! 2. **A repeat the engine's record cannot account for** is the stream's own,
 //!    on the untied input — and on a TIED one Rule W deletes it instead. Both
 //!    directions are pinned:
@@ -469,9 +510,17 @@ pub enum AgreementOutcome {
   /// every split Rule W would accept is one the prefill budget refuses, or the
   /// one the budget forces would strand the hypothesis's own suffix (see
   /// `split_at_a_strict_boundary`), in which case the result was kept like any
-  /// other agreeing one. The deferral is deliberately not its own variant: what
-  /// this value reports is whether the watermark moved, and no in-crate caller
-  /// branches on the reason.
+  /// other agreeing one.
+  ///
+  /// The deferral is deliberately not its own variant, and codex round 4 on
+  /// PR #95 is why that survives its strongest objection. The objection was
+  /// that a caller cannot escape a state it cannot see, which is true and was
+  /// the finding: the deferral used to repeat without bound. It is bounded now
+  /// -- one round, measured (`split_at_a_strict_boundary`'s arm 3) -- so there
+  /// is no state left for a caller to be told about that the engine does not
+  /// leave by itself, and a `Blocked` variant would report a wait that has
+  /// already ended. What this value reports stays what it always reported:
+  /// whether the watermark moved.
   AwaitingAgreement,
   /// The result carried no word timings to agree over; it was still kept
   /// (Swift `:403-409` falls through to the unconditional append).
@@ -558,22 +607,33 @@ pub struct LocalAgreement {
   /// four untouched, so this keeps describing the last hypothesis that actually
   /// had words to agree over — exactly the pair `finalize` reasons about.
   holdback_superseded: bool,
-  /// Whether the most recent WORDED hypothesis AGREED with the previous one and
-  /// the round still did not advance, because `split_at_a_strict_boundary` had
-  /// no acceptable boundary to advance to: none legal at or above the prefill
-  /// budget floor, or a forced empty holdback whose watermark would have
-  /// stranded a word this hypothesis produced beyond `common` (#94, codex
-  /// round 3 on PR #95, both findings). `Self::finalize` needs
-  /// it for the same reason it needs [`Self::holdback_superseded`]: on such a
-  /// round the holdback belongs to an EARLIER agreement while
-  /// [`Self::hypothesis_words`] already re-covers that whole span and more, so
-  /// Swift's `lastAgreedWords + differentSuffix` decomposition would drop
-  /// everything between them.
+  /// `Some(common.len())` when the most recent WORDED hypothesis AGREED with
+  /// the previous one and the round still did not advance, because
+  /// `split_at_a_strict_boundary` had no acceptable boundary to advance to:
+  /// none legal at or above the prefill budget floor, or a forced empty
+  /// holdback whose watermark would have stranded a word this hypothesis
+  /// produced beyond `common` (#94, codex round 3 on PR #95, both findings).
+  /// `None` on every other worded round.
+  ///
+  /// `Self::finalize` needs the BOOLEAN for the same reason it needs
+  /// [`Self::holdback_superseded`]: on such a round the holdback belongs to an
+  /// EARLIER agreement while [`Self::hypothesis_words`] already re-covers that
+  /// whole span and more, so Swift's `lastAgreedWords + differentSuffix`
+  /// decomposition would drop everything between them.
+  ///
+  /// `Self::ingest` needs the LENGTH, and that is the whole of the deferral's
+  /// liveness bound (#94, codex round 4 on PR #95). A deferral is a WAIT for
+  /// tail growth: `common` grows, and a boundary the split can legally take
+  /// appears above the budget floor. Deferring again over a `common` no LONGER
+  /// than the one that already deferred is therefore a wait that has already
+  /// been measured and found to buy nothing, which is a repeating state rather
+  /// than a wait — see `split_at_a_strict_boundary`'s escape.
   ///
   /// Maintained on exactly the same schedule as `Self::holdback_superseded` —
   /// only on the worded path, so the [`AgreementOutcome::NoWordTimings`] early
-  /// return leaves it describing the last hypothesis that had words.
-  split_deferred: bool,
+  /// return leaves it describing the last hypothesis that had words, and a
+  /// wordless stride between two deferrals neither relieves nor repeats one.
+  deferred_common_len: Option<usize>,
   confirmed_words: Vec<WordTiming>,
   results: Vec<TranscriptionResult>,
   /// A sink for the reproducibility facts of EVERY ingested hypothesis —
@@ -603,7 +663,7 @@ impl LocalAgreement {
       hypothesis_words: Vec::new(),
       last_agreed_words: Vec::new(),
       holdback_superseded: false,
-      split_deferred: false,
+      deferred_common_len: None,
       confirmed_words: Vec::new(),
       results: Vec::new(),
       ingested_facts: TaskFactsAccumulator::new(),
@@ -878,7 +938,7 @@ impl LocalAgreement {
 
     let mut advanced = false;
     let mut skip_append = false;
-    let mut deferred = false;
+    let mut deferred: Option<usize> = None;
     // :374 — absent on the first-ever call, so nothing below runs and
     // this falls through to the `AwaitingAgreement` append below.
     if let Some(previous) = &self.prev_result {
@@ -914,16 +974,32 @@ impl LocalAgreement {
         //
         // So the round simply does not advance. It costs nothing that round --
         // `finalize` emits `confirmed ++ hypothesis_words` either way, see
-        // `Self::finalize` -- and it is not the blocking policy this issue's
-        // ledger refuted for deadlock: TAIL growth relieves it, the same relief
-        // `split_at_a_strict_boundary`'s back-off already relies on, since one
-        // word starting strictly later opens a boundary above the floor and one
-        // word joining `common` gives an interior split something to hold.
+        // `Self::finalize` -- and it is a WAIT for tail growth rather than the
+        // blocking policy this issue's ledger refuted for deadlock: one word
+        // starting strictly later opens a boundary above the floor and one word
+        // joining `common` gives an interior split something to hold.
+        //
+        // THE WAIT IS BOUNDED (#94, codex round 4 on PR #95). A wait that is
+        // not waiting for anything is a stall, and `common` growing is the
+        // whole of what it waits for -- so a deferral over a `common` no longer
+        // than the one that ALREADY deferred is the same round again, and
+        // repeating it is unbounded. Two shapes reach it and neither needs an
+        // exotic count: hypotheses that ALTERNATE past the agreed prefix keep
+        // `common` pinned at the words they still share, and a hypothesis that
+        // simply REPEATS with a tied run above the budget floor pins it with no
+        // disagreement at all. `deferral_gained_nothing` is that measurement,
+        // read off the round before rather than predicted, and
+        // `split_at_a_strict_boundary` takes the empty holdback instead of
+        // deferring again.
+        let deferral_gained_nothing = self
+          .deferred_common_len
+          .is_some_and(|already_deferred| common.len() <= already_deferred);
         let boundary = split_at_a_strict_boundary(
           common,
           &self.hypothesis_words[common.len()..],
           requested,
           self.confirmed_words.last().map(WordTiming::start),
+          deferral_gained_nothing,
         );
         if let Some(split) = boundary {
           // `common` REPLACES the still-open record: it is the span two consecutive
@@ -937,28 +1013,30 @@ impl LocalAgreement {
           //
           // With NOTHING held back -- which takes a single word whose OWN
           // tokens exceed the prefill budget, the one thing that pushes the
-          // budget floor to `common.len()`, on a round where nothing beyond
-          // `common` would be stranded by the result; an over-budget tied RUN
-          // and a live strand both defer instead (see
-          // `split_at_a_strict_boundary`) -- there is no held word to measure
-          // against, and `empty_holdback_watermark` is the answer. That is the
-          // SAME function the deferral decision above consults, deliberately:
-          // the guard and the value it guards may not drift apart.
+          // budget floor to `common.len()`, or a round that escaped a repeating
+          // deferral -- there is no held word to measure against, and
+          // `empty_holdback_watermark` is the answer. That is the SAME function,
+          // called with the SAME arguments, that the deferral decision above
+          // consults, deliberately: the guard and the value it guards may not
+          // drift apart, and the value is now the LOWEST instant that clears the
+          // last confirmed word's start rather than a fixed one.
           //
           // Monotone: every word of `common` starts at or past the old watermark,
-          // `end >= start` for any word the pipeline emits, and `next_up` only
-          // increases. A NaN start cannot break the postcondition either -- `max`
-          // returns the non-NaN side, and `start >= watermark` is false for a NaN
-          // start, so such a word is never offered back in the first place.
+          // `end >= start` for any word the pipeline emits, `next_up` only
+          // increases, and the sparing minimum is taken only over words that
+          // themselves cleared the old watermark. A NaN start cannot break the
+          // postcondition either -- `max` returns the non-NaN side, and
+          // `start >= watermark` is false for a NaN start, so such a word is
+          // never offered back in the first place.
           //
           // `common` is non-empty here (its length is at least
           // `agreement_count_needed`, clamped to at least one), so the final
           // fallback is unreachable and only keeps this total.
           self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
             || {
-              common
-                .last()
-                .map_or(self.last_agreed_seconds, empty_holdback_watermark)
+              common.last().map_or(self.last_agreed_seconds, |last| {
+                empty_holdback_watermark(last, &self.hypothesis_words[common.len()..])
+              })
             },
             WordTiming::start,
           );
@@ -966,8 +1044,9 @@ impl LocalAgreement {
         } else {
           // The hypotheses AGREED, so `result` is KEPT below (`:402`/`:408-410`,
           // no `skipAppend`) and the next round compares against it -- that is
-          // what lets tail growth reach `common` and relieve this.
-          deferred = true;
+          // what lets tail growth reach `common` and relieve this. `common.len()`
+          // rides along as the measurement the NEXT deferral is judged against.
+          deferred = Some(common.len());
         }
       } else {
         // :395-400 — disagreement; `result` is dropped below.
@@ -983,8 +1062,10 @@ impl LocalAgreement {
     // nothing can have been superseded.
     self.holdback_superseded = skip_append;
     // Assigned on EVERY worded ingest for the same reason, so an advance or a
-    // disagreement clears a deferral the round before it.
-    self.split_deferred = deferred;
+    // disagreement clears a deferral the round before it -- which is also what
+    // keeps `deferral_gained_nothing` above a claim about the IMMEDIATELY
+    // preceding worded round rather than about some older one.
+    self.deferred_common_len = deferred;
 
     // :402 (unconditional) + :408-410 (`!skipAppend`).
     if skip_append {
@@ -1032,7 +1113,9 @@ impl LocalAgreement {
   /// the ingest strip carries only the wholly-unknown span, so the fold cannot
   /// supply the exact count, round 12); see `Self::ingest`.
   pub(crate) fn finalize(mut self, options: &DecodingOptions) -> TranscriptionResult {
-    if (self.holdback_superseded || self.split_deferred) && !self.hypothesis_words.is_empty() {
+    if (self.holdback_superseded || self.deferred_common_len.is_some())
+      && !self.hypothesis_words.is_empty()
+    {
       // DIVERGENCE from `:418-419` — see this module's doc for the full
       // argument. Swift's `lastAgreedWords + differentSuffix(prevWords,
       // hypothesisWords)` is only a valid decomposition when the final round
@@ -1047,7 +1130,7 @@ impl LocalAgreement {
       // SUFFIX would instead drop the leading words both hypotheses produced,
       // which is the same defect's other face when the holdback is empty.
       //
-      // DEFERRED (`split_deferred`, codex round 3 on PR #95): the two hypotheses
+      // DEFERRED (`deferred_common_len`, codex round 3 on PR #95): the two hypotheses
       // AGREED but no legal split existed at or above the prefill budget floor,
       // so `last_agreed_words` is an EARLIER agreement's holdback and Swift's sum
       // would drop everything between it and `common`'s end. `hypothesis_words`
@@ -1160,8 +1243,19 @@ impl LocalAgreement {
 ///    over the HEAD of the offered list, which only an advance can move, whereas
 ///    this defers a split position that TAIL growth relieves, and it advances
 ///    the holdback rather than refusing the round.
-/// 3. **`None` -- DEFER**, on either of two states. The first is where the
-///    budget floor is `1` or more and no legal
+/// 3. **`Some(common.len())` -- the ESCAPE**, where neither search found a legal
+///    boundary and `deferral_gained_nothing`. See arm 4 for the wait this
+///    bounds; the holdback goes empty and the watermark is
+///    `empty_holdback_watermark`'s lowest sparing instant, exactly as in arm 5.
+/// 4. **`None` -- DEFER**, on either of two states, and each is a WAIT rather
+///    than a refusal: it costs nothing on the deferring round itself --
+///    `finalize` emits `confirmed ++ hypothesis_words` either way (see
+///    `LocalAgreement::finalize`) -- and the divergence is entirely in what
+///    LATER ingests can still see. **The wait is BOUNDED** by
+///    `deferral_gained_nothing`, and that bound is the whole of arm 3; the two
+///    states below are what the FIRST wait is worth taking for.
+///
+///    The first is where the budget floor is `1` or more and no legal
 ///    boundary sits at or above it. A tied run whose OWN tokens exceed
 ///    `MAX_HOLDBACK_PREFILL_TOKENS` is the shape: the floor lands strictly
 ///    inside the run, every boundary the search and the back-off can reach ties,
@@ -1176,44 +1270,61 @@ impl LocalAgreement {
 ///    ingest filters them from both hypotheses at once and `LocalAgreement::
 ///    finalize` cannot recover them (codex round 3 on PR #95).
 ///
-///    So the round does not advance at all, and `LocalAgreement::ingest` records
-///    it for `LocalAgreement::finalize`. It is the same policy as the back-off
+///    So the round waits instead, and `LocalAgreement::ingest` records it for
+///    `LocalAgreement::finalize`. It is the same policy as the back-off
 ///    above -- Rule W may not empty the holdback -- carried into the state where
-///    the back-off has nowhere legal to land, and it is relieved the same way,
-///    by TAIL growth: one word starting strictly later opens a boundary at or
-///    above the floor, because a single word's tokens raise the floor by at most
-///    that word's own cost. It costs nothing on the deferring round itself --
-///    `finalize` emits `confirmed ++ hypothesis_words` either way (see
-///    `LocalAgreement::finalize`) -- and the divergence is entirely in what
-///    LATER ingests can still see.
+///    the back-off has nowhere legal to land, and TAIL growth relieves it: one
+///    word starting strictly later opens a boundary at or above the floor,
+///    because a single word's tokens raise the floor by at most that word's own
+///    cost.
 ///
-///    The second state is arm 4's, refused: the budget FORCES the empty
+///    The second state is arm 5's, refused: the budget FORCES the empty
 ///    holdback, and the watermark that advance would set --
-///    `empty_holdback_watermark(common.last())` -- lies strictly past a word of
-///    `beyond_common`. That word is stranded exactly as above, and what it costs
-///    is one step worse: this round's own `finalize` PUBLISHES it, through
-///    `find_longest_different_suffix`, so losing it on the next ingest RETRACTS
-///    transcript rather than merely never emitting it. `confirmed_words`'
-///    append-only guarantee never sees it -- the word was never confirmed. The
-///    same relief applies: tail growth either moves the strand into `common`,
-///    where an ordinary interior split can hold it, or opens a boundary above
-///    the floor.
-/// 4. **`Some(common.len())`** -- tested FIRST in the code, since its condition
+///    `empty_holdback_watermark(common.last(), beyond_common)` -- still lies
+///    past a word of `beyond_common`, which after that function's sparing fold
+///    takes a word TIED to the last confirmed start. That word is stranded
+///    exactly as above, and what it costs is one step worse: this round's own
+///    `finalize` PUBLISHES it, through `find_longest_different_suffix`, so
+///    losing it on the next ingest RETRACTS transcript rather than merely never
+///    emitting it. `confirmed_words`' append-only guarantee never sees it -- the
+///    word was never confirmed. The same relief applies: tail growth either
+///    moves the strand into `common`, where an ordinary interior split can hold
+///    it, or opens a boundary above the floor.
+///
+///    **What relief actually requires, and why the wait needed a bound** (#94,
+///    codex round 4 on PR #95). Both reliefs are `common` GROWING, and nothing
+///    makes it grow. Two hypotheses that ALTERNATE past the agreed prefix pin
+///    `common` at the words they still share, round after round, and a
+///    hypothesis that simply REPEATS pins it with no disagreement at all -- so
+///    `None` came back every round, the watermark never moved, the caller read
+///    `AwaitingAgreement` forever, and in the driver the clip kept re-decoding
+///    from a boundary that never advanced while the buffer grew past it. The
+///    earlier liveness argument -- "one word starting strictly later opens a
+///    boundary" -- is about a suffix that STABILIZES and reaches neither state.
+///    `deferral_gained_nothing` is the bound: a deferral over a `common` no
+///    longer than the one the round before already deferred over is that round
+///    again, measured rather than predicted, so arm 3 takes the empty holdback
+///    instead. It costs at most one round, and BOTH states are bounded by it --
+///    exempting either from its own bound is not a bound
+///    (`an_alternating_suffix_escapes_the_deferral_instead_of_stalling`,
+///    `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`).
+/// 5. **`Some(common.len())`** -- tested FIRST in the code, since its condition
 ///    is a property of the budget alone and neither search runs on it. Only
 ///    where the BUDGET FLOOR itself reaches `common.len()` is that length
-///    returned and the holdback left empty. That takes a LAST word whose own
-///    tokens exceed the budget, since nothing else runs `budgeted_split`'s loop
-///    off the end, and it is the one state where the empty holdback is FORCED:
-///    no split leaves a holdback the prefill could carry, so there is no anchor
-///    to wait for and deferring would wait forever. Confirming is round 7
-///    finding 2's own repair, and `LocalAgreement::ingest`'s watermark then
-///    anchors strictly past the last confirmed start rather than at its `end`.
-///    This arm is the WHOLE of what reaches the empty holdback.
+///    returned on the FIRST round and the holdback left empty. That takes a LAST
+///    word whose own tokens exceed the budget, since nothing else runs
+///    `budgeted_split`'s loop off the end, and it is the one state where the
+///    empty holdback is FORCED: no split leaves a holdback the prefill could
+///    carry, so there is no anchor to wait for and deferring would wait forever.
+///    Confirming is round 7 finding 2's own repair, and
+///    `LocalAgreement::ingest`'s watermark then anchors strictly past the last
+///    confirmed start rather than at its `end`. This arm and arm 3 are the whole
+///    of what reaches the empty holdback.
 ///
 ///    "There is no anchor to wait for" is a claim about `common` alone, and it
 ///    is why this arm may not simply defer -- but the ADVANCE is not a property
 ///    of `common` alone, which is what `beyond_common` is here to supply. Where
-///    a word past `common` would be stranded by this arm's own watermark, arm 3
+///    a word past `common` would be stranded by this arm's own watermark, arm 4
 ///    takes the round instead; where nothing is, this arm advances exactly as
 ///    before. The guard is that narrow on purpose: widening it to "defer
 ///    whenever the budget forces the empty holdback" re-opens round 7 finding
@@ -1246,8 +1357,14 @@ impl LocalAgreement {
 /// again: a deferred round is not an advance, so it moves neither side of the
 /// inequality and there is no state for the claim to be excluded from. `None`
 /// REMOVES reachable advances rather than adding unguarded ones, and the second
-/// state removes a strict subset of arm 4's, which the `next_up` anchor already
+/// state removes a strict subset of arm 5's, which the `next_up` anchor already
 /// carried.
+///
+/// It stays total under the ESCAPE too, which ADDS advances rather than removing
+/// them: every escape splits at `common.len()`, and there
+/// `LocalAgreement::ingest` anchors at `empty_holdback_watermark`, whose result
+/// is strictly greater than `common.last().start()` for every input -- the
+/// sparing fold skips exactly the starts that are not (see that function).
 ///
 /// # A second postcondition
 ///
@@ -1258,9 +1375,22 @@ impl LocalAgreement {
 /// free -- the watermark is `common[split].start()` and word starts inside one
 /// hypothesis are non-decreasing, so everything from `split` on is at or past
 /// it. Where the split is `common.len()` the watermark is strictly PAST the last
-/// confirmed start, so it is not free, and the `beyond_common` test in arm 4 is
-/// what buys it. `the_split_never_cuts_at_a_tied_start` sweeps it beside the
-/// first postcondition.
+/// confirmed start, so it is not free, and two things buy it: the sparing fold
+/// in `empty_holdback_watermark`, which lowers the anchor to the earliest word
+/// of `beyond_common` it can, and the `beyond_common` test in arm 5, which waits
+/// where it cannot lower it far enough.
+///
+/// **It has ONE exception, and only since the deferral was bounded** (#94, codex
+/// round 4 on PR #95): a round that takes arm 3's ESCAPE may strand a word of
+/// `beyond_common` that starts at the last confirmed word's own instant. There
+/// no value serves both claims -- the first postcondition demands a watermark
+/// strictly past that start, and every such watermark filters the strand -- so
+/// this is the module's residual 1 reached one round earlier than the residual's
+/// own route, not a policy. It is exactly that narrow: at any other start the
+/// sparing fold spares the word, and only an escape may use it.
+/// `the_split_never_cuts_at_a_tied_start` sweeps both postconditions and the
+/// exception, and counts the escapes and the strands so neither can pass by
+/// being unreachable.
 ///
 /// It is a claim about the LAST confirmed word, and that is as strong as it needs
 /// to be exactly while word starts inside one hypothesis are non-decreasing --
@@ -1271,6 +1401,7 @@ fn split_at_a_strict_boundary(
   beyond_common: &[WordTiming],
   requested: usize,
   confirmed_last_start: Option<f32>,
+  deferral_gained_nothing: bool,
 ) -> Option<usize> {
   let strictly_after_the_preceding_start = |at: usize| {
     let preceding = if at == 0 {
@@ -1279,6 +1410,22 @@ fn split_at_a_strict_boundary(
       Some(common[at - 1].start())
     };
     preceding.is_none_or(|preceding| preceding < common[at].start())
+  };
+  // The EMPTY holdback strands a word exactly when `empty_holdback_watermark`
+  // cannot be lowered far enough to spare it, which takes a word of
+  // `beyond_common` starting at or before the last confirmed word's own start
+  // -- an exact tie, since starts inside one hypothesis do not run backwards.
+  // Everything else is spared by the watermark itself, which folds over exactly
+  // those starts.
+  //
+  // `start < watermark` is `watermark_filtered`'s own `start >= watermark`
+  // negated, and totally so: every word of `beyond_common` reached this call
+  // through that filter, so none of their starts is NaN.
+  let empty_holdback_strands = || {
+    common.last().is_some_and(|last| {
+      let watermark = empty_holdback_watermark(last, beyond_common);
+      beyond_common.iter().any(|word| word.start() < watermark)
+    })
   };
   // `budgeted_split` with nothing requested IS the budget's own floor: the
   // earliest split whose holdback fits `MAX_HOLDBACK_PREFILL_TOKENS`.
@@ -1291,25 +1438,23 @@ fn split_at_a_strict_boundary(
     // is round 7 finding 2's own repair; deferring where nothing would be
     // stranded would wait for an anchor that can never arrive.
     //
-    // But the advance would anchor the watermark at
-    // `empty_holdback_watermark(common.last())`, and every word the newer
-    // hypothesis produced BEFORE that instant beyond `common` is stranded by it
-    // (codex round 3 on PR #95, second finding): the next worded ingest filters
-    // it out of both hypotheses at once, and it is a word THIS round's
-    // `LocalAgreement::finalize` already published through
-    // `find_longest_different_suffix`. So the forced advance is available
-    // exactly while it strands nothing, and the strand is what
-    // `beyond_common` is here to see -- without it this arm decides on `common`
-    // alone and cannot know what lies past it.
+    // But the advance anchors the watermark at
+    // `empty_holdback_watermark(common.last(), beyond_common)`, and a word the
+    // newer hypothesis produced beyond `common` at the last confirmed word's own
+    // instant is stranded by it (codex round 3 on PR #95, second finding): the
+    // next worded ingest filters it out of both hypotheses at once, and it is a
+    // word THIS round's `LocalAgreement::finalize` already published through
+    // `find_longest_different_suffix`. So the forced advance defers while it
+    // would strand -- and the strand is what `beyond_common` is here to see,
+    // since on `common` alone this arm cannot know what lies past it.
     //
-    // `start < watermark` is `watermark_filtered`'s own `start >= watermark`
-    // negated, and totally so: every word of `beyond_common` reached this call
-    // through that filter, so none of their starts is NaN.
-    let strands_a_suffix = common.last().is_some_and(|last| {
-      let watermark = empty_holdback_watermark(last);
-      beyond_common.iter().any(|word| word.start() < watermark)
-    });
-    if strands_a_suffix {
+    // Unless deferring has already been measured and bought nothing, in which
+    // case the wait is a stall and the round takes the advance anyway (codex
+    // round 4 on PR #95). What that costs is exactly this module's residual 1,
+    // one round earlier than the residual's own route: at an exact tie a word
+    // beyond `common` and a re-offer of the settled word in front of it are the
+    // same value to a timestamp filter, so no watermark serves both.
+    if empty_holdback_strands() && !deferral_gained_nothing {
       return None;
     }
     return Some(common.len());
@@ -1322,6 +1467,26 @@ fn split_at_a_strict_boundary(
         .rev()
         .find(|&at| strictly_after_the_preceding_start(at))
     })
+    // No INTERIOR boundary is legal, so this arm's deferral protects the
+    // holdback rather than a strand: the tied run stays revisable and the next
+    // stride keeps its prefill anchor (see
+    // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`).
+    // That is worth exactly one wait. A `common` that did not grow since the
+    // deferral before it is not going to be relieved by waiting again -- a
+    // hypothesis REPEATING a tied run above the floor pins it with no
+    // disagreement anywhere, which is the shape an all-zero alignment matrix
+    // produces -- so the empty holdback is taken instead, still at the lowest
+    // watermark that clears the last confirmed start.
+    //
+    // `empty_holdback_strands()` is deliberately NOT consulted here, exactly as
+    // the forced arm stops consulting it once the wait has repeated: a bound
+    // that exempts the state it is there to escape is not a bound, and a tied
+    // run whose SUFFIX alternates at the run's own instant reaches this arm in
+    // precisely that state
+    // (`a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`'s
+    // second half). Both arms therefore strand the same thing on a repeating
+    // wait -- a word at the settled instant, residual 1 -- and nothing else.
+    .or_else(|| deferral_gained_nothing.then_some(common.len()))
 }
 
 /// Where an advance splits `common` into the part that is CONFIRMED and the
@@ -1397,8 +1562,9 @@ fn split_at_a_strict_boundary(
 /// line it may not cross: below it `prefill_tokens` silently truncates and the
 /// erased words are neither re-offered nor confirmed, which is the whole of
 /// round 7's finding 2. Where nothing legal sits at or above the floor, that
-/// rule DEFERS the round rather than crossing the floor or widening off the end
-/// — both of which delete a word — and the floor stays hard.
+/// rule DEFERS the round rather than crossing the floor — the one thing it never
+/// does, the floor being hard — and widens off the end only once that wait has
+/// been measured and found to buy nothing (its arm 3).
 ///
 /// **Documented deviation**: with `agreement_count_needed` at its
 /// [`DEFAULT_AGREEMENT_COUNT_NEEDED`] a two-word holdback of words
@@ -1434,17 +1600,46 @@ fn budgeted_split(common: &[WordTiming], requested: usize) -> usize {
   split
 }
 
-/// The watermark an advance that holds NOTHING back anchors at: the first
-/// instant strictly past `last`'s start, where `last` is the word that advance
-/// confirms last.
+/// The watermark an advance that holds NOTHING back anchors at: the LOWEST
+/// instant strictly past `last`'s start that spares as much of `beyond_common`
+/// as any such instant can, where `last` is the word that advance confirms last
+/// and `beyond_common` is what the same hypothesis produced past the agreed
+/// prefix.
 ///
-/// `end` is the answer whenever that word has any duration at all; where it does
-/// NOT, `end == start` and the word would satisfy
+/// Strictly past `last`'s start is the hard part and the whole of #94: `end` is
+/// the answer whenever that word has any duration at all; where it does NOT,
+/// `end == start` and the word would satisfy
 /// `LocalAgreement::watermark_filtered`'s own `start >= watermark` against its
-/// own confirmation, which is the whole of #94. `next_up` is the IMMEDIATE `f32`
-/// successor, so nothing representable lies between the result and the start it
-/// excludes: exactly one instant is refused rather than a span, which an
-/// `end + epsilon` tolerance would not have managed.
+/// own confirmation. `next_up` is the IMMEDIATE `f32` successor, so nothing
+/// representable lies between the result and the start it excludes: exactly one
+/// instant is refused rather than a span, which an `end + epsilon` tolerance
+/// would not have managed.
+///
+/// SPARING is the rest (#94, codex round 4 on PR #95). Nothing requires the
+/// watermark to clear `last`'s far EDGE -- only its start -- and word ends
+/// inside a hypothesis are not monotone, so `end` can reach past a word the
+/// hypothesis has already produced beyond `common`. Anchoring there would filter
+/// that word out of the next round's hypotheses for nothing, so the anchor drops
+/// to the earliest such start instead.
+///
+/// The fold skips the starts that do NOT clear `last`'s own, and skipping rather
+/// than abandoning the sparing is deliberate: a word tied to `last` cannot be
+/// spared by ANY watermark this may return, but the words BEHIND that tie can,
+/// and an anchor that gave up on all of them because one was unsparable stranded
+/// them as collateral (measured on the sweep: a strand at 2.5 s lost to a tie at
+/// 2.0 s). So the result is the LOWEST instant that both clears `last`'s start
+/// and spares every word that any such instant could spare, and what it can
+/// still strand is exactly the tie -- this module's residual 1, which is the
+/// impossibility rather than a policy. `split_at_a_strict_boundary` is what
+/// decides whether to advance into that at all.
+///
+/// Total, never NaN, and always strictly greater than `last.start()`:
+/// `past_the_confirmed_start` is, and every start the filter keeps is; `last`
+/// and every word of `beyond_common` reached this through
+/// `LocalAgreement::watermark_filtered`, whose `start >= watermark` is false for
+/// a NaN start, so no start here is NaN; `f32::max` and `f32::min` both return
+/// the non-NaN side, so a NaN `end` falls through to `start.next_up()` rather
+/// than poisoning the fold.
 ///
 /// It is a named function rather than an expression at its one obvious site
 /// because it has TWO callers with opposite jobs and they may not disagree.
@@ -1452,8 +1647,13 @@ fn budgeted_split(common: &[WordTiming], requested: usize) -> usize {
 /// decides whether setting it would strand a word the newer hypothesis produced
 /// beyond `common`, which is a question about this exact value. Computing it
 /// twice would let the guard drift off the thing it guards, silently.
-fn empty_holdback_watermark(last: &WordTiming) -> f32 {
-  last.end().max(last.start().next_up())
+fn empty_holdback_watermark(last: &WordTiming, beyond_common: &[WordTiming]) -> f32 {
+  let past_the_confirmed_start = last.end().max(last.start().next_up());
+  beyond_common
+    .iter()
+    .map(WordTiming::start)
+    .filter(|start| *start > last.start())
+    .fold(past_the_confirmed_start, f32::min)
 }
 
 // ---------------------------------------------------------------------

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -75,13 +75,32 @@
 //!   strictly earlier — searching forward from the requested split first, then
 //!   BACKING OFF when the forward search would run off the end of `common`,
 //!   because widening past a tied run that reaches that end would empty the
-//!   holdback and anchor the watermark on the run's own last word. And where the
-//!   holdback is empty anyway — the prefill budget is the only thing that can
-//!   still do that — `LocalAgreement::ingest` anchors the watermark at
+//!   holdback and anchor the watermark on the run's own last word, and finally
+//!   DEFERRING the round outright where the prefill budget floor sits at or
+//!   above every legal boundary, which is where the back-off has nowhere legal
+//!   to land. And where the holdback is empty anyway — a single word the prefill
+//!   cannot carry WHOLE is the only thing that can still do that —
+//!   `LocalAgreement::ingest` anchors the watermark at
 //!   `end.max(start.next_up())` rather than at `end`, since `end == start` for a
 //!   zero-duration word. `next_up` is the IMMEDIATE f32 successor: it refuses
 //!   exactly the one instant the confirmed word occupies and no span of
 //!   instants, which an `end + epsilon` tolerance would not have managed.
+//!
+//!   The DEFERRAL closes a DELETION rather than a re-confirmation (codex round 3
+//!   on PR #95). A tied run whose own tokens exceed
+//!   [`MAX_HOLDBACK_PREFILL_TOKENS`] — 113 ORDINARY one-token words sharing a
+//!   start, which `add_word_timestamps` produces from an ALL-ZERO alignment
+//!   matrix, measured at 130 such words — puts the budget floor strictly inside
+//!   the run, so every boundary the forward search and the back-off can reach
+//!   ties while split `0` is below the floor. Widening off the end there
+//!   confirmed the whole run, emptied the holdback and anchored the watermark
+//!   strictly PAST the run's instant: every word the newest hypothesis produced
+//!   at that same instant beyond `common` — words nothing had confirmed — was
+//!   then filtered out of both hypotheses on the next worded ingest and lost.
+//!   `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix` is the
+//!   falsifier. Deferring costs nothing on the round itself, since
+//!   `LocalAgreement::finalize` emits the same words either way, and TAIL growth
+//!   relieves it.
 //!
 //!   The first shape of this rule widened unconditionally and left the empty
 //!   holdback anchored at `end`, which put the ORIGINAL duplicate-confirmation
@@ -178,8 +197,10 @@
 //!   That split runs all the way to `common.len()` when it has to, so **an
 //!   advance can leave the holdback EMPTY** and the watermark anchored on the
 //!   last confirmed word's own far edge instead of the first held one's start.
-//!   The BUDGET is now the only thing that can do that — Rule W's own widening
-//!   backs off rather than empties (see `split_at_a_strict_boundary`) — and the
+//!   A single word whose OWN tokens exceed the budget is now the only thing that
+//!   can do that — Rule W's own widening backs off, and DEFERS where the
+//!   back-off has nowhere legal to land, rather than emptying (see
+//!   `split_at_a_strict_boundary`) — and the
 //!   anchor is `end.max(start.next_up())`, so a zero-duration word there is
 //!   still strictly behind the watermark. It has to:
 //!   stopping while one word remained left a single word whose OWN tokens exceed
@@ -212,9 +233,12 @@
 //!   `commonPrefix.count` leading words both hypotheses actually produced.
 //!   `LocalAgreement::finalize` instead emits the final hypothesis's own
 //!   post-watermark words on that path (`holdback_superseded` is the flag), and
-//!   keeps Swift's shape everywhere else — including when the final hypothesis
-//!   contributes nothing at or past the watermark, where nothing supersedes the
-//!   holdback. How much of the holdback that path actually replaces is the
+//!   on the DEFERRED one too (`split_deferred`), where the hypotheses agreed but
+//!   no legal split existed at or above the prefill budget floor so the holdback
+//!   is an earlier agreement's and Swift's sum would drop everything between it
+//!   and `common`'s end. It keeps Swift's shape everywhere else — including when
+//!   the final hypothesis contributes nothing at or past the watermark, where
+//!   nothing supersedes the holdback. How much of the holdback that path actually replaces is the
 //!   window's question, below; what is NOT replaced is emitted ahead of the
 //!   hypothesis's words rather than sending the whole thing back to Swift's
 //!   expression, whose prefix subtraction has no holdback to justify it once the
@@ -333,7 +357,14 @@
 //!    non-default [`LocalAgreement::agreement_count_needed`]: an earlier form of
 //!    this entry listed one, and the default count reaches the same state
 //!    whenever that one word is the last of the agreed prefix (measured).
-//!    `add_word_timestamps` emitting a 112-token word is the whole of the gate.
+//!    `add_word_timestamps` emitting a 112-token word is the whole of the gate —
+//!    and only since the deferral: an AGGREGATE tied run over budget used to
+//!    reach the same empty holdback with no oversized word anywhere, and what it
+//!    cost there was the DELETION of the words at the run's own instant rather
+//!    than this residual's single dropped word. That route now defers instead
+//!    (codex round 3 on PR #95;
+//!    `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix`), which
+//!    is what restores this sentence.
 //!    `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed` drives it
 //!    at count 1, and `the_split_never_cuts_at_a_tied_start` sweeps both counts.
 //! 2. **A repeat the engine's record cannot account for** is the stream's own,
@@ -397,10 +428,15 @@ pub enum AgreementOutcome {
   /// [`LocalAgreement::agreement_count_needed`] words: the confirmation
   /// watermark advanced and the result was kept.
   Advanced,
-  /// Either there is no previous result to agree with yet (the first
-  /// ingested result), or the new hypothesis disagreed with the previous
-  /// one — the watermark is unchanged and, in the disagreement case, the
-  /// result was dropped rather than kept.
+  /// The watermark is unchanged. Three routes reach it: there is no previous
+  /// result to agree with yet (the first ingested result); the new hypothesis
+  /// disagreed with the previous one, in which case the result was dropped
+  /// rather than kept; or the two agreed and the round was DEFERRED because no
+  /// legal split exists at or above the prefill budget floor (see
+  /// `split_at_a_strict_boundary`), in which case the result was kept like any
+  /// other agreeing one. The deferral is deliberately not its own variant: what
+  /// this value reports is whether the watermark moved, and no in-crate caller
+  /// branches on the reason.
   AwaitingAgreement,
   /// The result carried no word timings to agree over; it was still kept
   /// (Swift `:403-409` falls through to the unconditional append).
@@ -487,6 +523,20 @@ pub struct LocalAgreement {
   /// four untouched, so this keeps describing the last hypothesis that actually
   /// had words to agree over — exactly the pair `finalize` reasons about.
   holdback_superseded: bool,
+  /// Whether the most recent WORDED hypothesis AGREED with the previous one and
+  /// the round still did not advance, because
+  /// `split_at_a_strict_boundary` found no legal boundary at or above the
+  /// prefill budget floor (#94, codex round 3 on PR #95). `Self::finalize` needs
+  /// it for the same reason it needs [`Self::holdback_superseded`]: on such a
+  /// round the holdback belongs to an EARLIER agreement while
+  /// [`Self::hypothesis_words`] already re-covers that whole span and more, so
+  /// Swift's `lastAgreedWords + differentSuffix` decomposition would drop
+  /// everything between them.
+  ///
+  /// Maintained on exactly the same schedule as `Self::holdback_superseded` —
+  /// only on the worded path, so the [`AgreementOutcome::NoWordTimings`] early
+  /// return leaves it describing the last hypothesis that had words.
+  split_deferred: bool,
   confirmed_words: Vec<WordTiming>,
   results: Vec<TranscriptionResult>,
   /// A sink for the reproducibility facts of EVERY ingested hypothesis —
@@ -516,6 +566,7 @@ impl LocalAgreement {
       hypothesis_words: Vec::new(),
       last_agreed_words: Vec::new(),
       holdback_superseded: false,
+      split_deferred: false,
       confirmed_words: Vec::new(),
       results: Vec::new(),
       ingested_facts: TaskFactsAccumulator::new(),
@@ -790,6 +841,7 @@ impl LocalAgreement {
 
     let mut advanced = false;
     let mut skip_append = false;
+    let mut deferred = false;
     // :374 — absent on the first-ever call, so nothing below runs and
     // this falls through to the `AwaitingAgreement` append below.
     if let Some(previous) = &self.prev_result {
@@ -803,51 +855,82 @@ impl LocalAgreement {
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
         let requested = common.len() - self.agreement_count_needed;
-        let split = split_at_a_strict_boundary(
+        // RULE W'S DEFERRAL (#94, codex round 3 on PR #95). `None` is "the two
+        // hypotheses agreed, but no legal boundary sits at or above the prefill
+        // budget floor" -- a tied run whose OWN tokens exceed the budget puts
+        // the floor strictly inside the run, so every boundary the forward
+        // search and the back-off can reach ties, and split 0, the one boundary
+        // a tied run always leaves legal, is below the floor.
+        //
+        // Widening off the end there -- what the old fallback did -- confirms
+        // the whole run, empties the holdback and anchors the watermark strictly
+        // PAST the run's instant. Every word the newest hypothesis produced at
+        // that same instant beyond `common` is then stranded: nothing confirmed
+        // it, the next worded ingest filters it out of BOTH hypotheses at once,
+        // and `finalize` has nothing left to recover it from. A deletion, which
+        // is this module's non-preferred direction.
+        //
+        // So the round simply does not advance. It costs nothing that round --
+        // `finalize` emits `confirmed ++ hypothesis_words` either way, see
+        // `Self::finalize` -- and it is not the blocking policy this issue's
+        // ledger refuted for deadlock: TAIL growth relieves it, the same relief
+        // `split_at_a_strict_boundary`'s back-off already relies on, since one
+        // word starting strictly later opens a boundary above the floor.
+        let boundary = split_at_a_strict_boundary(
           common,
           requested,
           self.confirmed_words.last().map(WordTiming::start),
         );
-        // `common` REPLACES the still-open record: it is the span two consecutive
-        // hypotheses have just re-agreed over it, and `last_agreed_words` is the
-        // one this hypothesis has superseded.
-        self.confirmed_words.extend_from_slice(&common[..split]);
-        self.last_agreed_words = common[split..].to_vec();
-        // RULE W'S WATERMARK (#94). The watermark is the first held-back word's
-        // start, which `split_at_a_strict_boundary` has already placed STRICTLY
-        // past the last confirmed word's start.
-        //
-        // With NOTHING held back -- which only the prefill budget can now cause
-        // (see `split_at_a_strict_boundary`) -- there is no held word to measure
-        // against and the still-open span begins where the confirmed one ends.
-        // `end` is the answer whenever the last confirmed word has any duration
-        // at all; where it does NOT, `end == start` and the word would satisfy
-        // `watermark_filtered`'s own `start >= watermark` against its own
-        // confirmation, which is the whole of #94. The watermark is therefore the
-        // first instant that is strictly past that start: `next_up` is the
-        // IMMEDIATE f32 successor, so nothing representable lies between it and
-        // the start it excludes, and it is a successor rather than a tolerance --
-        // no span of instants is moved, only the single instant the confirmed
-        // word already occupies is refused.
-        //
-        // Monotone: every word of `common` starts at or past the old watermark,
-        // `end >= start` for any word the pipeline emits, and `next_up` only
-        // increases. A NaN start cannot break the postcondition either -- `max`
-        // returns the non-NaN side, and `start >= watermark` is false for a NaN
-        // start, so such a word is never offered back in the first place.
-        //
-        // `common` is non-empty here (its length is at least
-        // `agreement_count_needed`, clamped to at least one), so the final
-        // fallback is unreachable and only keeps this total.
-        self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
-          || {
-            common.last().map_or(self.last_agreed_seconds, |last| {
-              last.end().max(last.start().next_up())
-            })
-          },
-          WordTiming::start,
-        );
-        advanced = true;
+        if let Some(split) = boundary {
+          // `common` REPLACES the still-open record: it is the span two consecutive
+          // hypotheses have just re-agreed over it, and `last_agreed_words` is the
+          // one this hypothesis has superseded.
+          self.confirmed_words.extend_from_slice(&common[..split]);
+          self.last_agreed_words = common[split..].to_vec();
+          // RULE W'S WATERMARK (#94). The watermark is the first held-back word's
+          // start, which `split_at_a_strict_boundary` has already placed STRICTLY
+          // past the last confirmed word's start.
+          //
+          // With NOTHING held back -- which now takes a single word whose OWN
+          // tokens exceed the prefill budget, the one thing that pushes the
+          // budget floor to `common.len()`; an over-budget tied RUN defers
+          // instead (see `split_at_a_strict_boundary`) -- there is no held word
+          // to measure against and the still-open span begins where the
+          // confirmed one ends.
+          // `end` is the answer whenever the last confirmed word has any duration
+          // at all; where it does NOT, `end == start` and the word would satisfy
+          // `watermark_filtered`'s own `start >= watermark` against its own
+          // confirmation, which is the whole of #94. The watermark is therefore the
+          // first instant that is strictly past that start: `next_up` is the
+          // IMMEDIATE f32 successor, so nothing representable lies between it and
+          // the start it excludes, and it is a successor rather than a tolerance --
+          // no span of instants is moved, only the single instant the confirmed
+          // word already occupies is refused.
+          //
+          // Monotone: every word of `common` starts at or past the old watermark,
+          // `end >= start` for any word the pipeline emits, and `next_up` only
+          // increases. A NaN start cannot break the postcondition either -- `max`
+          // returns the non-NaN side, and `start >= watermark` is false for a NaN
+          // start, so such a word is never offered back in the first place.
+          //
+          // `common` is non-empty here (its length is at least
+          // `agreement_count_needed`, clamped to at least one), so the final
+          // fallback is unreachable and only keeps this total.
+          self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
+            || {
+              common.last().map_or(self.last_agreed_seconds, |last| {
+                last.end().max(last.start().next_up())
+              })
+            },
+            WordTiming::start,
+          );
+          advanced = true;
+        } else {
+          // The hypotheses AGREED, so `result` is KEPT below (`:402`/`:408-410`,
+          // no `skipAppend`) and the next round compares against it -- that is
+          // what lets tail growth reach `common` and relieve this.
+          deferred = true;
+        }
       } else {
         // :395-400 — disagreement; `result` is dropped below.
         skip_append = true;
@@ -861,6 +944,9 @@ impl LocalAgreement {
     // run at all) also lands on `false`: nothing has been held back yet, so
     // nothing can have been superseded.
     self.holdback_superseded = skip_append;
+    // Assigned on EVERY worded ingest for the same reason, so an advance or a
+    // disagreement clears a deferral the round before it.
+    self.split_deferred = deferred;
 
     // :402 (unconditional) + :408-410 (`!skipAppend`).
     if skip_append {
@@ -883,8 +969,10 @@ impl LocalAgreement {
   /// final hypothesis added beyond the final previous result
   /// ([`crate::audio::whisper::text::find_longest_different_suffix`] over the last
   /// ingested pair), both folded onto [`Self::confirmed_words_slice`] —
-  /// **except when the final hypothesis DISAGREED**, where this port emits that
-  /// hypothesis's own post-watermark words instead of the superseded holdback
+  /// **except when the holdback is not the final estimate of its own span** —
+  /// the final hypothesis DISAGREED with it, or the final round was DEFERRED so
+  /// the holdback belongs to an earlier agreement — where this port emits that
+  /// hypothesis's own post-watermark words instead
   /// (see this module's doc, "The final hypothesis's holdback");
   /// [`merge_transcription_results_with_words`] then merges every kept
   /// [`Self::results_slice`] result with that word list as the merged
@@ -906,17 +994,32 @@ impl LocalAgreement {
   /// the ingest strip carries only the wholly-unknown span, so the fold cannot
   /// supply the exact count, round 12); see `Self::ingest`.
   pub(crate) fn finalize(mut self, options: &DecodingOptions) -> TranscriptionResult {
-    if self.holdback_superseded && !self.hypothesis_words.is_empty() {
+    if (self.holdback_superseded || self.split_deferred) && !self.hypothesis_words.is_empty() {
       // DIVERGENCE from `:418-419` — see this module's doc for the full
       // argument. Swift's `lastAgreedWords + differentSuffix(prevWords,
-      // hypothesisWords)` is only a valid decomposition when the final
-      // hypothesis AGREED. Here it did not: `last_agreed_words` belongs to the
+      // hypothesisWords)` is only a valid decomposition when the final round
+      // ADVANCED, so that `last_agreed_words` is the holdback that round itself
+      // produced. On the two paths here it is not.
+      //
+      // DISAGREED: `last_agreed_words` belongs to the
       // hypothesis this one just superseded, while `hypothesis_words` — filtered
       // to `start >= last_agreed_words[0].start()` — already re-covers that exact
       // span carrying the revision. Emitting both duplicates the span and strands
       // the superseded reading beside its own replacement; emitting only the
       // SUFFIX would instead drop the leading words both hypotheses produced,
       // which is the same defect's other face when the holdback is empty.
+      //
+      // DEFERRED (`split_deferred`, codex round 3 on PR #95): the two hypotheses
+      // AGREED but no legal split existed at or above the prefill budget floor,
+      // so `last_agreed_words` is an EARLIER agreement's holdback and Swift's sum
+      // would drop everything between it and `common`'s end. `hypothesis_words`
+      // is the latest full reading of the whole post-watermark span and subsumes
+      // both. It is also byte-identical to what the widen-off-the-end fallback
+      // this replaced produced on the same round: that fallback confirmed
+      // `common`, left the holdback empty and finalized
+      // `confirmed ++ common ++ hypothesis-beyond-common`, which is
+      // `confirmed ++ hypothesis_words` written out. The whole divergence is in
+      // what LATER ingests can still see, not in this round's transcript.
       //
       // The non-empty guard is load-bearing: a result whose every word falls
       // BEFORE the watermark still clears the `has_words` gate (`:371`) and
@@ -1019,12 +1122,42 @@ impl LocalAgreement {
 ///    over the HEAD of the offered list, which only an advance can move, whereas
 ///    this defers a split position that TAIL growth relieves, and it advances
 ///    the holdback rather than refusing the round.
-/// 3. Only where the BUDGET FLOOR itself sits at or above every legal boundary
-///    is `common.len()` returned and the holdback left empty -- the floor is
-///    never crossed, because below it `prefill_tokens` silently truncates the
-///    prefill and the erased words are neither re-offered nor confirmed (codex
-///    round 7, finding 2). `LocalAgreement::ingest`'s watermark then anchors
-///    strictly past the last confirmed start rather than at its `end`.
+/// 3. **`None` -- DEFER** where the budget floor is `1` or more and no legal
+///    boundary sits at or above it. A tied run whose OWN tokens exceed
+///    `MAX_HOLDBACK_PREFILL_TOKENS` is the shape: the floor lands strictly
+///    inside the run, every boundary the search and the back-off can reach ties,
+///    and split `0` -- the boundary a tied run always leaves legal -- is below
+///    the floor. Neither of the two positions that ARE available is acceptable.
+///    Crossing the floor issues a prefill `prefill_tokens` truncates at the
+///    head, and the head then exists in no hypothesis and in no confirmed list
+///    (codex round 7, finding 2, exactly). Widening off the end -- what this
+///    used to do -- confirms the whole run, empties the holdback and anchors the
+///    watermark strictly PAST the run's instant, stranding every word the newest
+///    hypothesis produced at that same instant beyond `common`: the next worded
+///    ingest filters them from both hypotheses at once and `LocalAgreement::
+///    finalize` cannot recover them (codex round 3 on PR #95).
+///
+///    So the round does not advance at all, and `LocalAgreement::ingest` records
+///    it for `LocalAgreement::finalize`. It is the same policy as the back-off
+///    above -- Rule W may not empty the holdback -- carried into the state where
+///    the back-off has nowhere legal to land, and it is relieved the same way,
+///    by TAIL growth: one word starting strictly later opens a boundary at or
+///    above the floor, because a single word's tokens raise the floor by at most
+///    that word's own cost. It costs nothing on the deferring round itself --
+///    `finalize` emits `confirmed ++ hypothesis_words` either way (see
+///    `LocalAgreement::finalize`) -- and the divergence is entirely in what
+///    LATER ingests can still see.
+/// 4. **`Some(common.len())`** -- tested FIRST in the code, since it is a
+///    property of the budget alone and neither search runs on it. Only where the
+///    BUDGET FLOOR itself reaches `common.len()` is that length
+///    returned and the holdback left empty. That takes a LAST word whose own
+///    tokens exceed the budget, since nothing else runs `budgeted_split`'s loop
+///    off the end, and it is the one state where the empty holdback is FORCED:
+///    no split leaves a holdback the prefill could carry, so there is no anchor
+///    to wait for and deferring would wait forever. Confirming is round 7
+///    finding 2's own repair, and `LocalAgreement::ingest`'s watermark then
+///    anchors strictly past the last confirmed start rather than at its `end`.
+///    This arm is now the WHOLE of what reaches the empty holdback.
 ///
 /// So `agreement_count_needed` is a target rather than an exact width in EITHER
 /// direction: the budget can shorten the holdback (see `budgeted_split`) and
@@ -1039,6 +1172,11 @@ impl LocalAgreement {
 /// the offered filter, and the re-admission question is unrepresentable rather
 /// than defended against.
 ///
+/// It stays TOTAL under the `None` arm rather than becoming conditional again:
+/// a deferred round is not an advance, so it moves neither side of the
+/// inequality and there is no state for the claim to be excluded from. `None`
+/// REMOVES reachable advances rather than adding unguarded ones.
+///
 /// It is a claim about the LAST confirmed word, and that is as strong as it needs
 /// to be exactly while word starts inside one hypothesis are non-decreasing --
 /// see this module's doc for the `find_alignment` guarantee that supplies it and
@@ -1047,7 +1185,7 @@ fn split_at_a_strict_boundary(
   common: &[WordTiming],
   requested: usize,
   confirmed_last_start: Option<f32>,
-) -> usize {
+) -> Option<usize> {
   let strictly_after_the_preceding_start = |at: usize| {
     let preceding = if at == 0 {
       confirmed_last_start
@@ -1059,6 +1197,17 @@ fn split_at_a_strict_boundary(
   // `budgeted_split` with nothing requested IS the budget's own floor: the
   // earliest split whose holdback fits `MAX_HOLDBACK_PREFILL_TOKENS`.
   let floor = budgeted_split(common, 0);
+  if floor == common.len() {
+    // The budget FORCES the empty holdback: no split leaves a non-empty one the
+    // prefill could carry, which takes a LAST word whose own tokens exceed
+    // `MAX_HOLDBACK_PREFILL_TOKENS` (that is the only way the loop in
+    // `budgeted_split` runs off the end). Confirming it is always available and
+    // is round 7 finding 2's own repair; deferring would wait for an anchor that
+    // can never arrive. `LocalAgreement::ingest`'s `next_up` anchor then keeps
+    // the postcondition on this path, and this arm is the whole of what still
+    // reaches it.
+    return Some(common.len());
+  }
   let widened = requested.max(floor);
   (widened..common.len())
     .find(|&at| strictly_after_the_preceding_start(at))
@@ -1067,7 +1216,6 @@ fn split_at_a_strict_boundary(
         .rev()
         .find(|&at| strictly_after_the_preceding_start(at))
     })
-    .unwrap_or(common.len())
 }
 
 /// Where an advance splits `common` into the part that is CONFIRMED and the
@@ -1142,7 +1290,9 @@ fn split_at_a_strict_boundary(
 /// value because its back-off moves the split EARLIER, and the floor is the one
 /// line it may not cross: below it `prefill_tokens` silently truncates and the
 /// erased words are neither re-offered nor confirmed, which is the whole of
-/// round 7's finding 2.
+/// round 7's finding 2. Where nothing legal sits at or above the floor, that
+/// rule DEFERS the round rather than crossing the floor or widening off the end
+/// — both of which delete a word — and the floor stays hard.
 ///
 /// **Documented deviation**: with `agreement_count_needed` at its
 /// [`DEFAULT_AGREEMENT_COUNT_NEEDED`] a two-word holdback of words

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -65,11 +65,23 @@
 //!
 //!   **Postcondition** — whenever [`LocalAgreement::last_agreed_words_slice`] is
 //!   non-empty, `confirmed_words.last().start() < last_agreed_seconds`
-//!   STRICTLY. No confirmed word can satisfy the offered filter's own
-//!   `start >= watermark`, so none can ever head a hypothesis and the
-//!   re-admission question is unrepresentable rather than defended against.
-//!   Adjudicated: Swift shares the bug, and "confirmed once and stable" wins
-//!   over parity here.
+//!   STRICTLY, so the LAST confirmed word cannot satisfy the offered filter's
+//!   own `start >= watermark` and cannot head a hypothesis. The re-admission
+//!   question is then unrepresentable rather than defended against. Adjudicated:
+//!   Swift shares the bug, and "confirmed once and stable" wins over parity here.
+//!
+//!   It is a claim about the LAST confirmed word, and that is as strong as it
+//!   needs to be exactly while word starts inside one hypothesis are
+//!   non-decreasing: `find_alignment` guarantees
+//!   `w[i].end() <= w[i + 1].start() + 1e-4`, so an earlier confirmed word
+//!   starts at or before the last one and so also before the watermark. It is
+//!   NOT a claim about the whole list under a hypothesis whose starts run
+//!   BACKWARDS — offered `[P@5.0, Q@1.0, R@2.0]` confirms `[P, Q]` at a 2.0 s
+//!   watermark, and `P` then passes the offered filter while `Q` does not
+//!   (measured). That input is unreachable now: `ingest` is `pub(crate)` and its
+//!   only in-crate caller is [`LocalAgreementTranscriber::push_samples`], whose
+//!   words come from `add_word_timestamps`. It is one more thing the seal below
+//!   is holding up, and one more reason the grep gate exists.
 //!
 //!   **[BEHAVIOUR CHANGE]** the rule confirms one word EARLIER on a tied input,
 //!   trading one round of revisability for a clip boundary that does not bisect
@@ -246,6 +258,50 @@
 //!
 //! `the_engine_exposes_no_public_mutator` in `tests/whisper/streaming.rs` is the
 //! falsifier: it greps this file and reds if any of those names is re-published.
+//!
+//! # Residuals
+//!
+//! Stated with the sequence that reaches each, rather than claimed closed. The
+//! module makes no totality claim.
+//!
+//! 1. **An empty holdback leaves a zero-duration word AT the watermark.** With
+//!    nothing held back the watermark anchors at `common.last().end()` instead
+//!    of the first held word's start, and Rule W has no `common[split]` to
+//!    anchor against — so a word with `start == end` there satisfies the offered
+//!    filter and a re-decode can confirm it twice. Needs a non-default
+//!    [`LocalAgreement::agreement_count_needed`], a word whose own tokens exceed
+//!    [`MAX_HOLDBACK_PREFILL_TOKENS`], and a zero-duration word, simultaneously.
+//!    `an_empty_holdback_leaves_a_zero_duration_word_at_the_watermark`; the very
+//!    next advance repairs it
+//!    (`the_split_widens_past_a_tie_with_the_confirmed_list_itself`).
+//! 2. **A repeat the engine's record cannot account for** is the stream's own,
+//!    on the untied input — and on a TIED one Rule W deletes it instead. Both
+//!    directions are pinned:
+//!    `a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream`
+//!    and `rule_w_deletes_an_unaccounted_repeat_of_a_settled_word`.
+//! 3. **Drift wider than the gap in front of the watermark.** A re-decode free
+//!    to move every timestamp it emits can push a settled word past the
+//!    watermark, where it reads as new speech rather than as a re-admission.
+//!    Pre-existing on `main`; under
+//!    `LocalAgreement::decoding_options_for_next` such a word is outside the
+//!    clip window and behind the forced prefill, so the driver cannot reach it.
+//! 4. **A crate-internal caller could still order the calls wrongly.** The seal
+//!    is privacy plus a grep gate, not a type. There is one call site —
+//!    [`LocalAgreementTranscriber::push_samples`], three lines in this file —
+//!    and nothing stops a future in-crate caller from handing `ingest` a result
+//!    it did not decode from `decoding_options_for_next`. Inverting the seam
+//!    (an engine-side `step(|options| decode(options))`) would make the ordering
+//!    unbreakable in-crate; flagged, not taken.
+//! 5. **A VAD-dropped chunk at [`LocalAgreementTranscriber::finalize`].** A
+//!    caller setting `chunking_strategy = Vad` on a stream longer than one
+//!    window can lose a chunk covering the holdback's span; the final hypothesis
+//!    then disagrees, the `holdback_superseded` path fires, and the record is
+//!    replaced by words that never re-read it. Pre-existing on `main` and
+//!    unchanged here — the coverage model this branch briefly carried did not
+//!    close it either, because the nominal clip schedule is not the effective
+//!    coverage. `task_facts().had_swallowed_error()` is a fact the PIPELINE
+//!    recorded rather than caller testimony and could preserve the record;
+//!    flagged, not taken.
 
 use crate::audio::whisper::{
   backend::InferenceBackend,

--- a/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/mod.rs
@@ -62,35 +62,74 @@
 //!   word whose start ties the confirmed one in front of it, cutting the clip
 //!   boundary INSIDE a span already settled (see `split_at_a_strict_boundary`).
 //!
-//!   **Postcondition (TOTAL)** — after every advance,
-//!   `confirmed_words.last().start() < last_agreed_seconds` STRICTLY, with no
-//!   condition on the holdback, so the LAST confirmed word cannot satisfy the
-//!   offered filter's own `start >= watermark` and cannot head a hypothesis. The
-//!   re-admission question is unrepresentable rather than defended against.
-//!   Adjudicated: Swift shares the bug, and "confirmed once and stable" wins
-//!   over parity here.
+//!   **Postcondition (TOTAL)** — after every advance, EVERY confirmed word
+//!   starts strictly before `last_agreed_seconds`, with no condition on the
+//!   holdback, so no confirmed word can satisfy the offered filter's own
+//!   `start >= watermark` and none can head a hypothesis. The re-admission
+//!   question is unrepresentable rather than defended against. Adjudicated:
+//!   Swift shares the bug, and "confirmed once and stable" wins over parity
+//!   here.
+//!
+//!   It is stated over the WHOLE list, and it used to be stated over its LAST
+//!   word with "starts inside one hypothesis are non-decreasing" carrying the
+//!   rest. That premise is false — see "Word starts run backwards" below — so
+//!   the claim now rests on nothing outside this module: the split and the
+//!   anchor both measure against `highest_start(confirmed_words)`, the
+//!   high-water settled start, rather than against the last word.
 //!
 //!   Two things carry it, and they are separable. `split_at_a_strict_boundary`
-//!   puts an INTERIOR split only on a boundary whose preceding word starts
-//!   strictly earlier — searching forward from the requested split first, then
-//!   BACKING OFF when the forward search would run off the end of `common`,
-//!   because widening past a tied run that reaches that end would empty the
-//!   holdback and anchor the watermark on the run's own last word — and widening
-//!   off the END only where the prefill budget floor sits at or above every
-//!   legal boundary, which is where the back-off has nowhere legal to land. And
-//!   where the holdback is empty, `LocalAgreement::ingest` anchors the watermark
-//!   at `empty_holdback_watermark`'s lowest sparing instant, never below
-//!   `end.max(start.next_up())`, rather than at `end` — since `end == start` for
-//!   a zero-duration word. `next_up` is the IMMEDIATE f32 successor: it refuses
-//!   exactly the one instant the confirmed word occupies and no span of
-//!   instants, which an `end + epsilon` tolerance would not have managed. The
-//!   SPARING fold is what keeps the empty holdback's cost to the impossibility
-//!   rather than to the policy: it lowers the anchor to the earliest word the
-//!   hypothesis already produced past `common`, so every such word at any start
-//!   strictly after the settled one stays offerable
+//!   puts an INTERIOR split only on a boundary whose start is strictly past
+//!   every settled start behind it — searching forward from the requested split
+//!   first, then BACKING OFF when the forward search would run off the end of
+//!   `common`, because widening past a tied run that reaches that end would
+//!   empty the holdback and anchor the watermark on the run's own last word —
+//!   and widening off the END only where the prefill budget floor sits at or
+//!   above every legal boundary, which is where the back-off has nowhere legal
+//!   to land. And where the holdback is empty, `LocalAgreement::ingest` anchors
+//!   at `empty_holdback_anchor`: the last confirmed word's own far edge, raised
+//!   to `past_the_settled_instant` where that word has no duration — since
+//!   `end == start` for a zero-duration word.
+//!
+//!   `past_the_settled_instant` is a SAMPLE-domain step, and it used to be
+//!   `f32::next_up`. The watermark is read in two coordinate systems:
+//!   `watermark_filtered` compares it against word starts in SECONDS, and
+//!   `LocalAgreement::decoding_options_for_next` hands the same value to
+//!   `clip_timestamps`, where `chunker::prepare_seek_clips` rounds it to a
+//!   SAMPLE. One ULP is a real step in the first and none at all in the second —
+//!   `2.0f32.next_up()` and `2.0` both clip to sample `32000` — so the anchor
+//!   moved the filter and left the CLIP where it was, and the next stride
+//!   re-read the settled word's own audio (codex round 7 on PR #95, finding 2;
+//!   `the_driver_does_not_re_read_the_settled_words_own_sample`). The anchor is
+//!   now the first instant strictly past the settled one in BOTH, which is the
+//!   sample after the one it clips to. What that widens: the filter refuses
+//!   every start inside the settled word's own sample rather than only the
+//!   settled instant. Every word `segment::update_segments_with_word_timings`
+//!   emits is centisecond-rounded — 160 samples — so nothing the pipeline can
+//!   produce falls in the widened gap.
+//!
+//!   The SPARING fold (`sparing_watermark`) is what keeps the cost to the
+//!   impossibility rather than to the policy, and it now runs on BOTH arms: it
+//!   lowers the anchor to the earliest start among the words this round did not
+//!   confirm — the holdback and everything past `common` — so every such word
+//!   strictly after the highest settled start stays offerable
 //!   (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`).
-//!   What no anchor can spare is a word at the settled start itself, and that is
-//!   residual 1.
+//!   On an interior split with non-decreasing starts it is the identity; it
+//!   bites where the starts run backwards. What no watermark can spare is a word
+//!   at or below the settled high-water start itself, and that is residual 1.
+//!
+//!   **Word starts run backwards, and the pipeline is where they come from.**
+//!   `segment::update_segments_with_word_timings` prefers a SEGMENT's own start
+//!   over a first word the DTW drifted more than half a second earlier
+//!   (`SegmentSeeker.swift:635-640`) and clamps that word to
+//!   `end - constrained_median`, which can land BEHIND the word in front of it —
+//!   measured, from a strictly non-decreasing alignment, in
+//!   `a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word`
+//!   (`[0.50, 0.80, 0.99, 0.81]`). `find_alignment`'s
+//!   `w[i].end() <= w[i + 1].start() + 1e-4` is a guarantee about its OWN
+//!   output, and the post-processing that follows it is not bound by it. Two
+//!   claims used to rest on the premise and neither does now: the postcondition
+//!   above reads the high-water start, and the second postcondition's exception
+//!   is stated at `<=` that start rather than at the tie.
 //!
 //!   The first shape of this rule widened unconditionally and left the empty
 //!   holdback anchored at `end`, which put the ORIGINAL duplicate-confirmation
@@ -103,18 +142,19 @@
 //!   state (an over-budget word) and not the STATE, and the property test's own
 //!   shape skipped the state, which read as coverage.
 //!
-//!   It is a claim about the LAST confirmed word, and that is as strong as it
-//!   needs to be exactly while word starts inside one hypothesis are
-//!   non-decreasing: `find_alignment` guarantees
-//!   `w[i].end() <= w[i + 1].start() + 1e-4`, so an earlier confirmed word
-//!   starts at or before the last one and so also before the watermark. It is
-//!   NOT a claim about the whole list under a hypothesis whose starts run
-//!   BACKWARDS — offered `[P@5.0, Q@1.0, R@2.0]` confirms `[P, Q]` at a 2.0 s
-//!   watermark, and `P` then passes the offered filter while `Q` does not
-//!   (measured). That input is unreachable now: `ingest` is `pub(crate)` and its
-//!   only in-crate caller is [`LocalAgreementTranscriber::push_samples`], whose
-//!   words come from `add_word_timestamps`. It is one more thing the seal below
-//!   is holding up, and one more reason the grep gate exists.
+//!   The claim runs over the whole confirmed list, so a hypothesis whose starts
+//!   run backwards does not escape it. `[P@1.15, Q@0.95, R@1.10]` is where the
+//!   difference shows: the adjacent-predecessor test this rule used to make
+//!   passes at `R` (`0.95 < 1.10`), confirms `P` at `1.15` and sets a `1.10`
+//!   watermark, and `P` then passes the offered filter against its own
+//!   confirmation — #94 reached from the backwards side. Against the running
+//!   maximum the same round backs off to a legal boundary instead
+//!   (`a_backwards_start_two_words_back_still_cannot_be_re_admitted`). That
+//!   exact shape is not one the segment pipeline emits — its clamp needs a word
+//!   spanning more than half a second and every word after a clamped one starts
+//!   at or after that word's own alignment end — so this is a STRENGTHENING that
+//!   removes a premise rather than a repair for a demonstrated route, and its
+//!   falsifier is hermetic because the input is.
 //!
 //!   **[BEHAVIOUR CHANGE]** the rule confirms one word EARLIER on a tied input
 //!   the forward search clears, trading one round of revisability for a clip
@@ -193,9 +233,10 @@
 //!   that no legal boundary is left at or above it (see
 //!   `split_at_a_strict_boundary`). Rule W's own widening backs off rather than
 //!   emptying wherever a legal boundary remains above the floor. The anchor is
-//!   `empty_holdback_watermark`'s lowest sparing instant, never below
-//!   `start.next_up()`, so a zero-duration word there is still strictly behind
-//!   the watermark and a word the hypothesis already produced past `common` is
+//!   `empty_holdback_anchor`, never below `past_the_settled_instant`, so a
+//!   zero-duration word there is still strictly behind the watermark in BOTH the
+//!   seconds the filter reads and the samples the clip does; `sparing_watermark`
+//!   then lowers it, so a word the hypothesis already produced past `common` is
 //!   spared wherever any instant could spare it. It has to:
 //!   stopping while one word remained left a single word whose OWN tokens exceed
 //!   the budget held anyway, and the cap silently did not cap (codex round 7,
@@ -306,12 +347,19 @@
 //! `the_split_never_cuts_at_a_tied_start`'s 512 fixed-seed trials, reading the
 //! published transcript after every round:
 //!
-//! | 512 fixed-seed trials | deferral | fallback |
+//! | 512 fixed-seed trials, drawn at `4b259ef` | deferral | fallback |
 //! |---|---|---|
 //! | words ERASED from the published transcript | 26 | 10 |
 //! | strands, all at the settled instant | 29 | 38 |
 //! | rounds with no legal boundary that took the empty holdback | 43 | 141 |
 //! | rounds with no legal boundary that WAITED instead | 113 | — |
+//!
+//! Those columns are of `the_split_never_cuts_at_a_tied_start`'s draw AS IT WAS
+//! at `4b259ef`, and they are not re-derivable from the sweep's current numbers:
+//! the backwards-start half added for codex round 7's finding 1 re-rolls every
+//! later draw, and the deferral tree is gone, so the comparison cannot be
+//! re-run. It is recorded with the commit it was measured on rather than
+//! restated as if it still described the shipped shape.
 //!
 //! The deferral produced 2.6x the published retractions. What it BOUGHT over the
 //! same suite was four words on the growing-tied-prefix row and one word each on
@@ -332,9 +380,9 @@
 //! to backstop.
 //!
 //! What the fallback keeps from that work, and what it does not. The SPARING
-//! FOLD in `empty_holdback_watermark` (`4f2a3c9`) is kept: it is separable from
-//! the deferral, it is what confines the loss to the settled instant, and
-//! dropping it reds
+//! FOLD (`4f2a3c9`, now `sparing_watermark` and shared with the interior arm) is
+//! kept: it is separable from the deferral, it is what confines the loss to the
+//! settled high-water start, and dropping it reds
 //! `a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`.
 //! What is not kept is the wait, its two bounds, the deferred flag and
 //! `finalize`'s clause for it. `jfk_simulated_stream_confirms_the_transcript` is
@@ -394,24 +442,35 @@
 //! W's postcondition IS total (see its entry above); the module claims no
 //! totality beyond it.
 //!
-//! 1. **A word at an empty holdback's own instant is DROPPED.** With nothing
-//!    held back the watermark is `empty_holdback_watermark`'s lowest sparing
-//!    instant — never below the last confirmed word's `end`, raised to
-//!    `start.next_up()` where that word has no duration — so a word at that same
-//!    start fails the offered filter and can never reach a hypothesis again. It
-//!    cannot be helped: to a timestamp filter that word and a re-offer of the
-//!    settled one are the same value, which is the issue's impossibility result,
-//!    and the alternative is the unbounded re-confirmation #94 is about. A
-//!    truncation is what the portable prefix property tolerates; a rewrite is
-//!    not. It needs the prefill budget to empty the holdback — Rule W's own
-//!    widening backs off wherever a legal boundary remains above the floor — and
-//!    two shapes do that: a single word at the end of `common` whose own tokens
-//!    exceed [`MAX_HOLDBACK_PREFILL_TOKENS`], and a TIED RUN whose tokens exceed
-//!    it in aggregate, which `add_word_timestamps` produces from an all-zero
-//!    alignment matrix. It does NOT additionally take a non-default
-//!    [`LocalAgreement::agreement_count_needed`]: an earlier form of this entry
-//!    listed one, and the default count reaches the same state whenever that one
-//!    word is the last of the agreed prefix (measured).
+//! 1. **A word at or below the settled high-water start is DROPPED.** The
+//!    watermark is strictly past every confirmed start (postcondition 1), so a
+//!    word this round did not confirm that starts at or below the highest
+//!    confirmed one fails the offered filter and can never reach a hypothesis
+//!    again. It cannot be helped: to a timestamp filter that word and a re-offer
+//!    of the settled one are the same value, which is the issue's impossibility
+//!    result, and the alternative is the unbounded re-confirmation #94 is about.
+//!    A truncation is what the portable prefix property tolerates; a rewrite is
+//!    not.
+//!
+//!    TWO shapes reach it, and they are the two halves of the second
+//!    postcondition's exception. AT the settled start is the TIE, which needs an
+//!    empty holdback: the prefill budget must run the split off the end of
+//!    `common` — Rule W's own widening backs off wherever a legal boundary
+//!    remains above the floor — and two things do that, a single word at the end
+//!    of `common` whose own tokens exceed [`MAX_HOLDBACK_PREFILL_TOKENS`], and a
+//!    TIED RUN whose tokens exceed it in aggregate, which `add_word_timestamps`
+//!    produces from an all-zero alignment matrix. It does NOT additionally take
+//!    a non-default [`LocalAgreement::agreement_count_needed`]: an earlier form
+//!    of this entry listed one, and the default count reaches the same state
+//!    whenever that one word is the last of the agreed prefix (measured).
+//!
+//!    BELOW the settled start is a BACKWARDS start, and it needs no empty
+//!    holdback at all: `segment::update_segments_with_word_timings` can put a
+//!    later word behind an earlier one (see "Word starts run backwards" above),
+//!    and an INTERIOR split that confirms past it strands it. This half was
+//!    invisible while the postcondition assumed non-decreasing starts (codex
+//!    round 7 on PR #95, finding 1); `the_split_never_cuts_at_a_tied_start`
+//!    counts it as `backward_strands` and reached it 4 times in 512 trials.
 //!
 //!    It covers a word the hypothesis had ALREADY produced past `common` as well
 //!    as one a later decode invents. Between `6987bec` and `b3ec5c6` the first
@@ -419,18 +478,20 @@
 //!    removing the deferral restores it, on measured evidence that the deferral
 //!    cost more published transcript than it saved (see "Why there is no
 //!    deferral" above). What is NOT covered is any other instant: the sparing
-//!    fold in `empty_holdback_watermark` lowers the anchor to the earliest word
-//!    beyond `common` it can, so a word starting strictly later stays offerable
+//!    fold in `sparing_watermark` lowers the anchor to the earliest unconfirmed
+//!    word it can, so a word starting strictly later stays offerable
 //!    (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`).
 //!    `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed` drives the
 //!    invented-later kind at count 1 — its dropped `" B"` arrives one hypothesis
 //!    later, which is why it is still dropped;
 //!    `an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant` and
 //!    `a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant` drive
-//!    the already-visible kind on each of the two shapes above; and
-//!    `the_split_never_cuts_at_a_tied_start` sweeps both counts and COUNTS the
-//!    strands and the erasures, so the residual cannot be reported as
-//!    unreachable.
+//!    the already-visible kind on each of the two shapes above;
+//!    `a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word`
+//!    is the pipeline-built witness for the backwards half, and shows the case
+//!    the sparing fold SAVES; and `the_split_never_cuts_at_a_tied_start` sweeps
+//!    both counts and COUNTS the strands (`tie_strands`, `backward_strands`) and
+//!    the erasures, so neither half can be reported as unreachable.
 //! 2. **A repeat the engine's record cannot account for** is the stream's own,
 //!    on the untied input — and on a TIED one Rule W deletes it instead. Both
 //!    directions are pinned:
@@ -439,9 +500,16 @@
 //! 3. **Drift wider than the gap in front of the watermark.** A re-decode free
 //!    to move every timestamp it emits can push a settled word past the
 //!    watermark, where it reads as new speech rather than as a re-admission.
-//!    Pre-existing on `main`; under
-//!    `LocalAgreement::decoding_options_for_next` such a word is outside the
-//!    clip window and behind the forced prefill, so the driver cannot reach it.
+//!    Pre-existing on `main`, and DRIVER-REACHABLE — an earlier form of this
+//!    entry said it was not, on the ground that `decoding_options_for_next` puts
+//!    such a word "outside the clip window and behind the forced prefill". The
+//!    second half stands; the first is false in general (codex round 7 on PR
+//!    #95, finding 2). The clip begins at `clip_seek_sample(watermark)`, so the
+//!    audio it excludes is what lies strictly before that SAMPLE — and a settled
+//!    word whose own end reaches the watermark, or which has no duration at all,
+//!    keeps its audio inside the next clip. Where the settled word has real
+//!    duration the exclusion is real, which is the case the earlier note
+//!    generalized from.
 //! 4. **A crate-internal caller could still order the calls wrongly.** The seal
 //!    is privacy plus a grep gate, not a type. There is one call site —
 //!    [`LocalAgreementTranscriber::push_samples`], three lines in this file —
@@ -477,8 +545,20 @@
 //!    the re-admission defence this issue's ledger already refuted. There is no
 //!    third reading available from the offered list: the two are byte-identical
 //!    there, which is the issue's impossibility result reached from the drift
-//!    side — residual 3's territory, and driver-unreachable for the same reason
-//!    it gives.
+//!    side — residual 3's territory.
+//!
+//!    **It is DRIVER-REACHABLE, and an earlier form of this entry said it was
+//!    not** (codex round 7 on PR #95, finding 2). The claim borrowed residual
+//!    3's "outside the clip window", and that is exactly the shape it does not
+//!    hold for: a 113-word tied run at 2 s is ZERO-DURATION, so the empty
+//!    holdback's anchor is `past_the_settled_instant(2.0)` and the next clip
+//!    begins one sample later — sample `32001` against the run's own `32000`.
+//!    One sample is not the run's audio. No boundary derived from a
+//!    zero-duration word's OWN timestamps can exclude the speech it came from,
+//!    because the word claims no extent, so this is not something the anchor can
+//!    close — and it was not closed by the `f32::next_up` anchor either, which
+//!    did not move the clip at all. What the sample-domain anchor buys here is
+//!    an HONEST boundary, not this residual.
 //!
 //!    **Unconstrained by any current assertion.** No test in this file, and no
 //!    shape the 512-trial sweep draws, pins either verdict: the sweep's
@@ -490,6 +570,7 @@
 //!    because deciding it needs the identity oracle #94 proves does not exist.
 
 use crate::audio::whisper::{
+  audio::chunker,
   backend::InferenceBackend,
   constants::{MAX_TOKEN_CONTEXT, SAMPLE_RATE},
   error::TranscribeError,
@@ -718,9 +799,12 @@ impl LocalAgreement {
   /// reordered, or taken back, which is why the trailing words of an agreement
   /// wait in [`Self::last_agreed_words_slice`] instead. RULE W (see
   /// `split_at_a_strict_boundary`) additionally guarantees, with no condition on
-  /// that holdback, that this list's last word starts STRICTLY before
+  /// that holdback, that EVERY word here starts STRICTLY before
   /// [`Self::last_agreed_seconds`] — so nothing here can be re-offered to the
-  /// agreement comparison and confirmed a second time.
+  /// agreement comparison and confirmed a second time. Over the whole list, not
+  /// merely its last word: the last one need not be the latest, since
+  /// `crate::audio::whisper::segment::update_segments_with_word_timings` emits
+  /// backwards word starts.
   #[inline(always)]
   pub const fn confirmed_words_slice(&self) -> &[WordTiming] {
     self.confirmed_words.as_slice()
@@ -824,16 +908,25 @@ impl LocalAgreement {
   /// no scope and no alignment behind it.
   ///
   /// It needs none. RULE W (see `split_at_a_strict_boundary`) refuses to put the
-  /// watermark at a start already settled — so `confirmed_words.last().start() <
-  /// last_agreed_seconds` STRICTLY after every advance, with no condition on the
-  /// holdback, and no confirmed word can pass this filter. The re-admission the
-  /// issue is about is unrepresentable rather than detected, which is why this
-  /// is the Swift line and not a rule.
+  /// watermark at a start already settled — so EVERY confirmed word starts
+  /// strictly before `last_agreed_seconds` after every advance, with no
+  /// condition on the holdback, and no confirmed word can pass this filter. The
+  /// re-admission the issue is about is unrepresentable rather than detected,
+  /// which is why this is the Swift line and not a rule.
+  ///
+  /// The threshold it compares against is also the next stride's CLIP start
+  /// (`Self::decoding_options_for_next`), and the two read it in different
+  /// coordinates — seconds here, samples there. `past_the_settled_instant` is
+  /// what keeps a step that moves this filter from being inert in the other one;
+  /// what it costs this filter is that a word starting inside the settled word's
+  /// own sample is refused, where the `f32::next_up` anchor refused only the
+  /// settled instant. Pipeline word starts are centisecond-rounded, so nothing
+  /// this crate emits falls in that gap (codex round 7 on PR #95, finding 2).
   ///
   /// What it deliberately leaves is the same short list the postcondition
   /// bounds, recorded in this module's doc and each with a named test: a repeat
   /// the engine's record cannot account for is read as the stream's own; a word
-  /// the stream genuinely produces at an empty holdback's own instant is
+  /// the stream genuinely produces at or below the settled high-water start is
   /// filtered out with the re-offer it cannot be told apart from; and a
   /// re-decode free to move every timestamp it emits can push a settled word
   /// past the watermark, where it reads as new speech.
@@ -933,48 +1026,62 @@ impl LocalAgreement {
       if common.len() >= self.agreement_count_needed {
         // :383-394 — advance the watermark.
         let requested = common.len() - self.agreement_count_needed;
-        let split = split_at_a_strict_boundary(
-          common,
-          requested,
-          self.confirmed_words.last().map(WordTiming::start),
-        );
+        let split =
+          split_at_a_strict_boundary(common, requested, highest_start(&self.confirmed_words));
         // `common` REPLACES the still-open record: it is the span two consecutive
         // hypotheses have just re-agreed over it, and `last_agreed_words` is the
         // one this hypothesis has superseded.
         self.confirmed_words.extend_from_slice(&common[..split]);
         self.last_agreed_words = common[split..].to_vec();
-        // RULE W'S WATERMARK (#94). The watermark is the first held-back word's
-        // start, which `split_at_a_strict_boundary` has already placed STRICTLY
-        // past the last confirmed word's start.
+        // RULE W'S WATERMARK (#94). Two steps, and BOTH postconditions are
+        // properties of the second one.
         //
-        // With NOTHING held back -- the fallback, reached where neither the
-        // forward search nor the back-off found a legal boundary at or above the
-        // prefill budget floor, and where the floor itself reaches
-        // `common.len()` -- there is no held word to measure against, and
-        // `empty_holdback_watermark` is the answer: the LOWEST instant that
-        // still clears the last confirmed word's own start, which spares every
-        // word this hypothesis produced past `common` that any such instant
-        // could spare. What it cannot spare is a word at that exact start, and
-        // that is this module's residual 1.
+        // The ANCHOR is where the advance would like to put the clip boundary.
+        // With a holdback it is the first held-back word's start, which
+        // `split_at_a_strict_boundary` has already placed strictly past every
+        // settled start. With NOTHING held back -- the fallback, reached where
+        // neither the forward search nor the back-off found a legal boundary at
+        // or above the prefill budget floor, and where the floor itself reaches
+        // `common.len()` -- there is no held word to measure against and
+        // `empty_holdback_anchor` supplies one: the last confirmed word's own
+        // far edge, raised to the first instant past the settled start in the
+        // SAMPLE domain the clip is read in.
         //
-        // Monotone: every word of `common` starts at or past the old watermark,
-        // `end >= start` for any word the pipeline emits, `next_up` only
-        // increases, and the sparing minimum is taken only over words that
-        // themselves cleared the old watermark. A NaN start cannot break the
-        // postcondition either -- `max` returns the non-NaN side, and
-        // `start >= watermark` is false for a NaN start, so such a word is
-        // never offered back in the first place.
+        // `sparing_watermark` then LOWERS that anchor to spare every word this
+        // hypothesis produced that the advance did not settle -- the holdback
+        // and everything past `common` alike. On a non-decreasing hypothesis
+        // that changes nothing on the interior arm (every unconfirmed word
+        // starts at or past the first held one) and is the fold the empty arm
+        // has carried since `4f2a3c9`. It bites where the starts run BACKWARDS,
+        // which `update_segments_with_word_timings` can produce (codex round 7
+        // on PR #95, finding 1): there the adjacent boundary is not the latest
+        // settled start, and an unconfirmed word can sit below the anchor.
+        //
+        // `settled_high` is read AFTER the append, so it covers what this very
+        // round confirmed. Postcondition 1 follows: the anchor is strictly past
+        // it and every folded candidate is filtered to be, so the minimum is --
+        // and it is the HIGHEST confirmed start, not merely the last, so no
+        // confirmed word can pass the offered filter. A NaN start cannot break
+        // it either: `highest_start` skips NaN, `f32::max`/`f32::min` return the
+        // non-NaN side, and `start >= watermark` is false for a NaN start, so
+        // such a word is never offered back in the first place.
         //
         // `common` is non-empty here (its length is at least
         // `agreement_count_needed`, clamped to at least one), so the final
         // fallback is unreachable and only keeps this total.
-        self.last_agreed_seconds = self.last_agreed_words.first().map_or_else(
+        let settled_high = highest_start(&self.confirmed_words);
+        let anchor = self.last_agreed_words.first().map_or_else(
           || {
             common.last().map_or(self.last_agreed_seconds, |last| {
-              empty_holdback_watermark(last, &self.hypothesis_words[common.len()..])
+              empty_holdback_anchor(last, settled_high.unwrap_or(f32::NEG_INFINITY))
             })
           },
           WordTiming::start,
+        );
+        self.last_agreed_seconds = sparing_watermark(
+          anchor,
+          settled_high.unwrap_or(f32::NEG_INFINITY),
+          &self.hypothesis_words[split..],
         );
         advanced = true;
       } else {
@@ -1124,32 +1231,36 @@ impl LocalAgreement {
 /// RULE W (#94, at its source): where an advance splits `common`, moved off any
 /// boundary that would put the watermark AT a start already settled.
 ///
-/// The watermark is the first held-back word's start, and it is also the CLIP
-/// this engine hands its own next decoder. Cutting at a word whose start TIES
-/// the last confirmed one puts that boundary INSIDE a span already settled: the
-/// confirmed word then satisfies `LocalAgreement::watermark_filtered`'s own
+/// The watermark is drawn from the first held-back word's start, and it is also
+/// the CLIP this engine hands its own next decoder. Cutting at a word whose
+/// start TIES a confirmed one puts that boundary INSIDE a span already settled:
+/// the confirmed word then satisfies `LocalAgreement::watermark_filtered`'s own
 /// `start >= watermark`, and the next hypothesis can re-offer it at the head of
 /// its word list. That is the state every re-admission defence in this issue's
 /// history was built to survive -- and the one that cannot be DECIDED from the
 /// offered list, because a re-offered settled word and the stream's own second
 /// occurrence of the same text are byte-identical there. Refuse to CREATE it.
 ///
-/// A split at `at` is legal exactly when the word that would then END the
-/// confirmed list starts STRICTLY before the word that would HEAD the holdback.
-/// At `at == 0` nothing of `common` is confirmed, so the preceding word is the
-/// engine's own last confirmed one -- the word the watermark would sit beside.
-/// That arm is provably never the blocking one: the postcondition below gives
-/// `confirmed.last().start() < last_agreed_seconds`, and every word of `common`
-/// cleared `start >= last_agreed_seconds` to be offered at all, so
-/// `confirmed.last().start() < common[0].start()` already. It is written as a
-/// CHECK rather than assumed so this function is correct on its own terms rather
-/// than on its caller's induction — but the proof is why it carries NO
-/// falsifier: replacing `confirmed_last_start` with `None` reds nothing in this
-/// crate, and no sequence through `LocalAgreement::ingest` can construct the
-/// state it guards, because that state IS the postcondition's negation. It was
-/// testable while the postcondition was conditional (through the empty-holdback
-/// residual, which the `next_up` anchor has since closed) and its test went with
-/// that state.
+/// A split at `at` is legal exactly when `common[at]` starts STRICTLY after
+/// every start a split there would settle -- everything already confirmed, plus
+/// `common[..at]`. That is a running MAXIMUM, not the adjacent predecessor:
+/// word starts inside one hypothesis are not non-decreasing (see the
+/// postconditions below), so the word immediately in front of the boundary is
+/// not necessarily the latest one behind it.
+///
+/// At `at == 0` nothing of `common` is confirmed, so the maximum is the engine's
+/// own `confirmed_start_high` -- the latest start the watermark would sit
+/// beside. That arm is provably never the blocking one: the postcondition below
+/// gives `high < last_agreed_seconds`, and every word of `common` cleared
+/// `start >= last_agreed_seconds` to be offered at all, so
+/// `high < common[0].start()` already. It is written as a CHECK rather than
+/// assumed so this function is correct on its own terms rather than on its
+/// caller's induction — but the proof is why it carries NO falsifier: replacing
+/// `confirmed_start_high` with `None` reds nothing in this crate, and no
+/// sequence through `LocalAgreement::ingest` can construct the state it guards,
+/// because that state IS the postcondition's negation. It was testable while the
+/// postcondition was conditional (through the empty-holdback residual, which the
+/// anchor has since closed) and its test went with that state.
 ///
 /// # Which legal boundary
 ///
@@ -1184,9 +1295,8 @@ impl LocalAgreement {
 ///    below it `prefill_tokens` silently truncates the prefill and the erased
 ///    words are neither re-offered nor confirmed (codex round 7, finding 2), so
 ///    the only position left is off the end: `common` is confirmed WHOLE, the
-///    holdback goes empty, and `LocalAgreement::ingest` anchors the watermark at
-///    `empty_holdback_watermark`'s lowest sparing instant rather than at
-///    `common.last().end()`. Two shapes reach it, and neither is exotic. The
+///    holdback goes empty, and `LocalAgreement::ingest` draws the watermark from
+///    `empty_holdback_anchor` rather than from a held word's start. Two shapes reach it, and neither is exotic. The
 ///    budget FLOOR itself can reach `common.len()`, which takes a LAST word
 ///    whose own tokens exceed `MAX_HOLDBACK_PREFILL_TOKENS` -- nothing else runs
 ///    `budgeted_split`'s loop off the end -- and there the empty holdback is
@@ -1200,14 +1310,14 @@ impl LocalAgreement {
 ///
 ///    **What this costs, and why it is not a DEFERRAL** (#94, measured on this
 ///    branch; see this module's doc, "Why there is no deferral"). The empty
-///    holdback anchors strictly past the last confirmed word's own start, so a
-///    word the newest hypothesis produced beyond `common` AT that same start is
-///    stranded: the next worded ingest filters it out of both hypotheses at
-///    once, and `LocalAgreement::finalize` cannot reach it afterwards -- after
-///    THIS round's `finalize` already published it through
-///    `find_longest_different_suffix`. That is this module's residual 1, and it
-///    is exactly that narrow: `empty_holdback_watermark`'s sparing fold lowers
-///    the anchor to spare every word at any OTHER instant
+///    holdback anchors strictly past the settled high-water start, so a word the
+///    newest hypothesis produced beyond `common` AT that same start is stranded:
+///    the next worded ingest filters it out of both hypotheses at once, and
+///    `LocalAgreement::finalize` cannot reach it afterwards -- after THIS
+///    round's `finalize` already published it through
+///    `find_longest_different_suffix`. That is the TIE half of this module's
+///    residual 1, and it is exactly that narrow: `sparing_watermark` lowers the
+///    anchor to spare every word at any HIGHER instant
 ///    (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`).
 ///
 ///    Between `6987bec` and `b3ec5c6` this arm did not advance at all: it
@@ -1228,14 +1338,21 @@ impl LocalAgreement {
 ///
 /// # Postcondition (TOTAL)
 ///
-/// After every advance, `confirmed_words.last().start() < last_agreed_seconds`
-/// STRICTLY -- with no condition on the holdback. Where the split is interior
-/// the boundary above is exactly that inequality; where it is `common.len()`
-/// `LocalAgreement::ingest`'s `empty_holdback_watermark` anchor is, whose result
-/// is strictly greater than `common.last().start()` for every input -- the
-/// sparing fold skips exactly the starts that are not (see that function). So no
-/// confirmed word can pass the offered filter, and the re-admission question is
-/// unrepresentable rather than defended against.
+/// After every advance, EVERY confirmed word starts strictly before
+/// `last_agreed_seconds` -- with no condition on the holdback. `sparing_watermark`
+/// is what delivers it on both arms: it folds a minimum over candidates it has
+/// already filtered to be strictly above `highest_start(confirmed_words)`,
+/// starting from an anchor that is strictly above it too. Where the split is
+/// interior the anchor is `common[split].start()` and the boundary rule above is
+/// exactly that inequality; where the split is `common.len()` the anchor is
+/// `empty_holdback_anchor`, which clears the settled high-water start by
+/// construction. So no confirmed word can pass the offered filter, and the
+/// re-admission question is unrepresentable rather than defended against.
+///
+/// It is stated over the whole list because the LAST confirmed word need not be
+/// the LATEST: `segment::update_segments_with_word_timings` emits backwards word
+/// starts (see this module's doc, "Word starts run backwards"). The claim
+/// therefore rests on no premise about the pipeline at all.
 ///
 /// The two arms above are the whole of the function, so there is no third state
 /// to exclude the claim from: every round with `common.len() >=
@@ -1249,65 +1366,73 @@ impl LocalAgreement {
 /// After every advance, every word of the driving hypothesis that the advance
 /// did NOT confirm still satisfies `LocalAgreement::watermark_filtered`'s own
 /// `start >= last_agreed_seconds`, so the round cannot put a word it left
-/// unsettled out of the next round's reach. Where the split is interior this is
-/// free -- the watermark is `common[split].start()` and word starts inside one
-/// hypothesis are non-decreasing, so everything from `split` on is at or past
-/// it. Where the split is `common.len()` the watermark is strictly PAST the last
-/// confirmed start, so it is not free, and the sparing fold in
-/// `empty_holdback_watermark` is what buys it: the anchor drops to the earliest
-/// word of `beyond_common` it can.
+/// unsettled out of the next round's reach. `sparing_watermark` is again what
+/// buys it, on both arms: the watermark is the LOWEST start among the words this
+/// round did not confirm that any legal watermark could still spare.
 ///
-/// **It has ONE exception, and the exception is the arm rather than a policy**
-/// (#94). A round whose split runs to `common.len()` may strand a word of the
-/// hypothesis beyond `common` that starts at the last confirmed word's OWN
-/// instant. There no value serves both claims -- the first postcondition demands
-/// a watermark strictly past that start, and every such watermark filters the
-/// strand -- so this is this module's residual 1, reached wherever the empty
-/// holdback is reached. It is exactly that narrow: word starts inside one
-/// hypothesis are non-decreasing, so a word beyond `common` starts at or after
-/// `common.last()`, and at any start strictly after it the sparing fold spares
-/// the word.
+/// **It has ONE exception, and the exception is the impossibility rather than a
+/// policy** (#94). A stranded word starts AT OR BELOW the highest confirmed
+/// start. There no value serves both claims -- the first postcondition demands a
+/// watermark strictly past that start, and every such watermark filters the
+/// strand -- so this is this module's residual 1.
 ///
-/// The exception's GATE moved when the deferral was removed, and its SHAPE did
-/// not. While the deferral existed the gate was "this round escaped a repeating
-/// wait", and the rounds that would otherwise have stranded deferred instead;
-/// now every empty-holdback advance carries it. Measured over the 512-trial
-/// sweep the wider gate is 38 strands where the deferral had 29 -- and 10 words
-/// erased from the published transcript where the deferral erased 26, which is
-/// the direction that decided it (this module's doc, "Why there is no
-/// deferral"). `the_split_never_cuts_at_a_tied_start` sweeps both postconditions
-/// and the exception, and counts the empty-holdback rounds and the strands so
-/// neither can pass by being unreachable -- and reads the published TRANSCRIPT
-/// across every round besides, which is where a retraction the confirmed list
-/// cannot see shows up.
+/// Both halves of `<=` are reachable and they are reached differently. AT is the
+/// TIE, and it takes an empty holdback: a zero-duration word the fallback arm
+/// settles last, with something the same hypothesis produced beyond `common` at
+/// that same instant. BELOW is a BACKWARDS start, and it takes no empty holdback
+/// at all -- an INTERIOR split can confirm a word that starts later than one it
+/// leaves unconfirmed, and then no watermark can clear the first while sparing
+/// the second. The exception was written at `==` and gated on the arm until
+/// codex round 7 on PR #95, finding 1; the gate was never what bounded this.
 ///
-/// It is a claim about the LAST confirmed word, and that is as strong as it needs
-/// to be exactly while word starts inside one hypothesis are non-decreasing --
-/// see this module's doc for the `find_alignment` guarantee that supplies it and
-/// for the backwards-starts input the `pub(crate)` seal excludes.
+/// The exception's GATE moved twice. While the deferral existed it read "this
+/// round escaped a repeating wait"; removing the deferral made it "this round's
+/// split ran off the END of `common`" (measured over the 512-trial sweep at
+/// `4b259ef`: 38 strands where the deferral had 29, and 10 words erased from the
+/// published transcript where the deferral erased 26 -- the direction that
+/// decided it, this module's doc, "Why there is no deferral"). The ARM gate is
+/// now gone, because a backwards start strands from an interior split too.
+/// `the_split_never_cuts_at_a_tied_start` sweeps both postconditions and both
+/// halves of the exception, counts the empty-holdback rounds, the tie strands
+/// and the backwards strands so none can pass by being unreachable -- and reads
+/// the published TRANSCRIPT across every round besides, which is where a
+/// retraction the confirmed list cannot see shows up.
 fn split_at_a_strict_boundary(
   common: &[WordTiming],
   requested: usize,
-  confirmed_last_start: Option<f32>,
+  confirmed_start_high: Option<f32>,
 ) -> usize {
-  let strictly_after_the_preceding_start = |at: usize| {
-    let preceding = if at == 0 {
-      confirmed_last_start
-    } else {
-      Some(common[at - 1].start())
-    };
-    preceding.is_none_or(|preceding| preceding < common[at].start())
-  };
+  // The HIGH-WATER settled start at each candidate boundary: everything already
+  // confirmed, plus everything a split at `at` would confirm. Read as a running
+  // maximum rather than as `common[at - 1].start()` because word starts inside
+  // one hypothesis are NOT non-decreasing -- `update_segments_with_word_timings`
+  // can pull a later segment's first word BACK past the word before it (codex
+  // round 7 on PR #95, finding 1; `a_backward_start_from_the_segment_pipeline_
+  // does_not_strand_a_later_word`), and against a backwards start the adjacent
+  // predecessor is not the word the postcondition has to clear.
+  //
+  // `NEG_INFINITY` is the nothing-confirmed-yet base, where every boundary is
+  // legal; `f32::max` returns the non-NaN side, so a NaN start neither poisons
+  // the running maximum nor makes a boundary look legal (`high < start` is false
+  // for a NaN `start`).
+  let mut running = confirmed_start_high.unwrap_or(f32::NEG_INFINITY);
+  let mut settled_before: Vec<f32> = Vec::with_capacity(common.len() + 1);
+  settled_before.push(running);
+  for word in common {
+    running = running.max(word.start());
+    settled_before.push(running);
+  }
+  let strictly_after_every_settled_start = |at: usize| settled_before[at] < common[at].start();
   // `budgeted_split` with nothing requested IS the budget's own floor: the
   // earliest split whose holdback fits `MAX_HOLDBACK_PREFILL_TOKENS`.
   let floor = budgeted_split(common, 0);
   let widened = requested.max(floor);
   (widened..common.len())
-    .find(|&at| strictly_after_the_preceding_start(at))
+    .find(|&at| strictly_after_every_settled_start(at))
     .or_else(|| {
       (floor..widened)
         .rev()
-        .find(|&at| strictly_after_the_preceding_start(at))
+        .find(|&at| strictly_after_every_settled_start(at))
     })
     .unwrap_or(common.len())
 }
@@ -1372,8 +1497,8 @@ fn split_at_a_strict_boundary(
 ///
 /// Where the holdback comes back empty, `LocalAgreement::ingest` anchors the
 /// watermark on the last confirmed word's own far edge — `end`, raised to
-/// `start.next_up()` where that word has no duration — rather than at the first
-/// held word's start; see the anchor at its advance branch.
+/// `past_the_settled_instant` where that word has no duration — rather than at
+/// the first held word's start; see the anchor at its advance branch.
 /// [`LocalAgreement::agreement_count_needed`] is then a maximum that reached
 /// zero for that round, the same way it becomes a maximum for any holdback the
 /// budget shortens.
@@ -1422,60 +1547,147 @@ fn budgeted_split(common: &[WordTiming], requested: usize) -> usize {
   split
 }
 
-/// The watermark an advance that holds NOTHING back anchors at: the LOWEST
-/// instant strictly past `last`'s start that spares as much of `beyond_common`
-/// as any such instant can, where `last` is the word that advance confirms last
-/// and `beyond_common` is what the same hypothesis produced past the agreed
-/// prefix.
+/// The ANCHOR an advance that holds NOTHING back starts from: the last
+/// confirmed word's own far edge, raised to the first instant past the settled
+/// start where that word has no duration.
 ///
-/// Strictly past `last`'s start is the hard part and the whole of #94: `end` is
-/// the answer whenever that word has any duration at all; where it does NOT,
+/// Strictly past `settled_high` is the hard part and the whole of #94: `end` is
+/// the answer whenever `last` has any duration at all; where it does NOT,
 /// `end == start` and the word would satisfy
 /// `LocalAgreement::watermark_filtered`'s own `start >= watermark` against its
-/// own confirmation. `next_up` is the IMMEDIATE `f32` successor, so nothing
-/// representable lies between the result and the start it excludes: exactly one
-/// instant is refused rather than a span, which an `end + epsilon` tolerance
-/// would not have managed.
+/// own confirmation. `past_the_settled_instant` is what supplies the rest — and
+/// it is a SAMPLE-domain step rather than the `f32::next_up` this used to take,
+/// because the same value is handed to `clip_timestamps` and one ULP of it
+/// rounds to the settled word's own sample (see that function).
 ///
-/// SPARING is the rest (#94, codex round 4 on PR #95). Nothing requires the
-/// watermark to clear `last`'s far EDGE -- only its start -- and word ends
-/// inside a hypothesis are not monotone, so `end` can reach past a word the
-/// hypothesis has already produced beyond `common`. Anchoring there would filter
-/// that word out of the next round's hypotheses for nothing, so the anchor drops
-/// to the earliest such start instead.
+/// `settled_high` rather than `last.start()`: with backwards starts reachable
+/// (see `split_at_a_strict_boundary`) the last word of `common` need not be the
+/// LATEST one confirmed, and it is the latest that the first postcondition has
+/// to clear. The two coincide on every non-decreasing input, which is why this
+/// takes the value rather than re-deriving it from `last`.
 ///
-/// The fold skips the starts that do NOT clear `last`'s own, and skipping rather
-/// than abandoning the sparing is deliberate: a word tied to `last` cannot be
-/// spared by ANY watermark this may return, but the words BEHIND that tie can,
-/// and an anchor that gave up on all of them because one was unsparable stranded
-/// them as collateral (measured on the sweep: a strand at 2.5 s lost to a tie at
-/// 2.0 s). So the result is the LOWEST instant that both clears `last`'s start
-/// and spares every word that any such instant could spare, and what it can
-/// still strand is exactly the tie -- this module's residual 1, which is the
-/// impossibility rather than a policy. `split_at_a_strict_boundary` is what
-/// decides whether to advance into that at all.
+/// This is only the anchor. `sparing_watermark` then lowers it to spare the
+/// words the same hypothesis produced beyond `common`, and what neither can
+/// spare is a word at or below `settled_high` — this module's residual 1, which
+/// is the impossibility rather than a policy. `split_at_a_strict_boundary` is
+/// what decides whether to advance into that at all.
 ///
-/// Total, never NaN, and always strictly greater than `last.start()`:
-/// `past_the_confirmed_start` is, and every start the filter keeps is; `last`
-/// and every word of `beyond_common` reached this through
-/// `LocalAgreement::watermark_filtered`, whose `start >= watermark` is false for
-/// a NaN start, so no start here is NaN; `f32::max` and `f32::min` both return
-/// the non-NaN side, so a NaN `end` falls through to `start.next_up()` rather
-/// than poisoning the fold.
+/// Total, never NaN, and always strictly greater than `settled_high`:
+/// `past_the_settled_instant` is, `f32::max` returns the non-NaN side so a NaN
+/// `end` falls through to it rather than poisoning the result, and every start
+/// that reached here did so through `LocalAgreement::watermark_filtered`, whose
+/// `start >= watermark` is false for a NaN start.
+fn empty_holdback_anchor(last: &WordTiming, settled_high: f32) -> f32 {
+  last.end().max(past_the_settled_instant(settled_high))
+}
+
+/// The highest `start` in `words`, or `None` where `words` is empty — the
+/// high-water settled start the two postconditions are stated against.
 ///
-/// It is a named function rather than an expression at its one obvious site
-/// because it has TWO callers with opposite jobs and they may not disagree.
-/// `LocalAgreement::ingest` SETS this watermark; `split_at_a_strict_boundary`
-/// decides whether setting it would strand a word the newer hypothesis produced
-/// beyond `common`, which is a question about this exact value. Computing it
-/// twice would let the guard drift off the thing it guards, silently.
-fn empty_holdback_watermark(last: &WordTiming, beyond_common: &[WordTiming]) -> f32 {
-  let past_the_confirmed_start = last.end().max(last.start().next_up());
-  beyond_common
+/// A MAXIMUM rather than `words.last()`: word starts inside one hypothesis are
+/// not non-decreasing (see `split_at_a_strict_boundary`), so the last confirmed
+/// word need not be the latest one, and it is the LATEST that a watermark has to
+/// clear before `LocalAgreement::watermark_filtered` can be trusted to refuse
+/// every confirmed word rather than only the final one.
+///
+/// `f32::max` returns the non-NaN side, so a NaN start is skipped rather than
+/// absorbing the fold.
+fn highest_start(words: &[WordTiming]) -> Option<f32> {
+  words
     .iter()
     .map(WordTiming::start)
-    .filter(|start| *start > last.start())
-    .fold(past_the_confirmed_start, f32::min)
+    .reduce(f32::max)
+    .filter(|high| !high.is_nan())
+}
+
+/// The lowest instant strictly past `settled` in BOTH coordinate systems the
+/// watermark is read in — seconds and SAMPLES.
+///
+/// The watermark has two consumers with two different granularities, and #94's
+/// codex round 7 finding 2 is that a step which satisfies one can be inert in
+/// the other. `LocalAgreement::watermark_filtered` compares it against word
+/// starts in SECONDS, where `f32::next_up` — the immediate successor — is
+/// enough to refuse exactly one instant.
+/// `LocalAgreement::decoding_options_for_next` hands the SAME value to
+/// [`DecodingOptions::clip_timestamps`](crate::audio::whisper::options::DecodingOptions::clip_timestamps_slice),
+/// where `chunker::prepare_seek_clips` rounds it to a sample index — and one ULP
+/// of a small `f32` is worth far less than half a sample, so `next_up` there
+/// moves NOTHING. Measured: `2.0f32.next_up()` is `2.000000238418579`, and both
+/// it and `2.0` round to sample `32000`. The "strictly past" guarantee was real
+/// in float space and vacuous in sample space, so the next stride re-read the
+/// settled word's own audio while the doc claimed it had been clipped away.
+///
+/// This closes that by asking `chunker::clip_seek_sample` — the rounding
+/// `prepare_seek_clips` itself applies — where `settled` lands, and returning an
+/// instant that lands strictly later. The first candidate is the exact time of
+/// the NEXT sample, which sits half a sample above the round-half-away-from-zero
+/// threshold; the loop then corrects for the quotient's own narrowing, which
+/// costs a whole sample only once `settled` is past roughly 500 s and `f32`
+/// seconds can no longer resolve one.
+///
+/// What it changes for the FILTER, stated rather than implied: the watermark
+/// this anchors now refuses every word starting within the settled word's own
+/// SAMPLE, where `next_up` refused only the settled instant itself. Every word
+/// [`crate::audio::whisper::segment::update_segments_with_word_timings`] emits
+/// is rounded to a centisecond (`rounded_to_places(_, 2)`), which is 160 samples
+/// — so no word the pipeline can produce falls in the widened gap, and the
+/// engine's residual 1 widens only for a caller synthesizing sub-centisecond
+/// starts (`the_watermark_clears_the_settled_sample_not_just_the_settled_instant`).
+///
+/// Total and terminating. `next_up` is strictly increasing on the finite
+/// floats, and `clip_seek_sample` is unbounded on them, so the loop exits; the
+/// `is_finite` guard is what keeps a `settled` of `+inf` — which
+/// `prepare_seek_clips` rejects outright and which `next_up` maps to itself —
+/// from spinning. On that input this returns `+inf`, exactly as the `next_up`
+/// anchor it replaces did.
+fn past_the_settled_instant(settled: f32) -> f32 {
+  let settled_sample = chunker::clip_seek_sample(settled);
+  let mut boundary = (settled_sample as f32 + 1.0) / SAMPLE_RATE as f32;
+  while boundary.is_finite()
+    && (boundary <= settled || chunker::clip_seek_sample(boundary) <= settled_sample)
+  {
+    boundary = boundary.next_up();
+  }
+  boundary
+}
+
+/// The watermark an advance actually sets: `anchor`, lowered to spare every
+/// UNCONFIRMED word of the driving hypothesis that any legal watermark could
+/// spare.
+///
+/// `settled_high` is the highest start in the confirmed list AFTER this
+/// round's append (`highest_start`), and it is the whole of the first
+/// postcondition: the result must be strictly greater than it, or a confirmed
+/// word passes `LocalAgreement::watermark_filtered`'s own `start >= watermark`
+/// and can be re-admitted. `anchor` already is — see its two callers in
+/// `LocalAgreement::ingest` — and every candidate this folds in is filtered to
+/// be, so the minimum is too.
+///
+/// `unconfirmed` is `hypothesis_words[split..]`: the holdback plus everything
+/// the same hypothesis produced past the agreed prefix. Every one of those words
+/// is a word this round did NOT settle, so pushing the watermark past it would
+/// filter it out of both hypotheses on the next worded ingest and leave
+/// `LocalAgreement::finalize` unable to reach it — after this round's own
+/// `finalize` has already published it. That is the second postcondition, and
+/// the fold is what buys it on BOTH arms rather than only on the empty-holdback
+/// one. On an interior split with non-decreasing starts it changes nothing: the
+/// anchor is `common[split].start()` and every later word starts at or past it,
+/// so the minimum is the anchor. It bites exactly where the starts run
+/// BACKWARDS, which `update_segments_with_word_timings` can produce (codex
+/// round 7 on PR #95, finding 1).
+///
+/// SKIPPING rather than abandoning on an unsparable word is deliberate and
+/// predates this generalization: a word at or below `settled_high` cannot be
+/// spared by ANY watermark the first postcondition permits, but the words
+/// BEHIND it can, and an anchor that gave up on all of them because one was
+/// unsparable stranded them as collateral (measured on the sweep: a strand at
+/// 2.5 s lost to a tie at 2.0 s).
+fn sparing_watermark(anchor: f32, settled_high: f32, unconfirmed: &[WordTiming]) -> f32 {
+  unconfirmed
+    .iter()
+    .map(WordTiming::start)
+    .filter(|start| *start > settled_high)
+    .fold(anchor, f32::min)
 }
 
 // ---------------------------------------------------------------------

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -407,6 +407,19 @@ fn the_split_never_cuts_at_a_tied_start() {
   // the holdback, and `empty_holdbacks` below is the non-vacuity proof that it
   // really happened.
   //
+  // The shape then still had ONE oversized word as its only route past the
+  // budget, and that could not build the AGGREGATE trigger (codex round 3 on
+  // PR #95): a TIED RUN of ordinary words whose TOTAL exceeds the budget, where
+  // the floor lands inside the run, every reachable boundary ties, and the round
+  // DEFERS instead of advancing. Measured on the shape this test had before:
+  // 25 deferred rounds of 1662 observations, all of them reached through the
+  // oversized word rather than through a run, and none of them DISTINGUISHED --
+  // the postcondition below holds under the old widen-off-the-end fallback too,
+  // which is why the deletion that fallback caused needed its own falsifier
+  // (`an_over_budget_tied_run_defers_rather_than_stranding_its_suffix`). The
+  // aggregate trials below take it to 133, and `deferrals` is that half's own
+  // non-vacuity proof.
+  //
   // The sweep draws starts from a coarse grid whose repeats make consecutive
   // words tie -- the `a=[0,0.5)/b=[0,1.0)` shape both #94 regressions are built
   // from, generalized -- keeps them non-decreasing the way `find_alignment`
@@ -426,7 +439,11 @@ fn the_split_never_cuts_at_a_tied_start() {
   // `next_up` anchor still holds the postcondition on that path, which is why
   // the back-off has its own falsifier in
   // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
-  // rather than being asserted here.
+  // rather than being asserted here. Restoring the widen-off-the-end fallback
+  // (`.or(Some(common.len()))` after the back-off) reds only the `deferrals`
+  // clause below, at `0 deferred rounds`, for the same reason: the postcondition
+  // survives that fallback, and what it costs is the DELETION its own falsifier
+  // pins.
   const TEXTS: [&str; 4] = [" A", " B", " C", " D"];
   // Repeated 0.0 entries are the ties; the rest keep the grid coarse enough for
   // two words to share an instant often.
@@ -466,13 +483,29 @@ fn the_split_never_cuts_at_a_tied_start() {
   let mut checked = 0u32;
   let mut empty_holdbacks = 0u32;
   let mut tied_truths = 0u32;
+  let mut deferrals = 0u32;
 
   for trial in 0..256u32 {
     let length = 4 + (next() % 5) as usize;
-    // The prefill budget is the only thing that can still empty the holdback, so
-    // one word in some trials is made too expensive for it to carry -- and it is
-    // placed anywhere, including last, where the split runs to `common.len()`.
-    let over_budget = if next() % 3 == 0 {
+    // TWO ways to blow the prefill budget, and the sweep drives BOTH.
+    //
+    // ONE OVERSIZED WORD is the route residual 1 needs: it is the only thing
+    // that can still leave the holdback EMPTY, and it is placed anywhere,
+    // including last, where the budget floor reaches `common.len()`.
+    //
+    // The AGGREGATE route needs no oversized word at all, and this test could
+    // not reach it before (codex round 3 on PR #95): ORDINARY words whose TIED
+    // RUN totals more than the budget put the floor strictly INSIDE the run, so
+    // every boundary the forward search and the back-off can reach ties while
+    // split 0 -- the boundary a tied run always leaves legal -- is below the
+    // floor. `AGGREGATE_TOKENS` is sized so any THREE such words exceed
+    // `MAX_HOLDBACK_PREFILL_TOKENS` and any two fit, which puts the floor two
+    // words from the end of every `common` and makes a three-word tie at the
+    // tail the trigger. That round DEFERS; `deferrals` below is its non-vacuity
+    // proof.
+    const AGGREGATE_TOKENS: usize = MAX_HOLDBACK_PREFILL_TOKENS / 3 + 1;
+    let aggregate = next() % 4 == 0;
+    let over_budget = if !aggregate && next() % 3 == 0 {
       Some((next() as usize) % length)
     } else {
       None
@@ -485,6 +518,8 @@ fn the_split_never_cuts_at_a_tied_start() {
       let end = start + DURATIONS[(next() % DURATIONS.len() as u64) as usize];
       truth.push(if over_budget == Some(index) {
         word_of_tokens(text, start, end, MAX_HOLDBACK_PREFILL_TOKENS + 1)
+      } else if aggregate {
+        word_of_tokens(text, start, end, AGGREGATE_TOKENS)
       } else {
         word(text, start, end)
       });
@@ -509,6 +544,10 @@ fn the_split_never_cuts_at_a_tied_start() {
       };
       for _ in 0..2 {
         agreement.ingest_streamed(result_with_words(offered.clone()));
+        // Read straight off the engine: a deferral returns
+        // `AwaitingAgreement`, which a disagreement returns too, so the outcome
+        // cannot tell them apart.
+        deferrals += u32::from(agreement.split_deferred);
         if let Some(empty) = postcondition(&agreement, trial, stride) {
           checked += 1;
           empty_holdbacks += u32::from(empty);
@@ -534,6 +573,11 @@ fn the_split_never_cuts_at_a_tied_start() {
     "the postcondition must be read against an EMPTY holdback too, which is \
      the state this test used to skip: {empty_holdbacks} of {checked} \
      observations",
+  );
+  assert!(
+    deferrals > 64,
+    "and the DEFERRED state must be reached, which is the state the \
+     one-oversized-word shape could not build: {deferrals} deferred rounds",
   );
 }
 #[test]
@@ -632,6 +676,194 @@ fn a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count() {
       "{token} must appear exactly once in {text:?}"
     );
   }
+}
+
+#[test]
+fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
+  // #94, codex round 3 on PR #95 -- the OTHER way the holdback empties, and the
+  // one Rule W's back-off cannot reach. The back-off may not cross the prefill
+  // budget FLOOR, and a tied run that is itself over budget puts that floor
+  // strictly inside the run: every boundary at or above it ties, split 0 -- the
+  // one boundary a tied run always leaves legal -- is below it, and the forward
+  // search and the back-off therefore BOTH fail. The old fallback confirmed the
+  // whole run and emptied the holdback, which is exactly what
+  // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
+  // refuses one state earlier.
+  //
+  // What the empty holdback costs here is a DELETION rather than a
+  // re-confirmation: the watermark anchors at `start.next_up()`, strictly past
+  // the run's instant, so any word the NEWER hypothesis produced at that same
+  // instant beyond `common` -- words nothing ever confirmed -- fails the offered
+  // filter on the next worded ingest, drops out of both hypotheses at once, and
+  // `finalize` has nothing left to recover them from.
+  //
+  // It takes no over-budget WORD, which is what separates it from
+  // `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed`: 113
+  // ORDINARY one-token words sharing one start are 113 tokens against a
+  // 112-token budget, and `add_word_timestamps` produces exactly that shape from
+  // an ALL-ZERO alignment matrix -- the zero-fill
+  // `add_word_timestamps_zero_pads_missing_rows` pins -- because DTW's tie-break
+  // walks the path down column 0 and every text-index step there records the
+  // same boundary time. Measured on that stack: 130 words, all at 0.0, all
+  // zero-duration, one token each.
+  //
+  // The repair is to DEFER: no legal boundary at or above the floor is a
+  // non-advancing round, not a licence to widen off the end. The watermark stays
+  // put, so nothing is filtered away; the holdback stays put, so the next stride
+  // still prefills what it prefilled before; and TAIL growth relieves it, the
+  // same relief the back-off relies on. `finalize` on a deferred round emits the
+  // latest hypothesis's own post-watermark words, which is byte-identical to
+  // what the fallback produced (`confirmed ++ common ++ hypothesis-beyond-common`
+  // either way) -- the divergence is entirely in what LATER ingests can still
+  // see.
+  //
+  // Mutation proof, every row run: restore the widen-off-the-end fallback
+  // (`.or(Some(common.len()))` after the back-off) and the deferral assertion
+  // below reds reading `(113, 0, 2.0000002, 0, 2)`; with that assertion
+  // neutralized the two FACES red next, the streaming one confirming the 113-word
+  // run against an empty holdback and the finalized one reading
+  // `[... "w112", "y"]` with `" x0"`/`" x1"` gone. Defer whenever the budget
+  // floor bites at all (`if floor > 0 { return None }`) and the deadlock clause
+  // below reds -- along with
+  // `an_over_budget_holdback_is_capped_rather_than_silently_truncated`, which is
+  // the ordinary budget path this may not swallow. Never CLEAR the flag
+  // (`|=` for `=` in `ingest`) and the finalized face reds, the advance's own
+  // Swift shape replaced by the hypothesis. Make `word` emit two tokens and the
+  // non-vacuity row reds at `(113, 226, false)`.
+  //
+  // The `finalize` half has its own two rows at its own assertions below.
+  const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
+  let tied: Vec<WordTiming> = (0..RUN)
+    .map(|index| word(&format!(" w{index:03}"), 2.0, 2.0))
+    .collect();
+  assert_eq!(
+    (
+      tied.len(),
+      tied
+        .iter()
+        .map(|word| word.tokens_slice().len())
+        .sum::<usize>(),
+      tied.iter().all(|word| word.tokens_slice().len() == 1),
+    ),
+    (113, MAX_HOLDBACK_PREFILL_TOKENS + 1, true),
+    "non-vacuous: ORDINARY one-token words, and it is their SUM that exceeds \
+     the budget -- no single word here is over budget",
+  );
+
+  // Two more words at the run's own instant, beyond the prefix the two
+  // hypotheses agree on. Nothing confirms these; the watermark is the only thing
+  // deciding whether they can still be offered.
+  let suffix = || vec![word(" x0", 2.0, 2.0), word(" x1", 2.0, 2.0)];
+  let older = || result_with_words(tied.clone());
+  let newer = || result_with_words([tied.clone(), suffix()].concat());
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, the only one the driver reaches",
+  );
+  agreement.ingest_streamed(older());
+  agreement.ingest_streamed(newer());
+  assert_eq!(
+    (
+      confirmed_texts(&agreement).len(),
+      held_back_texts(&agreement).len(),
+      agreement.last_agreed_seconds(),
+      // The consequence, read through the filter that consumes the watermark:
+      // every word the newer hypothesis produced at the run's instant is still
+      // OFFERABLE. Folded into this assertion rather than standing beside it,
+      // since it is a function of the watermark above and could never red first.
+      LocalAgreement::watermark_filtered(&newer(), agreement.last_agreed_seconds()).len(),
+      // The hypotheses AGREED, so Swift KEEPS the result (`:408-410`,
+      // `!skipAppend`) and it reaches the `finalize` merge as a segment source.
+      // Dropping it here reds nothing else in this suite -- the merged TEXT is
+      // the confirmed word list either way -- so the keep is pinned here.
+      agreement.results_slice().len(),
+    ),
+    (0, 0, 0.0, RUN + 2, 2),
+    "no legal boundary at or above the budget floor is a DEFERRED round: \
+     nothing is confirmed, the holdback is untouched, the watermark does not \
+     move, so nothing at the run's instant is filtered away -- and the agreeing \
+     result is kept",
+  );
+
+  // THE SECOND CLAUSE OF THE REPAIR, on its own. "Do not advance" alone loses
+  // the transcript: `finalize`'s Swift shape is `confirmed ++ last_agreed_words
+  // ++ differentSuffix(prev, hypothesis)`, and on a deferred round the holdback
+  // is an EARLIER agreement's -- here it does not exist at all -- so the sum
+  // drops every word the two hypotheses agreed on. A deferred round therefore
+  // finalizes from the latest hypothesis instead (`split_deferred`).
+  //
+  // Mutation proof for that clause alone: drop `|| self.split_deferred` from
+  // `finalize`'s guard and this reads `" x0 x1"` -- the whole 113-word run gone,
+  // exactly the `commonPrefix.count` leading words the Swift expression cannot
+  // account for once the holdback is not the round's own.
+  let deferred_transcript = agreement
+    .clone()
+    .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+    .text()
+    .to_string();
+  assert_eq!(
+    deferred_transcript.split_whitespace().count(),
+    RUN + 2,
+    "a stream that ENDS on a deferred round still finalizes every word it \
+     produced: {deferred_transcript:?}",
+  );
+
+  // And the same with the two hypotheses IDENTICAL, where the differing suffix
+  // is EMPTY as well -- the shape a plain non-advancing policy finalizes as `""`.
+  let mut agreed_twice = agreement.clone();
+  agreed_twice.ingest_streamed(newer());
+  let identical_transcript = agreed_twice
+    .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+    .text()
+    .to_string();
+  assert_eq!(
+    identical_transcript.split_whitespace().count(),
+    RUN + 2,
+    "with nothing confirmed, nothing held and no differing suffix either, the \
+     Swift shape would finalize the empty string: {identical_transcript:?}",
+  );
+
+  // Tail growth is what relieves the deferral: one word starting strictly later
+  // opens a legal boundary above the floor, and it takes two ingests for that
+  // word to reach `common`.
+  let grown = || result_with_words([tied.clone(), suffix(), vec![word(" y", 3.0, 4.0)]].concat());
+  agreement.ingest_streamed(grown());
+  assert!(
+    agreement.ingest_streamed(grown()).is_advanced(),
+    "and the deferral is not a deadlock: the grown tail opens a boundary above \
+     the floor and the round advances",
+  );
+
+  let mut expected: Vec<String> = (0..RUN).map(|index| format!(" w{index:03}")).collect();
+  expected.push(" x0".to_string());
+  expected.push(" x1".to_string());
+  assert_eq!(
+    (confirmed_texts(&agreement), held_back_texts(&agreement)),
+    (
+      expected.iter().map(String::as_str).collect::<Vec<_>>(),
+      vec![" y"],
+    ),
+    "the STREAMING face: the whole tied run and both words at its instant are \
+     confirmed exactly once, and the word that opened the boundary is held",
+  );
+
+  let text = agreement
+    .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+    .text()
+    .to_string();
+  expected.push(" y".to_string());
+  assert_eq!(
+    text.split_whitespace().collect::<Vec<_>>(),
+    expected
+      .iter()
+      .map(|word| word.trim_start())
+      .collect::<Vec<_>>(),
+    "the FINALIZED face: every word the stream produced, each exactly once and \
+     in order",
+  );
 }
 
 #[test]

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -11,22 +11,12 @@ fn word(text: &str, start: f32, end: f32) -> WordTiming {
 /// A word carrying `token_count` distinct plain-vocabulary token ids — for the
 /// prefill-budget cases, where what matters is how many TOKENS the holdback
 /// costs, not how many words it holds. Ids stay far below any Whisper
-/// vocabulary's `special_token_begin`, so `prefill_tokens`' other filter cannot
+/// vocabulary's special range, so `prefill_tokens`' other reduction cannot
 /// confuse the measurement.
 fn word_of_tokens(text: &str, start: f32, end: f32, token_count: usize) -> WordTiming {
   let first = start as u32 * 1000 + 1;
   let tokens: Vec<u32> = (0..token_count as u32).map(|index| first + index).collect();
   WordTiming::new(text, tokens, start, end, 0.9)
-}
-
-/// A word whose tokens `prefill_tokens` ERASES: every id is at or above
-/// [`MIN_SPECIAL_TOKEN_BEGIN`], so the filter drops the lot and the word
-/// contributes NOTHING to the initial prompt. `add_word_timestamps` never emits
-/// one — it strips exactly those ids and skips an alignment entry that has
-/// nothing left — so this is a hand-built shape, reachable only through
-/// [`LocalAgreement::ingest`]'s public, hand-built [`TranscriptionResult`].
-fn special_only_word(text: &str, start: f32, end: f32) -> WordTiming {
-  WordTiming::new(text, vec![MIN_SPECIAL_TOKEN_BEGIN], start, end, 0.9)
 }
 
 /// The tiny model's tokenizer — the same artifact `decode`'s own tests read, and
@@ -1709,10 +1699,10 @@ fn an_over_budget_holdback_is_capped_rather_than_silently_truncated() {
   //
   // Mutation proof: make `budgeted_split` return its `requested` argument
   // unchanged and both faces red -- the confirmed list stalls at two words
-  // instead of four, and the finalized text loses " w2 w3" entirely. The empty
-  // PENDING half has its own falsifier: relax the advance's `word.end() >
-  // self.last_agreed_seconds` to `>=` and " w3" is deferred instead of
-  // confirmed, though nothing offered can ever overlap it.
+  // instead of four, and the finalized text loses " w2 w3" entirely. Stop the
+  // budget loop one word short (`split + 1 < common.len()`, round 7's own
+  // defect) and `the_split_holds_back_exactly_what_the_prefill_budget_carries`
+  // reds on the single-oversized-word row.
   let words = budget_words();
   let mut agreement = LocalAgreement::new().with_agreement_count_needed(5);
 
@@ -1860,232 +1850,23 @@ fn a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held() {
 }
 
 #[test]
-fn a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held() {
-  // #94 (codex round 8, finding 1). THE CAP MUST CAP THE OTHER FILTER TOO.
-  // `prefill_tokens` reduces `prefix_tokens` twice on its way to the decoder: it
-  // keeps only the last `MAX_HOLDBACK_PREFILL_TOKENS` ids, AND it drops every id
-  // at or above the vocabulary's `special_token_begin`. `budgeted_split` bounded
-  // only the first. So a hand-built stream can settle a word, hold a word made
-  // of ids the decoder never receives, and have `decoding_options_for_next`
-  // issue a retarget that promises the decoder a holdback it will never be
-  // given.
+fn the_split_holds_back_exactly_what_the_prefill_budget_carries() {
+  // `budgeted_split`'s POSTCONDITION and its MINIMALITY, written out longhand
+  // rather than by calling the code under test, so a mutation cannot mutate its
+  // own falsifier with it: the holdback the split leaves fits
+  // `MAX_HOLDBACK_PREFILL_TOKENS`, and no EARLIER split would have.
   //
-  // REACHABILITY, since round 3 classified this half unreachable. That
-  // classification's evidence is correct -- `update_segments_with_word_timings`
-  // strips `id >= special_token_begin` from every `WordTiming` and emits no word
-  // at all for an all-special entry, so this crate's pipeline never produces
-  // one. What it does not cover is `ingest` itself, which is public, takes a
-  // hand-built `TranscriptionResult`, and sets `last_agreed_words` to
-  // `common[split..]` -- elements of the caller's own hypothesis, tokens
-  // included. `WordTiming::new` takes the token vector directly. Nothing between
-  // there and `holdback_prefill_tokens` looks at an id.
-  //
-  // NEITHER SEAM IS THE REPAIR, which is why the fix is in the split. Read the
-  // arithmetic of this very stream three ways:
-  //
-  //   - HELD (the defect): " S" is never confirmed, the re-offer supersedes the
-  //     holdback that carried it, and the transcript loses it -- " A A Y C".
-  //   - CONFIRMED instead of held (this fix): " A S A Y C", every word two
-  //     hypotheses agreed on, and the later revision still applied.
-  //
-  // Confirming is no weaker a claim than any other confirmation carries --
-  // `common` is the prefix two consecutive hypotheses agreed on, LocalAgreement-2's
-  // entire criterion -- and holding buys nothing, because whatever the next
-  // hypothesis produces over that extent was decoded from a prefix the held word
-  // is not in, so it is neither a corroboration of it nor a revision of it.
-  //
-  // Mutation proof: drop `budgeted_split`'s `rposition` floor (equivalently,
-  // weaken `prefill_carries_whole` to `true`) and every assertion below reds --
-  // " S" is held rather than confirmed, the issued prefix carries the id the
-  // filter erases, and the transcript reads " A A Y C" with " S" gone. The
-  // opposite mutation has its own falsifier where it stands: widen
-  // `prefill_carries_whole` to `false` for every word and the issued prefill
-  // goes EMPTY.
-  let a0 = || word(" A", 0.5, 1.0);
-  let s = || special_only_word(" S", 1.0, 1.5);
-  let a1 = || word(" A", 1.5, 2.0);
-  let b = || word(" B", 2.0, 2.5);
-  let c = || word(" C", 2.5, 3.0);
-  // " Y" revises " B", at " B"'s own extent.
-  let y = || word(" Y", 2.0, 2.5);
-  assert!(
-    s()
-      .tokens_slice()
-      .iter()
-      .all(|&id| id >= MIN_SPECIAL_TOKEN_BEGIN),
-    "non-vacuous: the held word is made only of ids `prefill_tokens` drops",
-  );
-
-  let mut agreement = LocalAgreement::new();
-  let opening = || result_with_words(vec![a0(), s(), a1()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-
-  // The streaming face, read between pushes: the word the prefill cannot carry
-  // is SETTLED, and the holdback is the one word that survives the filter whole.
-  assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A", " S"],
-    "a word the decoder can never be given is CONFIRMED, never held",
-  );
-  assert_eq!(
-    agreement
-      .last_agreed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" A"],
-    "and the holdback keeps only what the prefill reproduces",
-  );
-  assert_eq!(
-    agreement.last_agreed_seconds(),
-    1.5,
-    "the watermark moves to the first word still held",
-  );
-
-  // The face the decoder sees: every id the engine issues survives BOTH of
-  // `prefill_tokens`'s reductions, so the retarget really does hand the decoder
-  // the whole holdback.
-  let next = agreement.decoding_options_for_next(&DecodingOptions::new());
-  assert!(
-    next
-      .prefix_tokens_slice()
-      .iter()
-      .all(|&id| id < MIN_SPECIAL_TOKEN_BEGIN),
-    "the issued prefix carries an id the decoder's filter erases: {:?}",
-    next.prefix_tokens_slice(),
-  );
-  assert!(
-    !next.prefix_tokens_slice().is_empty(),
-    "and it is not empty, so there is something for the decoder to reproduce",
-  );
-
-  let re_offer = || result_with_words(vec![a1(), b(), c()]);
-
-  // The continuation. The re-offer reproduces the one held word and carries the
-  // stream on; the pair agrees on the next stride and settles it. Outcome and
-  // settled span are read TOGETHER at each step, so the step itself has a
-  // falsifier rather than only the state after it.
-  assert_eq!(
-    (
-      agreement.ingest_streamed(re_offer()),
-      confirmed_texts(&agreement)
-    ),
-    (AgreementOutcome::AwaitingAgreement, vec![" A", " S"]),
-    "one reproduced word is short of `agreement_count_needed`, so nothing new \
-     settles here",
-  );
-  assert_eq!(
-    (
-      agreement.ingest_streamed(re_offer()),
-      confirmed_texts(&agreement)
-    ),
-    (AgreementOutcome::Advanced, vec![" A", " S", " A"]),
-    "the settled span grows over the word the prefill could not carry, never \
-     through it",
-  );
-
-  // The genuine later revision, which must still be applied: " B" is only HELD,
-  // so a hypothesis that revises it to " Y" supersedes it.
-  let revised = agreement.ingest_streamed(result_with_words(vec![y(), c()]));
-  assert_eq!(
-    (
-      revised,
-      agreement
-        .finalize(&DecodingOptions::new())
-        .text()
-        .to_string()
-    ),
-    (
-      AgreementOutcome::AwaitingAgreement,
-      " A S A Y C".to_string()
-    ),
-    "the finalized face: the unreproducible word survives BECAUSE it was \
-     confirmed, and the later revision is still free to land",
-  );
-}
-
-#[test]
-fn the_split_holds_back_exactly_what_the_prefill_carries_whole() {
-  // The postcondition `budgeted_split` now has, and its MINIMALITY -- written out
-  // longhand rather than through `prefill_carries_whole`, so a mutation of that
-  // predicate cannot mutate its own falsifier along with it.
-  //
-  // Four things a row here pins that the end-to-end counterexample does not: a
-  // word with NO tokens at all (it contributes nothing to `prefix_tokens`, so the
-  // decoder is never given it either -- the same defect, with no vocabulary
-  // knowledge required to see it); a filtered word BEHIND a carriable one, which
-  // is why the floor reads `rposition` and not `position` (the FIRST such word is
-  // not the one the split has to clear); the two reductions side by side, so
-  // neither is enforced only by cancelling the other; and the id filter read
-  // against a THRESHOLD rather than against the constant, rows 6 and 7 differing
-  // in nothing else (codex round 12, finding 2).
-  //
-  // Mutation proof, every row enumerated by running it: drop `!tokens.is_empty()`
-  // and row 1 reds; use `position` for the floor and row 3 reds; drop the floor
-  // entirely and rows 0-3 and 6 red on the postcondition; make `budgeted_split`
-  // the identity and rows 0-4 and 6 do; return `common.len()` unconditionally and
-  // rows 0, 1, 3, 4, 5, 6 and 7 red on the MINIMALITY clause instead; read
-  // `MIN_SPECIAL_TOKEN_BEGIN` in `budgeted_split` instead of the threshold it is
-  // given and row 6 reds alone.
+  // Mutation proof, every row enumerated by running it: make `budgeted_split`
+  // the identity (`requested`) and rows 0, 1 and 2 red on the postcondition;
+  // return `common.len()` unconditionally and rows 3 and 4 red on the MINIMALITY
+  // clause instead; stop the loop at `split + 1 < common.len()` (round 7's
+  // defect, the cap that did not cap) and row 2 reds.
   let plain =
     |text: &str, start: f32, count: usize| word_of_tokens(text, start, start + 1.0, count);
-  let filtered = |text: &str, start: f32| special_only_word(text, start, start + 1.0);
-  let tokenless =
-    |text: &str, start: f32| WordTiming::new(text, Vec::new(), start, start + 1.0, 0.9);
-  // An id BELOW `MIN_SPECIAL_TOKEN_BEGIN` and so carriable under the floor, but
-  // at or above the lower threshold rows 6/7 configure -- the artifact shape
-  // codex round 12, finding 2 is about.
-  let below_floor =
-    |text: &str, start: f32| WordTiming::new(text, vec![45_000], start, start + 1.0, 0.9);
 
-  // `(common, requested, special_token_begin)`.
-  let cases: Vec<(Vec<WordTiming>, usize, u32)> = vec![
-    // 0: the counterexample's own shape -- a filtered word at the holdback head.
-    (
-      vec![
-        plain(" A", 0.0, 1),
-        filtered(" S", 1.0),
-        plain(" B", 2.0, 1),
-      ],
-      1,
-      MIN_SPECIAL_TOKEN_BEGIN,
-    ),
-    // 1: no tokens at all, in the same position.
-    (
-      vec![
-        plain(" A", 0.0, 1),
-        tokenless(" S", 1.0),
-        plain(" B", 2.0, 1),
-      ],
-      1,
-      MIN_SPECIAL_TOKEN_BEGIN,
-    ),
-    // 2: a filtered word at the holdback TAIL -- the split has to clear that one
-    //    too, so the holdback comes back empty.
-    (
-      vec![
-        plain(" A", 0.0, 1),
-        plain(" B", 1.0, 1),
-        filtered(" S", 2.0),
-      ],
-      1,
-      MIN_SPECIAL_TOKEN_BEGIN,
-    ),
-    // 3: a carriable word BETWEEN two filtered ones. `position` stops at the
-    //    first and leaves the second held; `rposition` clears both.
-    (
-      vec![
-        plain(" A", 0.0, 1),
-        filtered(" S", 1.0),
-        plain(" B", 2.0, 1),
-        filtered(" T", 3.0),
-        plain(" C", 4.0, 1),
-      ],
-      1,
-      MIN_SPECIAL_TOKEN_BEGIN,
-    ),
-    // 4: the length reduction, unchanged by any of the above.
+  // `(common, requested)`.
+  let cases: Vec<(Vec<WordTiming>, usize)> = vec![
+    // 0: one over-budget word at the holdback head.
     (
       vec![
         plain(" A", 0.0, 1),
@@ -2093,9 +1874,27 @@ fn the_split_holds_back_exactly_what_the_prefill_carries_whole() {
         plain(" C", 2.0, MAX_HOLDBACK_PREFILL_TOKENS),
       ],
       1,
-      MIN_SPECIAL_TOKEN_BEGIN,
     ),
-    // 5: nothing to do -- every word carriable, the whole holdback in budget.
+    // 1: the budget blown by the SUM rather than by any single word.
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        plain(" B", 1.0, MAX_HOLDBACK_PREFILL_TOKENS / 2 + 1),
+        plain(" C", 2.0, MAX_HOLDBACK_PREFILL_TOKENS / 2 + 1),
+      ],
+      1,
+    ),
+    // 2: ONE word whose own tokens exceed the budget, so the split has to run to
+    //    `common.len()` and leave the holdback EMPTY (codex round 7, finding 2 --
+    //    a loop that stopped one word short held it anyway).
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        plain(" B", 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1),
+      ],
+      1,
+    ),
+    // 3: nothing to do -- the whole holdback is in budget.
     (
       vec![
         plain(" A", 0.0, 1),
@@ -2103,88 +1902,39 @@ fn the_split_holds_back_exactly_what_the_prefill_carries_whole() {
         plain(" C", 2.0, 1),
       ],
       1,
-      MIN_SPECIAL_TOKEN_BEGIN,
     ),
-    // 6: an id the FLOOR calls carriable and a lower-threshold vocabulary
-    //    filters. The split must clear it against the threshold it was GIVEN,
-    //    not against the constant (codex round 12, finding 2).
-    (
-      vec![
-        plain(" A", 0.0, 1),
-        below_floor(" S", 1.0),
-        plain(" B", 2.0, 1),
-      ],
-      1,
-      40_000,
-    ),
-    // 7: row 6's own control -- the same three words under the default floor,
-    //    where the same id IS carriable and nothing needs clearing. Rows 6 and 7
-    //    differ only in the threshold, so a split that ignored it would fail one
-    //    of them whatever it returned.
-    (
-      vec![
-        plain(" A", 0.0, 1),
-        below_floor(" S", 1.0),
-        plain(" B", 2.0, 1),
-      ],
-      1,
-      MIN_SPECIAL_TOKEN_BEGIN,
-    ),
+    // 4: nothing to do with an empty holdback either.
+    (vec![plain(" A", 0.0, 1), plain(" B", 1.0, 1)], 2),
   ];
 
-  let holdable = |words: &[WordTiming], special_token_begin: u32| {
-    words.iter().all(|word| {
-      !word.tokens_slice().is_empty()
-        && word
-          .tokens_slice()
-          .iter()
-          .all(|&id| id < special_token_begin)
-    }) && words
+  let holdable = |words: &[WordTiming]| {
+    words
       .iter()
       .map(|word| word.tokens_slice().len())
       .sum::<usize>()
       <= MAX_HOLDBACK_PREFILL_TOKENS
   };
 
-  for (row, (common, requested, special_token_begin)) in cases.iter().enumerate() {
-    let split = budgeted_split(common, *requested, *special_token_begin);
+  for (row, (common, requested)) in cases.iter().enumerate() {
+    let split = budgeted_split(common, *requested);
     let texts: Vec<&str> = common.iter().map(WordTiming::word).collect();
     assert!(
       (*requested..=common.len()).contains(&split),
       "row {row} ({texts:?}): split {split} left the requested-to-end range",
     );
     assert!(
-      holdable(&common[split..], *special_token_begin),
-      "row {row} ({texts:?}): the holdback at {split} is not one the prefill \
-       carries whole",
+      holdable(&common[split..]),
+      "row {row} ({texts:?}): the holdback at {split} is over \
+       MAX_HOLDBACK_PREFILL_TOKENS, so `prefill_tokens` would silently trim it",
     );
     for earlier in *requested..split {
       assert!(
-        !holdable(&common[earlier..], *special_token_begin),
+        !holdable(&common[earlier..]),
         "row {row} ({texts:?}): split {split} confirms more than it has to -- \
-         {earlier} already holds only carriable words within budget",
+         {earlier} already holds a within-budget holdback",
       );
     }
   }
-}
-
-#[test]
-#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
-fn the_prefill_token_ceiling_is_below_the_vocabularys_special_range() {
-  // `MIN_SPECIAL_TOKEN_BEGIN` is the bound `budgeted_split` tests against with no
-  // tokenizer in hand, and it is only sound while it is at or below the LOADED
-  // vocabulary's own `special_token_begin` -- otherwise an id `prefill_tokens`
-  // filters would be held anyway. Asserted against the real artifact rather than
-  // argued from the constant's doc.
-  //
-  // Mutation proof: raise the constant above the shipped vocabulary's threshold
-  // (`50_258`) and this reds.
-  let special_token_begin = tiny_tokenizer().special_tokens().special_token_begin();
-  assert!(
-    special_token_begin >= MIN_SPECIAL_TOKEN_BEGIN,
-    "the vocabulary reserves ids from {special_token_begin}, below the \
-     {MIN_SPECIAL_TOKEN_BEGIN} the holdback rule assumes",
-  );
 }
 
 // ---------------------------------------------------------------------
@@ -2482,118 +2232,5 @@ fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
     " P Y Z",
     "the overlapping confirmed word and the later re-reading of its audio are \
      BOTH in the transcript -- the append-only contract",
-  );
-}
-
-#[test]
-fn the_holdback_filter_reads_the_configured_special_range_not_the_floor() {
-  // #94 (codex round 12, finding 2). THE FLOOR IS AN ASSUMPTION, NOT AN
-  // INVARIANT. `MIN_SPECIAL_TOKEN_BEGIN` is correct for the 50256/50257
-  // families, but `WhisperTokenizer::from_folder` loads any parseable
-  // `tokenizer.json` and probes `<|endoftext|>` for that artifact's OWN
-  // threshold, rejecting nothing below the floor. For such an artifact the
-  // engine calls an id carriable that `prefill_tokens` erases, so the retarget
-  // promises a prefix the decoder is given only part of, and round 8's defect is
-  // back with no caller lying.
-  //
-  // Threading the real value closes it where the value is known and costs
-  // nothing where it is not: the default is exactly the floor, so no existing
-  // caller moves, and `LocalAgreementTranscriber` sets it from the very
-  // tokenizer whose `prefill_tokens` will apply the filter (see
-  // `the_driver_takes_its_special_range_from_the_loaded_vocabulary`). Rejecting
-  // the artifact at load instead would refuse a vocabulary this crate otherwise
-  // decodes correctly, over a premise only the streaming engine has a stake in.
-  //
-  // Mutation proof, both faces: read `MIN_SPECIAL_TOKEN_BEGIN` in
-  // `budgeted_split` instead of the threshold it is given and the configured
-  // engine's holdback reads back [" S", " B"] carrying id 40005 -- an id the
-  // artifact's own filter erases.
-  const LOW: u32 = 40_000;
-  let a = || word(" A", 0.0, 0.5);
-  // Below the floor, so carriable under the default; at or above LOW, so not
-  // carriable for an artifact that reserves ids from there.
-  let s = || WordTiming::new(" S", vec![LOW + 5], 0.5, 1.0, 0.9);
-  let b = || word(" B", 1.0, 1.5);
-  assert!(
-    s()
-      .tokens_slice()
-      .iter()
-      .all(|&id| id < MIN_SPECIAL_TOKEN_BEGIN),
-    "non-vacuous: the floor calls every one of these ids carriable",
-  );
-
-  let run = |engine: LocalAgreement| {
-    let mut engine = engine;
-    let opening = || result_with_words(vec![a(), s(), b()]);
-    engine.ingest_streamed(opening());
-    assert!(engine.ingest_streamed(opening()).is_advanced());
-    let holdback: Vec<String> = engine
-      .last_agreed_words_slice()
-      .iter()
-      .map(|word| word.word().to_string())
-      .collect();
-    let prefill = engine
-      .decoding_options_for_next(&DecodingOptions::new())
-      .prefix_tokens_slice()
-      .to_vec();
-    (holdback, prefill)
-  };
-
-  // The default engine: the floor, and the artifact's filter erases what it
-  // issues.
-  let engine = LocalAgreement::new();
-  assert_eq!(engine.special_token_begin(), MIN_SPECIAL_TOKEN_BEGIN);
-  let (holdback, prefill) = run(engine);
-  assert_eq!(holdback, vec![" S".to_string(), " B".to_string()]);
-  assert!(
-    prefill.iter().any(|&id| id >= LOW),
-    "non-vacuous: this is the defect -- the issued prefix {prefill:?} carries \
-     an id a vocabulary reserving from {LOW} drops",
-  );
-
-  // Told the artifact's own threshold: the same word is widened past instead,
-  // and every id the engine issues survives that vocabulary's filter.
-  let engine = LocalAgreement::new().with_special_token_begin(LOW);
-  assert_eq!(engine.special_token_begin(), LOW);
-  let (holdback, prefill) = run(engine);
-  assert_eq!(
-    holdback,
-    vec![" B".to_string()],
-    "the holdback keeps only what THAT vocabulary's prefill carries whole",
-  );
-  assert!(
-    !prefill.is_empty() && prefill.iter().all(|&id| id < LOW),
-    "and the issued prefix {prefill:?} survives its filter intact",
-  );
-}
-
-#[test]
-#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
-fn the_driver_takes_its_special_range_from_the_loaded_vocabulary() {
-  // The path that needs nothing remembered: the driver holds the very tokenizer
-  // whose `prefill_tokens` applies the filter `budgeted_split` is standing in
-  // for, so it hands the engine the exact threshold instead of the floor. Read
-  // off the real artifact rather than argued from the constant.
-  //
-  // Mutation proof: drop the `with_special_token_begin(...)` from
-  // `LocalAgreementTranscriber::new` and this reads back
-  // `MIN_SPECIAL_TOKEN_BEGIN`.
-  let tokenizer = tiny_tokenizer();
-  let vocabulary = tokenizer.special_tokens().special_token_begin();
-  assert_ne!(
-    vocabulary, MIN_SPECIAL_TOKEN_BEGIN,
-    "non-vacuous: the shipped vocabulary's threshold is not the floor, so the \
-     two answers are distinguishable",
-  );
-
-  let kit = crate::audio::whisper::transcribe::WhisperKit::with_backend(
-    crate::audio::whisper::backend::mock::MockBackend::new(),
-    tokenizer,
-  );
-  let streamer = kit.local_agreement_transcriber(DecodingOptions::new());
-  assert_eq!(
-    streamer.agreement().special_token_begin(),
-    vocabulary,
-    "the driver's engine reads the loaded vocabulary, not the floor",
   );
 }

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -403,66 +403,62 @@ fn the_split_never_cuts_at_a_tied_start() {
   // coverage). The postcondition is now asserted on EVERY observation with a
   // non-empty confirmed list, and the sweep DRIVES the empty holdback rather
   // than avoiding it: some trials raise the prefill cost of one word past
-  // `MAX_HOLDBACK_PREFILL_TOKENS`, which is the only thing that still empties
-  // the holdback -- on a round that strands nothing past `common`, since one
-  // that would defers -- and `empty_holdbacks` below is the non-vacuity proof
-  // that it really happened.
+  // `MAX_HOLDBACK_PREFILL_TOKENS`, and some build a TIED RUN whose tokens
+  // exceed it in aggregate -- the two shapes that empty the holdback -- and
+  // `empty_holdbacks` below is the non-vacuity proof that it really happened.
   //
   // The shape then still had ONE oversized word as its only route past the
   // budget, and that could not build the AGGREGATE trigger (codex round 3 on
   // PR #95): a TIED RUN of ordinary words whose TOTAL exceeds the budget, where
-  // the floor lands inside the run, every reachable boundary ties, and the round
-  // DEFERS instead of advancing. Measured on the shape this test had before:
-  // 25 deferred rounds of 1662 observations, all of them reached through the
-  // oversized word rather than through a run, and none of them DISTINGUISHED --
-  // the postcondition below holds under the old widen-off-the-end fallback too,
-  // which is why the deletion that fallback caused needed its own falsifier
-  // (`an_over_budget_tied_run_defers_rather_than_stranding_its_suffix`). The
-  // aggregate trials below took it to 133, and `deferrals` is that half's own
-  // non-vacuity proof.
+  // the floor lands inside the run, every reachable boundary ties, and the split
+  // runs off the end of `common`. Measured on the shape this test had before:
+  // 25 such rounds of 1662 observations, all of them reached through the
+  // oversized word rather than through a run, and none of them DISTINGUISHED.
+  // `aggregate_fallbacks` is that half's own non-vacuity proof, and it counts
+  // the ROUTE rather than the arm: a fallback round in which no word of `common`
+  // is over budget on its own can only have got there through the run.
   //
   // A SECOND POSTCONDITION now rides the same sweep, and reaching the state it
   // speaks about needed one more shape change (codex round 3 on PR #95, second
   // finding). `nothing_unconfirmed_falls_below_the_watermark` is the claim that
   // an advance may not push the watermark past a word of its own hypothesis it
-  // did not confirm; the state that breaks it is the FORCED arm reached with a
+  // did not confirm; the state that tests it is the FORCED arm reached with a
   // live suffix beyond `common`, and offering every stride TWICE could not build
   // it -- measured at 0 rounds of 1353. `repeats` below offers a stride once in
   // three, which leaves the next stride's first ingest comparing consecutive
   // GROWING lists, and `forced_strands` is that half's non-vacuity proof.
   //
-  // A FOURTH shape change reaches the DEFERRAL's own liveness (codex round 4 on
-  // PR #95). Everything above offers PREFIXES, so every hypothesis is a prefix
-  // of the next, `common` grows on every round, and a deferral is always
-  // relieved by waiting -- the assumption the deferral's own liveness argument
-  // made, and the reason this sweep could not see the stall. `alternating`
-  // rewrites the LAST offered word on every other offering, which pins `common`
-  // in front of it; `contradictions` is that half's non-vacuity proof, `escapes`
-  // proves the bound fires, and `tie_strands` proves the second postcondition's
-  // one exception is reached rather than merely written down.
+  // A FOURTH shape change makes two consecutive hypotheses CONTRADICT each
+  // other past the agreed prefix (codex round 4 on PR #95). Everything above
+  // offers PREFIXES, so every hypothesis is a prefix of the next and `common`
+  // grows on every round; `alternating` rewrites the LAST offered word on every
+  // other offering, which pins `common` in front of it and holds the engine on
+  // the fallback arm round after round. `contradictions` is that half's
+  // non-vacuity proof, and `tie_strands` proves the second postcondition's one
+  // exception is reached rather than merely written down.
   //
-  // A FIFTH reaches the two shapes the LENGTH bound got wrong (codex round 5 on
-  // PR #95). Both are pairs of CONSECUTIVE deferrals, which is what a bound is
-  // read from, and the sweep had neither. `growth_deferrals` counts finding 1's:
-  // a `common` that is LONGER every round, which the length predicate never
-  // escapes -- reached by the aggregate tied runs above, whose trailing tie
-  // survives the prefix growth. `shift_deferrals` counts finding 2's: EQUAL
-  // lengths whose terminal instant MOVED, which the length predicate escapes
-  // although the wait it measured was a different one -- reached by `retiming`,
-  // which drifts a whole offering's timings and leaves its texts alone.
-  // `signature_escapes` and `counted_escapes` prove that BOTH bounds fire, since
-  // neither subsumes the other, and `erasures` is the non-vacuity proof for the
-  // TRANSCRIPT-level property below.
+  // A FIFTH drifts a whole offering's TIMINGS while leaving its texts alone
+  // (`retiming`), so the normalized prefix two hypotheses agree on is unchanged
+  // while the instant an empty-holdback advance anchors past MOVES.
+  // `drifted_advances` is its non-vacuity proof. This half was added for a
+  // deferral bound that no longer exists (codex round 5 on PR #95, finding 2)
+  // and is KEPT because the shape is otherwise unswept: it is also the shape
+  // this module's residual 6 records as unconstrained -- at 0.03 s per offering
+  // the drift stays inside the gap in front of the watermark, so the sweep
+  // reaches the re-timing without ever reaching the whole-run jump past it.
   //
-  // Measured on the shape below, at 512 trials: 495 tied truths, 2383
-  // observations, 277 empty holdbacks, 113 deferrals, 49 forced-arm rounds with
-  // a live suffix, 1207 contradicting rounds, 43 escapes (41 from a repeating
-  // signature, 2 from the count), 29 of which stranded at the settled instant,
-  // 17 growth deferrals, 10 shift deferrals, and 26 rounds that erased a word
-  // from the published transcript. (On the round-4 shape: 489, 2292, 268, 176,
-  // 37, 1221, 79 escapes, 12 tie strands, and neither round-5 shape reachable at
-  // all. On the shape before THAT: 491, 2736, 265, 231, 12, and no escape
-  // reachable at all.)
+  // Measured on the shape below, at 512 trials: 495 tied truths, 2482
+  // observations, 413 empty holdbacks, 141 fallback rounds (46 of them through
+  // the aggregate route), 34 forced-arm rounds with a live suffix, 1162
+  // contradicting rounds, 38 strands at the settled instant, 759 drifted
+  // advances, and 10 rounds that erased a word from the published transcript.
+  //
+  // On the DEFERRAL shape this branch carried between `6987bec` and `b3ec5c6`,
+  // same draw: 2383 observations, 277 empty holdbacks, 113 rounds that WAITED
+  // where no legal boundary existed and 43 that escaped the wait, 49 forced-arm
+  // rounds, 29 tie strands and 26 erasures -- 2.6x the published retractions
+  // for a word apiece at the settled instant. That measurement is what removed
+  // it; see the engine module's doc, "Why there is no deferral".
   //
   // The sweep draws starts from a coarse grid whose repeats make consecutive
   // words tie -- the `a=[0,0.5)/b=[0,1.0)` shape both #94 regressions are built
@@ -474,57 +470,51 @@ fn the_split_never_cuts_at_a_tied_start() {
   // `omitting_a_confirmed_tied_word_does_not_drop_provisional_words` is built
   // from.
   //
-  // Mutation proof: drop the `.max(last.start().next_up())` from
-  // `empty_holdback_watermark` and this reds on a swept over-budget
-  // zero-duration word; make the boundary non-strict (`<=` for `<` in
-  // `split_at_a_strict_boundary`) and it reds on a swept tie; let the back-off
-  // cross the prefill budget floor (`0..widened` for `floor..widened`) and it
-  // reds too. It does NOT red when the back-off arm is deleted outright: the
-  // `next_up` anchor still holds the postcondition on that path, which is why
-  // the back-off has its own falsifier in
+  // Mutation proof, every row RUN on this shape. Make the boundary non-strict
+  // (`<=` for `<` in `split_at_a_strict_boundary`) and the FIRST postcondition
+  // reds on a swept tie at trial 0. Drop the `.max(last.start().next_up())` from
+  // `empty_holdback_watermark` and it reds on a swept over-budget zero-duration
+  // word. Keep the fold but drop its `*start > last.start()` filter and it reds
+  // again, the watermark having landed on the confirmed word's own start.
+  // Return `common.len() - 1` from the final `unwrap_or` and it reds a third
+  // time. It does NOT red when the back-off arm is deleted outright: the
+  // empty-holdback anchor still holds the postcondition on that path, which is
+  // why the back-off is pinned in
   // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
-  // rather than being asserted here. Restoring the widen-off-the-end fallback
-  // (`.or(Some(common.len()))` after the back-off) reds the SECOND postcondition
-  // now that the alternation half below builds a stranding round for it --
-  // `[(" Z", 1.5)]` stranded on a round that did not escape -- and with that
-  // clause's `escaped` gate removed it falls through to the `deferrals` clause
-  // at `21 deferred rounds`. It used to red only the latter, the sweep having no
-  // shape that could strand.
+  // (measured: that test alone reds, 384 of 385 still green).
   //
-  // The SECOND postcondition has its own rows. Hand
-  // `split_at_a_strict_boundary` an empty `beyond_common` at the call site --
-  // the information state it had before this repair -- and
-  // `nothing_unconfirmed_falls_below_the_watermark` reds on a swept forced-arm
-  // round; return `repeats` to a constant 2 and `forced_strands` reds at
-  // `0 rounds` instead, the state being unreachable rather than unguarded.
+  // The SECOND postcondition has two clauses and they fail differently. Drop the
+  // sparing FOLD from `empty_holdback_watermark` (return
+  // `past_the_confirmed_start`) and the TIE clause reds on a strand BEYOND the
+  // settled instant -- `[(" B", 2.5)]` below a 3 s watermark at a 2.0 s settled
+  // start. Confirm one word FEWER on the advance (`common[..split - 1]`) and the
+  // `ran_off_the_end` GATE reds instead, on an INTERIOR round that stranded at
+  // the settled instant, where the tie clause is silent by construction.
   //
-  // The LIVENESS rows: force `alternating` to `false` and `contradictions` reds
-  // at `14 rounds` against its floor of 128 -- the state the prefix-only shape
-  // could not build. Drop the sparing FOLD from `empty_holdback_watermark`
-  // (return `past_the_confirmed_start`) and the second postcondition reds on a
-  // swept round whose strand is BEYOND the settled instant; drop only its filter
-  // (fold over every start) and the FIRST postcondition reds, the watermark
-  // having landed on the confirmed word's own start.
+  // The gate reds NOTHING when mutated alone -- replace it with `true` and all
+  // 385 tests stay green -- and it is DOMINATED in the observed mutation set:
+  // every engine mutation that reaches a strand at all (no-`next_up`, no-fold,
+  // interior anchor at `end`, confirm-one-fewer) also trips the tie clause
+  // somewhere later in the sweep, so the gate is never the unique reason this
+  // test fails. It is kept because it is the clause that says WHICH arm may
+  // strand, which is the whole of residual 1's claim, and because under the
+  // confirm-one-fewer mutation it is the FIRST and most precise failure.
   //
-  // The ROUND 5 rows: restore round 4's own predicate (`DeferralWait::is_over`
-  // reading `previous.is_some_and(|before| signature.common_len <=
-  // before.common_len)`) and `shift_deferrals` reds at `0 rounds` -- that state
-  // ESCAPES under it rather than deferring, which is the finding. Drop the count
-  // from `is_over` and the counter's own cap row reds at `5 deferrals stand
-  // against a cap of 4` -- read INSIDE the loop, since a stall is only visible
-  // while it is happening. Drop the signature instead and `signature_escapes`
-  // reds at `0`. Force `retiming` to `false` and `shift_deferrals` reds at
-  // `0 rounds` again, the state being unreachable rather than unguarded.
-  //
-  // The exception's two clauses red nothing when mutated ALONE, because on a
-  // correct engine neither state they reject is reachable -- an ordinary advance
-  // never strands, and an escape never strands beyond the settled instant. Each
-  // is the sole discriminator for one engine mutation, and that is where they
-  // are pinned: drop the `escaped` gate and the widen-off-the-end fallback above
-  // stops reding the second postcondition, falling through to `deferrals`
-  // instead; drop the tie clause and the no-sparing-fold mutation above stops
-  // reding it. Neither is dead -- they are conditional on mutants, not on
-  // inputs.
+  // The SHAPE rows, each forced off and re-measured. `aggregate` off:
+  // `aggregate_fallbacks` reds at `0 of 134`, the tied-run route to the empty
+  // holdback being unreachable while the oversized-word route still supplies
+  // 134. `retiming` off: `drifted_advances` reds at `0 rounds`. `alternating`
+  // off: `contradictions` reds at `18 rounds` against its floor of 128 -- but
+  // only with `nothing_the_stream_still_says_is_erased` neutralized first, since
+  // that helper fires at trial 92 on a re-timing its `offered` membership test
+  // cannot tell from an erasure (the transcript keeps one `(" A", 0.5)` and the
+  // result offers one; the multiset difference blames the retained copy). The
+  // `alternating` shape hides that on the shipped draw. `repeats` pinned at 2 --
+  // the row that used to red `forced_strands` at `0` -- now reds NOTHING:
+  // `forced_strands` measures 32 against its floor of 4, the forced arm with a
+  // live suffix being reachable without the one-offering cadence once an
+  // agreeing round always advances. The cadence is kept anyway, being the
+  // driver's own; the row is recorded as DOMINATED rather than deleted.
   const TEXTS: [&str; 4] = [" A", " B", " C", " D"];
   // Repeated 0.0 entries are the ties; the rest keep the grid coarse enough for
   // two words to share an instant often.
@@ -570,22 +560,27 @@ fn the_split_never_cuts_at_a_tied_start() {
   /// `appended` is measured across the call rather than read off a split, so
   /// this cannot be satisfied by the same arithmetic that produced it.
   ///
-  /// IT HAS ONE EXCEPTION since the deferral was bounded (codex round 4 on
-  /// PR #95), and the exception is as narrow as the impossibility that forces
-  /// it: on a round that ESCAPED a repeating deferral, a stranded word may sit
-  /// at the last confirmed word's OWN start. There no instant serves both --
-  /// every watermark strictly past that start (which the first postcondition
-  /// requires) filters the strand, and every watermark that spares the strand
-  /// re-admits the settled word. It is this module's residual 1 reached one
-  /// round earlier than its own route. `escaped` gates it, so an ordinary
-  /// advance may not use it, and `empty_holdback_watermark`'s sparing fold is
-  /// what keeps every other overlap out of it. Returns whether the exception was
-  /// taken, which is the non-vacuity proof that the escape really strands
-  /// something somewhere.
+  /// IT HAS ONE EXCEPTION, and the exception is as narrow as the impossibility
+  /// that forces it: on a round whose split ran off the END of `common`, a
+  /// stranded word may sit at the last confirmed word's OWN start. There no
+  /// instant serves both -- every watermark strictly past that start (which the
+  /// first postcondition requires) filters the strand, and every watermark that
+  /// spares the strand re-admits the settled word. It is this module's
+  /// residual 1. `ran_off_the_end` gates it, so an INTERIOR advance may not use
+  /// it -- there the watermark is the first held word's own start and nothing
+  /// unconfirmed can be below it -- and `empty_holdback_watermark`'s sparing
+  /// fold is what keeps every other overlap out of it.
+  ///
+  /// The gate used to read "this round ESCAPED a repeating deferral" (codex
+  /// round 4 on PR #95). Removing the deferral widened WHICH rounds may take the
+  /// exception and left its SHAPE untouched: measured over these 512 trials, 38
+  /// strands where the deferral had 29, every one of them at the settled
+  /// instant. Returns whether the exception was taken, which is the non-vacuity
+  /// proof that the empty holdback really strands something somewhere.
   fn nothing_unconfirmed_falls_below_the_watermark(
     agreement: &LocalAgreement,
     appended: usize,
-    escaped: bool,
+    ran_off_the_end: bool,
     trial: u32,
     stride: usize,
   ) -> bool {
@@ -604,7 +599,7 @@ fn the_split_never_cuts_at_a_tied_start() {
       .map(WordTiming::start);
     let stranded = &below[appended..];
     assert!(
-      escaped
+      ran_off_the_end
         && stranded
           .iter()
           .all(|(_, start)| settled.is_some_and(|settled| *start <= settled)),
@@ -612,11 +607,11 @@ fn the_split_never_cuts_at_a_tied_start() {
        the {} s watermark ({below:?}) but only {appended} were confirmed this \
        round -- {stranded:?} are STRANDED: the next worded ingest filters them \
        out of both hypotheses at once and `finalize` can no longer reach them, \
-       after this round's own `finalize` already published them. Only an \
-       ESCAPE round (this one escaped: {escaped}) may strand, and only at or \
-       before the settled start {settled:?} -- with starts non-decreasing \
-       inside one hypothesis that is the exact TIE, where no watermark serves \
-       both",
+       after this round's own `finalize` already published them. Only a round \
+       whose split ran off the END of `common` (this one did: \
+       {ran_off_the_end}) may strand, and only at or before the settled start \
+       {settled:?} -- with starts non-decreasing inside one hypothesis that is \
+       the exact TIE, where no watermark serves both",
       below.len(),
       agreement.last_agreed_seconds(),
     );
@@ -658,17 +653,16 @@ fn the_split_never_cuts_at_a_tied_start() {
   /// the strand — this module's residual 1. Anything strictly below that is a
   /// word the engine erased while it could still have held it.
   ///
-  /// **What this does NOT catch, stated rather than implied.** The retraction in
-  /// round 5's finding 2 IS at the settled instant — an escape strands exactly
-  /// the tie — so it is identical in SHAPE to the residual-1 retraction this
-  /// permits, and no property over the transcript alone can separate them. What
-  /// separates them is whether the engine had already waited on that state,
-  /// which is a fact about the DEFERRAL rather than about the transcript, and
-  /// `DeferralSignature` is where it is decided
-  /// (`a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat`). What
-  /// this DOES buy is the bound: retraction is confined to that one instant on
-  /// every round of every shape the sweep drives, and counted so the confinement
-  /// is not vacuous.
+  /// **What this does NOT catch, stated rather than implied.** Every retraction
+  /// an empty-holdback advance can cause is AT the settled instant, so all of
+  /// them are identical in SHAPE to the residual-1 retraction this permits, and
+  /// no property over the transcript alone can separate a necessary one from an
+  /// avoidable one. What this DOES buy is the bound: retraction is confined to
+  /// that one instant on every round of every shape the sweep drives, and
+  /// COUNTED so the confinement is not vacuous. The count is also the number
+  /// that removed the deferral — 10 erasures here against the deferral's 26 on
+  /// the identical draw (see the engine module's doc, "Why there is no
+  /// deferral").
   ///
   /// **It is DOMINATED, and by which assertion.** Every transcript
   /// `LocalAgreement::finalize` publishes is a subset of
@@ -741,15 +735,12 @@ fn the_split_never_cuts_at_a_tied_start() {
   let mut checked = 0u32;
   let mut empty_holdbacks = 0u32;
   let mut tied_truths = 0u32;
-  let mut deferrals = 0u32;
   let mut forced_strands = 0u32;
   let mut contradictions = 0u32;
-  let mut escapes = 0u32;
+  let mut fallbacks = 0u32;
+  let mut aggregate_fallbacks = 0u32;
   let mut tie_strands = 0u32;
-  let mut growth_deferrals = 0u32;
-  let mut shift_deferrals = 0u32;
-  let mut signature_escapes = 0u32;
-  let mut counted_escapes = 0u32;
+  let mut drifted_advances = 0u32;
   let mut erasures = 0u32;
 
   for trial in 0..512u32 {
@@ -768,8 +759,8 @@ fn the_split_never_cuts_at_a_tied_start() {
     // floor. `AGGREGATE_TOKENS` is sized so any THREE such words exceed
     // `MAX_HOLDBACK_PREFILL_TOKENS` and any two fit, which puts the floor two
     // words from the end of every `common` and makes a three-word tie at the
-    // tail the trigger. That round DEFERS; `deferrals` below is its non-vacuity
-    // proof.
+    // tail the trigger. That round runs the split off the END of `common`;
+    // `fallbacks` below is its non-vacuity proof.
     const AGGREGATE_TOKENS: usize = MAX_HOLDBACK_PREFILL_TOKENS / 3 + 1;
     let aggregate = next() % 4 == 0;
     let over_budget = if !aggregate && next() % 3 == 0 {
@@ -835,13 +826,13 @@ fn the_split_never_cuts_at_a_tied_start() {
         // ALTERNATION, the shape codex round 4 on PR #95 needed and neither
         // half above could build. Growing prefixes and re-offered strides make
         // every hypothesis a PREFIX of the next, so `common` grows on every
-        // round and a deferral is always relieved by waiting -- which is
-        // precisely the assumption the deferral's own liveness argument made.
+        // round and the fallback arm is left almost as soon as it is entered.
         // Rewriting the LAST offered word on every other offering instead makes
         // two consecutive hypotheses CONTRADICT each other there, which pins
         // `common` at everything in front of it for as long as the rewriting
         // continues. `contradictions` below is this half's non-vacuity proof,
-        // and `escapes` is the proof that the bound actually fires.
+        // and `fallbacks` is the proof that the arm it pins the engine on is
+        // actually taken.
         let mut offered = offered.clone();
         if alternating
           && offering % 2 == 1
@@ -855,22 +846,23 @@ fn the_split_never_cuts_at_a_tied_start() {
             last.probability(),
           );
         }
-        // THE SHIFT, the shape codex round 5 on PR #95 (finding 2) needed and
-        // no half above could build. `alternating` rewrites the last word's
-        // TEXT, which pins `common` in FRONT of it; this rewrites TIMINGS and
-        // leaves every text alone, so the words stay inside `common` and the
-        // NORMALIZED PREFIX two consecutive hypotheses agree on is unchanged
-        // while the instant an escape would have to anchor past MOVES. That is
-        // the exact pair of deferrals a `common.len()` record cannot tell apart.
+        // THE SHIFT. `alternating` rewrites the last word's TEXT, which pins
+        // `common` in FRONT of it; this rewrites TIMINGS and leaves every text
+        // alone, so the words stay inside `common` and the NORMALIZED PREFIX
+        // two consecutive hypotheses agree on is unchanged while the instant an
+        // empty-holdback advance anchors past MOVES. Added for codex round 5's
+        // finding 2 on PR #95 and kept past the deferral it measured: it is the
+        // only re-timing this sweep drives, and this module's residual 6 is
+        // about the whole-run re-timing it does NOT reach.
         //
         // The WHOLE offering drifts, by a step that only ever grows. Two weaker
         // shapes were tried and are wrong: shifting the last word alone breaks
-        // it out of the trailing tie and OPENS the boundary the deferral is
-        // waiting for, relieving the state instead of building it; shifting the
-        // trailing tied run alternately moves those words BACK again on the next
-        // offering, which is this module's residual 3 (drift wider than the gap
-        // in front of the watermark) and loses words for a reason that has
-        // nothing to do with the bound. Drifting everything monotonically keeps
+        // it out of the trailing tie and OPENS a legal boundary above the floor,
+        // relieving the state instead of building it; shifting the trailing tied
+        // run alternately moves those words BACK again on the next offering,
+        // which is this module's residual 3 (drift wider than the gap in front
+        // of the watermark) and loses words for a reason that has nothing to do
+        // with the split. Drifting everything monotonically keeps
         // every start non-decreasing across offerings as well as within one, so
         // the only thing that moves is the instant itself.
         // OFF the 0.5 grid the starts are drawn from, deliberately: a drift of
@@ -903,32 +895,16 @@ fn the_split_never_cuts_at_a_tied_start() {
           .map(|word| (word.word().to_string(), word.start()))
           .collect();
         let before = agreement.confirmed_words_slice().len();
-        // Captured BEFORE the call, since `ingest` overwrites all three: they
-        // are the inputs the escape decision is actually made from.
-        let deferred_before = agreement.deferred;
-        let taken_before = agreement.deferrals_since_advance;
+        // Captured BEFORE the call, since `ingest` overwrites it: it is one of
+        // the inputs the split decision is actually made from.
         let confirmed_last_before = agreement
           .confirmed_words_slice()
           .last()
           .map(WordTiming::start);
-        agreement.ingest_streamed(result_with_words(offered));
-        // Read straight off the engine: a deferral returns
-        // `AwaitingAgreement`, which a disagreement returns too, so the outcome
-        // cannot tell them apart.
-        deferrals += u32::from(agreement.deferred.is_some());
-        // THE TWO SHAPES ROUND 5's FINDINGS ARE, counted so a repair cannot be
-        // reported as swept without the sweep having built them. GROWTH is
-        // finding 1: consecutive deferrals whose `common` is LONGER every round,
-        // which round 4's length predicate never escapes. A SHIFT is finding 2:
-        // consecutive deferrals of EQUAL length whose terminal instant moved,
-        // which round 4's length predicate escapes although the wait it measured
-        // was a different one.
-        if let (Some(before), Some(now)) = (deferred_before, agreement.deferred) {
-          growth_deferrals += u32::from(now.common_len > before.common_len);
-          shift_deferrals += u32::from(
-            now.common_len == before.common_len && now.terminal_start != before.terminal_start,
-          );
-        }
+        let outcome = agreement.ingest_streamed(result_with_words(offered));
+        // The RE-TIMED half's own non-vacuity: a drifted offering must actually
+        // reach the advance path, not merely be constructed and disagreed with.
+        drifted_advances += u32::from(drift > 0.0 && outcome.is_advanced());
         forced_strands += u32::from(forced_arm_with_a_live_suffix(&agreement));
         let common_len = common_prefix_len(&agreement);
         contradictions += u32::from(
@@ -936,46 +912,41 @@ fn the_split_never_cuts_at_a_tied_start() {
             && common_len < agreement.prev_words.len()
             && common_len < agreement.hypothesis_words.len(),
         );
-        // EXACT, rather than inferred from the outcome: re-ask
-        // `split_at_a_strict_boundary` what it would have answered with NO wait
-        // behind it at all, from the same inputs the engine handed it. An escape
-        // is a round that would have deferred and did not.
-        let would_defer = common_len >= agreement.agreement_count_needed()
-          && matches!(
-            split_at_a_strict_boundary(
-              &agreement.hypothesis_words[..common_len],
-              &agreement.hypothesis_words[common_len..],
-              common_len - agreement.agreement_count_needed(),
-              confirmed_last_before,
-              DeferralWait {
-                previous: None,
-                taken: 0,
-              },
-            ),
-            SplitDecision::Defer(_)
-          );
-        let escaped = would_defer && agreement.deferred.is_none();
-        escapes += u32::from(escaped);
-        // WHICH bound authorized it. The signature ends a wait that repeated;
-        // the count ends one that never does. Both are counted so neither can be
-        // reported as firing on the strength of the other.
-        if escaped {
-          if taken_before >= MAX_CONSECUTIVE_DEFERRALS {
-            counted_escapes += 1;
-          } else {
-            signature_escapes += 1;
-          }
-        }
-        assert!(
-          taken_before <= MAX_CONSECUTIVE_DEFERRALS,
-          "trial {trial}, stride {stride}: {taken_before} deferrals stand \
-           against a cap of {MAX_CONSECUTIVE_DEFERRALS} -- the counter may not \
-           pass the bound it is, since a round only defers while it is below it",
+        // EXACT, rather than inferred from the outcome or read off the
+        // engine's own holdback: re-ask `split_at_a_strict_boundary` WHERE it
+        // put this round's split, from the same inputs the engine handed it.
+        // `common.len()` is arm 3 -- the FALLBACK, the one position that leaves
+        // the holdback empty, and so the only one that can strand anything.
+        //
+        // Reading `last_agreed_words_slice().is_empty()` instead would be
+        // LOOSER in two directions and both of them weaken the gate below: it is
+        // true on a round that did not advance at all, and true on a round that
+        // inherited an empty holdback from an earlier one. This asks the
+        // function.
+        let ran_off_the_end = common_len >= agreement.agreement_count_needed()
+          && split_at_a_strict_boundary(
+            &agreement.hypothesis_words[..common_len],
+            common_len - agreement.agreement_count_needed(),
+            confirmed_last_before,
+          ) == common_len;
+        fallbacks += u32::from(ran_off_the_end);
+        // WHICH route emptied the holdback. A fallback round in which NO word
+        // of `common` is over budget on its own is the AGGREGATE route: the
+        // floor landed strictly inside a tied run whose words exceed the budget
+        // only between them, every boundary at or above it tied, and split 0 --
+        // the boundary a tied run always leaves legal -- was below the floor.
+        // That is the shape `add_word_timestamps` produces from an all-zero
+        // alignment matrix, and the one the oversized-word half cannot build.
+        aggregate_fallbacks += u32::from(
+          ran_off_the_end
+            && agreement.hypothesis_words[..common_len]
+              .iter()
+              .all(|word| word.tokens_slice().len() <= MAX_HOLDBACK_PREFILL_TOKENS),
         );
         tie_strands += u32::from(nothing_unconfirmed_falls_below_the_watermark(
           &agreement,
           agreement.confirmed_words_slice().len() - before,
-          escaped,
+          ran_off_the_end,
           trial,
           stride,
         ));
@@ -1018,9 +989,18 @@ fn the_split_never_cuts_at_a_tied_start() {
      observations",
   );
   assert!(
-    deferrals > 64,
-    "and the DEFERRED state must be reached, which is the state the \
-     one-oversized-word shape could not build: {deferrals} deferred rounds",
+    fallbacks > 64,
+    "and arm 3 -- the FALLBACK, where no legal boundary sits at or above the \
+     budget floor and the split runs off the end -- must actually be taken, \
+     since it is the only arm that can strand anything: {fallbacks} rounds",
+  );
+  assert!(
+    aggregate_fallbacks > 16,
+    "and it must be reached through the AGGREGATE route -- a tied run whose \
+     tokens exceed the budget between them, with no single word over it, which \
+     is the shape `add_word_timestamps` produces from an all-zero alignment \
+     matrix and the one the oversized-word half cannot build: \
+     {aggregate_fallbacks} of {fallbacks} fallback rounds",
   );
   assert!(
     forced_strands > 4,
@@ -1032,39 +1012,22 @@ fn the_split_never_cuts_at_a_tied_start() {
     contradictions > 128,
     "and two consecutive hypotheses must actually CONTRADICT each other past \
      `common` -- growing prefixes alone make every hypothesis a prefix of the \
-     next, which is the assumption the deferral's liveness argument made: \
+     next, which relieves the fallback arm before it can be read: \
      {contradictions} rounds",
-  );
-  assert!(
-    escapes > 8,
-    "and the deferral's BOUND must actually fire -- a repeating deferral that \
-     takes the empty holdback instead of waiting again: {escapes} rounds",
   );
   assert!(
     tie_strands > 0,
     "and the second postcondition's one exception must be reached rather than \
-     merely written down -- an escape that strands at the settled instant, \
-     which is the only strand any watermark leaves: {tie_strands} rounds",
+     merely written down -- an empty-holdback advance that strands at the \
+     settled instant, which is the only strand any watermark leaves: \
+     {tie_strands} rounds",
   );
   assert!(
-    growth_deferrals > 0,
-    "and a deferral must be reached whose `common` GREW since the deferral \
-     before it -- codex round 5's finding 1, the shape a `common.len()` bound \
-     never escapes because the length rises every round: {growth_deferrals} \
+    drifted_advances > 0,
+    "and the RE-TIMED half must actually reach the advance path rather than \
+     only being constructed -- a whole offering whose instants drifted while \
+     its texts did not, agreed with and advanced over: {drifted_advances} \
      rounds",
-  );
-  assert!(
-    shift_deferrals > 0,
-    "and a deferral must be reached whose `common` is the same LENGTH as the \
-     one before it while its terminal instant MOVED -- codex round 5's finding \
-     2, the pair of different waits a `common.len()` bound cannot tell apart: \
-     {shift_deferrals} rounds",
-  );
-  assert!(
-    signature_escapes > 0 && counted_escapes > 0,
-    "and BOTH bounds must actually fire, since neither subsumes the other: \
-     {signature_escapes} escapes from a repeating signature, {counted_escapes} \
-     from the {MAX_CONSECUTIVE_DEFERRALS}-round count",
   );
   assert!(
     erasures > 0,
@@ -1173,23 +1136,27 @@ fn a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count() {
 }
 
 #[test]
-fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
+fn an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant() {
+  // CHARACTERIZATION of Rule W's fallback arm, not a property that holds. This
+  // pins what the engine does TODAY; the CORRECT answer is in the failure
+  // messages below, so the day the trade is revisited this test goes red and
+  // hands the next author the expectation.
+  //
   // #94, codex round 3 on PR #95 -- the OTHER way the holdback empties, and the
   // one Rule W's back-off cannot reach. The back-off may not cross the prefill
   // budget FLOOR, and a tied run that is itself over budget puts that floor
   // strictly inside the run: every boundary at or above it ties, split 0 -- the
   // one boundary a tied run always leaves legal -- is below it, and the forward
-  // search and the back-off therefore BOTH fail. The old fallback confirmed the
-  // whole run and emptied the holdback, which is exactly what
-  // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
-  // refuses one state earlier.
+  // search and the back-off therefore BOTH fail. The split runs off the end,
+  // confirming the whole run and emptying the holdback.
   //
-  // What the empty holdback costs here is a DELETION rather than a
-  // re-confirmation: the watermark anchors at `start.next_up()`, strictly past
+  // WHAT THAT COSTS: the watermark anchors at `start.next_up()`, strictly past
   // the run's instant, so any word the NEWER hypothesis produced at that same
   // instant beyond `common` -- words nothing ever confirmed -- fails the offered
   // filter on the next worded ingest, drops out of both hypotheses at once, and
-  // `finalize` has nothing left to recover them from.
+  // `finalize` has nothing left to recover them from. This round's own
+  // `finalize` has ALREADY published them, so it is a RETRACTION of transcript
+  // and `confirmed_words`' append-only guarantee cannot see it.
   //
   // It takes no over-budget WORD, which is what separates it from
   // `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed`: 113
@@ -1201,44 +1168,16 @@ fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
   // same boundary time. Measured on that stack: 130 words, all at 0.0, all
   // zero-duration, one token each.
   //
-  // The repair is to DEFER: no legal boundary at or above the floor is a
-  // non-advancing round, not a licence to widen off the end. The watermark stays
-  // put, so nothing is filtered away; the holdback stays put, so the next stride
-  // still prefills what it prefilled before; and TAIL growth relieves it, the
-  // same relief the back-off relies on. `finalize` on a deferred round emits the
-  // latest hypothesis's own post-watermark words, which is byte-identical to
-  // what the fallback produced (`confirmed ++ common ++ hypothesis-beyond-common`
-  // either way) -- the divergence is entirely in what LATER ingests can still
-  // see.
-  //
-  // This wait is the FIRST one, and TAIL growth really does relieve it here:
-  // both rounds after the deferral grow `common`, so neither bound in
-  // `split_at_a_strict_boundary`'s arm 3 fires -- the signature never repeats
-  // and two deferrals is under `MAX_CONSECUTIVE_DEFERRALS`. RELIEF COSTS TWO
-  // ROUNDS here, one for the anchor to appear in a hypothesis and one for it to
-  // be corroborated into `common`, which is where that constant's number comes
-  // from. What happens when growth does NOT arrive is
-  // `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`;
-  // what happens when it arrives and never helps is
-  // `a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`.
-  //
-  // Mutation proof, every row run: restore the widen-off-the-end fallback
-  // (`.or(Some(common.len()))` after the back-off) and the deferral assertion
-  // below reds reading `(113, 0, 2.0000002, 0, 2)`; with that assertion
-  // neutralized the two FACES red next, the streaming one confirming the 113-word
-  // run against an empty holdback and the finalized one reading
-  // `[... "w112", "y"]` with `" x0"`/`" x1"` gone. Defer whenever the budget
-  // floor bites at all (`if floor > 0 { return None }`) and the deadlock clause
-  // below reds -- along with
-  // `an_over_budget_holdback_is_capped_rather_than_silently_truncated`, which is
-  // the ordinary budget path this may not swallow. Make the escape
-  // unconditional (`DeferralWait::is_over` returning `true`) and the deferral
-  // assertion reds, the first wait taken away; never clear the record
-  // (`self.deferred = deferred.or(self.deferred)`) and it reds the same way --
-  // the advance's own Swift shape replaced by the hypothesis. Make `word` emit
-  // two tokens and the non-vacuity row reds at `(113, 226, false)`.
-  //
-  // The `finalize` half has its own two rows at its own assertions below.
+  // WHY IT IS ACCEPTED. To a timestamp filter a genuinely new word at the run's
+  // instant and a re-offer of the run's own last word are the same value, which
+  // is this issue's impossibility result; every watermark that spares the strand
+  // re-admits the settled word, which is #94. Between `6987bec` and `b3ec5c6`
+  // this round DEFERRED instead, waiting for `common` to grow. Measured over the
+  // accumulated counterexample suite and the 512-trial sweep, that wait cost 26
+  // words erased from the published transcript where this fallback costs 10, and
+  // its liveness bound was defeated by `At(0)`; see the engine module's doc,
+  // "Why there is no deferral". So the loss below is this module's residual 1,
+  // reached on the shape the pipeline can actually produce.
   const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
   let tied: Vec<WordTiming> = (0..RUN)
     .map(|index| word(&format!(" w{index:03}"), 2.0, 2.0))
@@ -1271,105 +1210,112 @@ fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
     "non-vacuous: the DEFAULT count, the only one the driver reaches",
   );
   agreement.ingest_streamed(older());
-  agreement.ingest_streamed(newer());
+  assert!(
+    agreement.ingest_streamed(newer()).is_advanced(),
+    "the agreeing round ADVANCES: an agreeing round always does",
+  );
   assert_eq!(
     (
       confirmed_texts(&agreement).len(),
       held_back_texts(&agreement).len(),
       agreement.last_agreed_seconds(),
       // The consequence, read through the filter that consumes the watermark:
-      // every word the newer hypothesis produced at the run's instant is still
-      // OFFERABLE. Folded into this assertion rather than standing beside it,
-      // since it is a function of the watermark above and could never red first.
+      // nothing the newer hypothesis produced at the run's instant is offerable
+      // any more -- the whole run AND the two words beyond it. Folded into this
+      // assertion rather than standing beside it, since it is a function of the
+      // watermark above and could never red first.
       LocalAgreement::watermark_filtered(&newer(), agreement.last_agreed_seconds()).len(),
       // The hypotheses AGREED, so Swift KEEPS the result (`:408-410`,
       // `!skipAppend`) and it reaches the `finalize` merge as a segment source.
-      // Dropping it here reds nothing else in this suite -- the merged TEXT is
-      // the confirmed word list either way -- so the keep is pinned here.
       agreement.results_slice().len(),
     ),
-    (0, 0, 0.0, RUN + 2, 2),
-    "no legal boundary at or above the budget floor is a DEFERRED round: \
-     nothing is confirmed, the holdback is untouched, the watermark does not \
-     move, so nothing at the run's instant is filtered away -- and the agreeing \
-     result is kept",
+    (RUN, 0, 2.0f32.next_up(), 0, 2),
+    "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94): no \
+     legal boundary sits at or above the budget floor, so the split runs off \
+     the END of `common` -- the whole 113-word run is confirmed, the holdback \
+     is empty, and the watermark anchors strictly past the run's instant. The \
+     CORRECT answer holds the run back and keeps \" x0\"/\" x1\" offerable; no \
+     watermark can do both, since one strictly past the run's start filters \
+     them and one at or below it re-admits the run's own last word. If the \
+     trade was revisited, assert (0, 0, 0.0, RUN + 2, 2) here and re-check the \
+     retraction below.",
   );
 
-  // THE SECOND CLAUSE OF THE REPAIR, on its own. "Do not advance" alone loses
-  // the transcript: `finalize`'s Swift shape is `confirmed ++ last_agreed_words
-  // ++ differentSuffix(prev, hypothesis)`, and on a deferred round the holdback
-  // is an EARLIER agreement's -- here it does not exist at all -- so the sum
-  // drops every word the two hypotheses agreed on. A deferred round therefore
-  // finalizes from the latest hypothesis instead (`deferred`).
-  //
-  // Mutation proof for that clause alone: drop `|| self.deferred.is_some()` from
-  // `finalize`'s guard and this reads `" x0 x1"` -- the whole 113-word run gone,
-  // exactly the `commonPrefix.count` leading words the Swift expression cannot
-  // account for once the holdback is not the round's own.
-  let deferred_transcript = agreement
+  // FINALIZE POINT ONE. The retraction is only visible across two of these, and
+  // this is the one that PUBLISHES the words: the round confirmed `common` and
+  // `find_longest_different_suffix` adds `[" x0", " x1"]` on top.
+  let published = agreement
     .clone()
     .finalize(&crate::audio::whisper::options::DecodingOptions::new())
     .text()
     .to_string();
   assert_eq!(
-    deferred_transcript.split_whitespace().count(),
+    published.split_whitespace().count(),
     RUN + 2,
-    "a stream that ENDS on a deferred round still finalizes every word it \
-     produced: {deferred_transcript:?}",
+    "a stream that ENDS on this round publishes every word it produced, the \
+     two at the settled instant included: {published:?}",
   );
 
-  // And the same with the two hypotheses IDENTICAL, where the differing suffix
-  // is EMPTY as well -- the shape a plain non-advancing policy finalizes as `""`.
-  let mut agreed_twice = agreement.clone();
-  agreed_twice.ingest_streamed(newer());
-  let identical_transcript = agreed_twice
+  // FINALIZE POINT TWO, one hypothesis later. `" x0"` and `" x1"` are below the
+  // watermark by now, so the filter drops them from the hypothesis AND from the
+  // re-read previous result -- both sides at once. The grown tail carries TWO
+  // words starting strictly later, which is what the default count needs to
+  // agree over anything again.
+  let grown = || {
+    result_with_words(
+      [
+        tied.clone(),
+        suffix(),
+        vec![word(" y", 3.0, 4.0), word(" z", 4.0, 5.0)],
+      ]
+      .concat(),
+    )
+  };
+  agreement.ingest_streamed(grown());
+  let retracted = agreement
+    .clone()
     .finalize(&crate::audio::whisper::options::DecodingOptions::new())
     .text()
     .to_string();
   assert_eq!(
-    identical_transcript.split_whitespace().count(),
-    RUN + 2,
-    "with nothing confirmed, nothing held and no differing suffix either, the \
-     Swift shape would finalize the empty string: {identical_transcript:?}",
+    (
+      retracted.split_whitespace().count(),
+      retracted
+        .split_whitespace()
+        .rev()
+        .take(3)
+        .collect::<Vec<_>>(),
+    ),
+    (RUN + 2, vec!["z", "y", "w112"]),
+    "CHARACTERIZATION, and a RETRACTION -- this module's non-preferred \
+     direction (https://github.com/findit-studio/coremlit/issues/94). The \
+     CORRECT answer is {} words with [\"x0\", \"x1\"] still between \"w112\" \
+     and \"y\": both hypotheses produced them, nothing contradicted them, and \
+     the round before this one already published them. They are gone because \
+     the empty holdback's watermark passed their instant. Accepted as \
+     residual 1 -- to a timestamp filter they are indistinguishable from a \
+     re-offer of the run's own last word, which is what #94 is. If that was \
+     revisited, assert {} words here and delete this message. Transcript: \
+     {retracted:?}",
+    RUN + 4,
+    RUN + 4,
   );
 
-  // Tail growth is what relieves the deferral: one word starting strictly later
-  // opens a legal boundary above the floor, and it takes two ingests for that
-  // word to reach `common`.
-  let grown = || result_with_words([tied.clone(), suffix(), vec![word(" y", 3.0, 4.0)]].concat());
-  agreement.ingest_streamed(grown());
+  // AND IT IS NOT A STALL: the grown tail reaches `common` on the next ingest
+  // and the stream keeps moving.
   assert!(
     agreement.ingest_streamed(grown()).is_advanced(),
-    "and the deferral is not a deadlock: the grown tail opens a boundary above \
-     the floor and the round advances",
+    "the grown tail reaches `common` and the round advances",
   );
-
-  let mut expected: Vec<String> = (0..RUN).map(|index| format!(" w{index:03}")).collect();
-  expected.push(" x0".to_string());
-  expected.push(" x1".to_string());
   assert_eq!(
-    (confirmed_texts(&agreement), held_back_texts(&agreement)),
     (
-      expected.iter().map(String::as_str).collect::<Vec<_>>(),
-      vec![" y"],
+      confirmed_texts(&agreement).len(),
+      held_back_texts(&agreement),
+      agreement.last_agreed_seconds(),
     ),
-    "the STREAMING face: the whole tied run and both words at its instant are \
-     confirmed exactly once, and the word that opened the boundary is held",
-  );
-
-  let text = agreement
-    .finalize(&crate::audio::whisper::options::DecodingOptions::new())
-    .text()
-    .to_string();
-  expected.push(" y".to_string());
-  assert_eq!(
-    text.split_whitespace().collect::<Vec<_>>(),
-    expected
-      .iter()
-      .map(|word| word.trim_start())
-      .collect::<Vec<_>>(),
-    "the FINALIZED face: every word the stream produced, each exactly once and \
-     in order",
+    (RUN, vec![" y", " z"], 3.0),
+    "and the tail is held back under an ordinary interior split, with the run \
+     confirmed exactly once",
   );
 }
 
@@ -2720,11 +2666,13 @@ fn a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held() {
   // `self.last_agreed_words.is_empty()` arm DEFER (`0` in place of
   // `widened.len()`) and both words wait for an anchor that can never arrive.
   //
-  // This is also what bounds the SUFFIX guard the forced arm grew in codex
-  // round 3 (see `a_forced_empty_holdback_defers_rather_than_retracting_its_
-  // suffix`): make that arm defer unconditionally instead of only where it would
-  // strand something, and the `is_advanced` assertion below reds. Nothing lies
-  // beyond `common` here, so deferring waits forever -- round 7's finding again.
+  // This is also the state that says the forced arm may not simply refuse to
+  // advance (see
+  // `a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant`, the
+  // round where refusing WOULD have saved a word): make that arm return `0`
+  // instead of `common.len()` and the `is_advanced` assertion below reds.
+  // Nothing lies beyond `common` here, so there is no anchor a wait could ever
+  // be waiting for -- round 7's finding again.
   let a = || word_of_tokens(" A", 1.0, 2.0, 1);
   let huge = || word_of_tokens(" H", 2.0, 3.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   assert!(
@@ -3060,13 +3008,13 @@ fn a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed() {
   // needs a non-default `agreement_count_needed` (here 1) and a zero-duration
   // word; `add_word_timestamps` never emits a 112-token word.
   //
-  // The forced arm still ADVANCES here, and this test is half of why it may:
-  // both hypotheses are `[" A", " Z"]`, so nothing lies beyond `common` for the
-  // advance to strand, and there is no anchor a deferral could ever wait for.
-  // The word this costs -- `" B"` below -- arrives one hypothesis LATER, which
-  // is outside what any split can see. Where the strand IS already visible the
-  // arm defers instead
-  // (`a_forced_empty_holdback_defers_rather_than_retracting_its_suffix`).
+  // The forced arm ADVANCES here with nothing to lose: both hypotheses are
+  // `[" A", " Z"]`, so nothing lies beyond `common` for the advance to strand,
+  // and there is no anchor a wait could ever be waiting for. The word this
+  // costs -- `" B"` below -- arrives one hypothesis LATER, which is outside
+  // what any split can see. Where the strand IS already visible the same
+  // advance retracts it, which is the characterization in
+  // `a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant`.
   //
   // Mutation proof: drop the `.max(last.start().next_up())` from `ingest`'s
   // empty-holdback watermark and this reds with `" Z"` confirmed twice.
@@ -3136,65 +3084,60 @@ fn a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed() {
   );
 }
 #[test]
-fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
-  // #94, codex round 3 on PR #95, SECOND FINDING -- the forced arm of
-  // `split_at_a_strict_boundary`, which the tied-run deferral deliberately left
-  // alone. Where the budget FLOOR itself reaches `common.len()` the split runs
-  // off the end unconditionally, and it does so WITHOUT LOOKING at what the
-  // newer hypothesis produced beyond `common`: the helper was handed `common`,
-  // `requested` and the last confirmed start, and nothing else.
+fn a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant() {
+  // CHARACTERIZATION of Rule W's FORCED arm, not a property that holds. This
+  // pins what the engine does TODAY; the CORRECT answer is in the failure
+  // messages below.
   //
-  // So the advance empties the holdback, anchors the watermark at
-  // `start.next_up()` -- strictly past the run's instant -- and every word the
-  // newer hypothesis produced AT that instant beyond `common` fails the offered
-  // filter from then on. That is not a deletion of something never emitted: the
-  // round's OWN `finalize` already emitted it, through
-  // `differentSuffix(prev, hypothesis)`. What the next hypothesis costs is a
-  // RETRACTION of published transcript, and `confirmed_words`' monotonicity --
-  // the #89 property -- cannot see it, because the retracted word was never
-  // confirmed.
+  // #94, codex round 3 on PR #95, SECOND FINDING. Where the budget FLOOR itself
+  // reaches `common.len()` the split runs off the end unconditionally: it takes
+  // a LAST word whose own tokens exceed `MAX_HOLDBACK_PREFILL_TOKENS`, since
+  // nothing else runs `budgeted_split`'s loop off the end, and there is no
+  // holdback the prefill could carry at any split. Confirming that word is round
+  // 7 finding 2's own repair -- leaving it held is the data loss that finding
+  // recorded.
   //
-  // It needs no unusual count: " H" alone exceeds `MAX_HOLDBACK_PREFILL_TOKENS`,
-  // which is the only thing that drives `budgeted_split`'s loop off the end, and
-  // that is the whole of the forced arm's condition (see
-  // `a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held`,
-  // the state this rule may NOT swallow: there the budget forces the empty
-  // holdback and nothing lies beyond `common`, so deferring would wait for an
-  // anchor that can never arrive).
+  // WHAT THAT COSTS: the advance empties the holdback, anchors the watermark at
+  // `start.next_up()` -- strictly past `" H"`'s instant -- and `" X"`, which the
+  // newer hypothesis produced AT that instant beyond `common`, fails the offered
+  // filter from then on. That is not a deletion of something never emitted: this
+  // round's OWN `finalize` emits it, through `differentSuffix(prev,
+  // hypothesis)`. What the next hypothesis costs is a RETRACTION of published
+  // transcript, and `confirmed_words`' monotonicity -- the #89 property -- cannot
+  // see it, because the retracted word was never confirmed.
   //
-  // The repair is the same one the tied run got, conditioned on the strand
-  // actually existing: `split_at_a_strict_boundary` now takes the hypothesis's
-  // post-`common` words and defers the forced advance exactly while one of them
-  // starts before the watermark that advance would set.
+  // WHY IT IS ACCEPTED. Deferring here is what this branch tried between
+  // `6987bec` and `b3ec5c6`: the round waited while a word beyond `common` would
+  // be stranded, under two bounds that ended the wait. Measured over the
+  // accumulated counterexample suite and the 512-trial sweep, the wait erased 26
+  // words from the published transcript where this arm erases 10, and its count
+  // bound was defeated by `At(0)` -- see the engine module's doc, "Why there is
+  // no deferral". The narrower repair is kept: `empty_holdback_watermark`'s
+  // sparing fold lowers the anchor to spare every word beyond `common` that
+  // starts strictly later
+  // (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`),
+  // so what is lost is exactly the TIE -- residual 1, the one instant no
+  // watermark serves.
   //
-  // This wait is the FIRST one, and it is the one worth taking: what ENDS it are
-  // the two bounds in `split_at_a_strict_boundary`'s arm 3, whose own falsifiers
-  // are `an_alternating_suffix_escapes_the_deferral_instead_of_stalling`,
-  // `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`
-  // and `a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`. The
-  // two rounds after the deferral here GROW `common` and the anchor arrives, so
-  // neither bound fires -- which is exactly what they must not do, and the two
-  // rounds relief takes here are what sizes `MAX_CONSECUTIVE_DEFERRALS`.
+  // The state this rule may NOT swallow is
+  // `a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held`:
+  // there the budget forces the empty holdback and nothing lies beyond `common`,
+  // so there is nothing to lose and nothing to wait for either.
   //
-  // Mutation proof, every row run: pass an empty `beyond_common` at the call
-  // site (the pre-repair information state) and the deferred-state row reds
-  // reading `([" A", " H"], [], 1.0000001)`; with that row neutralized the
-  // RETRACTION row reds at `" A H Y"`, `" X"` gone from a transcript that had
-  // already published it. Defer the forced arm unconditionally (drop the
-  // `beyond_common` test, keeping the bound) and
-  // `a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held`
-  // reds -- the anchor that can never arrive, and the bound does not rescue it,
-  // since that shape never defers twice. Make the escape unconditional
-  // (`DeferralWait::is_over` returning `true`) and this test's deferred-state row
-  // reds instead, and so does never clearing the record
-  // (`self.deferred = deferred.or(self.deferred)`). Drop
-  // `|| self.deferred.is_some()` from `finalize`'s guard and the
-  // IMMEDIATE row reds at `" X"`, the deferred round's own transcript reduced to
-  // the differing suffix.
+  // Mutation proof, every row run: drop `.max(last.start().next_up())` from
+  // `empty_holdback_watermark` and the state row reds at a 1.0 watermark, `" H"`
+  // re-admissible. Drop the sparing FOLD and this stays green while
+  // `a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`
+  // reds -- the fold cannot help an exact tie, which is why that test exists
+  // beside this one.
   let a = || word(" A", 0.0, 1.0);
   let over = || word_of_tokens(" H", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   let tied = || word(" X", 1.0, 1.0);
   let anchor = || word(" Y", 2.0, 3.0);
+  // A SECOND word starting strictly later: the default count needs two agreed
+  // words to advance over anything at all, and the tail below is what proves
+  // this arm is not a stall.
+  let anchor2 = || word(" Z", 3.0, 4.0);
   assert_eq!(
     (
       over().tokens_slice().len() > MAX_HOLDBACK_PREFILL_TOKENS,
@@ -3210,7 +3153,7 @@ fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
 
   let older = || result_with_words(vec![a(), over()]);
   let newer = || result_with_words(vec![a(), over(), tied()]);
-  let later = || result_with_words(vec![a(), over(), tied(), anchor()]);
+  let later = || result_with_words(vec![a(), over(), tied(), anchor(), anchor2()]);
 
   let mut agreement = LocalAgreement::new();
   assert_eq!(
@@ -3219,24 +3162,29 @@ fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
     "non-vacuous: the DEFAULT count, the only one the driver reaches",
   );
   agreement.ingest_streamed(older());
-  agreement.ingest_streamed(newer());
+  assert!(
+    agreement.ingest_streamed(newer()).is_advanced(),
+    "the agreeing round ADVANCES: an agreeing round always does",
+  );
   assert_eq!(
     (
       confirmed_texts(&agreement),
       held_back_texts(&agreement),
       agreement.last_agreed_seconds(),
     ),
-    (Vec::new(), Vec::new(), 0.0),
-    "the forced empty holdback would strand \" X\", so the round DEFERS: \
-     nothing is confirmed, the watermark does not move, and \" X\" stays \
-     offerable",
+    (vec![" A", " H"], Vec::new(), 1.0f32.next_up()),
+    "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94): \
+     the budget floor reaches `common.len()`, so the split runs off the end -- \
+     `[\" A\", \" H\"]` is confirmed, the holdback is empty, and the watermark \
+     anchors strictly past `\" H\"`'s instant, which is `\" X\"`'s instant too. \
+     The CORRECT answer keeps `\" X\"` offerable, and no watermark does that \
+     while also clearing `\" H\"`'s own start. If the trade was revisited, \
+     assert ([], [], 0.0) here and re-check the retraction below.",
   );
 
   // FINALIZE POINT ONE. The retraction is only visible across two of these, and
-  // this is the one that publishes the word: byte-identical to what the
-  // unconditional forced advance produced on this same round, since a deferred
-  // round finalizes `confirmed ++ hypothesis_words` and that advance finalized
-  // `confirmed ++ common ++ differentSuffix`, which is the same list.
+  // this is the one that publishes the word: the advance confirmed `common` and
+  // `find_longest_different_suffix` adds `" X"` on top.
   assert_eq!(
     agreement
       .clone()
@@ -3244,15 +3192,14 @@ fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
       .text()
       .to_string(),
     " A H X",
-    "a stream ENDING here publishes \" X\" either way -- the divergence is \
-     entirely in what a LATER ingest can still see",
+    "a stream ENDING here publishes \" X\" -- which is what makes losing it a \
+     retraction rather than a word never emitted",
   );
 
   // FINALIZE POINT TWO, after a hypothesis that repeats " X" and carries an
-  // anchor starting strictly later. Under the unconditional forced advance " X"
-  // is below the watermark by then, so the filter drops it from the hypothesis
-  // AND from the re-read previous result -- both sides at once -- and this reads
-  // " A H Y".
+  // anchor starting strictly later. `" X"` is below the watermark by now, so
+  // the filter drops it from the hypothesis AND from the re-read previous
+  // result -- both sides at once.
   agreement.ingest_streamed(later());
   assert_eq!(
     agreement
@@ -3260,47 +3207,50 @@ fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
       .finalize(&DecodingOptions::new())
       .text()
       .to_string(),
-    " A H X Y",
-    "THE RETRACTION: a word this engine already published stays published",
+    " A H Y Z",
+    "CHARACTERIZATION, and a RETRACTION -- this module's non-preferred \
+     direction (https://github.com/findit-studio/coremlit/issues/94). The \
+     CORRECT answer is \" A H X Y Z\": both hypotheses produced \" X\", \
+     nothing contradicted it, and the round before this one already published \
+     it. It is gone because the empty holdback's watermark passed its instant, \
+     and no watermark both passes \" H\"'s start and spares a word AT it. \
+     Accepted as residual 1. If that was revisited, assert \" A H X Y Z\" \
+     here and delete this message.",
   );
 
-  // And the deferral is relieved rather than a deadlock: the anchor reaches
-  // `common` on the second ingest and opens a legal boundary above the floor.
+  // AND IT IS NOT A STALL: the anchor reaches `common` on the next ingest and
+  // an ordinary interior split takes over.
   assert!(
     agreement.ingest_streamed(later()).is_advanced(),
-    "the anchor's strictly later start opens a boundary the forced arm no \
-     longer needs",
-  );
-  let advanced = (
-    confirmed_texts(&agreement)
-      .into_iter()
-      .map(str::to_string)
-      .collect::<Vec<_>>(),
-    held_back_texts(&agreement)
-      .into_iter()
-      .map(str::to_string)
-      .collect::<Vec<_>>(),
-    agreement.last_agreed_seconds(),
+    "the anchor's strictly later start opens an ordinary interior boundary",
   );
   assert_eq!(
     (
-      advanced,
+      confirmed_texts(&agreement)
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>(),
+      held_back_texts(&agreement)
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>(),
+      agreement.last_agreed_seconds(),
       agreement
         .finalize(&DecodingOptions::new())
         .text()
         .to_string(),
     ),
     (
-      (
-        vec![" A".to_string(), " H".to_string(), " X".to_string()],
-        vec![" Y".to_string()],
-        2.0,
-      ),
-      " A H X Y".to_string(),
+      vec![" A".to_string(), " H".to_string()],
+      vec![" Y".to_string(), " Z".to_string()],
+      2.0,
+      " A H Y Z".to_string(),
     ),
-    "and \" X\" is confirmed exactly once, by the ordinary interior split",
+    "and the stream keeps moving: the tail is held under an interior split and \
+     nothing is confirmed twice",
   );
 }
+
 /// One round of the STREAMING face — the outcome a caller reads back plus the
 /// three pieces of engine state it can see between pushes. Built as a value so a
 /// whole run of rounds compares in ONE assertion: a stall is a face that repeats,
@@ -3324,69 +3274,56 @@ fn streaming_face(
 }
 
 #[test]
-fn an_alternating_suffix_escapes_the_deferral_instead_of_stalling() {
-  // #94, codex round 4 on PR #95 -- the DEFERRAL's own liveness, and the first
-  // finding on this branch that is not a correctness hole.
+fn an_alternating_suffix_advances_instead_of_stalling() {
+  // #94, codex round 4 on PR #95 -- LIVENESS on the forced arm, kept past the
+  // deferral it was written against.
   //
-  // Rule W's deferral is a WAIT for tail growth: `common` grows, and a boundary
-  // the split may legally take appears. Nothing bounded that wait. Hypotheses
-  // that ALTERNATE past the agreed prefix -- `[A, H, X]` then `[A, H, Y]` then
-  // `[A, H, X]` -- pin `common` at `[A, H]` forever: the forced arm sees the
-  // same over-budget `" H"` at the end of the same `common` every round, the
-  // same live suffix beyond it, and returns `None` every round. The watermark
-  // never moves, nothing is ever confirmed, the caller reads
-  // `awaiting_agreement` forever, and in the driver the clip keeps re-decoding
-  // from a boundary that never advances while the buffer grows past it.
+  // Hypotheses that ALTERNATE past the agreed prefix -- `[A, H, X]` then
+  // `[A, H, Y]` then `[A, H, X]` -- pin `common` at `[A, H]` forever: the forced
+  // arm sees the same over-budget `" H"` at the end of the same `common` every
+  // round, and the same live suffix beyond it. Whatever the split does with that
+  // state, it must not do it FOREVER: the watermark has to move, or the caller
+  // reads `awaiting_agreement` while the driver's clip keeps re-decoding from a
+  // boundary that never advances and the buffer grows past it.
   //
-  // The earlier liveness argument -- "one word starting strictly later opens a
-  // boundary" -- is about a suffix that STABILIZES, and does not reach this
-  // state: `" T"` and `" U"` below DO start strictly later, and they never help,
-  // because they can only join `common` once the words in front of them agree.
+  // The split runs off the END of `common` on the first such round, so the
+  // stream is a stream: `[" A", " H"]` is confirmed at the only instant that
+  // clears `" H"`'s own start, the alternation stops blocking the tail, and
+  // `[" T", " U"]` is held back under an ordinary interior split from then on.
   //
-  // THE BOUND: a deferral whose boundary-relevant SIGNATURE repeats the previous
-  // round's is that round again. It is a measurement of the wait that has
-  // already happened, not a prediction about the next one, and it costs exactly
-  // one round. Round 1 defers; round 2 finds the identical state -- same floor,
-  // same `common.len()`, same terminal instant, same watermark an escape would
-  // anchor at -- and takes the empty holdback instead. The OTHER bound,
-  // `MAX_CONSECUTIVE_DEFERRALS`, is for the wait that never repeats
-  // (`a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`); here
-  // it would fire three rounds later and the signature gets there first.
+  // Between `6987bec` and `b3ec5c6` this round DEFERRED instead and the escape
+  // came one round later; every face below is that same run shifted by one
+  // ingest, and the two transcripts at the end are byte-identical either way.
+  // The measurement that removed the deferral is in the engine module's doc
+  // ("Why there is no deferral"): the wait cost 26 published erasures against
+  // this fallback's 10 over the same 512 trials.
   //
-  // WHAT THAT TRADES, stated in the direction that costs something. `" X"` and
+  // WHAT THIS TRADES, stated in the direction that costs something. `" X"` and
   // `" Y"` sit at `" H"`'s own instant, so no watermark strictly past `" H"`'s
   // start can spare them (`empty_holdback_watermark` lowers the anchor as far as
-  // it can, and here it cannot lower it at all) -- this module's residual 1,
-  // reached one round earlier than the residual's own route. A stream that ENDS
-  // inside the stall keeps the disputed word, since a deferred round finalizes
-  // `confirmed ++ hypothesis_words`; a stream that CONTINUES gets a transcript
-  // instead of a frozen one. Both are asserted below. The disputed word is also
-  // the one thing the deferral could never have delivered: `find_longest_common_
-  // prefix` stops at it by construction, so it is uncorroborated on every round
-  // it is offered, and `finalize` already published a DIFFERENT one each round.
+  // it can, and here it cannot lower it at all) -- this module's residual 1. A
+  // stream that ENDS on the round before keeps the disputed word; a stream that
+  // CONTINUES gets a transcript instead of a frozen one. Both are asserted
+  // below. The disputed word is also the one thing no wait could ever have
+  // delivered: `find_longest_common_prefix` stops at it by construction, so it
+  // is uncorroborated on every round it is offered, and `finalize` already
+  // published a DIFFERENT one each round.
   //
-  // Mutation proof, every row run: drop `!wait.is_over(&signature)` from the
-  // forced arm's test (`if empty_holdback_strands()`) and this test alone reds,
-  // with eight `awaiting_agreement` rounds at watermark 0 -- the stall itself.
-  // Drop the SIGNATURE from `DeferralWait::is_over` (count only) and it reds the
-  // same way at three deferrals where it asserts one, which is what makes the
-  // signature bound load-bearing beside the count. Make the escape unconditional
-  // (`is_over` returning `true`) and
-  // `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` and
-  // `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix` red
-  // instead -- the FIRST wait is the one that is worth taking. Restore round 4's
-  // own predicate (`is_over` reading `previous.is_some_and(|before|
-  // signature.common_len <= before.common_len)`) and this stays GREEN, `common`
-  // being EQUAL in length here: that predicate was right about THIS shape and
-  // wrong about two others, which is why round 5 replaced it rather than
-  // widening it.
+  // Mutation proof, every row run: drop the `.or_else(...)` back-off from
+  // `split_at_a_strict_boundary` and this stays green (the forced arm never
+  // reaches either search), which is why the back-off is pinned in
+  // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
+  // instead. Drop `.max(last.start().next_up())` from `empty_holdback_watermark`
+  // and the face reds at round 1 with a 1.0 watermark, `" H"` re-admissible.
+  // Drop the sparing FOLD and the face reds at round 2 instead, `[" T", " U"]`
+  // filtered away by a 3.0 anchor they never earned.
   let a = || word(" A", 0.0, 1.0);
   let over = || word_of_tokens(" H", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   let x = || word(" X", 1.0, 1.0);
   let y = || word(" Y", 1.0, 1.0);
-  // Two words the deferral's own liveness argument would call relief. They start
-  // strictly later, they are in every hypothesis, and they cannot reach `common`
-  // while the words in front of them disagree.
+  // Two words a WAIT would have called relief. They start strictly later, they
+  // are in every hypothesis, and they cannot reach `common` while the words in
+  // front of them disagree -- which is why waiting for them never ended.
   let tail = || vec![word(" T", 2.0, 3.0), word(" U", 3.0, 4.0)];
   let odd = || result_with_words([vec![a(), over(), x()], tail()].concat());
   let even = || result_with_words([vec![a(), over(), y()], tail()].concat());
@@ -3415,13 +3352,13 @@ fn an_alternating_suffix_escapes_the_deferral_instead_of_stalling() {
   const ROUNDS: usize = 8;
   let mut face = Vec::with_capacity(ROUNDS);
   let mut forced_arm = Vec::with_capacity(ROUNDS);
-  let mut stalled_transcript = String::new();
+  let mut fallback_transcript = String::new();
   for round in 0..ROUNDS {
     let outcome = agreement.ingest_streamed(if round % 2 == 0 { odd() } else { even() });
     face.push(streaming_face(outcome, &agreement));
     forced_arm.push(forced_arm_with_a_live_suffix(&agreement));
     if round == 1 {
-      stalled_transcript = agreement
+      fallback_transcript = agreement
         .clone()
         .finalize(&DecodingOptions::new())
         .text()
@@ -3430,14 +3367,14 @@ fn an_alternating_suffix_escapes_the_deferral_instead_of_stalling() {
   }
 
   // NON-VACUOUS, per round: the forced arm really is the arm being driven, with
-  // a live suffix beyond `common`, on BOTH the round that defers and the round
-  // that escapes. Without this the face below could be produced by an engine
-  // that never reached the state at all.
+  // a live suffix beyond `common`, on the round that takes the fallback.
+  // Without this the face below could be produced by an engine that never
+  // reached the state at all.
   assert_eq!(
     forced_arm,
-    vec![false, true, true, false, false, false, false, false],
-    "the deferring round and the escaping round must both BE the forced arm \
-     with a live suffix; round 0 has no previous hypothesis and rounds 3+ have \
+    vec![false, true, false, false, false, false, false, false],
+    "the round that runs the split off the end must BE the forced arm with a \
+     live suffix; round 0 has no previous hypothesis and rounds 2+ have \
      advanced past the over-budget word",
   );
 
@@ -3462,14 +3399,13 @@ fn an_alternating_suffix_escapes_the_deferral_instead_of_stalling() {
     vec![
       // No previous hypothesis to agree with.
       awaiting(&[], &[], 0.0),
-      // THE WAIT, worth taking once: `common` may yet grow past `" H"`.
-      awaiting(&[], &[], 0.0),
-      // THE ESCAPE. `common` is `[" A", " H"]` again, so the wait bought
-      // nothing; the empty holdback is taken at the only instant that clears
+      // THE FALLBACK. `common` is `[" A", " H"]` and the budget floor reaches
+      // its end, so the empty holdback is taken at the only instant that clears
       // `" H"`'s own start.
       advanced(&[" A", " H"], &[], 1.0f32.next_up()),
-      // And the stream is a stream again: the tail the alternation was blocking
+      // And the stream is a stream: the tail the alternation was blocking
       // reaches `common` and is held back under an ordinary interior split.
+      advanced(&[" A", " H"], &[" T", " U"], 2.0),
       advanced(&[" A", " H"], &[" T", " U"], 2.0),
       advanced(&[" A", " H"], &[" T", " U"], 2.0),
       advanced(&[" A", " H"], &[" T", " U"], 2.0),
@@ -3480,11 +3416,12 @@ fn an_alternating_suffix_escapes_the_deferral_instead_of_stalling() {
   );
 
   // THE TRADE, both directions, so neither can be reported as free. A stream
-  // that ENDS inside the wait publishes the disputed word; one that CONTINUES
-  // past it does not, and gets everything after it instead.
+  // that ENDS on the round that took the fallback still publishes the disputed
+  // word, through `find_longest_different_suffix`; one that CONTINUES past it
+  // does not, and gets everything after it instead.
   assert_eq!(
     (
-      stalled_transcript.as_str(),
+      fallback_transcript.as_str(),
       agreement
         .finalize(&DecodingOptions::new())
         .text()
@@ -3492,53 +3429,56 @@ fn an_alternating_suffix_escapes_the_deferral_instead_of_stalling() {
         .as_str(),
     ),
     (" A H Y T U", " A H T U"),
-    "the escape drops the word at the settled instant -- residual 1, one round \
-     earlier than its own route -- and keeps the transcript moving",
+    "the empty holdback drops the word at the settled instant -- residual 1 -- \
+     and keeps the transcript moving",
   );
 }
 
 #[test]
-fn a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling() {
-  // #94, codex round 4 on PR #95 -- the SAME unbounded wait on the OTHER
-  // deferral arm, and the one this crate's own pipeline can actually reach.
+fn a_tied_run_above_the_budget_floor_advances_instead_of_stalling() {
+  // #94, codex round 4 on PR #95 -- the SAME liveness question on the arm this
+  // crate's own pipeline can actually reach, kept past the deferral it was
+  // written against.
   //
   // The alternating shape above needs a single word carrying more than
   // `MAX_HOLDBACK_PREFILL_TOKENS` tokens. This one needs no over-budget word, no
   // alternation, and nothing beyond `common` at all: 113 ORDINARY one-token
   // words sharing one instant, offered UNCHANGED on every stride. Their SUM puts
   // the budget floor strictly inside the run, every boundary at or above it
-  // ties, and the back-off may not cross the floor -- so `split_at_a_strict_
-  // boundary` returns `None`, and it returns `None` again next round because a
-  // repeated hypothesis grows nothing. `add_word_timestamps` produces exactly
-  // that shape from an ALL-ZERO alignment matrix (`add_word_timestamps_zero_
-  // pads_missing_rows`; measured at 130 such words), which is why this is the
-  // reachability answer for the finding rather than the shape above.
+  // ties, and the back-off may not cross the floor -- so both searches fail and
+  // the split runs off the END of `common`. A repeated hypothesis grows nothing,
+  // so the state is the same again next round and the round after.
+  // `add_word_timestamps` produces exactly that shape from an ALL-ZERO alignment
+  // matrix (`add_word_timestamps_zero_pads_missing_rows`; measured at 130 such
+  // words), which is why this is the reachability answer for the finding rather
+  // than the shape above.
   //
-  // Nothing is stranded here: `beyond_common` is EMPTY, so the escape's
+  // Nothing is stranded on the FIRST half: `beyond_common` is EMPTY, so the
   // watermark filters nothing away that any hypothesis had produced, and BOTH of
-  // Rule W's postconditions hold across it unweakened. What the wait was
-  // protecting is the HOLDBACK -- the tied run stays revisable and the next
-  // stride keeps its prefill anchor -- and that is worth exactly one round.
+  // Rule W's postconditions hold across it unweakened. What a wait would have
+  // been protecting is the HOLDBACK -- the tied run stays revisable and the next
+  // stride keeps its prefill anchor -- and a repeated hypothesis never delivers
+  // it.
   //
   // The SECOND half drives the same arm with a suffix that ALTERNATES at the
-  // run's own instant, which is where a strand-conditional escape would have
-  // gone on deferring forever. Both halves are here because they are one arm
-  // and one bound; splitting them would let a repair pass on the half it
-  // happened to cover.
+  // run's own instant, which is where a strand-conditional wait would have gone
+  // on deferring forever. Both halves are here because they are one arm;
+  // splitting them would let a repair pass on the half it happened to cover.
   //
-  // Mutation proof, every row run: delete the escape arm outright (the
-  // `None if wait.is_over(&signature)` row of `split_at_a_strict_boundary`'s
-  // final match) and the STABLE face reds with six `awaiting_agreement` rounds
-  // at watermark 0. Re-introduce a `!empty_holdback_strands()` guard beside
-  // `wait.is_over(&signature)` there -- the shape that exempts the arm's own
-  // strand from its own bound -- and the ALTERNATING face reds the same way
-  // while the stable one stays green, which is why both halves are here. Drop
-  // the SIGNATURE from `DeferralWait::is_over` (count only) and both faces red
-  // at three deferrals where they assert one. Make the escape unconditional
-  // (`is_over` returning `true`) and
-  // `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix`,
-  // `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` and the
-  // sweep red, the first wait taken away.
+  // Between `6987bec` and `b3ec5c6` the first agreeing round DEFERRED and the
+  // advance came one round later; both faces below are that same run shifted by
+  // one ingest, and the finalized transcript is byte-identical either way. See
+  // the engine module's doc, "Why there is no deferral", for the measurement.
+  //
+  // Mutation proof, every row run: return `common.len() - 1` from
+  // `split_at_a_strict_boundary`'s `unwrap_or` and the STABLE face reds at
+  // round 1 -- 112 confirmed against 113, and a watermark of 2.0 that re-admits
+  // the run's own last word. Drop `.max(last.start().next_up())` from
+  // `empty_holdback_watermark` and both faces red at a 2.0 watermark with 113
+  // words still offerable, which is the unbounded re-confirmation #94 is about.
+  // Let the back-off cross the floor (`0..widened` for `floor..widened`) and the
+  // stable face reds at round 1 with a two-word holdback the prefill cannot
+  // carry.
   const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
   let tied: Vec<WordTiming> = (0..RUN)
     .map(|index| word(&format!(" w{index:03}"), 2.0, 2.0))
@@ -3578,7 +3518,8 @@ fn a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling() 
       agreement.last_agreed_seconds(),
       // Nothing this hypothesis produced falls below the watermark that is not
       // confirmed: the SECOND postcondition, read on every round of this shape
-      // rather than swept, since the escape is where it could have broken.
+      // rather than swept, since the empty holdback is where it could have
+      // broken.
       LocalAgreement::watermark_filtered(&stable(), agreement.last_agreed_seconds()).len()
         + agreement.confirmed_words_slice().len(),
     ));
@@ -3587,9 +3528,7 @@ fn a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling() 
     face,
     vec![
       ("awaiting_agreement".to_string(), 0, 0, 0.0, RUN),
-      // THE WAIT: `common` may yet grow past the tie.
-      ("awaiting_agreement".to_string(), 0, 0, 0.0, RUN),
-      // THE ESCAPE, at the only instant that clears the run's own.
+      // THE FALLBACK, at the only instant that clears the run's own.
       ("advanced".to_string(), RUN, 0, 2.0f32.next_up(), RUN),
       // The run is behind the watermark now, so a hypothesis that keeps
       // repeating it offers nothing -- which is the input being degenerate, not
@@ -3615,9 +3554,16 @@ fn a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling() 
         2.0f32.next_up(),
         RUN
       ),
+      (
+        "awaiting_agreement".to_string(),
+        RUN,
+        0,
+        2.0f32.next_up(),
+        RUN
+      ),
     ],
     "a hypothesis that simply REPEATS must not freeze the stream, and the \
-     escape must strand nothing: every word is either still offerable or \
+     advance must strand nothing: every word is either still offerable or \
      confirmed",
   );
 
@@ -3633,9 +3579,10 @@ fn a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling() 
 
   // ── SECOND HALF: the same arm, with a live strand at the run's own instant.
   //
-  // Two words alternate past the run, both at the run's instant, so the escape
-  // cannot spare either -- and a bound that refused to fire while a strand
-  // existed would defer here forever, which is the state it exists to leave.
+  // Two words alternate past the run, both at the run's instant, so no watermark
+  // that clears the run's own start can spare either -- and a rule that refused
+  // to advance while a strand existed would wait here forever, since the strand
+  // is renewed by the next hypothesis every round.
   let x0 = || word(" x0", 2.0, 2.0);
   let x1 = || word(" x1", 2.0, 2.0);
   let odd = || result_with_words([tied.clone(), vec![x0()]].concat());
@@ -3664,520 +3611,49 @@ fn a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling() 
     alternating_face,
     vec![
       ("awaiting_agreement".to_string(), 0, 0, 0.0),
-      ("awaiting_agreement".to_string(), 0, 0, 0.0),
       ("advanced".to_string(), RUN, 0, 2.0f32.next_up()),
       ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
       ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
       ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
+      ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
     ],
-    "an alternating suffix at the run's own instant must not freeze this arm      either -- the run is confirmed and the disputed words at its instant are      the residual, not the reason to wait",
+    "an alternating suffix at the run's own instant must not freeze this arm \
+     either -- the run is confirmed and the disputed words at its instant are \
+     the residual, not a reason to wait",
   );
 }
 
 #[test]
-fn a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals() {
-  // #94, codex round 5 on PR #95, FINDING 1 -- the deferral's liveness again,
-  // and the shape round 4's bound could not see.
+fn a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded() {
+  // #94, codex round 4 on PR #95 -- the SPARING fold, which keeps the empty
+  // holdback from stranding anything it does not have to.
   //
-  // That bound was a LENGTH: escape once `common` is no longer than the length
-  // the round before already deferred over. It measures a wait that REPEATED,
-  // and it is blind to a wait whose state MOVES. An over-budget tied run that
-  // gains one more TIED word every stride moves it every round: `common` is
-  // longer each time, the budget floor rises with it, every boundary the forward
-  // search and the back-off can reach still ties, and `common.len() <= already`
-  // is false forever. Every round defers, nothing is confirmed, the watermark
-  // never moves -- and because an AGREEING round is a KEPT round, one whole
-  // result is retained per round over a clip window that never advances. The
-  // stall is unbounded in rounds and in retention both.
+  // The forced empty holdback used to anchor at `common.last().end()` flatly, so
+  // every word the hypothesis had already produced beyond `common` that started
+  // before that edge was filtered away. But word ENDS inside a hypothesis are
+  // not monotone (`an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_
+  // too`), so `end` can reach past a word that is already there -- and nothing
+  // needs it to. All the watermark owes #94 is to clear the last CONFIRMED
+  // word's START. So `empty_holdback_watermark` lowers the anchor to the
+  // earliest such word's start when that still clears it, and the word stays
+  // offerable instead of being lost.
   //
-  // The driver's own cadence is one hypothesis per stride and
-  // `add_word_timestamps` produces exactly this run from an all-zero alignment
-  // matrix, so the shape needs no over-budget WORD and no alternation: 113
-  // ordinary one-token words at one instant, then 114, then 115.
+  // What that leaves is the EXACT TIE alone, which is the case no instant
+  // serves -- this module's residual 1, characterized in
+  // `a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant`.
   //
-  // THE BOUND IS A COUNT, and the count is asserted here as a NUMBER rather than
-  // implied by an outcome: at most `MAX_CONSECUTIVE_DEFERRALS` rounds may defer
-  // between advances, whatever their signatures say. What it costs when it fires
-  // is this module's residual 1 and nothing else -- the escape anchors at
-  // `empty_holdback_watermark`'s lowest sparing instant, so the only word it can
-  // strand is one at the settled instant, which here is the run's own.
-  //
-  // Mutation proof, every row run: restore round 4's predicate
-  // (`is_over` reading `previous.is_some_and(|before| signature.common_len <=
-  // before.common_len)`) and the face below reds with EIGHT
-  // `awaiting_agreement` rounds at watermark 0 -- the stall itself, retaining a
-  // result on every one of them. Drop the count from `DeferralWait::is_over`
-  // (leaving the signature) and it reds the same way, the signature being fresh
-  // every round. Drop the SIGNATURE instead (leaving the count) and this stays
-  // green while `an_alternating_suffix_escapes_the_deferral_instead_of_stalling`
-  // and `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_
-  // stalling` red at three deferrals where they assert one -- which is why both
-  // halves are here and neither is redundant. Reset `deferrals_since_advance` on
-  // a disagreement as well as on an advance and this stays green, since nothing
-  // here disagrees; `a_deferral_alternating_with_a_disagreement_is_bounded_too`
-  // is that clause's own falsifier.
-  const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
-  let tied = |words: usize| -> Vec<WordTiming> {
-    (0..words)
-      .map(|index| word(&format!(" w{index:03}"), 2.0, 2.0))
-      .collect()
-  };
-  assert_eq!(
-    (
-      tied(RUN).len(),
-      tied(RUN)
-        .iter()
-        .map(|word| word.tokens_slice().len())
-        .sum::<usize>()
-        > MAX_HOLDBACK_PREFILL_TOKENS,
-      tied(RUN).iter().all(|word| word.start() == 2.0),
-    ),
-    (113, true, true),
-    "non-vacuous: ORDINARY one-token words, over the budget by their SUM at ONE \
-     instant -- the shape an all-zero alignment matrix produces, not a \
-     hand-built oversized word",
-  );
-
-  let mut agreement = LocalAgreement::new();
-  assert_eq!(
-    agreement.agreement_count_needed(),
-    DEFAULT_AGREEMENT_COUNT_NEEDED,
-    "non-vacuous: the DEFAULT count, the only one the driver reaches",
-  );
-
-  // One MORE tied word each round, which is the driver's one-hypothesis-per-
-  // stride cadence over a run that keeps growing.
-  const ROUNDS: usize = 8;
-  let mut face = Vec::with_capacity(ROUNDS);
-  let mut deferred_lengths = Vec::new();
-  let mut deferrals = 0usize;
-  let mut stalled_transcript = String::new();
-  for round in 0..ROUNDS {
-    let outcome = agreement.ingest_streamed(result_with_words(tied(RUN + round)));
-    if let Some(signature) = agreement.deferred {
-      deferrals += 1;
-      deferred_lengths.push(signature.common_len);
-    }
-    if round == 2 {
-      stalled_transcript = agreement
-        .clone()
-        .finalize(&DecodingOptions::new())
-        .text()
-        .to_string();
-    }
-    face.push((
-      outcome.to_string(),
-      agreement.confirmed_words_slice().len(),
-      // The RETENTION the bound bounds: an agreeing round is a kept round, so a
-      // round that defers costs one whole retained result over a clip that has
-      // not moved.
-      agreement.results_slice().len(),
-      agreement.last_agreed_seconds(),
-    ));
-  }
-
-  // THE NUMBER, asserted directly rather than read off the outcomes: the wait is
-  // this many rounds and no more.
-  assert_eq!(
-    (deferrals, MAX_CONSECUTIVE_DEFERRALS),
-    (MAX_CONSECUTIVE_DEFERRALS, 4),
-    "the wait must be bounded by the count, and the count is what it says it is",
-  );
-  // NON-VACUOUS, and the whole of finding 1: `common` GREW on every one of those
-  // rounds, so round 4's length predicate was false on every one of them and
-  // could never have ended this wait.
-  assert_eq!(
-    deferred_lengths,
-    vec![RUN, RUN + 1, RUN + 2, RUN + 3],
-    "every deferral must be over a LONGER `common` than the one before it -- \
-     otherwise a length bound would have escaped and this test would be \
-     measuring the wrong stall",
-  );
-
-  let awaiting = |confirmed: usize, results: usize, watermark: f32| {
-    (
-      "awaiting_agreement".to_string(),
-      confirmed,
-      results,
-      watermark,
-    )
-  };
-  assert_eq!(
-    face,
-    vec![
-      // No previous hypothesis to agree with.
-      awaiting(0, 1, 0.0),
-      // THE WAIT, four rounds of it, each retaining its own result.
-      awaiting(0, 2, 0.0),
-      awaiting(0, 3, 0.0),
-      awaiting(0, 4, 0.0),
-      awaiting(0, 5, 0.0),
-      // THE ESCAPE, at the only instant that clears the run's own start. The
-      // 117 words two hypotheses had agreed on are confirmed; the 118th, at that
-      // same instant, is the residual.
-      ("advanced".to_string(), RUN + 4, 6, 2.0f32.next_up()),
-      // Every word this degenerate stream has is at one instant, so a longer run
-      // now offers nothing past the watermark. That is the input being
-      // degenerate, not the engine stalling -- and the result is DROPPED rather
-      // than retained, so even that costs no memory.
-      awaiting(RUN + 4, 6, 2.0f32.next_up()),
-      awaiting(RUN + 4, 6, 2.0f32.next_up()),
-    ],
-    "a growing tied prefix must not freeze the stream, and the wait must cost \
-     exactly `MAX_CONSECUTIVE_DEFERRALS` retained results",
-  );
-
-  // THE TRADE, both directions. A stream that ENDS inside the wait publishes
-  // every word it produced; one that CONTINUES loses the word at the settled
-  // instant and keeps moving.
-  let escaped_transcript = agreement
-    .finalize(&DecodingOptions::new())
-    .text()
-    .to_string();
-  assert_eq!(
-    (
-      stalled_transcript.split_whitespace().count(),
-      escaped_transcript.split_whitespace().count(),
-    ),
-    (RUN + 2, RUN + 4),
-    "a deferred round finalizes `confirmed ++ hypothesis_words`, so the wait \
-     costs nothing on its own rounds; the escape confirms everything two \
-     hypotheses agreed on and strands only the word at the settled instant",
-  );
-}
-
-#[test]
-fn a_deferral_alternating_with_a_disagreement_is_bounded_too() {
-  // #94, codex round 5 on PR #95 -- the clause that decides WHICH rounds reset
-  // the count, pinned on its own because nothing else in this suite reaches it.
-  //
-  // `LocalAgreement::deferred` is cleared by an advance AND by a disagreement,
-  // since either one moves the state a signature describes. If
-  // `deferrals_since_advance` were cleared on the same schedule, a stream that
-  // alternates a deferral with a disagreement would reset the count every other
-  // round, never repeat a signature, and never advance -- the unbounded wait
-  // back again through a door the signature cannot close. So only an ADVANCE
-  // resets it.
-  //
-  // Mutation proof: reset `deferrals_since_advance` on a disagreement as well
-  // (`if advanced || skip_append`) and the face below reds with ten
-  // `awaiting_agreement` rounds at watermark 0.
-  const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
-  let tied: Vec<WordTiming> = (0..RUN)
-    .map(|index| word(&format!(" w{index:03}"), 2.0, 2.0))
-    .collect();
-  // AGREES with the run and defers: every boundary at or above the floor ties.
-  let agreeing = || result_with_words(tied.clone());
-  // DISAGREES with it outright, from its very first word, so no prefix survives
-  // and the round is `skipAppend` rather than a deferral.
-  let disagreeing = || {
-    result_with_words(
-      (0..RUN)
-        .map(|index| word(&format!(" d{index:03}"), 2.0, 2.0))
-        .collect(),
-    )
-  };
-
-  // A DEFERRAL takes two consecutive AGREEING hypotheses, so the cycle is three
-  // rounds long: agree, agree (defer), disagree. The round after a disagreement
-  // agrees with nothing either -- it is compared against the disagreeing
-  // hypothesis -- which is what makes every deferral here a FRESH one with no
-  // signature behind it, and the count the only thing that can end the run.
-  let mut agreement = LocalAgreement::new();
-  const ROUNDS: usize = 3 * MAX_CONSECUTIVE_DEFERRALS + 2;
-  let mut outcomes = Vec::with_capacity(ROUNDS);
-  let mut deferrals = 0usize;
-  let mut repeats = 0usize;
-  for round in 0..ROUNDS {
-    let previous = agreement.deferred;
-    let outcome = if round % 3 == 2 {
-      agreement.ingest_streamed(disagreeing())
-    } else {
-      agreement.ingest_streamed(agreeing())
-    };
-    if let Some(now) = agreement.deferred {
-      deferrals += 1;
-      repeats += usize::from(previous == Some(now));
-    }
-    outcomes.push(outcome.to_string());
-  }
-  assert_eq!(
-    (
-      deferrals,
-      repeats,
-      outcomes.iter().filter(|o| *o == "advanced").count(),
-    ),
-    (MAX_CONSECUTIVE_DEFERRALS, 0, 1),
-    "a deferral every third round must still reach the count, with no \
-     signature ever repeating to end it sooner: {outcomes:?}",
-  );
-  assert!(
-    agreement.last_agreed_seconds() > 2.0,
-    "and the watermark must actually have moved past the run rather than \
-     staying at {}",
-    agreement.last_agreed_seconds(),
-  );
-}
-
-#[test]
-fn a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat() {
-  // #94, codex round 5 on PR #95, FINDING 2 -- the other half of the same
-  // predicate, and a TRANSCRIPT-level regression rather than a liveness one.
-  //
-  // Round 4's bound was `common.len()`, and equal lengths do not establish that
-  // the wait already taken covered the state now in front of the engine.
-  // Agreement compares NORMALIZED TEXT; the escape's cost is a question about
-  // TIMINGS. Defer over `[" A", " H"@1]` with a tied strand `" X"@1`, then offer
-  // `[" A", " H"@2, " Y"@2]`: the normalized prefix is unchanged and two words
-  // long either way, while the hazardous boundary has moved from 1 s to 2 s.
-  // Escaping there is escaping from a DIFFERENT deferral: it confirms `" H"@2`,
-  // anchors past 2 s and strands `" Y"` -- a word this round's own `finalize`
-  // publishes and the NEXT ingest retracts. `confirmed_words`' append-only
-  // guarantee cannot see it, because `" Y"` was never confirmed.
-  //
-  // And the wait would have WORKED: repeating that hypothesis grows `common` to
-  // include `" Y"`, which is why the loss is a loss rather than an ordering. The
-  // assertions below are `finalize` before and after, which is the only place it
-  // shows.
-  //
-  // `DeferralSignature` is the repair: the floor, the length, the terminal
-  // instant and the watermark an escape would anchor at, compared for EQUALITY.
-  // The two rounds above differ in the last two, so the second is a new wait.
-  //
-  // REACHABILITY, both halves. The first is the finding's own sequence and needs
-  // a single 113-token word to force the empty holdback, which
-  // `add_word_timestamps` does not emit -- the same artificial word
-  // `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` needs.
-  // The SECOND half runs the same shift on the aggregate arm, where the trigger
-  // is 113 ORDINARY one-token words at one instant, which that function does
-  // produce from an all-zero alignment matrix. The timestamp SHIFT itself is
-  // ordinary either way: a re-decode over a longer window is free to move the
-  // instants it emits, and `find_longest_common_prefix` compares text alone, so
-  // the prefix is unchanged while the instant is not.
-  //
-  // Mutation proof, every row run: restore round 4's predicate
-  // (`is_over` reading `previous.is_some_and(|before| signature.common_len <=
-  // before.common_len)`) and BOTH halves red -- the first at `" A H"`, `" Y"`
-  // retracted from a transcript that had published it, the second at 113 words
-  // where it asserts 114. Drop `terminal_start` and `escape_watermark` from the
-  // signature (comparing floor and length alone) and they red the same way,
-  // which is what makes those two fields the load-bearing ones.
-  //
-  // ONE MUTATION REDS NOTHING and is recorded rather than dropped: comparing the
-  // length with `<=` beside equality on the rest -- escaping where `common`
-  // SHRANK at an otherwise identical state. That is a SUITE GAP, not dead code:
-  // `common` shrinks whenever the newest hypothesis agrees with its predecessor
-  // on less, so the state is reachable, and no shape in this file or in the
-  // sweep produces it (measured: 0 shrinking deferral pairs in 512 sweep
-  // trials). Equality is kept because its direction is the safe one -- it can
-  // only make the engine WAIT longer, and `MAX_CONSECUTIVE_DEFERRALS` caps that
-  // at four rounds -- so the gap costs a mutation score rather than a
-  // correctness claim.
-  let a = || word(" A", 0.0, 1.0);
-  let over = |at: f32| word_of_tokens(" H", at, at, MAX_HOLDBACK_PREFILL_TOKENS + 1);
-  let x = || word(" X", 1.0, 1.0);
-  let y = || word(" Y", 2.0, 2.0);
-  assert_eq!(
-    (
-      over(1.0).tokens_slice().len() > MAX_HOLDBACK_PREFILL_TOKENS,
-      over(1.0).word() == over(2.0).word(),
-      over(1.0).start() == x().start(),
-      over(2.0).start() == y().start(),
-      over(1.0).start() < over(2.0).start(),
-    ),
-    (true, true, true, true, true),
-    "non-vacuous: ONE word over the budget, the SAME word by text at two \
-     different instants, each tied by a strand at its own instant",
-  );
-
-  let older = || result_with_words(vec![a(), over(1.0)]);
-  let tied_at_one = || result_with_words(vec![a(), over(1.0), x()]);
-  let tied_at_two = || result_with_words(vec![a(), over(2.0), y()]);
-
-  let mut agreement = LocalAgreement::new();
-  assert_eq!(
-    agreement.agreement_count_needed(),
-    DEFAULT_AGREEMENT_COUNT_NEEDED,
-    "non-vacuous: the DEFAULT count, the only one the driver reaches",
-  );
-  agreement.ingest_streamed(older());
-  agreement.ingest_streamed(tied_at_one());
-  let deferred_at_one = agreement.deferred;
-  let published_at_one = agreement
-    .clone()
-    .finalize(&DecodingOptions::new())
-    .text()
-    .to_string();
-  agreement.ingest_streamed(tied_at_two());
-  let deferred_at_two = agreement.deferred;
-  let published_at_two = agreement
-    .clone()
-    .finalize(&DecodingOptions::new())
-    .text()
-    .to_string();
-
-  // NON-VACUOUS: both rounds really did DEFER, and their signatures really do
-  // agree on the length round 4 compared while differing on the timings it did
-  // not. Without this the transcript below could be produced by an engine that
-  // never reached the state.
-  assert_eq!(
-    (
-      deferred_at_one.map(|signature| signature.common_len),
-      deferred_at_two.map(|signature| signature.common_len),
-      deferred_at_one.map(|signature| signature.terminal_start),
-      deferred_at_two.map(|signature| signature.terminal_start),
-      deferred_at_one == deferred_at_two,
-    ),
-    (Some(2), Some(2), Some(1.0), Some(2.0), false),
-    "two deferrals of EQUAL `common.len()` whose hazardous instant MOVED -- the \
-     exact pair a length record cannot tell apart",
-  );
-
-  // THE REGRESSION, at `finalize` across the rounds it spans. The escape is one
-  // ingest late in showing itself: the escaping round still publishes the strand
-  // through `find_longest_different_suffix`, and only the NEXT hypothesis loses
-  // it.
-  agreement.ingest_streamed(tied_at_two());
-  let published_after = agreement
-    .clone()
-    .finalize(&DecodingOptions::new())
-    .text()
-    .to_string();
-  assert_eq!(
-    (
-      published_at_one.as_str(),
-      published_at_two.as_str(),
-      published_after.as_str(),
-    ),
-    (" A H X", " A H Y", " A H Y"),
-    "the shifted round is a NEW wait, so `\" Y\"` stays published; escaping it \
-     as a repeat confirms `\" H\"@2`, anchors past 2 s and retracts `\" Y\"` on \
-     the next ingest",
-  );
-
-  // And the wait ENDS: the repeat above really does repeat the signature, so the
-  // round after it escapes -- with `" Y"` inside `common` by then, which is
-  // exactly what waiting bought.
-  assert!(
-    agreement.ingest_streamed(tied_at_two()).is_advanced(),
-    "the repeated signature must end the wait rather than extend it",
-  );
-  let settled = (
-    confirmed_texts(&agreement)
-      .into_iter()
-      .map(str::to_string)
-      .collect::<Vec<_>>(),
-    held_back_texts(&agreement)
-      .into_iter()
-      .map(str::to_string)
-      .collect::<Vec<_>>(),
-  );
-  assert_eq!(
-    (
-      settled,
-      agreement
-        .finalize(&DecodingOptions::new())
-        .text()
-        .to_string(),
-    ),
-    (
-      (
-        vec![" A".to_string(), " H".to_string(), " Y".to_string()],
-        Vec::new(),
-      ),
-      " A H Y".to_string(),
-    ),
-    "and what the wait bought is `\" Y\"` CONFIRMED rather than stranded",
-  );
-
-  // ── SECOND HALF: the same shift on the arm this crate's own pipeline reaches.
-  const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
-  let run_at = |at: f32| -> Vec<WordTiming> {
-    (0..RUN)
-      .map(|index| word(&format!(" w{index:03}"), at, at))
-      .collect()
-  };
-  let run_at_one = || result_with_words([run_at(1.0), vec![word(" x", 1.0, 1.0)]].concat());
-  let run_at_two = || result_with_words([run_at(2.0), vec![word(" y", 2.0, 2.0)]].concat());
-  assert_eq!(
-    (
-      run_at(1.0)
-        .iter()
-        .map(|word| word.tokens_slice().len())
-        .sum::<usize>()
-        > MAX_HOLDBACK_PREFILL_TOKENS,
-      run_at(1.0)
-        .iter()
-        .all(|word| word.tokens_slice().len() == 1),
-    ),
-    (true, true),
-    "non-vacuous: no single word here is over budget -- it is the SUM of \
-     ordinary one-token words at one instant, which is the shape \
-     `add_word_timestamps` produces from an all-zero alignment matrix",
-  );
-
-  let mut aggregate = LocalAgreement::new();
-  aggregate.ingest_streamed(result_with_words(run_at(1.0)));
-  aggregate.ingest_streamed(run_at_one());
-  let aggregate_at_one = aggregate.deferred;
-  aggregate.ingest_streamed(run_at_two());
-  let aggregate_at_two = aggregate.deferred;
-  let after_shift = aggregate
-    .clone()
-    .finalize(&DecodingOptions::new())
-    .text()
-    .to_string();
-  aggregate.ingest_streamed(run_at_two());
-  let after_repeat = aggregate
-    .clone()
-    .finalize(&DecodingOptions::new())
-    .text()
-    .to_string();
-  assert_eq!(
-    (
-      aggregate_at_one.map(|signature| signature.common_len),
-      aggregate_at_two.map(|signature| signature.common_len),
-      aggregate_at_one == aggregate_at_two,
-      after_shift.split_whitespace().count(),
-      after_repeat.split_whitespace().count(),
-    ),
-    (Some(RUN), Some(RUN), false, RUN + 1, RUN + 1),
-    "the same two deferrals of equal length at moved instants, on the arm no \
-     over-budget word is needed to reach -- and `\" y\"` survives the round \
-     that would have escaped: {after_repeat:?}",
-  );
-  assert!(
-    aggregate.ingest_streamed(run_at_two()).is_advanced(),
-    "and this wait ends on its repeat too",
-  );
-}
-
-#[test]
-fn a_strand_starting_strictly_later_lowers_the_watermark_instead_of_deferring() {
-  // #94, codex round 4 on PR #95 -- the NARROWING that keeps the escape above
-  // from having to strand anything it does not have to.
-  //
-  // The forced empty holdback used to anchor at `common.last().end()` flatly,
-  // and defer whenever a word the hypothesis had produced beyond `common`
-  // started before it. But word ENDS inside a hypothesis are not monotone
-  // (`an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too`), so
-  // `end` can reach past a word that is already there -- and nothing needs it
-  // to. All the watermark owes #94 is to clear the last CONFIRMED word's START.
-  // So `empty_holdback_watermark` lowers the anchor to the earliest such word's
-  // start when that still clears it, the round advances, and the word stays
-  // offerable instead of being waited for.
-  //
-  // What that leaves the deferral is the EXACT TIE alone, which is the case no
-  // instant serves: `an_alternating_suffix_escapes_the_deferral_instead_of_
-  // stalling` is that half.
+  // The fold is SEPARABLE from the deferral this branch briefly carried and was
+  // kept when that was removed: it is the whole of what confines the loss to the
+  // tie, and it is measured here rather than argued.
   //
   // Mutation proof, every row run: drop the `fold` and return
-  // `past_the_confirmed_start` and this reds -- round 1 reads
-  // `("awaiting_agreement", [], [], 0.0)`, the deferral this narrowing removes.
-  // Keep the fold but drop its `*start > last.start()` filter and this stays
-  // green while `the_split_never_cuts_at_a_tied_start` reds on a swept exact tie
-  // (`" C" at 1.5, which is not strictly before the 1.5 s watermark`) -- the
-  // filter is postcondition ONE, asserted where it is swept.
+  // `past_the_confirmed_start` and this reds -- round 1 confirms `[" A", " H"]`
+  // at a 3.0 watermark and `" X"` is gone from round 2's holdback, stranded by
+  // an edge it never earned. Keep the fold but drop its `*start > last.start()`
+  // filter and this stays green while `the_split_never_cuts_at_a_tied_start`
+  // reds on a swept exact tie (`" C" at 1.5, which is not strictly before the
+  // 1.5 s watermark`) -- the filter is postcondition ONE, asserted where it is
+  // swept.
   let a = || word(" A", 0.0, 1.0);
   let over = || word_of_tokens(" H", 1.0, 3.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   let strand = || word(" X", 2.0, 2.5);
@@ -4191,7 +3667,7 @@ fn a_strand_starting_strictly_later_lowers_the_watermark_instead_of_deferring() 
     (true, true, true),
     "non-vacuous: the forced arm's own condition, and a word beyond `common` \
      that starts strictly AFTER the last agreed word's start and strictly \
-     BEFORE its end -- the overlap the flat anchor used to defer over",
+     BEFORE its end -- the overlap the flat anchor used to strand",
   );
 
   let older = || result_with_words(vec![a(), over()]);
@@ -4217,8 +3693,9 @@ fn a_strand_starting_strictly_later_lowers_the_watermark_instead_of_deferring() 
         Vec::new(),
         0.0
       ),
-      // The round that used to DEFER: it advances, and the anchor is the
-      // strand's own start rather than `" H"`'s far edge.
+      // The anchor is the strand's OWN start rather than `" H"`'s far edge, so
+      // the advance clears the settled start without reaching past a word the
+      // hypothesis has already produced.
       (
         "advanced".to_string(),
         vec![" A".to_string(), " H".to_string()],
@@ -4234,8 +3711,8 @@ fn a_strand_starting_strictly_later_lowers_the_watermark_instead_of_deferring() 
         2.0,
       ),
     ],
-    "a strand that starts strictly later is SPARED by lowering the anchor, not \
-     waited for",
+    "a word beyond `common` that starts strictly later is SPARED by lowering \
+     the anchor, not stranded by the last agreed word's far edge",
   );
 
   assert_eq!(

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -466,6 +466,19 @@ fn the_split_never_cuts_at_a_tied_start() {
   // the drift stays inside the gap in front of the watermark, so the sweep
   // reaches the re-timing without ever reaching the whole-run jump past it.
   //
+  // A SEVENTH addition is not a shape at all but an ORACLE (codex round 8 on PR
+  // #95, the HIGH finding). Every strand the sweep counts is now asked whether
+  // it was AVOIDABLE -- whether any split at or above the prefill budget floor
+  // would have lost nothing -- and `avoidable_backward_strands` and
+  // `avoidable_tie_strands` are asserted at ZERO. The counts alone could not see
+  // the finding: the second postcondition's exception was stated as "at or below
+  // the highest confirmed start", the strands satisfied it, and the assertion
+  // passed on 4 backwards strands of which 2 were the engine erasing a word it
+  // could still have held. The oracle is `a_split_that_loses_nothing_exists`,
+  // brute force over the round's raw inputs, calling neither the function under
+  // test nor `budgeted_split`; `loss_free_rounds` is its own non-vacuity proof,
+  // since an oracle stuck at `false` would report zero avoidable strands too.
+  //
   // A SIXTH shape draws BACKWARDS starts (codex round 7 on PR #95, finding 1).
   // Every shape above keeps its starts non-decreasing, which is the premise the
   // second postcondition used to be free under on an interior split -- and
@@ -474,12 +487,21 @@ fn the_split_never_cuts_at_a_tied_start() {
   // this half's non-vacuity proof, and `backward_strands` proves the half of the
   // exception only a backwards start can reach.
   //
-  // Measured on the shape below, at 512 trials: 477 tied truths, 2488
+  // Measured on the shape below, at 512 trials: 477 tied truths, 2486
   // observations, 410 empty holdbacks, 140 fallback rounds (40 of them through
-  // the aggregate route), 28 forced-arm rounds with a live suffix, 1041
-  // contradicting rounds, 166 backwards truths, 26 tie strands, 4 backwards
-  // strands, 696 drifted advances, and 13 rounds that erased a word from the
-  // published transcript.
+  // the aggregate route), 28 forced-arm rounds with a live suffix, 1040
+  // contradicting rounds, 166 backwards truths, 26 tie strands, 2 backwards
+  // strands, 2825 rounds with a loss-free split available, 0 avoidable strands
+  // of either kind, 696 drifted advances, and 11 rounds that erased a word from
+  // the published transcript.
+  //
+  // The BEFORE column for codex round 8's finding, on this identical draw: 4
+  // backwards strands of which 2 were avoidable, and 13 erasures. Completing the
+  // legality predicate removed exactly those 2 strands and 2 erasures and moved
+  // nothing else -- the fallback rounds (140), the empty holdbacks (410) and the
+  // tie strands (26) are the same on both sides, so the fix costs nothing on the
+  // forced arm. Unlike the deferral comparison below, this one IS re-derivable:
+  // no shape was added, so the draw did not re-roll.
   //
   // The DEFERRAL comparison that removed the wait was measured on the draw this
   // test carried at `4b259ef`, BEFORE the backwards half existed: 26 words
@@ -509,27 +531,43 @@ fn the_split_never_cuts_at_a_tied_start() {
   // and it reds on a swept over-budget zero-duration word. Keep the sparing fold
   // but drop its `*start > settled_high` filter and it reds again, the watermark
   // having landed on a confirmed word's own start. Return `common.len() - 1`
-  // from the final `unwrap_or` and it reds a third time. It does NOT red when
-  // the back-off arm is deleted outright: the empty-holdback anchor still holds
-  // the postcondition on that path, which is why the back-off is pinned in
-  // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
-  // (measured: that test alone reds, 384 of 385 still green). It also does not
-  // red when the boundary is read against the ADJACENT predecessor rather than
-  // the running maximum: nothing this shape draws puts two backwards steps close
-  // enough together to need the difference, and
-  // `a_backwards_start_two_words_back_still_cannot_be_re_admitted` is that
-  // mutation's sole falsifier.
+  // from the final `unwrap_or` and it reds a third time.
   //
-  // The SECOND postcondition is one clause now, and the ARM gate that used to
-  // ride beside it is gone. Return `anchor` from `sparing_watermark` and it reds
-  // on a strand ABOVE the highest confirmed start. Confirm one word FEWER on the
-  // advance (`common[..split.saturating_sub(1)]`) and it reds again, on the word
-  // the round declined to settle. The gate said WHICH ARM may strand -- only a
-  // split that ran off the end of `common` -- and a backwards start makes that
-  // false: an interior split confirms past a word behind it and strands it too
-  // (`a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word`
-  // is the pipeline-built witness). What actually bounds the exception is the
-  // highest confirmed start, on either arm, so that is what is asserted.
+  // TWO rows this test used to be BLIND to it now catches, both re-measured at
+  // codex round 8 on PR #95, and the reason is the same for both: completing the
+  // legality predicate makes the back-off run on backwards starts as well as on
+  // ties, so the sweep now visits split positions it never reached before.
+  // Delete the back-off arm outright and `avoidable_backward_strands` reds at 3
+  // of 5 -- every one of them a round whose forward search found nothing and
+  // whose only remaining position was off the end. It used to red NOTHING here,
+  // the empty-holdback anchor holding the first postcondition on that path, and
+  // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count` was
+  // the sole falsifier at 384 of 385 green; that test still reds, now alongside
+  // 5 others. Read the boundary against the ADJACENT predecessor rather than the
+  // running maximum and the FIRST postcondition reds at trial 65, on a confirmed
+  // list reaching a 1 s watermark -- where it used to leave
+  // `a_backwards_start_two_words_back_still_cannot_be_re_admitted` the sole
+  // falsifier, nothing the old shape drew putting two backwards steps close
+  // enough together to need the difference. Neither named test is deleted from
+  // the record: they remain the mutations' DIRECT falsifiers, this sweep having
+  // reached them only incidentally.
+  //
+  // The SECOND postcondition is one clause, and the AVOIDABILITY oracle rides
+  // beside it rather than an arm gate. Return `anchor` from `sparing_watermark`
+  // and it reds on a strand ABOVE the highest confirmed start. Confirm one word
+  // FEWER on the advance (`common[..split.saturating_sub(1)]`) and it reds
+  // again, on the word the round declined to settle. Drop the suffix-minimum
+  // conjunct from `split_at_a_strict_boundary`'s predicate -- the half-predicate
+  // codex round 8 found -- and the postcondition itself stays GREEN while
+  // `avoidable_backward_strands` reds at 2 of 4, which is why the oracle is
+  // here: the exception's own wording admitted those strands. Seed that suffix
+  // minimum with `f32::INFINITY` instead of the minimum over the words beyond
+  // `common` and this sweep stays green too, the beyond-`common` half being
+  // pinned by `a_backward_start_beyond_common_backs_the_split_off_too` and
+  // `a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forever`
+  // instead. The gate that used to ride here said WHICH ARM may strand; it was
+  // removed in round 7 when a backwards start reached an interior split, and
+  // round 8 removed the interior route rather than the gate.
   //
   // The SHAPE rows, each forced off and re-measured. `aggregate` off:
   // `aggregate_fallbacks` reds at `0 of 134`, the tied-run route to the empty
@@ -657,6 +695,58 @@ fn the_split_never_cuts_at_a_tied_start() {
     )
   }
 
+  /// WHETHER THE STRAND WAS AVOIDABLE -- whether ANY split at or above the
+  /// prefill budget floor would have lost nothing (#94, codex round 8 on PR
+  /// #95, the HIGH finding).
+  ///
+  /// The exception to the second postcondition used to be stated as "a word at
+  /// or below the highest confirmed start is intrinsically unsparable", and
+  /// that claim is TOO BROAD: the highest confirmed start is ENDOGENOUS to the
+  /// split. A split one word earlier settles less, so it clears less, so a word
+  /// unsparable under one split can be spared under another. What is actually
+  /// unsparable is a word no split at or above the FLOOR avoids -- the floor
+  /// being the one line the back-off may not cross.
+  ///
+  /// Computed by BRUTE FORCE from the round's own raw inputs, and it calls
+  /// neither `split_at_a_strict_boundary` nor `budgeted_split`, so a mutation to
+  /// either cannot mutate this oracle along with it. "Loses nothing" is the
+  /// watermark's own question and is read straight off `sparing_watermark`'s
+  /// contract: a split at `at` settles `common[..at]` on top of what was already
+  /// confirmed, and the fold spares exactly the unconfirmed words starting
+  /// strictly above that maximum -- so the split loses nothing iff the MAXIMUM
+  /// start it settles is strictly below the MINIMUM start it leaves
+  /// unconfirmed, over `hypothesis_words[at..]`, which is the fold's own set.
+  fn a_split_that_loses_nothing_exists(
+    agreement: &LocalAgreement,
+    common_len: usize,
+    confirmed_high_before: Option<f32>,
+  ) -> bool {
+    let words = &agreement.hypothesis_words;
+    // The budget floor, longhand: the earliest split whose holdback fits
+    // `MAX_HOLDBACK_PREFILL_TOKENS`. Token sums only shrink as `at` grows, so
+    // the first `at` that fits is the least one.
+    let floor = (0..=common_len)
+      .find(|&at| {
+        words[at..common_len]
+          .iter()
+          .map(|word| word.tokens_slice().len())
+          .sum::<usize>()
+          <= MAX_HOLDBACK_PREFILL_TOKENS
+      })
+      .unwrap_or(common_len);
+    (floor..common_len).any(|at| {
+      let settled = words[..at]
+        .iter()
+        .map(WordTiming::start)
+        .fold(confirmed_high_before.unwrap_or(f32::NEG_INFINITY), f32::max);
+      let unconfirmed = words[at..]
+        .iter()
+        .map(WordTiming::start)
+        .fold(f32::INFINITY, f32::min);
+      settled < unconfirmed
+    })
+  }
+
   /// THE PUBLISHED TRANSCRIPT, with its timings — `LocalAgreement::finalize`'s
   /// own word list rather than its merged text, which is why
   /// `take_finalized_words` exists as a function at all.
@@ -782,6 +872,10 @@ fn the_split_never_cuts_at_a_tied_start() {
   let mut backward_truths = 0u32;
   let mut drifted_advances = 0u32;
   let mut erasures = 0u32;
+  let mut loss_free_rounds = 0u32;
+  let mut avoidable_backward_strands = 0u32;
+  let mut avoidable_tie_strands = 0u32;
+  let mut interior_strands = 0u32;
 
   for trial in 0..512u32 {
     let length = 4 + (next() % 5) as usize;
@@ -974,11 +1068,12 @@ fn the_split_never_cuts_at_a_tied_start() {
           .collect();
         let before = agreement.confirmed_words_slice().len();
         // Captured BEFORE the call, since `ingest` overwrites it: it is one of
-        // the inputs the split decision is actually made from.
-        let confirmed_last_before = agreement
-          .confirmed_words_slice()
-          .last()
-          .map(WordTiming::start);
+        // the inputs the split decision is actually made from. The HIGH-WATER
+        // start rather than the last confirmed word's, which is what the engine
+        // itself passes -- word starts inside one hypothesis are not
+        // non-decreasing, so the two differ exactly on the rounds this sweep
+        // exists to drive.
+        let confirmed_high_before = highest_start(agreement.confirmed_words_slice());
         let outcome = agreement.ingest_streamed(result_with_words(offered));
         // The RE-TIMED half's own non-vacuity: a drifted offering must actually
         // reach the advance path, not merely be constructed and disagreed with.
@@ -1004,8 +1099,9 @@ fn the_split_never_cuts_at_a_tied_start() {
         let ran_off_the_end = common_len >= agreement.agreement_count_needed()
           && split_at_a_strict_boundary(
             &agreement.hypothesis_words[..common_len],
+            &agreement.hypothesis_words[common_len..],
             common_len - agreement.agreement_count_needed(),
-            confirmed_last_before,
+            confirmed_high_before,
           ) == common_len;
         fallbacks += u32::from(ran_off_the_end);
         // WHICH route emptied the holdback. A fallback round in which NO word
@@ -1021,14 +1117,31 @@ fn the_split_never_cuts_at_a_tied_start() {
               .iter()
               .all(|word| word.tokens_slice().len() <= MAX_HOLDBACK_PREFILL_TOKENS),
         );
+        // AVOIDABILITY, asked of the round's raw inputs rather than of the
+        // function under test. Every strand below is separated by it, and the
+        // avoidable count is asserted at ZERO: a strand is this module's
+        // residual 1 only where the budget floor left no loss-free split to
+        // take, and anything else is a word the engine erased while it could
+        // still have held it (#94, codex round 8 on PR #95).
+        let loss_free = common_len >= agreement.agreement_count_needed()
+          && a_split_that_loses_nothing_exists(&agreement, common_len, confirmed_high_before);
+        loss_free_rounds += u32::from(loss_free);
         match nothing_unconfirmed_falls_below_the_watermark(
           &agreement,
           agreement.confirmed_words_slice().len() - before,
           trial,
           stride,
         ) {
-          Some(true) => tie_strands += 1,
-          Some(false) => backward_strands += 1,
+          Some(true) => {
+            tie_strands += 1;
+            avoidable_tie_strands += u32::from(loss_free);
+            interior_strands += u32::from(!ran_off_the_end);
+          }
+          Some(false) => {
+            backward_strands += 1;
+            avoidable_backward_strands += u32::from(loss_free);
+            interior_strands += u32::from(!ran_off_the_end);
+          }
           None => {}
         }
         // Read AFTER the ingest and kept for the next round, so every round is
@@ -1120,6 +1233,34 @@ fn the_split_never_cuts_at_a_tied_start() {
      only being constructed -- a whole offering whose instants drifted while \
      its texts did not, agreed with and advanced over: {drifted_advances} \
      rounds",
+  );
+  assert!(
+    loss_free_rounds > 128,
+    "and the AVOIDABILITY oracle must actually find loss-free splits, or the \
+     zero it reports below is vacuous: {loss_free_rounds} rounds had one at or \
+     above the budget floor",
+  );
+  assert!(
+    avoidable_backward_strands == 0,
+    "and NO backwards strand may be AVOIDABLE (#94, codex round 8 on PR #95): \
+     {avoidable_backward_strands} of {backward_strands} happened on a round \
+     where some split at or above the budget floor would have lost nothing. \
+     The highest confirmed start is endogenous to the split, so `at or below \
+     the settled high' does not by itself make a word unsparable -- only a \
+     floor with no loss-free split above it does",
+  );
+  assert!(
+    avoidable_tie_strands == 0,
+    "and neither may a TIE strand, for the same reason and by the same oracle: \
+     {avoidable_tie_strands} of {tie_strands}",
+  );
+  assert!(
+    interior_strands == 0,
+    "and the ARM GATE the exception is stated with must hold: every strand takes \
+     the `common.len()` FALLBACK, because an INTERIOR boundary is taken only \
+     where a sparing watermark exists for it and where one exists nothing is \
+     stranded. {interior_strands} of {} strands were on an interior split",
+    tie_strands + backward_strands,
   );
   assert!(
     erasures > 0,
@@ -4452,5 +4593,415 @@ fn a_backwards_start_two_words_back_still_cannot_be_re_admitted() {
       .iter()
       .all(|offered| offered.word() != " P"),
     "and nothing confirmed can head the next hypothesis",
+  );
+}
+
+#[test]
+fn a_backward_start_past_the_requested_split_backs_off_instead_of_stranding_it() {
+  // #94, codex round 8 on PR #95 -- the HIGH finding. Rule W's legality
+  // predicate is ONE statement read in halves, and only the SETTLED half was
+  // ever completed. Round 7's finding 1 made `settled_before[at]` a running
+  // MAXIMUM over everything a split at `at` settles, because word starts inside
+  // one hypothesis are NOT non-decreasing. The UNSETTLED half went on reading
+  // `common[at]` alone -- the FIRST unconfirmed word -- which is the right
+  // comparand only under the very premise round 7 had just destroyed.
+  //
+  // THE COUNTEREXAMPLE, and its provenance. A monotone alignment whose LAST
+  // word heads a segment the timestamp tokens put 0.58 s later than DTW did,
+  // which opens `SegmentSeeker.swift:635-640` and clamps that word BACK past
+  // the word in front of it -- emitted starts `[0.00, 0.70, 1.50, 2.20, 2.30,
+  // 2.19]`. Both halves of that provenance are asserted below rather than
+  // assumed, so this cannot drift away from an input the pipeline can reach.
+  //
+  // WHAT THE HALF-PREDICATE DID with it, at the DEFAULT count. `settled_before`
+  // is `[-inf, 0.00, 0.70, 1.50, 2.20, 2.30, 2.30]`, so at the requested split
+  // 4 the old test read `2.20 < common[4].start() == 2.30` and ACCEPTED it. That
+  // confirms `[0.00, 0.70, 1.50, 2.20]` and holds `[2.30, 2.19]`, and no
+  // watermark then serves both claims: `sparing_watermark` filters every
+  // candidate at or below the 2.20 confirmed high, so the 2.19 word is skipped,
+  // the watermark stays 2.30, and the next identical ingest filters that word
+  // out of BOTH hypotheses at once -- after this round's own `finalize` had
+  // already published it. A RETRACTION.
+  //
+  // WHAT MAKES IT A DEFECT rather than this module's residual 1: split 3 loses
+  // NOTHING. It confirms `[0.00, 0.70, 1.50]`, holds `[2.20, 2.30, 2.19]`, and
+  // 2.19 clears the 1.50 confirmed high, so a single watermark spares all three.
+  // The highest confirmed start is ENDOGENOUS to the split, so "at or below the
+  // settled high is intrinsically unsparable" was too broad a claim: it is
+  // unsparable only where no split at or above the budget floor avoids it, and
+  // the floor here is 0.
+  //
+  // Mutation proof: this test IS the pre-fix state's falsifier -- restore
+  // `|at| settled_before[at] < common[at].start()` as the whole predicate in
+  // `split_at_a_strict_boundary` and it reds on the transcript assertion below.
+  const CONSTRAINED_MEDIAN: f32 = 0.70;
+  const LAST_SEGMENT_START: f32 = 2.88;
+  /// `find_alignment`'s own output for this shape, `(start, end)` per word.
+  const ALIGNMENT: [(f32, f32); 6] = [
+    (0.00, 0.70),
+    (0.70, 1.40),
+    (1.50, 2.20),
+    (2.20, 2.30),
+    (2.30, 2.30),
+    (2.30, 2.89),
+  ];
+  const TEXTS: [&str; 6] = [" A", " B", " C", " D", " E", " F"];
+
+  assert!(
+    ALIGNMENT
+      .windows(2)
+      .all(|pair| pair[0].1 <= pair[1].0 + 1e-4),
+    "the INPUT is what `find_alignment` guarantees about its own output: \
+     non-decreasing and non-overlapping (`segment::tests` pins `w[i].end() <= \
+     w[i + 1].start() + 1e-4`). Everything backwards below is the \
+     post-processing's doing.",
+  );
+  let (drifted_start, drifted_end) = ALIGNMENT[5];
+  assert!(
+    LAST_SEGMENT_START < drifted_end && LAST_SEGMENT_START - 0.5 > drifted_start,
+    "the `SegmentSeeker.swift:635-640` branch is OPEN on this input -- \
+     `segment.start() < w0.end() && segment.start() - 0.5 > w0.start()` with a \
+     segment at {LAST_SEGMENT_START} over a word spanning \
+     {drifted_start}..{drifted_end}",
+  );
+  // `update_segments_with_word_timings`' own arithmetic, verbatim:
+  // `(w0_end - constrained_median_duration).min(segment.start()).max(0.0)`.
+  // 0.70 is `calculate_word_duration_constraints`' ceiling (`median.min(0.7)`).
+  #[allow(clippy::manual_clamp)] // The mirror IS the point: this is
+  // `update_segments_with_word_timings`' own expression, and `clamp` reorders it.
+  let clamped = (drifted_end - CONSTRAINED_MEDIAN)
+    .min(LAST_SEGMENT_START)
+    .max(0.0);
+  assert!(
+    clamped < ALIGNMENT[3].0 && clamped > ALIGNMENT[2].0,
+    "THE PROVENANCE: the clamp puts the last word at {clamped}, BEHIND both the \
+     {} in front of it and the {} two back, and still ahead of the {} three \
+     back -- so a split at 3 clears it and a split at 4 does not. Word starts \
+     inside one hypothesis are not non-decreasing.",
+    ALIGNMENT[4].0,
+    ALIGNMENT[3].0,
+    ALIGNMENT[2].0,
+  );
+
+  let words: Vec<WordTiming> = TEXTS
+    .iter()
+    .zip(&ALIGNMENT)
+    .enumerate()
+    .map(|(index, (text, (start, end)))| {
+      word(text, if index == 5 { clamped } else { *start }, *end)
+    })
+    .collect();
+  assert_eq!(
+    budgeted_split(&words, 0),
+    0,
+    "non-vacuous: the prefill budget floor is 0 on these one-token words, so \
+     every boundary is reachable and nothing here is budget-forced",
+  );
+  let offered = || result_with_words(words.clone());
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, which is the driver's own",
+  );
+  agreement.ingest_streamed(offered());
+  assert!(agreement.ingest_streamed(offered()).is_advanced());
+
+  // THE FINDING, read on the PUBLISHED TRANSCRIPT across rounds rather than on
+  // the confirmed list -- which is append-only and cannot see a retraction.
+  let mut continued = agreement.clone();
+  let outcome = continued.ingest_streamed(offered());
+  let published = continued.finalize(&DecodingOptions::new());
+  assert!(
+    published.text().contains('F'),
+    "THE FINDING: the {clamped} s word is GONE from the transcript after one \
+     more identical ingest ({outcome}), which published {:?}. The advance \
+     confirmed past it and no watermark could then both clear the confirmed \
+     high and spare it -- yet a split one word earlier loses nothing. \
+     Watermark {}, confirmed {:?}",
+    published.text(),
+    agreement.last_agreed_seconds(),
+    confirmed_texts(&agreement),
+  );
+
+  assert_eq!(
+    (
+      confirmed_texts(&agreement),
+      held_back_texts(&agreement),
+      agreement.last_agreed_seconds(),
+    ),
+    (vec![" A", " B", " C"], vec![" D", " E", " F"], clamped),
+    "the forward search from the requested split 4 finds no boundary that \
+     leaves every unconfirmed word above what it settles, so the back-off lands \
+     at 3 and the watermark is the lowest unconfirmed start -- the BACKWARDS \
+     one. The half-predicate accepted split 4 and set a {} s watermark instead.",
+    ALIGNMENT[4].0,
+  );
+
+  let settled_high = highest_start(agreement.confirmed_words_slice()).unwrap();
+  assert!(
+    settled_high < agreement.last_agreed_seconds(),
+    "FIRST postcondition: every confirmed word starts strictly before the \
+     watermark. Highest confirmed start {settled_high}, watermark {}",
+    agreement.last_agreed_seconds(),
+  );
+  let below: Vec<(&str, f32)> = agreement
+    .hypothesis_words
+    .iter()
+    .skip(agreement.confirmed_words_slice().len())
+    .filter(|word| word.start() < agreement.last_agreed_seconds())
+    .map(|word| (word.word(), word.start()))
+    .collect();
+  assert!(
+    below.is_empty(),
+    "SECOND postcondition: nothing this round left unconfirmed is below the \
+     watermark, so nothing was stranded: {below:?}",
+  );
+}
+
+#[test]
+fn a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forever() {
+  // LIVENESS, which is the hard requirement on the completed predicate (#94,
+  // codex round 8 on PR #95). Comparing the settled maximum against the
+  // UNSETTLED MINIMUM refuses boundaries the half-predicate accepted, so the
+  // back-off runs further and an advance can confirm FEWER words -- down to
+  // ZERO. A rule that can confirm zero words has to be shown it cannot do so
+  // INDEFINITELY, and this branch has already killed one candidate for exactly
+  // that (a deferral whose count bound was reset by an advance at split 0, which
+  // held an `L, L, S` cycle at zero confirmed words for 30 rounds; see the
+  // engine module's doc, "Why there is no deferral").
+  //
+  // THE WORST SHAPE the completed predicate can be driven into: a word that is
+  // PERMANENTLY behind everything else, re-offered at the tail of every
+  // hypothesis while the speech in front of it advances a second per round. No
+  // interior boundary is ever legal -- every one of them settles a start above
+  // the backwards word -- so the search can only ever land at 0, and every round
+  // confirms nothing and holds everything.
+  //
+  // WHAT ENDS IT is the prefill budget, and the bound is exact rather than
+  // asymptotic. The back-off may not cross `budgeted_split`'s floor, and the
+  // floor is the earliest split whose holdback fits
+  // `MAX_HOLDBACK_PREFILL_TOKENS`. So `split == 0` REQUIRES `floor == 0`, which
+  // requires the whole of `common` to fit the budget -- and `common` grows by a
+  // word a round. The moment it does not fit, no legal boundary remains at or
+  // above the floor, the `unwrap_or(common.len())` fallback fires, and the round
+  // confirms `common` WHOLE. Zero-confirming rounds are therefore bounded by the
+  // budget itself, on any input, and nothing weaker than the budget is relied on.
+  //
+  // NOTHING IS LOST WHILE IT HOLDS, which is the other half of liveness being
+  // acceptable rather than merely bounded: the words are in the holdback, and
+  // `finalize` publishes the holdback. The transcript is COMPLETE on every one
+  // of those rounds, asserted below round by round. Holding is not losing --
+  // that is the whole trade this finding is about, since the half-predicate
+  // confirmed fast and ERASED the backwards word every round instead.
+  //
+  // NOT PIPELINE-REACHABLE, stated rather than implied. The only backwards mover
+  // this crate has is `update_segments_with_word_timings`' segment-start clamp,
+  // which lowers a word to `end - constrained_median` -- at most 0.7 s behind
+  // its own end, so a real backwards word sits among its neighbours rather than
+  // minutes behind them, and the back-off moves the split by a word or two. This
+  // is the hermetic worst case, driven because the bound has to hold there too.
+  const BACKWARDS_START: f32 = 0.5;
+  const TEXTS: [&str; 4] = [" A", " B", " C", " D"];
+  // One word per round, each a single token, so `common`'s token cost IS its
+  // length and the budget bound below is readable as a word count.
+  let offering = |length: usize| -> Vec<WordTiming> {
+    let mut words: Vec<WordTiming> = (0..length)
+      .map(|index| {
+        let start = 1.0 + index as f32;
+        word(TEXTS[index % TEXTS.len()], start, start + 0.1)
+      })
+      .collect();
+    words.push(word(" Z", BACKWARDS_START, BACKWARDS_START + 0.1));
+    words
+  };
+  assert!(
+    offering(3)
+      .iter()
+      .all(|word| word.tokens_slice().len() == 1),
+    "non-vacuous: single-token words, so the budget floor rises exactly when \
+     `common` passes {MAX_HOLDBACK_PREFILL_TOKENS} WORDS",
+  );
+
+  // Two rounds past the budget: `common` is one word shorter than the offering
+  // (the backwards tail is beyond it) and one round is needed to build a
+  // `common` at all.
+  let expected_confirmation_round = MAX_HOLDBACK_PREFILL_TOKENS + 2;
+  let mut agreement = LocalAgreement::new();
+  let mut first_confirmation = None;
+  let mut confirmed_after: Vec<usize> = Vec::new();
+  for round in 1..=expected_confirmation_round + 6 {
+    let offered = offering(round);
+    let published_words = offered.len();
+    agreement.ingest_streamed(result_with_words(offered));
+    let confirmed = agreement.confirmed_words_slice().len();
+    if confirmed > 0 && first_confirmation.is_none() {
+      first_confirmation = Some(round);
+    }
+    if first_confirmation.is_none() {
+      assert_eq!(
+        agreement.clone().take_finalized_words().len(),
+        published_words,
+        "round {round} confirmed nothing, and the transcript it publishes must \
+         still carry every word the stream said -- holding is not losing. \
+         Holdback {}",
+        agreement.last_agreed_words_slice().len(),
+      );
+    }
+    confirmed_after.push(confirmed);
+  }
+
+  assert_eq!(
+    first_confirmation,
+    Some(expected_confirmation_round),
+    "THE BOUND: the stream must confirm, and it must confirm exactly where the \
+     prefill budget forces it to -- the first round whose `common` no longer \
+     fits {MAX_HOLDBACK_PREFILL_TOKENS} tokens, which is the first round with \
+     no legal boundary at or above a floor above 0. Confirmed counts by round: \
+     {confirmed_after:?}",
+  );
+  assert_eq!(
+    confirmed_after[expected_confirmation_round - 1],
+    MAX_HOLDBACK_PREFILL_TOKENS + 1,
+    "and it confirms `common` WHOLE on that round rather than one word of it, \
+     which is the fallback arm",
+  );
+  assert!(
+    confirmed_after.last() > confirmed_after.get(expected_confirmation_round - 1),
+    "and it KEEPS confirming afterwards rather than returning to zero for good: \
+     {confirmed_after:?}",
+  );
+}
+
+#[test]
+fn a_backward_start_beyond_common_backs_the_split_off_too() {
+  // WHICH SET "everything left unconfirmed" MEANS (#94, codex round 8 on PR
+  // #95). The completed predicate compares the maximum start a split settles
+  // against the minimum start it leaves unconfirmed, and that second set is
+  // `hypothesis_words[split..]` -- `common[split..]` PLUS the words the driving
+  // hypothesis produced BEYOND the agreed prefix -- rather than `common[split..]`
+  // alone.
+  //
+  // THE AUTHORITY IS `sparing_watermark`, not a judgement call: it folds over
+  // `hypothesis_words[split..]` exactly, so a predicate reading a SMALLER set
+  // would declare a split legal that the fold cannot then spare, and the second
+  // postcondition would fail on the very word the fold was added for. A
+  // beyond-`common` word is unconfirmed in precisely the sense that matters
+  // here: this round's own `finalize` PUBLISHES it (through
+  // `find_longest_different_suffix`), and a watermark above it retracts it from
+  // the transcript on the next worded ingest. That it has been corroborated by
+  // only one hypothesis rather than two changes what it is EVIDENCE of, not
+  // whether the engine can still reach it.
+  //
+  // THE SHAPE, with the same provenance as
+  // `a_backward_start_past_the_requested_split_backs_off_instead_of_stranding_it`
+  // and the backwards word moved past the agreed prefix: six words both
+  // hypotheses produce, then a seventh only the newer one does, clamped by
+  // `SegmentSeeker.swift:635-640` to 2.19 -- behind the 2.20 the requested split
+  // would settle. Reading `common` alone accepts split 4, confirms up to 2.20,
+  // and no watermark then spares 2.19.
+  //
+  // Mutation proof: seed the suffix minimum with `f32::INFINITY` instead of the
+  // minimum over `beyond_common` in `split_at_a_strict_boundary` and this reds
+  // (measured: this test and
+  // `a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forever`
+  // are that mutation's only two falsifiers, 42 of 44 still green).
+  const CONSTRAINED_MEDIAN: f32 = 0.70;
+  const LAST_SEGMENT_START: f32 = 2.88;
+  /// `find_alignment`'s own output, `(start, end)` per word -- the seventh being
+  /// the one only the newer hypothesis produces.
+  const ALIGNMENT: [(f32, f32); 7] = [
+    (0.00, 0.70),
+    (0.70, 1.40),
+    (1.50, 2.20),
+    (2.20, 2.30),
+    (2.30, 2.35),
+    (2.35, 2.35),
+    (2.35, 2.89),
+  ];
+  const TEXTS: [&str; 7] = [" A", " B", " C", " E", " F", " G", " D"];
+
+  assert!(
+    ALIGNMENT
+      .windows(2)
+      .all(|pair| pair[0].1 <= pair[1].0 + 1e-4),
+    "the INPUT is what `find_alignment` guarantees about its own output",
+  );
+  let (drifted_start, drifted_end) = ALIGNMENT[6];
+  assert!(
+    LAST_SEGMENT_START < drifted_end && LAST_SEGMENT_START - 0.5 > drifted_start,
+    "the `SegmentSeeker.swift:635-640` branch is OPEN on the seventh word",
+  );
+  #[allow(clippy::manual_clamp)] // The mirror IS the point: this is
+  // `update_segments_with_word_timings`' own expression, and `clamp` reorders it.
+  let clamped = (drifted_end - CONSTRAINED_MEDIAN)
+    .min(LAST_SEGMENT_START)
+    .max(0.0);
+  assert!(
+    clamped < ALIGNMENT[3].0,
+    "THE PROVENANCE: the clamp puts the beyond-`common` word at {clamped}, \
+     behind the {} the requested split would settle",
+    ALIGNMENT[3].0,
+  );
+
+  let build = |length: usize| -> Vec<WordTiming> {
+    TEXTS
+      .iter()
+      .zip(&ALIGNMENT)
+      .take(length)
+      .enumerate()
+      .map(|(index, (text, (start, end)))| {
+        word(text, if index == 6 { clamped } else { *start }, *end)
+      })
+      .collect()
+  };
+  let agreed = build(6);
+  let with_beyond = build(7);
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, which is the driver's own",
+  );
+  agreement.ingest_streamed(result_with_words(agreed));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(with_beyond.clone()))
+      .is_advanced()
+  );
+  assert_eq!(
+    (
+      confirmed_texts(&agreement),
+      held_back_texts(&agreement),
+      agreement.last_agreed_seconds(),
+    ),
+    (vec![" A", " B", " C"], vec![" E", " F", " G"], clamped,),
+    "the requested split 4 settles {} and leaves a beyond-`common` word at \
+     {clamped} unconfirmed, so it is refused and the back-off lands at 3 -- \
+     where one watermark clears everything settled and spares everything else",
+    ALIGNMENT[3].0,
+  );
+
+  // And the round trip, on the published transcript: the word beyond `common`
+  // is still offerable, and the stream that keeps saying it keeps it.
+  assert!(
+    LocalAgreement::watermark_filtered(
+      &result_with_words(with_beyond.clone()),
+      agreement.last_agreed_seconds(),
+    )
+    .iter()
+    .any(|offered| offered.word() == " D"),
+    "`\" D\"` is still offerable, so a later hypothesis can revise or \
+     corroborate it",
+  );
+  agreement.ingest_streamed(result_with_words(with_beyond));
+  let published = agreement.finalize(&DecodingOptions::new());
+  assert!(
+    published.text().contains('D'),
+    "and it reaches the published transcript rather than being retracted out \
+     of it: {:?}",
+    published.text(),
   );
 }

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -382,9 +382,9 @@ fn omitting_a_confirmed_tied_word_does_not_drop_provisional_words() {
 
 #[test]
 fn the_split_never_cuts_at_a_tied_start() {
-  // RULE W's POSTCONDITION, swept rather than pinned to one fixture: whenever
-  // the holdback is non-empty, the last CONFIRMED word starts strictly before
-  // the watermark.
+  // RULE W's POSTCONDITION, swept rather than pinned to one fixture, and TOTAL:
+  // the last CONFIRMED word starts strictly before the watermark, with NO
+  // condition on the holdback.
   //
   // That inequality is the whole of #94. `watermark_filtered` offers every
   // hypothesis word whose `start >= watermark`, so a confirmed word that TIES
@@ -392,8 +392,20 @@ fn the_split_never_cuts_at_a_tied_start() {
   // hypothesis -- and there it is byte-identical to the stream's own second
   // occurrence of the same text, which is the issue's impossibility result.
   // Every defeated rule in this module's ledger tried to DECIDE that state.
-  // Rule W refuses to create it: the split widens past a tie instead of cutting
-  // at one, so the state is unreachable and needs no decision.
+  // Rule W refuses to create it: the split lands only on a boundary whose
+  // preceding word starts strictly earlier, and where no such boundary exists at
+  // or after the requested split it backs OFF rather than widening off the end.
+  //
+  // THE SHAPE THIS TEST USED TO HAVE SKIPPED THE EMPTY HOLDBACK, and the state
+  // it skipped is the one the property did not hold in: with nothing held back
+  // the watermark came from `common.last().end()`, which for a zero-duration
+  // word is that word's own start (codex round 1 on PR #95 -- the skip read as
+  // coverage). The postcondition is now asserted on EVERY observation with a
+  // non-empty confirmed list, and the sweep DRIVES the empty holdback rather
+  // than avoiding it: some trials raise the prefill cost of one word past
+  // `MAX_HOLDBACK_PREFILL_TOKENS`, which is the only thing that still empties
+  // the holdback, and `empty_holdbacks` below is the non-vacuity proof that it
+  // really happened.
   //
   // The sweep draws starts from a coarse grid whose repeats make consecutive
   // words tie -- the `a=[0,0.5)/b=[0,1.0)` shape both #94 regressions are built
@@ -405,9 +417,16 @@ fn the_split_never_cuts_at_a_tied_start() {
   // `omitting_a_confirmed_tied_word_does_not_drop_provisional_words` is built
   // from.
   //
-  // Mutation proof: drop Rule W's widening loop from `ingest` (leaving the bare
-  // `budgeted_split`) and this reds on the first swept tie, reporting the
-  // confirmed word whose start equals the watermark.
+  // Mutation proof: drop the `.max(last.start().next_up())` from `ingest`'s
+  // empty-holdback watermark and this reds on a swept over-budget zero-duration
+  // word; make the boundary non-strict (`<=` for `<` in
+  // `split_at_a_strict_boundary`) and it reds on a swept tie; let the back-off
+  // cross the prefill budget floor (`0..widened` for `floor..widened`) and it
+  // reds too. It does NOT red when the back-off arm is deleted outright: the
+  // `next_up` anchor still holds the postcondition on that path, which is why
+  // the back-off has its own falsifier in
+  // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
+  // rather than being asserted here.
   const TEXTS: [&str; 4] = [" A", " B", " C", " D"];
   // Repeated 0.0 entries are the ties; the rest keep the grid coarse enough for
   // two words to share an instant often.
@@ -417,24 +436,24 @@ fn the_split_never_cuts_at_a_tied_start() {
   // between two distinct starts.
   const DURATIONS: [f32; 4] = [0.0, 0.2, 0.5, 1.0];
 
-  fn postcondition(agreement: &LocalAgreement, trial: u32, stride: usize) -> bool {
-    if agreement.last_agreed_words_slice().is_empty() {
-      return false;
-    }
-    let Some(last) = agreement.confirmed_words_slice().last() else {
-      return false;
-    };
+  /// `None` when nothing is confirmed yet and the postcondition has nothing to
+  /// speak about; otherwise `Some(the holdback was empty)`, which is the state
+  /// this test's earlier shape skipped.
+  fn postcondition(agreement: &LocalAgreement, trial: u32, stride: usize) -> Option<bool> {
+    let last = agreement.confirmed_words_slice().last()?;
     assert!(
       last.start() < agreement.last_agreed_seconds(),
       "trial {trial}, stride {stride}: the confirmed list {:?} ends on {:?} at \
        {}, which is not strictly before the {} s watermark -- that word passes \
-       `watermark_filtered`'s own `start >= watermark` and can be re-admitted",
+       `watermark_filtered`'s own `start >= watermark` and can be re-admitted. \
+       The holdback here is {:?}",
       confirmed_texts(agreement),
       last.word(),
       last.start(),
       agreement.last_agreed_seconds(),
+      held_back_texts(agreement),
     );
-    true
+    Some(agreement.last_agreed_words_slice().is_empty())
   }
 
   let mut state: u64 = 0x2545_F491_4F6C_DD1D;
@@ -445,17 +464,30 @@ fn the_split_never_cuts_at_a_tied_start() {
     state
   };
   let mut checked = 0u32;
+  let mut empty_holdbacks = 0u32;
   let mut tied_truths = 0u32;
 
   for trial in 0..256u32 {
     let length = 4 + (next() % 5) as usize;
+    // The prefill budget is the only thing that can still empty the holdback, so
+    // one word in some trials is made too expensive for it to carry -- and it is
+    // placed anywhere, including last, where the split runs to `common.len()`.
+    let over_budget = if next() % 3 == 0 {
+      Some((next() as usize) % length)
+    } else {
+      None
+    };
     let mut truth: Vec<WordTiming> = Vec::with_capacity(length);
     let mut start = 0.0f32;
-    for _ in 0..length {
+    for index in 0..length {
       let text = TEXTS[(next() % TEXTS.len() as u64) as usize];
       start += STEPS[(next() % STEPS.len() as u64) as usize];
       let end = start + DURATIONS[(next() % DURATIONS.len() as u64) as usize];
-      truth.push(word(text, start, end));
+      truth.push(if over_budget == Some(index) {
+        word_of_tokens(text, start, end, MAX_HOLDBACK_PREFILL_TOKENS + 1)
+      } else {
+        word(text, start, end)
+      });
     }
     if truth
       .windows(2)
@@ -464,7 +496,10 @@ fn the_split_never_cuts_at_a_tied_start() {
       tied_truths += 1;
     }
 
-    let mut agreement = LocalAgreement::new();
+    // Both counts the engine can be driven at: 1 makes every agreement an
+    // advance, 2 is the driver's own `DEFAULT_AGREEMENT_COUNT_NEEDED`.
+    let mut agreement =
+      LocalAgreement::new().with_agreement_count_needed(1 + (next() % 2) as usize);
     for stride in 2..=truth.len() {
       let omit_head = stride > 2 && next() % 4 == 0;
       let offered = if omit_head {
@@ -474,16 +509,18 @@ fn the_split_never_cuts_at_a_tied_start() {
       };
       for _ in 0..2 {
         agreement.ingest_streamed(result_with_words(offered.clone()));
-        if postcondition(&agreement, trial, stride) {
+        if let Some(empty) = postcondition(&agreement, trial, stride) {
           checked += 1;
+          empty_holdbacks += u32::from(empty);
         }
       }
     }
   }
 
-  // Non-vacuity, both halves: the sweep really did build tied truths, and the
-  // postcondition really was READ against a non-empty holdback and a non-empty
-  // confirmed list rather than skipped.
+  // Non-vacuity, all three halves: the sweep really did build tied truths, the
+  // postcondition really was READ against a non-empty confirmed list rather than
+  // skipped, and the EMPTY-HOLDBACK state -- the one the earlier shape of this
+  // test skipped, and the one #94 was re-opened from -- really was reached.
   assert!(
     tied_truths > 64,
     "the sweep must actually produce tied starts: {tied_truths} of 256 trials",
@@ -492,84 +529,109 @@ fn the_split_never_cuts_at_a_tied_start() {
     checked > 256,
     "the postcondition must actually be reachable: {checked} observations",
   );
+  assert!(
+    empty_holdbacks > 64,
+    "the postcondition must be read against an EMPTY holdback too, which is \
+     the state this test used to skip: {empty_holdbacks} of {checked} \
+     observations",
+  );
 }
-
 #[test]
-fn the_split_widens_past_a_tie_with_the_confirmed_list_itself() {
-  // RULE W's BASE CASE, which `the_split_never_cuts_at_a_tied_start`'s sweep
-  // cannot reach. When the split has moved past nothing (`split == 0`, i.e.
-  // `common.len() == agreement_count_needed` and the budget widened nothing),
-  // there is no `common[split - 1]` to anchor against and the rule falls back to
-  // the engine's own last CONFIRMED word -- the word the watermark would
-  // otherwise sit beside.
+fn a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count() {
+  // #94, codex round 1 on PR #95 -- the ORIGINAL duplicate-confirmation defect,
+  // back on the DEFAULT driver path. Rule W's widening runs to `common.len()`
+  // whenever the agreed prefix ENDS in a tied run: the holdback empties, the
+  // watermark falls back to `common.last().end()`, and for a zero-duration word
+  // that EQUALS its own start -- so `watermark_filtered`'s `start >= watermark`
+  // re-admits it and every later stride confirms the whole run AGAIN.
   //
-  // The sweep never gets here because the fallback is inert while the
-  // postcondition already holds: `confirmed.last().start() < watermark` and
-  // every offered word starts at or past the watermark, so `anchor >=
-  // common[0].start()` is false by induction. The one state that breaks the
-  // induction is the documented residual
-  // (`an_empty_holdback_leaves_a_zero_duration_word_at_the_watermark`): with an
-  // EMPTY holdback the watermark anchors at `common.last().end()`, so a
-  // zero-duration word there leaves `confirmed.last().start() == watermark`, and
-  // the NEXT advance is the only place that can repair it.
+  // It needs neither an over-budget word nor a non-default
+  // `agreement_count_needed`, which is what separates it from the empty-holdback
+  // state `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed` reaches
+  // through the prefill budget: two ingests of one four-word hypothesis whose
+  // last three words tie is enough.
   //
-  //   agreement_count_needed 1
-  //   ingest [A@0.0-1.0, Z@1.0-1.0 (over budget)] twice
-  //     -> confirmed [A, Z], holdback EMPTY, watermark 1.0 == Z's own start
-  //   ingest [W@1.0-2.0] twice
-  //     -> common [W], requested 0, budget widens nothing, so split == 0
-  //     -> the fallback sees Z@1.0 >= W@1.0 and widens to 1
+  // The repair has two separable halves and this test pins the SECOND. The
+  // watermark's `next_up` anchor (see
+  // `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed`) is what
+  // closes the DUPLICATION: with it in place the re-offered run is filtered out
+  // even when the holdback is empty. The back-off is what keeps Rule W from
+  // emptying the holdback in the first place, so the tied run stays revisable,
+  // the next stride still gets a prefill anchor, and a genuinely new word at the
+  // run's own instant is not filtered away with it.
   //
-  // Mutation proof: seed the anchor with `None` instead of
-  // `self.confirmed_words.last().map(WordTiming::start)` and this reds -- the
-  // split stays at 0, `" W"` is held back at a 1.0 s watermark, and `" Z"` is
-  // left confirmed at exactly that instant, where it passes
-  // `watermark_filtered`'s own `start >= watermark` and can be re-admitted.
-  // Nothing else in this module reds with that mutation, which is why this test
-  // exists.
-  let a = || word(" A", 0.0, 1.0);
-  let zero = || word_of_tokens(" Z", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
-  let w = || word(" W", 1.0, 2.0);
-
-  let mut agreement = LocalAgreement::new().with_agreement_count_needed(1);
-  let opening = || result_with_words(vec![a(), zero()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  // Mutation proof: delete the back-off arm (the `.or_else(...)` in
+  // `split_at_a_strict_boundary`) and this reds -- `([" X", " A", " B", " C"],
+  // [], 2.0000002)` against `([" X"], [" A", " B", " C"], 2.0)`. Take the
+  // EARLIEST legal boundary instead of the latest (drop the `.rev()`) and it
+  // reds the other way, confirming nothing at all: `([], [" X", " A", " B",
+  // " C"], 0.0)`.
+  //
+  // Before either half existed, this read `[" X", " A", " B", " C", " A", " B",
+  // " C", " A", " B", " C"]` after the four ingests below, growing by the whole
+  // run on every further stride.
+  let hypothesis = || {
+    result_with_words(vec![
+      word(" X", 0.0, 1.0),
+      word(" A", 2.0, 2.0),
+      word(" B", 2.0, 2.0),
+      word(" C", 2.0, 2.0),
+    ])
+  };
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, the only one the driver reaches",
+  );
+  agreement.ingest_streamed(hypothesis());
+  assert!(agreement.ingest_streamed(hypothesis()).is_advanced());
   assert_eq!(
     (
       confirmed_texts(&agreement),
-      agreement.last_agreed_words_slice().len(),
-      agreement.last_agreed_seconds()
+      held_back_texts(&agreement),
+      agreement.last_agreed_seconds(),
     ),
-    (vec![" A", " Z"], 0, 1.0),
-    "non-vacuous setup: the budget emptied the holdback and left the last \
-     confirmed word starting exactly at the watermark -- the only state from \
-     which the base case below has anything to repair",
+    (vec![" X"], vec![" A", " B", " C"], 2.0),
+    "Rule W may not empty the holdback: with no legal boundary at or after the \
+     requested split it backs off to the last one BEFORE the tied run, so the \
+     run stays provisional instead of being confirmed against a watermark that \
+     sits on its own start",
   );
 
-  // Two ingests: the first disagrees (so `prev_result` becomes this hypothesis
-  // without advancing), the second agrees with it on the single word " W".
-  let onward = || result_with_words(vec![w()]);
-  assert!(agreement.ingest_streamed(onward()).is_awaiting_agreement());
-  assert!(agreement.ingest_streamed(onward()).is_advanced());
+  // The re-decode reproduces the holdback and nothing else -- the exact shape
+  // `decoding_options_for_next` forces, clipped at the 2.0 s watermark.
+  let reproduction = || {
+    result_with_words(vec![
+      word(" A", 2.0, 2.0),
+      word(" B", 2.0, 2.0),
+      word(" C", 2.0, 2.0),
+    ])
+  };
+  agreement.ingest_streamed(reproduction());
+  agreement.ingest_streamed(reproduction());
   assert_eq!(
-    (confirmed_texts(&agreement), agreement.last_agreed_seconds()),
-    (vec![" A", " Z", " W"], 2.0),
-    "the split had moved past nothing, so Rule W anchored on the confirmed \
-     list itself and widened past the tie -- restoring the postcondition the \
-     empty-holdback watermark had broken",
+    (confirmed_texts(&agreement), held_back_texts(&agreement)),
+    (vec![" X"], vec![" A", " B", " C"]),
+    "and NO stride re-confirms the run: the reproduction offers nothing that \
+     starts strictly later, so the same back-off holds it exactly once",
   );
-  let last = agreement
-    .confirmed_words_slice()
-    .last()
-    .expect("the confirmed list is non-empty");
-  assert!(
-    last.start() < agreement.last_agreed_seconds(),
-    "the postcondition is repaired: {:?} starts at {} against a {} s watermark",
-    last.word(),
-    last.start(),
-    agreement.last_agreed_seconds(),
+  let text = agreement
+    .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+    .text()
+    .to_string();
+  assert_eq!(
+    text, " X A B C",
+    "and the finalized face agrees with the streaming one -- the holdback the \
+     back-off kept is still emitted, so nothing is lost by holding it",
   );
+  for token in ["X", "A", "B", "C"] {
+    assert_eq!(
+      text.matches(token).count(),
+      1,
+      "{token} must appear exactly once in {text:?}"
+    );
+  }
 }
 
 #[test]
@@ -1262,6 +1324,17 @@ fn a_stutter_at_the_watermark_keeps_both_occurrences() {
     " A A B",
     "both stuttered A's are the hypothesis's own words, not a re-admission",
   );
+}
+
+/// `last_agreed_words_slice()` as text -- the still-provisional half of the
+/// streaming face, asserted beside `confirmed_texts` wherever a word could be in
+/// one list rather than the other.
+fn held_back_texts(agreement: &LocalAgreement) -> Vec<&str> {
+  agreement
+    .last_agreed_words_slice()
+    .iter()
+    .map(WordTiming::word)
+    .collect()
 }
 
 /// `confirmed_words_slice()` as text — the face a streaming caller reads
@@ -2175,30 +2248,32 @@ fn the_prefill_reaches_decode_text_as_the_whole_holdback() {
 }
 
 #[test]
-fn an_empty_holdback_leaves_a_zero_duration_word_at_the_watermark() {
-  // RULE W's ONE RESIDUAL, characterized rather than closed. The postcondition
-  // -- `confirmed.last().start() < last_agreed_seconds` strictly -- is a claim
-  // about a NON-EMPTY holdback, because the watermark is then the first held
-  // word's start and the rule widens past any tie with it. When
-  // `budgeted_split` empties the holdback the watermark falls back to
-  // `common.last().end()` instead, and Rule W has no `common[split]` to anchor
-  // against: if that last word has `start == end` the watermark EQUALS its
-  // start, the word passes `watermark_filtered`'s own `start >= watermark`, and
-  // a re-decode that offers it back -- with no holdback, so no prefill to
-  // displace it -- confirms it a SECOND time.
+fn a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed() {
+  // RULE W'S POSTCONDITION ON THE ONE PATH THAT STILL EMPTIES THE HOLDBACK.
+  // With nothing held back there is no held word to measure the watermark
+  // against, so `ingest` anchors it at the last confirmed word's END -- and for
+  // a ZERO-DURATION word that is its own START, which used to leave it passing
+  // `watermark_filtered`'s `start >= watermark` against its own confirmation and
+  // being confirmed a SECOND time (#94 residual 1, characterized here until
+  // codex round 1 on PR #95 found the same state on the default path).
   //
-  // Reaching it needs three things at once, and the driver supplies none of
-  // them: a non-default `agreement_count_needed` (here 1), a word whose OWN
-  // tokens exceed `MAX_HOLDBACK_PREFILL_TOKENS` so the split runs to
-  // `common.len()`, and a ZERO-DURATION word in that position.
-  // `LocalAgreementTranscriber` never leaves `DEFAULT_AGREEMENT_COUNT_NEEDED`,
-  // and `add_word_timestamps` never emits a 112-token word.
+  // Closed, not characterized: the watermark is `end.max(start.next_up())`, the
+  // first instant strictly past the settled start. `next_up` is the IMMEDIATE
+  // f32 successor, so no representable instant lies between it and the start it
+  // excludes -- it refuses exactly one instant rather than moving a cliff, which
+  // is what an `end + epsilon` tolerance would have done.
   //
-  // Recorded, not repaired: the alternatives are anchoring the empty-holdback
-  // watermark at `end + epsilon` (a threshold with the same cliff one instant
-  // further on, and one that makes the watermark a value no word's `start` ever
-  // equals) or refusing the advance (the blocking policy this issue's ledger
-  // already refuted for deadlock).
+  // Only the PREFILL BUDGET can reach this state now. Rule W's own widening no
+  // longer empties the holdback (it backs off instead --
+  // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`), and
+  // the back-off may not cross the budget floor, which here sits at
+  // `common.len()`: `" Z"` alone exceeds `MAX_HOLDBACK_PREFILL_TOKENS`, so there
+  // is nothing the prefill could carry whole (codex round 7, finding 2). It also
+  // needs a non-default `agreement_count_needed` (here 1) and a zero-duration
+  // word; `add_word_timestamps` never emits a 112-token word.
+  //
+  // Mutation proof: drop the `.max(last.start().next_up())` from `ingest`'s
+  // empty-holdback watermark and this reds with `" Z"` confirmed twice.
   let a = || word(" A", 0.0, 1.0);
   let zero = || word_of_tokens(" Z", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   let b = || word(" B", 1.0, 2.0);
@@ -2211,46 +2286,59 @@ fn an_empty_holdback_leaves_a_zero_duration_word_at_the_watermark() {
     (
       confirmed_texts(&agreement),
       agreement.last_agreed_words_slice().len(),
-      agreement.last_agreed_seconds()
     ),
-    (vec![" A", " Z"], 0, 1.0),
-    "non-vacuous: the budget emptied the holdback, so the watermark is \
-     \" Z\"'s END -- which for a zero-duration word is also its START",
+    (vec![" A", " Z"], 0),
+    "non-vacuous: the budget could hold nothing back, so this is the \
+     empty-holdback watermark rather than a held word's start",
   );
   assert_eq!(
-    agreement
-      .confirmed_words_slice()
-      .last()
-      .map(WordTiming::start),
-    Some(agreement.last_agreed_seconds()),
-    "the postcondition is VACUOUS here: with no held-back word the last \
-     confirmed word's start EQUALS the watermark instead of preceding it",
+    agreement.last_agreed_seconds(),
+    1.0f32.next_up(),
+    "and \" Z\"'s own END is 1.0, so `end` alone would have put the watermark \
+     on \" Z\"'s own start",
+  );
+  let last_confirmed_start = agreement
+    .confirmed_words_slice()
+    .last()
+    .map(WordTiming::start)
+    .expect("the confirmed list is non-empty");
+  assert!(
+    last_confirmed_start < agreement.last_agreed_seconds(),
+    "the postcondition is TOTAL: {last_confirmed_start} is strictly before the \
+     {} s watermark even with an empty holdback",
+    agreement.last_agreed_seconds(),
   );
 
   // The re-decode offers " Z" back at the head of its word list. Nothing
   // displaces it: the holdback is empty, so `decoding_options_for_next` attaches
   // an empty prefix and the decoder was never fed a reproduction to begin with.
-  //
-  // One ingest is enough: the previous hypothesis already contributed " Z" at
-  // this watermark, so the pair agrees on it immediately.
+  // The watermark is the only thing standing between " Z" and a second
+  // confirmation, and it now does stand there.
   assert!(
     agreement
       .ingest_streamed(result_with_words(vec![zero(), b()]))
-      .is_advanced()
+      .is_awaiting_agreement()
   );
   assert_eq!(
     confirmed_texts(&agreement),
-    vec![" A", " Z", " Z"],
-    "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94, \
-     residual 1): the CORRECT answer is [\" A\", \" Z\"] -- \" Z\" is one word \
-     the stream produced once and it reaches the confirmed list twice. Rule W \
-     cannot help: it widens the split past a tie with `common[split]`, and here \
-     the split ran to `common.len()` so there is no `common[split]` to widen \
-     past. If this state is ever closed, assert [\" A\", \" Z\"] and delete this \
-     message.",
+    vec![" A", " Z"],
+    "\" Z\" is one word the stream produced once and it reaches the confirmed \
+     list once",
+  );
+  assert_eq!(
+    agreement
+      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+      .text(),
+    " A Z",
+    "COST, recorded as this rule's residual: \" B\" is a genuinely NEW word \
+     that begins at the same instant the zero-duration \" Z\" occupies, and no \
+     watermark can admit it while refusing \" Z\" -- the two are byte-identical \
+     to a timestamp filter. It is dropped. The trade is the module's own \
+     adjudicated bias applied to the evidence: an unbounded re-confirmation \
+     REWRITES the confirmed text and breaks the portable prefix property, while \
+     this leaves a truncation, which that property tolerates.",
   );
 }
-
 #[test]
 fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
   // #94 (codex round 13, finding 1), REFUTED RATHER THAN FIXED, and this is the

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -8,6 +8,25 @@ fn word(text: &str, start: f32, end: f32) -> WordTiming {
   WordTiming::new(text, vec![start as u32 + 1], start, end, 0.9)
 }
 
+/// The instant an empty-holdback advance anchors at when the word it settles
+/// last is ZERO-DURATION and sits at 1.0 s: the exact time of sample 16001, the
+/// first sample strictly after the one 1.0 s clips to.
+///
+/// Written as the sample's own instant rather than by calling the engine's
+/// `past_the_settled_instant`, so these assertions state which SAMPLE the
+/// anchor has to clear rather than repeating the arithmetic that produced it.
+/// The `f32::next_up` anchor this replaced was `1.0000001` — a real step in
+/// seconds and no step at all in samples, so the next stride re-read the
+/// settled word's own audio while the module doc claimed it had been clipped
+/// away (#94, codex round 7 on PR #95, finding 2). The pin that the two
+/// coordinate systems agree is
+/// `the_watermark_clears_the_settled_sample_not_just_the_settled_instant`.
+const PAST_ONE_SECOND: f32 = 1.0000625;
+
+/// The same anchor for a zero-duration settled word at 2.0 s — sample 32001's
+/// own instant. See [`PAST_ONE_SECOND`].
+const PAST_TWO_SECONDS: f32 = 2.0000625;
+
 /// A word carrying `token_count` distinct plain-vocabulary token ids — for the
 /// prefill-budget cases, where what matters is how many TOKENS the holdback
 /// costs, not how many words it holds. Ids stay far below any Whisper
@@ -447,58 +466,70 @@ fn the_split_never_cuts_at_a_tied_start() {
   // the drift stays inside the gap in front of the watermark, so the sweep
   // reaches the re-timing without ever reaching the whole-run jump past it.
   //
-  // Measured on the shape below, at 512 trials: 495 tied truths, 2482
-  // observations, 413 empty holdbacks, 141 fallback rounds (46 of them through
-  // the aggregate route), 34 forced-arm rounds with a live suffix, 1162
-  // contradicting rounds, 38 strands at the settled instant, 759 drifted
-  // advances, and 10 rounds that erased a word from the published transcript.
+  // A SIXTH shape draws BACKWARDS starts (codex round 7 on PR #95, finding 1).
+  // Every shape above keeps its starts non-decreasing, which is the premise the
+  // second postcondition used to be free under on an interior split -- and
+  // `segment::update_segments_with_word_timings` does not honour it. The
+  // backwards draw reproduces that function's own clamp; `backward_truths` is
+  // this half's non-vacuity proof, and `backward_strands` proves the half of the
+  // exception only a backwards start can reach.
   //
-  // On the DEFERRAL shape this branch carried between `6987bec` and `b3ec5c6`,
-  // same draw: 2383 observations, 277 empty holdbacks, 113 rounds that WAITED
-  // where no legal boundary existed and 43 that escaped the wait, 49 forced-arm
-  // rounds, 29 tie strands and 26 erasures -- 2.6x the published retractions
-  // for a word apiece at the settled instant. That measurement is what removed
-  // it; see the engine module's doc, "Why there is no deferral".
+  // Measured on the shape below, at 512 trials: 477 tied truths, 2488
+  // observations, 410 empty holdbacks, 140 fallback rounds (40 of them through
+  // the aggregate route), 28 forced-arm rounds with a live suffix, 1041
+  // contradicting rounds, 166 backwards truths, 26 tie strands, 4 backwards
+  // strands, 696 drifted advances, and 13 rounds that erased a word from the
+  // published transcript.
+  //
+  // The DEFERRAL comparison that removed the wait was measured on the draw this
+  // test carried at `4b259ef`, BEFORE the backwards half existed: 26 words
+  // erased from the published transcript against this fallback's 10 on that
+  // identical draw, and 29 tie strands against 38. Adding a shape re-rolls every
+  // later draw, so those two columns cannot be re-derived from the numbers
+  // above and are not restated as if they could; the decision they support is
+  // in the engine module's doc, "Why there is no deferral", with the tree it
+  // compared against.
   //
   // The sweep draws starts from a coarse grid whose repeats make consecutive
   // words tie -- the `a=[0,0.5)/b=[0,1.0)` shape both #94 regressions are built
-  // from, generalized -- keeps them non-decreasing the way `find_alignment`
-  // guarantees (`segment::tests`: `w[i].end() <= w[i+1].start() + 1e-4`), and
-  // drives growing prefixes through `ingest_streamed`, the MARKED path the
-  // driver uses, so every advance carries the prefill premise the engine issues
-  // for itself. One stride in four omits the leading word, which is the rewrite
+  // from, generalized -- and drives growing prefixes through `ingest_streamed`,
+  // the MARKED path the driver uses, so every advance carries the prefill
+  // premise the engine issues for itself. The draw is non-decreasing BEFORE the
+  // backwards clamp, the way `find_alignment` guarantees (`segment::tests`:
+  // `w[i].end() <= w[i+1].start() + 1e-4`), and the clamp is the only thing that
+  // breaks it -- which is the pipeline's own arrangement. One stride in four
+  // omits the leading word, which is the rewrite
   // `omitting_a_confirmed_tied_word_does_not_drop_provisional_words` is built
   // from.
   //
   // Mutation proof, every row RUN on this shape. Make the boundary non-strict
   // (`<=` for `<` in `split_at_a_strict_boundary`) and the FIRST postcondition
-  // reds on a swept tie at trial 0. Drop the `.max(last.start().next_up())` from
-  // `empty_holdback_watermark` and it reds on a swept over-budget zero-duration
-  // word. Keep the fold but drop its `*start > last.start()` filter and it reds
-  // again, the watermark having landed on the confirmed word's own start.
-  // Return `common.len() - 1` from the final `unwrap_or` and it reds a third
-  // time. It does NOT red when the back-off arm is deleted outright: the
-  // empty-holdback anchor still holds the postcondition on that path, which is
-  // why the back-off is pinned in
+  // reds on a swept tie at trial 0. Drop the
+  // `.max(past_the_settled_instant(settled_high))` from `empty_holdback_anchor`
+  // and it reds on a swept over-budget zero-duration word. Keep the sparing fold
+  // but drop its `*start > settled_high` filter and it reds again, the watermark
+  // having landed on a confirmed word's own start. Return `common.len() - 1`
+  // from the final `unwrap_or` and it reds a third time. It does NOT red when
+  // the back-off arm is deleted outright: the empty-holdback anchor still holds
+  // the postcondition on that path, which is why the back-off is pinned in
   // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
-  // (measured: that test alone reds, 384 of 385 still green).
+  // (measured: that test alone reds, 384 of 385 still green). It also does not
+  // red when the boundary is read against the ADJACENT predecessor rather than
+  // the running maximum: nothing this shape draws puts two backwards steps close
+  // enough together to need the difference, and
+  // `a_backwards_start_two_words_back_still_cannot_be_re_admitted` is that
+  // mutation's sole falsifier.
   //
-  // The SECOND postcondition has two clauses and they fail differently. Drop the
-  // sparing FOLD from `empty_holdback_watermark` (return
-  // `past_the_confirmed_start`) and the TIE clause reds on a strand BEYOND the
-  // settled instant -- `[(" B", 2.5)]` below a 3 s watermark at a 2.0 s settled
-  // start. Confirm one word FEWER on the advance (`common[..split - 1]`) and the
-  // `ran_off_the_end` GATE reds instead, on an INTERIOR round that stranded at
-  // the settled instant, where the tie clause is silent by construction.
-  //
-  // The gate reds NOTHING when mutated alone -- replace it with `true` and all
-  // 385 tests stay green -- and it is DOMINATED in the observed mutation set:
-  // every engine mutation that reaches a strand at all (no-`next_up`, no-fold,
-  // interior anchor at `end`, confirm-one-fewer) also trips the tie clause
-  // somewhere later in the sweep, so the gate is never the unique reason this
-  // test fails. It is kept because it is the clause that says WHICH arm may
-  // strand, which is the whole of residual 1's claim, and because under the
-  // confirm-one-fewer mutation it is the FIRST and most precise failure.
+  // The SECOND postcondition is one clause now, and the ARM gate that used to
+  // ride beside it is gone. Return `anchor` from `sparing_watermark` and it reds
+  // on a strand ABOVE the highest confirmed start. Confirm one word FEWER on the
+  // advance (`common[..split.saturating_sub(1)]`) and it reds again, on the word
+  // the round declined to settle. The gate said WHICH ARM may strand -- only a
+  // split that ran off the end of `common` -- and a backwards start makes that
+  // false: an interior split confirms past a word behind it and strands it too
+  // (`a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word`
+  // is the pipeline-built witness). What actually bounds the exception is the
+  // highest confirmed start, on either arm, so that is what is asserted.
   //
   // The SHAPE rows, each forced off and re-measured. `aggregate` off:
   // `aggregate_fallbacks` reds at `0 of 134`, the tied-run route to the empty
@@ -518,26 +549,33 @@ fn the_split_never_cuts_at_a_tied_start() {
   const TEXTS: [&str; 4] = [" A", " B", " C", " D"];
   // Repeated 0.0 entries are the ties; the rest keep the grid coarse enough for
   // two words to share an instant often.
-  const STEPS: [f32; 6] = [0.0, 0.0, 0.0, 0.5, 0.5, 1.0];
+  const STEPS: [f32; 7] = [0.0, 0.0, 0.0, 0.1, 0.5, 0.5, 1.0];
   // The 0.0 duration is a zero-length word, which is the one shape that could
   // satisfy `start >= watermark` from inside the confirmed list without a tie
-  // between two distinct starts.
-  const DURATIONS: [f32; 4] = [0.0, 0.2, 0.5, 1.0];
+  // between two distinct starts. The 0.55 is the BACKWARDS draw's own entry: the
+  // segment-start clamp fires only for a word spanning more than half a second
+  // and only moves it back by `CLAMP_MEDIAN - duration`, so 0.55 is the one
+  // duration here that both opens the branch and lands behind where it started
+  // -- by 0.15 s, which is wider than the 0.1 STEP so the clamped word can duck
+  // below a word the same round confirms rather than merely tying it.
+  const DURATIONS: [f32; 5] = [0.0, 0.2, 0.5, 0.55, 1.0];
+  /// `calculate_word_duration_constraints`' own ceiling (`median.min(0.7)`), and
+  /// the value `SegmentSeeker.swift:635-640` subtracts from a drifted first
+  /// word's END to get its new start.
+  const CLAMP_MEDIAN: f32 = 0.7;
 
   /// `None` when nothing is confirmed yet and the postcondition has nothing to
   /// speak about; otherwise `Some(the holdback was empty)`, which is the state
   /// this test's earlier shape skipped.
   fn postcondition(agreement: &LocalAgreement, trial: u32, stride: usize) -> Option<bool> {
-    let last = agreement.confirmed_words_slice().last()?;
+    let high = highest_start(agreement.confirmed_words_slice())?;
     assert!(
-      last.start() < agreement.last_agreed_seconds(),
-      "trial {trial}, stride {stride}: the confirmed list {:?} ends on {:?} at \
-       {}, which is not strictly before the {} s watermark -- that word passes \
+      high < agreement.last_agreed_seconds(),
+      "trial {trial}, stride {stride}: the confirmed list {:?} reaches {high}, \
+       which is not strictly before the {} s watermark -- that word passes \
        `watermark_filtered`'s own `start >= watermark` and can be re-admitted. \
        The holdback here is {:?}",
       confirmed_texts(agreement),
-      last.word(),
-      last.start(),
       agreement.last_agreed_seconds(),
       held_back_texts(agreement),
     );
@@ -548,74 +586,75 @@ fn the_split_never_cuts_at_a_tied_start() {
   /// (codex round 3 on PR #95, second finding): an advance may not push the
   /// watermark past a word of its own hypothesis that it did not CONFIRM.
   ///
-  /// Word starts inside one hypothesis are non-decreasing, so the words that
-  /// fall below the new watermark are a PREFIX of `hypothesis_words` -- and each
-  /// one is either a word this round appended to the confirmed list or a word
-  /// the stream can never offer again. Counting the first against the second is
-  /// the whole statement. It is TOTAL for the same reason the first
+  /// Every word of `hypothesis_words` past the split is either a word this
+  /// round appended to the confirmed list or a word the stream can still offer
+  /// again; anything else is a strand. It is TOTAL for the same reason the first
   /// postcondition is: a round that does not advance appends nothing and moves
   /// no watermark, and every word of `hypothesis_words` cleared `start >=
-  /// last_agreed_seconds` to be there at all, so both sides are zero.
+  /// last_agreed_seconds` to be there at all, so there is nothing below it.
   ///
   /// `appended` is measured across the call rather than read off a split, so
-  /// this cannot be satisfied by the same arithmetic that produced it.
+  /// this cannot be satisfied by the same arithmetic that produced it. The
+  /// unconfirmed words are `hypothesis_words[appended..]` exactly: `common` is a
+  /// PREFIX of `hypothesis_words` and the advance appends `common[..split]`, so
+  /// the index is the split. It used to be read as a filtered PREFIX instead,
+  /// which was only equivalent while starts were non-decreasing.
   ///
   /// IT HAS ONE EXCEPTION, and the exception is as narrow as the impossibility
-  /// that forces it: on a round whose split ran off the END of `common`, a
-  /// stranded word may sit at the last confirmed word's OWN start. There no
-  /// instant serves both -- every watermark strictly past that start (which the
-  /// first postcondition requires) filters the strand, and every watermark that
-  /// spares the strand re-admits the settled word. It is this module's
-  /// residual 1. `ran_off_the_end` gates it, so an INTERIOR advance may not use
-  /// it -- there the watermark is the first held word's own start and nothing
-  /// unconfirmed can be below it -- and `empty_holdback_watermark`'s sparing
-  /// fold is what keeps every other overlap out of it.
+  /// that forces it: a stranded word may sit at or below the HIGHEST confirmed
+  /// start. There no instant serves both -- every watermark strictly past that
+  /// start (which the first postcondition requires) filters the strand, and
+  /// every watermark that spares the strand re-admits the settled word. It is
+  /// this module's residual 1, and `sparing_watermark` is what keeps every other
+  /// overlap out of it.
+  ///
+  /// The exception is read at `<=` rather than `==` because BOTH halves are
+  /// reachable and they are reached differently. AT the highest start is the TIE
+  /// -- a zero-duration word an empty-holdback advance settles last, which is
+  /// what residual 1 has always been about. BELOW it is a BACKWARDS start:
+  /// `segment::update_segments_with_word_timings` can put a later word behind an
+  /// earlier one (codex round 7 on PR #95, finding 1), and an interior split can
+  /// then confirm past it. `tie_strands` and `backward_strands` count the two
+  /// separately so neither can pass by being unreachable.
   ///
   /// The gate used to read "this round ESCAPED a repeating deferral" (codex
-  /// round 4 on PR #95). Removing the deferral widened WHICH rounds may take the
-  /// exception and left its SHAPE untouched: measured over these 512 trials, 38
-  /// strands where the deferral had 29, every one of them at the settled
-  /// instant. Returns whether the exception was taken, which is the non-vacuity
-  /// proof that the empty holdback really strands something somewhere.
+  /// round 4 on PR #95), then "this round's split ran off the END of `common`".
+  /// The ARM gate is gone: with backwards starts an INTERIOR split strands too,
+  /// so the arm was never what bounded this -- the highest confirmed start is.
+  /// Returns whether the exception was taken.
   fn nothing_unconfirmed_falls_below_the_watermark(
     agreement: &LocalAgreement,
     appended: usize,
-    ran_off_the_end: bool,
     trial: u32,
     stride: usize,
-  ) -> bool {
-    let below: Vec<(&str, f32)> = agreement
-      .hypothesis_words
+  ) -> Option<bool> {
+    let watermark = agreement.last_agreed_seconds();
+    let stranded: Vec<(&str, f32)> = agreement.hypothesis_words[appended..]
       .iter()
-      .filter(|word| word.start() < agreement.last_agreed_seconds())
+      .filter(|word| word.start() < watermark)
       .map(|word| (word.word(), word.start()))
       .collect();
-    if below.len() <= appended {
-      return false;
+    if stranded.is_empty() {
+      return None;
     }
-    let settled = agreement
-      .confirmed_words_slice()
-      .last()
-      .map(WordTiming::start);
-    let stranded = &below[appended..];
+    let settled = highest_start(agreement.confirmed_words_slice());
     assert!(
-      ran_off_the_end
-        && stranded
-          .iter()
-          .all(|(_, start)| settled.is_some_and(|settled| *start <= settled)),
-      "trial {trial}, stride {stride}: {} words of the hypothesis are below \
-       the {} s watermark ({below:?}) but only {appended} were confirmed this \
-       round -- {stranded:?} are STRANDED: the next worded ingest filters them \
-       out of both hypotheses at once and `finalize` can no longer reach them, \
-       after this round's own `finalize` already published them. Only a round \
-       whose split ran off the END of `common` (this one did: \
-       {ran_off_the_end}) may strand, and only at or before the settled start \
-       {settled:?} -- with starts non-decreasing inside one hypothesis that is \
-       the exact TIE, where no watermark serves both",
-      below.len(),
-      agreement.last_agreed_seconds(),
+      stranded
+        .iter()
+        .all(|(_, start)| settled.is_some_and(|settled| *start <= settled)),
+      "trial {trial}, stride {stride}: {stranded:?} of the hypothesis are \
+       below the {watermark} s watermark and were NOT confirmed this round \
+       (which confirmed {appended}) -- they are STRANDED: the next worded \
+       ingest filters them out of both hypotheses at once and `finalize` can no \
+       longer reach them, after this round's own `finalize` already published \
+       them. Only a word at or below the highest confirmed start {settled:?} \
+       may go that way, which is where no watermark serves both claims",
     );
-    true
+    Some(
+      stranded
+        .iter()
+        .any(|(_, start)| settled.is_some_and(|settled| *start == settled)),
+    )
   }
 
   /// THE PUBLISHED TRANSCRIPT, with its timings — `LocalAgreement::finalize`'s
@@ -648,10 +687,12 @@ fn the_split_never_cuts_at_a_tied_start() {
   /// has since put out of reach. Nothing revised it; the engine simply cannot
   /// see it any more, and no later `finalize` can reach it.
   ///
-  /// Each such word must sit at the last confirmed word's OWN start, the one
-  /// instant where no watermark both clears the confirmed start (#94) and spares
-  /// the strand — this module's residual 1. Anything strictly below that is a
-  /// word the engine erased while it could still have held it.
+  /// Each such word must sit at or below the HIGHEST confirmed start, the range
+  /// where no watermark both clears every confirmed start (#94) and spares the
+  /// strand — this module's residual 1. Anything above that is a word the engine
+  /// erased while it could still have held it. It reads the high-water start
+  /// rather than the last confirmed word's because word starts inside one
+  /// hypothesis are not non-decreasing (codex round 7 on PR #95, finding 1).
   ///
   /// **What this does NOT catch, stated rather than implied.** Every retraction
   /// an empty-holdback advance can cause is AT the settled instant, so all of
@@ -689,10 +730,7 @@ fn the_split_never_cuts_at_a_tied_start() {
     stride: usize,
   ) -> bool {
     let watermark = agreement.last_agreed_seconds();
-    let settled = agreement
-      .confirmed_words_slice()
-      .last()
-      .map(WordTiming::start);
+    let settled = highest_start(agreement.confirmed_words_slice());
     // MULTISET, not set: the sweep's alphabet is four texts over a coarse grid,
     // so one transcript can carry the same (text, start) twice and a set-shaped
     // comparison would call the second copy retained by the first.
@@ -712,14 +750,14 @@ fn the_split_never_cuts_at_a_tied_start() {
     assert!(
       erased
         .iter()
-        .all(|(_, start)| settled.is_some_and(|settled| *start == settled)),
+        .all(|(_, start)| settled.is_some_and(|settled| *start <= settled)),
       "trial {trial}, stride {stride}: {erased:?} left the published transcript \
        while this very result still offers them, and they sit below the \
        {watermark} s watermark -- so nothing revised them, no hypothesis can \
        carry them again and no `finalize` can reach them, after this engine had \
-       already published them. Only the settled instant {settled:?} may lose a \
-       word that way. Transcript before: {before:?}; after: {after:?}; offered: \
-       {offered:?}; confirmed: {:?}",
+       already published them. Only a word at or below the highest confirmed \
+       start {settled:?} may go that way. Transcript before: {before:?}; after: \
+       {after:?}; offered: {offered:?}; confirmed: {:?}",
       confirmed_texts(agreement),
     );
     !erased.is_empty()
@@ -740,6 +778,8 @@ fn the_split_never_cuts_at_a_tied_start() {
   let mut fallbacks = 0u32;
   let mut aggregate_fallbacks = 0u32;
   let mut tie_strands = 0u32;
+  let mut backward_strands = 0u32;
+  let mut backward_truths = 0u32;
   let mut drifted_advances = 0u32;
   let mut erasures = 0u32;
 
@@ -781,6 +821,44 @@ fn the_split_never_cuts_at_a_tied_start() {
       } else {
         word(text, start, end)
       });
+    }
+    // THE BACKWARDS DRAW (codex round 7 on PR #95, finding 1). Everything above
+    // generates non-decreasing starts, which is the premise Rule W's second
+    // postcondition used to be free under on an interior split -- and
+    // `segment::update_segments_with_word_timings` does not honour it. Its
+    // segment-start preference (`SegmentSeeker.swift:635-640`) pulls a segment's
+    // first word back to `end - constrained_median` whenever the segment's own
+    // timestamp start ran more than half a second ahead of it, and that lands
+    // BEHIND the word in front of it.
+    // `a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word`
+    // is the proof built through that function; this reproduces the SHAPE so the
+    // sweep can drive it at every split position and every count.
+    //
+    // The clamp's own arithmetic, not a free-hand backwards step: the branch
+    // needs the word to span more than half a second, and it lowers the start to
+    // `end - CLAMP_MEDIAN` -- a step back of `CLAMP_MEDIAN - duration`, under
+    // 0.2 s, on ONE word per draw. `DURATIONS`' 0.6 is the only entry that both
+    // opens the branch and moves the word backwards; the others leave this a
+    // no-op, which is why `backward_truths` below is the non-vacuity proof.
+    let spin = (next() as usize) % length;
+    let clamped_at = (1..truth.len())
+      .map(|offset| 1 + (spin + offset) % (truth.len() - 1))
+      .find(|&at| {
+        truth[at].end() - truth[at].start() > 0.5
+          && truth[at].end() - CLAMP_MEDIAN < truth[at].start()
+      });
+    if next() % 2 == 0
+      && let Some(at) = clamped_at
+    {
+      let target = &truth[at];
+      truth[at] = WordTiming::new(
+        target.word(),
+        target.tokens_slice().to_vec(),
+        target.end() - CLAMP_MEDIAN,
+        target.end(),
+        target.probability(),
+      );
+      backward_truths += 1;
     }
     if truth
       .windows(2)
@@ -943,13 +1021,16 @@ fn the_split_never_cuts_at_a_tied_start() {
               .iter()
               .all(|word| word.tokens_slice().len() <= MAX_HOLDBACK_PREFILL_TOKENS),
         );
-        tie_strands += u32::from(nothing_unconfirmed_falls_below_the_watermark(
+        match nothing_unconfirmed_falls_below_the_watermark(
           &agreement,
           agreement.confirmed_words_slice().len() - before,
-          ran_off_the_end,
           trial,
           stride,
-        ));
+        ) {
+          Some(true) => tie_strands += 1,
+          Some(false) => backward_strands += 1,
+          None => {}
+        }
         // Read AFTER the ingest and kept for the next round, so every round is
         // compared against the transcript the round before it published.
         let after = published(&agreement);
@@ -1016,11 +1097,22 @@ fn the_split_never_cuts_at_a_tied_start() {
      {contradictions} rounds",
   );
   assert!(
+    backward_truths > 32,
+    "and the sweep must actually produce BACKWARDS starts -- the shape \
+     `segment::update_segments_with_word_timings` emits and the one every \
+     non-decreasing generator misses: {backward_truths} of 512 trials",
+  );
+  assert!(
     tie_strands > 0,
-    "and the second postcondition's one exception must be reached rather than \
-     merely written down -- an empty-holdback advance that strands at the \
-     settled instant, which is the only strand any watermark leaves: \
-     {tie_strands} rounds",
+    "and the second postcondition's exception must be reached rather than \
+     merely written down, on BOTH halves. AT the highest confirmed start is the \
+     tie an empty-holdback advance leaves: {tie_strands} rounds",
+  );
+  assert!(
+    backward_strands > 0,
+    "and BELOW it is the backwards start, which an interior split can confirm \
+     past -- the half that did not exist while the generator kept its starts \
+     non-decreasing: {backward_strands} rounds",
   );
   assert!(
     drifted_advances > 0,
@@ -1053,7 +1145,7 @@ fn a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count() {
   // last three words tie is enough.
   //
   // The repair has two separable halves and this test pins the SECOND. The
-  // watermark's `next_up` anchor (see
+  // watermark's sample-domain anchor (see
   // `a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed`) is what
   // closes the DUPLICATION: with it in place the re-offered run is filtered out
   // even when the holdback is empty. The back-off is what keeps Rule W from
@@ -1150,7 +1242,8 @@ fn an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant() {
   // search and the back-off therefore BOTH fail. The split runs off the end,
   // confirming the whole run and emptying the holdback.
   //
-  // WHAT THAT COSTS: the watermark anchors at `start.next_up()`, strictly past
+  // WHAT THAT COSTS: the watermark anchors at `past_the_settled_instant`,
+  // strictly past
   // the run's instant, so any word the NEWER hypothesis produced at that same
   // instant beyond `common` -- words nothing ever confirmed -- fails the offered
   // filter on the next worded ingest, drops out of both hypotheses at once, and
@@ -1178,6 +1271,17 @@ fn an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant() {
   // its liveness bound was defeated by `At(0)`; see the engine module's doc,
   // "Why there is no deferral". So the loss below is this module's residual 1,
   // reached on the shape the pipeline can actually produce.
+  //
+  // WHICH HALF of residual 1 this is. The second postcondition's exception is
+  // "at or below the highest confirmed start", and this test drives the AT half
+  // -- the TIE, where the stranded word shares the settled word's own instant
+  // and the empty holdback is what creates it. The BELOW half needs no empty
+  // holdback and no tie: a backwards word start lets an INTERIOR split confirm
+  // past a word it leaves unconfirmed
+  // (`a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word`,
+  // codex round 7 on PR #95, finding 1). The name of this test says "at the
+  // settled instant" because that is the half it drives, not because the
+  // exception is only that wide.
   const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
   let tied: Vec<WordTiming> = (0..RUN)
     .map(|index| word(&format!(" w{index:03}"), 2.0, 2.0))
@@ -1229,7 +1333,7 @@ fn an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant() {
       // `!skipAppend`) and it reaches the `finalize` merge as a segment source.
       agreement.results_slice().len(),
     ),
-    (RUN, 0, 2.0f32.next_up(), 0, 2),
+    (RUN, 0, PAST_TWO_SECONDS, 0, 2),
     "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94): no \
      legal boundary sits at or above the budget floor, so the split runs off \
      the END of `common` -- the whole 113-word run is confirmed, the holdback \
@@ -2019,8 +2123,8 @@ fn a_stutter_at_the_watermark_keeps_both_occurrences() {
 /// that the advance's own watermark would put out of reach.
 ///
 /// Written LONGHAND from the engine's recorded comparison state rather than by
-/// calling `budgeted_split` or `empty_holdback_watermark`, so a mutation to
-/// either cannot mutate this counter along with them:
+/// calling `budgeted_split`, so a mutation to it cannot mutate this counter
+/// along with it:
 ///
 /// `find_longest_common_prefix`'s answer for the round the engine has just
 /// finished, recomputed from the two word lists it left behind. The sweep's
@@ -2051,7 +2155,7 @@ fn forced_arm_with_a_live_suffix(agreement: &LocalAgreement) -> bool {
   if last.tokens_slice().len() <= MAX_HOLDBACK_PREFILL_TOKENS {
     return false;
   }
-  let watermark = last.end().max(last.start().next_up());
+  let watermark = empty_holdback_anchor(last, last.start());
   agreement.hypothesis_words[common_len..]
     .iter()
     .any(|word| word.start() < watermark)
@@ -2993,11 +3097,14 @@ fn a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed() {
   // being confirmed a SECOND time (#94 residual 1, characterized here until
   // codex round 1 on PR #95 found the same state on the default path).
   //
-  // Closed, not characterized: the watermark is `end.max(start.next_up())`, the
-  // first instant strictly past the settled start. `next_up` is the IMMEDIATE
-  // f32 successor, so no representable instant lies between it and the start it
-  // excludes -- it refuses exactly one instant rather than moving a cliff, which
-  // is what an `end + epsilon` tolerance would have done.
+  // Closed, not characterized: the watermark is
+  // `end.max(past_the_settled_instant(settled_high))`, the first instant
+  // strictly past the settled start in BOTH the seconds `watermark_filtered`
+  // compares and the samples `clip_timestamps` is rounded to. It refuses exactly
+  // the settled word's own sample rather than moving a cliff, which is what an
+  // `end + epsilon` tolerance would have done -- and unlike the `f32::next_up`
+  // this used to take, it actually moves the clip (codex round 7 on PR #95,
+  // finding 2).
   //
   // Only the PREFILL BUDGET can reach this state now. Rule W's own widening no
   // longer empties the holdback (it backs off instead --
@@ -3016,8 +3123,8 @@ fn a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed() {
   // advance retracts it, which is the characterization in
   // `a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant`.
   //
-  // Mutation proof: drop the `.max(last.start().next_up())` from `ingest`'s
-  // empty-holdback watermark and this reds with `" Z"` confirmed twice.
+  // Mutation proof: drop the `.max(past_the_settled_instant(settled_high))`
+  // from `empty_holdback_anchor` and this reds with `" Z"` confirmed twice.
   let a = || word(" A", 0.0, 1.0);
   let zero = || word_of_tokens(" Z", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   let b = || word(" B", 1.0, 2.0);
@@ -3037,7 +3144,7 @@ fn a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed() {
   );
   assert_eq!(
     agreement.last_agreed_seconds(),
-    1.0f32.next_up(),
+    PAST_ONE_SECOND,
     "and \" Z\"'s own END is 1.0, so `end` alone would have put the watermark \
      on \" Z\"'s own start",
   );
@@ -3098,7 +3205,7 @@ fn a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant() {
   // recorded.
   //
   // WHAT THAT COSTS: the advance empties the holdback, anchors the watermark at
-  // `start.next_up()` -- strictly past `" H"`'s instant -- and `" X"`, which the
+  // `past_the_settled_instant` -- strictly past `" H"`'s instant -- and `" X"`, which the
   // newer hypothesis produced AT that instant beyond `common`, fails the offered
   // filter from then on. That is not a deletion of something never emitted: this
   // round's OWN `finalize` emits it, through `differentSuffix(prev,
@@ -3112,20 +3219,31 @@ fn a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant() {
   // accumulated counterexample suite and the 512-trial sweep, the wait erased 26
   // words from the published transcript where this arm erases 10, and its count
   // bound was defeated by `At(0)` -- see the engine module's doc, "Why there is
-  // no deferral". The narrower repair is kept: `empty_holdback_watermark`'s
+  // no deferral". The narrower repair is kept: `sparing_watermark`'s
   // sparing fold lowers the anchor to spare every word beyond `common` that
   // starts strictly later
   // (`a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`),
-  // so what is lost is exactly the TIE -- residual 1, the one instant no
-  // watermark serves.
+  // so what is lost is exactly the TIE -- residual 1's AT half, the one instant
+  // no watermark serves once the settled start is fixed.
+  //
+  // WHICH HALF, and why the name is narrower than the exception. The second
+  // postcondition's exception reads "at or below the highest confirmed start".
+  // This test and `an_over_budget_tied_run_strands_its_suffix_at_the_settled_
+  // instant` drive the AT half, which is what their names say. BELOW is the
+  // other half and needs neither an empty holdback nor a tie -- a backwards word
+  // start (codex round 7 on PR #95, finding 1) lets an INTERIOR split confirm
+  // past a word it leaves unconfirmed, pinned in
+  // `a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word`
+  // and counted by the sweep as `backward_strands`.
   //
   // The state this rule may NOT swallow is
   // `a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held`:
   // there the budget forces the empty holdback and nothing lies beyond `common`,
   // so there is nothing to lose and nothing to wait for either.
   //
-  // Mutation proof, every row run: drop `.max(last.start().next_up())` from
-  // `empty_holdback_watermark` and the state row reds at a 1.0 watermark, `" H"`
+  // Mutation proof, every row run: drop
+  // `.max(past_the_settled_instant(settled_high))` from `empty_holdback_anchor`
+  // and the state row reds at a 1.0 watermark, `" H"`
   // re-admissible. Drop the sparing FOLD and this stays green while
   // `a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded`
   // reds -- the fold cannot help an exact tie, which is why that test exists
@@ -3172,7 +3290,7 @@ fn a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant() {
       held_back_texts(&agreement),
       agreement.last_agreed_seconds(),
     ),
-    (vec![" A", " H"], Vec::new(), 1.0f32.next_up()),
+    (vec![" A", " H"], Vec::new(), PAST_ONE_SECOND),
     "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94): \
      the budget floor reaches `common.len()`, so the split runs off the end -- \
      `[\" A\", \" H\"]` is confirmed, the holdback is empty, and the watermark \
@@ -3300,7 +3418,7 @@ fn an_alternating_suffix_advances_instead_of_stalling() {
   //
   // WHAT THIS TRADES, stated in the direction that costs something. `" X"` and
   // `" Y"` sit at `" H"`'s own instant, so no watermark strictly past `" H"`'s
-  // start can spare them (`empty_holdback_watermark` lowers the anchor as far as
+  // start can spare them (`sparing_watermark` lowers the anchor as far as
   // it can, and here it cannot lower it at all) -- this module's residual 1. A
   // stream that ENDS on the round before keeps the disputed word; a stream that
   // CONTINUES gets a transcript instead of a frozen one. Both are asserted
@@ -3313,7 +3431,8 @@ fn an_alternating_suffix_advances_instead_of_stalling() {
   // `split_at_a_strict_boundary` and this stays green (the forced arm never
   // reaches either search), which is why the back-off is pinned in
   // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
-  // instead. Drop `.max(last.start().next_up())` from `empty_holdback_watermark`
+  // instead. Drop `.max(past_the_settled_instant(settled_high))` from
+  // `empty_holdback_anchor`
   // and the face reds at round 1 with a 1.0 watermark, `" H"` re-admissible.
   // Drop the sparing FOLD and the face reds at round 2 instead, `[" T", " U"]`
   // filtered away by a 3.0 anchor they never earned.
@@ -3402,7 +3521,7 @@ fn an_alternating_suffix_advances_instead_of_stalling() {
       // THE FALLBACK. `common` is `[" A", " H"]` and the budget floor reaches
       // its end, so the empty holdback is taken at the only instant that clears
       // `" H"`'s own start.
-      advanced(&[" A", " H"], &[], 1.0f32.next_up()),
+      advanced(&[" A", " H"], &[], PAST_ONE_SECOND),
       // And the stream is a stream: the tail the alternation was blocking
       // reaches `common` and is held back under an ordinary interior split.
       advanced(&[" A", " H"], &[" T", " U"], 2.0),
@@ -3473,8 +3592,8 @@ fn a_tied_run_above_the_budget_floor_advances_instead_of_stalling() {
   // Mutation proof, every row run: return `common.len() - 1` from
   // `split_at_a_strict_boundary`'s `unwrap_or` and the STABLE face reds at
   // round 1 -- 112 confirmed against 113, and a watermark of 2.0 that re-admits
-  // the run's own last word. Drop `.max(last.start().next_up())` from
-  // `empty_holdback_watermark` and both faces red at a 2.0 watermark with 113
+  // the run's own last word. Drop `.max(past_the_settled_instant(settled_high))`
+  // from `empty_holdback_anchor` and both faces red at a 2.0 watermark with 113
   // words still offerable, which is the unbounded re-confirmation #94 is about.
   // Let the back-off cross the floor (`0..widened` for `floor..widened`) and the
   // stable face reds at round 1 with a two-word holdback the prefill cannot
@@ -3529,7 +3648,7 @@ fn a_tied_run_above_the_budget_floor_advances_instead_of_stalling() {
     vec![
       ("awaiting_agreement".to_string(), 0, 0, 0.0, RUN),
       // THE FALLBACK, at the only instant that clears the run's own.
-      ("advanced".to_string(), RUN, 0, 2.0f32.next_up(), RUN),
+      ("advanced".to_string(), RUN, 0, PAST_TWO_SECONDS, RUN),
       // The run is behind the watermark now, so a hypothesis that keeps
       // repeating it offers nothing -- which is the input being degenerate, not
       // the engine stalling: every word it has is at one instant.
@@ -3537,28 +3656,28 @@ fn a_tied_run_above_the_budget_floor_advances_instead_of_stalling() {
         "awaiting_agreement".to_string(),
         RUN,
         0,
-        2.0f32.next_up(),
+        PAST_TWO_SECONDS,
         RUN
       ),
       (
         "awaiting_agreement".to_string(),
         RUN,
         0,
-        2.0f32.next_up(),
+        PAST_TWO_SECONDS,
         RUN
       ),
       (
         "awaiting_agreement".to_string(),
         RUN,
         0,
-        2.0f32.next_up(),
+        PAST_TWO_SECONDS,
         RUN
       ),
       (
         "awaiting_agreement".to_string(),
         RUN,
         0,
-        2.0f32.next_up(),
+        PAST_TWO_SECONDS,
         RUN
       ),
     ],
@@ -3611,11 +3730,11 @@ fn a_tied_run_above_the_budget_floor_advances_instead_of_stalling() {
     alternating_face,
     vec![
       ("awaiting_agreement".to_string(), 0, 0, 0.0),
-      ("advanced".to_string(), RUN, 0, 2.0f32.next_up()),
-      ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
-      ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
-      ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
-      ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
+      ("advanced".to_string(), RUN, 0, PAST_TWO_SECONDS),
+      ("awaiting_agreement".to_string(), RUN, 0, PAST_TWO_SECONDS),
+      ("awaiting_agreement".to_string(), RUN, 0, PAST_TWO_SECONDS),
+      ("awaiting_agreement".to_string(), RUN, 0, PAST_TWO_SECONDS),
+      ("awaiting_agreement".to_string(), RUN, 0, PAST_TWO_SECONDS),
     ],
     "an alternating suffix at the run's own instant must not freeze this arm \
      either -- the run is confirmed and the disputed words at its instant are \
@@ -3634,7 +3753,7 @@ fn a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded
   // not monotone (`an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_
   // too`), so `end` can reach past a word that is already there -- and nothing
   // needs it to. All the watermark owes #94 is to clear the last CONFIRMED
-  // word's START. So `empty_holdback_watermark` lowers the anchor to the
+  // word's START. So `sparing_watermark` lowers the anchor to the
   // earliest such word's start when that still clears it, and the word stays
   // offerable instead of being lost.
   //
@@ -3783,5 +3902,555 @@ fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
     " P Y Z",
     "the overlapping confirmed word and the later re-reading of its audio are \
      BOTH in the transcript -- the append-only contract",
+  );
+}
+
+// ── The two coordinate systems the watermark is read in ──────────────────────
+
+#[test]
+fn the_watermark_clears_the_settled_sample_not_just_the_settled_instant() {
+  // #94, codex round 7 on PR #95, finding 2 -- the ARITHMETIC half, pinned
+  // before the driver-level regression below reads its consequence.
+  //
+  // The empty-holdback anchor used to be `end.max(start.next_up())`, and
+  // `f32::next_up` is the IMMEDIATE successor: a real step in SECONDS, which is
+  // the coordinate `watermark_filtered` compares in. The same value is also
+  // handed to `clip_timestamps`, where `chunker::prepare_seek_clips` rounds it
+  // to a SAMPLE -- and one ULP of a small `f32` is worth a few thousandths of a
+  // sample, so the step vanished. The rows below are the measurement: every
+  // whole second's `next_up` clips to the settled word's OWN sample, so the
+  // "strictly past" guarantee was real in float space and vacuous in sample
+  // space, and the next stride re-read the audio the doc claimed it had clipped
+  // away.
+  //
+  // Mutation proof: replace `past_the_settled_instant`'s body with
+  // `settled.next_up()` and the `clip_seek_sample` column below reds on every
+  // row.
+  for settled in [0.0f32, 0.5, 1.0, 2.0, 3.0, 10.0, 0.07, 1.44] {
+    let settled_sample = chunker::clip_seek_sample(settled);
+    assert_eq!(
+      chunker::clip_seek_sample(settled.next_up()),
+      settled_sample,
+      "the ULP step is INERT in sample space, which is the finding: \
+       {settled} and {} both clip to sample {settled_sample}",
+      settled.next_up(),
+    );
+    let boundary = past_the_settled_instant(settled);
+    assert!(
+      boundary > settled,
+      "strictly past in SECONDS, which is what `watermark_filtered` compares: \
+       {boundary} vs {settled}",
+    );
+    assert!(
+      chunker::clip_seek_sample(boundary) > settled_sample,
+      "and strictly past in SAMPLES, which is what `clip_timestamps` reads: \
+       {boundary} clips to {} and {settled} clips to {settled_sample}",
+      chunker::clip_seek_sample(boundary),
+    );
+  }
+  // The two constants the empty-holdback characterizations assert, derived here
+  // from the sample index rather than trusted at their literal value.
+  assert_eq!(past_the_settled_instant(1.0), PAST_ONE_SECOND);
+  assert_eq!(past_the_settled_instant(2.0), PAST_TWO_SECONDS);
+  assert_eq!(chunker::clip_seek_sample(PAST_ONE_SECOND), 16_001);
+  assert_eq!(chunker::clip_seek_sample(PAST_TWO_SECONDS), 32_001);
+  // TOTAL on the degenerate inputs the fold can hand it: `+inf` is what
+  // `f32::next_up` mapped to itself, so this keeps that answer rather than
+  // spinning, and a NEGATIVE instant saturates to sample 0 on the way in.
+  assert_eq!(past_the_settled_instant(f32::INFINITY), f32::INFINITY);
+  assert!(past_the_settled_instant(-1.0) > 0.0);
+}
+
+/// A [`crate::audio::whisper::backend::mock::MockBackend`] that RECORDS the
+/// first sample of every window `TranscribeTask` asks it to extract features
+/// from, then delegates.
+///
+/// `TranscribeTask` calls `extract_features` on
+/// `pad_or_trim(&audio[seek..seek + segment_size], window_samples)`, so over
+/// RAMP audio (`samples[i] == i as f32`) that first sample IS the seek index —
+/// the exact audio each stride re-read. That is the observation #94's codex
+/// round 7 finding 2 is about, and it cannot be read off the engine's own
+/// state: the watermark is in SECONDS and the re-read is in SAMPLES.
+struct WindowRecordingBackend {
+  inner: crate::audio::whisper::backend::mock::MockBackend,
+  window_starts: std::sync::Mutex<Vec<usize>>,
+}
+
+impl WindowRecordingBackend {
+  fn new(inner: crate::audio::whisper::backend::mock::MockBackend) -> Self {
+    Self {
+      inner,
+      window_starts: std::sync::Mutex::new(Vec::new()),
+    }
+  }
+
+  fn window_starts(&self) -> Vec<usize> {
+    self
+      .window_starts
+      .lock()
+      .expect("window-start record lock poisoned")
+      .clone()
+  }
+}
+
+impl InferenceBackend for WindowRecordingBackend {
+  type Features = <crate::audio::whisper::backend::mock::MockBackend as InferenceBackend>::Features;
+  type EncoderOutput =
+    <crate::audio::whisper::backend::mock::MockBackend as InferenceBackend>::EncoderOutput;
+  type DecoderState =
+    <crate::audio::whisper::backend::mock::MockBackend as InferenceBackend>::DecoderState;
+
+  fn extract_features(
+    &self,
+    audio: &[f32],
+  ) -> Result<Self::Features, crate::audio::whisper::backend::BackendError> {
+    if let Some(&first) = audio.first() {
+      self
+        .window_starts
+        .lock()
+        .expect("window-start record lock poisoned")
+        .push(first as usize);
+    }
+    self.inner.extract_features(audio)
+  }
+
+  fn encode(
+    &self,
+    features: &Self::Features,
+  ) -> Result<Self::EncoderOutput, crate::audio::whisper::backend::BackendError> {
+    self.inner.encode(features)
+  }
+
+  fn new_decoder_state(
+    &self,
+  ) -> Result<Self::DecoderState, crate::audio::whisper::backend::BackendError> {
+    self.inner.new_decoder_state()
+  }
+
+  fn reset_decoder_state(&self, state: &mut Self::DecoderState) {
+    self.inner.reset_decoder_state(state);
+  }
+
+  fn decode_step(
+    &self,
+    token: u32,
+    position: usize,
+    encoder_output: &Self::EncoderOutput,
+    state: &mut Self::DecoderState,
+    logits: &mut Vec<f32>,
+  ) -> Result<(), crate::audio::whisper::backend::BackendError> {
+    self
+      .inner
+      .decode_step(token, position, encoder_output, state, logits)
+  }
+
+  fn commit_alignment_row(&self, state: &mut Self::DecoderState) {
+    self.inner.commit_alignment_row(state);
+  }
+
+  fn alignment_weights<'state>(
+    &self,
+    state: &'state Self::DecoderState,
+  ) -> Option<crate::audio::whisper::backend::AlignmentView<'state>> {
+    self.inner.alignment_weights(state)
+  }
+
+  fn dims(&self) -> crate::audio::whisper::backend::ModelDims {
+    self.inner.dims()
+  }
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn the_driver_does_not_re_read_the_settled_words_own_sample() {
+  // #94, codex round 7 on PR #95, finding 2 -- the DRIVER-level regression, and
+  // the reason the arithmetic pin above is not enough on its own. The finding is
+  // not that a float compared wrong; it is that the value the engine calls "the
+  // first instant strictly past the settled start" is ALSO the next stride's
+  // clip start, and `chunker::prepare_seek_clips` rounds it to a sample -- where
+  // the `f32::next_up` step it used to take moved nothing. So the driver handed
+  // the decoder the settled word's OWN audio again while this module's residuals
+  // 3 and 6 claimed that audio was outside the clip window. Those notes were
+  // wrong for a concrete arithmetic reason and are corrected with this test.
+  //
+  // The state is reached THROUGH the driver, not asserted about it: the scripted
+  // window decodes `" Hi" " World" " Helloaaa..."`, whose last word carries 114
+  // tokens against a 112-token prefill budget and lands ZERO-DURATION at 1.0 s
+  // (its own alignment column and the closing timestamps' are the same). So
+  // `budgeted_split`'s floor reaches `common.len()`, the advance confirms all
+  // three words, the holdback empties, and `empty_holdback_anchor` -- not a held
+  // word's start -- is what the next clip is drawn from. That is the ONE arm
+  // where the anchor's own sample matters: give the last word any real duration
+  // and `end` already clears the settled sample by itself.
+  //
+  // Mutation proof: replace `past_the_settled_instant`'s body with
+  // `settled.next_up()` and the final window start below reds at 16_000 -- the
+  // settled word's own sample -- against 16_001.
+  use crate::audio::whisper::{
+    backend::{ModelDims, mock::MockBackend},
+    tokenizer::SpecialTokens,
+    transcribe::WhisperKit,
+  };
+
+  let tokenizer = tiny_tokenizer();
+  let specials = SpecialTokens::whisper_defaults();
+  let hi = tokenizer.encode(" Hi").unwrap()[0];
+  let world = tokenizer.encode(" World").unwrap()[0];
+  let hello = tokenizer.encode(" Hello").unwrap()[0];
+  // No leading space, so `split_to_word_tokens` appends every one of these to
+  // `" Hello"` rather than starting a new word -- which is how one WORD comes to
+  // carry more tokens than the prefill can hold.
+  let filler = tokenizer.encode("a").unwrap()[0];
+  let one_hot = |token: u32| {
+    let mut logits = vec![0.0f32; 51_865];
+    logits[token as usize] = 10.0;
+    logits
+  };
+
+  let mut mock = MockBackend::new().with_dims(
+    ModelDims::new()
+      .with_window_samples(16_000)
+      .with_n_audio_ctx(100),
+  );
+  // `(token, alignment peak column)`. 100 columns over the window put one column
+  // at 0.02 s, so column 50 is 1.0 s. `" Hello"` and all 113 fillers peak on THAT
+  // column and the closing timestamps peak past it, which is what leaves the
+  // last word zero-duration at exactly 1.0 s.
+  let mut script: Vec<(u32, usize)> = vec![
+    (specials.english_token(), 1),
+    (specials.transcribe_token(), 2),
+    (specials.time_token_begin(), 3),
+    (hi, 10),
+    (world, 50),
+    (hello, 50),
+  ];
+  script.extend(std::iter::repeat_n((filler, 50), 113));
+  script.push((specials.time_token_begin() + 100, 60));
+  script.push((specials.time_token_begin() + 100, 60));
+  script.push((specials.end_token(), 60));
+  for (token, peak) in &script {
+    let mut row = vec![0.0f32; 100];
+    row[*peak] = 1.0;
+    mock.push_step_with_alignment(one_hot(*token), row);
+  }
+
+  // The temperature LADDER is switched off and the sampler SEEDED, so this
+  // scripted window decodes the same way every run. The 113-token filler run
+  // trips `needs_fallback`'s compression-ratio check, and a fallback attempt
+  // samples at a non-zero temperature -- from an unseeded draw by default, which
+  // made the assertions below depend on the draw rather than on the split.
+  let kit = WhisperKit::with_backend(WindowRecordingBackend::new(mock), tokenizer);
+  let mut streamer = kit
+    .local_agreement_transcriber(
+      DecodingOptions::new()
+        .with_temperature_fallback_count(0)
+        .with_seed(94),
+    )
+    .with_agreement_count_needed(1);
+  // A RAMP, so the backend's record of each window's first sample is that
+  // window's seek index.
+  let ramp: Vec<f32> = (0..64_000).map(|index| index as f32).collect();
+  let mut chunks = ramp.chunks(STRIDE_SAMPLES);
+  for chunk in chunks.by_ref().take(3) {
+    streamer.push_samples(chunk).unwrap();
+  }
+
+  let settled = streamer
+    .agreement()
+    .confirmed_words_slice()
+    .last()
+    .expect("the advance confirmed the whole agreed prefix")
+    .clone();
+  assert_eq!(
+    (
+      streamer.agreement().confirmed_words_slice().len(),
+      streamer.agreement().last_agreed_words_slice().len(),
+      settled.tokens_slice().len() > MAX_HOLDBACK_PREFILL_TOKENS,
+      settled.start(),
+      settled.end(),
+    ),
+    (3, 0, true, 1.0, 1.0),
+    "non-vacuous: the DRIVER reached the empty-holdback arm, and the word it \
+     settled last is the ZERO-DURATION one -- the only shape where the anchor's \
+     own sample decides the next clip",
+  );
+  assert_eq!(
+    chunker::clip_seek_sample(settled.start()),
+    16_000,
+    "the settled word's own audio is sample 16_000",
+  );
+
+  let before = kit.backend().window_starts();
+  streamer.push_samples(chunks.next().unwrap()).unwrap();
+  let after = kit.backend().window_starts();
+  let fresh: Vec<usize> = after[before.len()..].to_vec();
+  assert!(
+    !fresh.is_empty(),
+    "non-vacuous: the last stride actually decoded a window",
+  );
+  assert_eq!(
+    fresh[0], 16_001,
+    "the stride after the empty-holdback advance must start at the sample AFTER \
+     the settled word's own -- {fresh:?}. At 16_000 the driver re-reads the very \
+     audio the watermark claims to have settled, which is what an `f32::next_up` \
+     anchor left it doing: a real step in seconds and none at all in samples.",
+  );
+  assert!(
+    fresh
+      .iter()
+      .all(|&start| start > chunker::clip_seek_sample(settled.start())),
+    "and no window of that stride reaches back into it: {fresh:?}",
+  );
+}
+
+// ── Backwards word starts, from the pipeline that emits them ─────────────────
+
+/// The three segments and the monotone alignment that make
+/// `segment::update_segments_with_word_timings` emit a BACKWARDS word start,
+/// plus the words it emits. Shared by the engine regression below and by the
+/// sweep's own shape note.
+///
+/// Nothing here is hand-timed: every value goes in as an alignment
+/// `find_alignment` could produce (`w[i].end() <= w[i + 1].start()`, the
+/// guarantee `segment::tests` pins) and comes out through Swift's own
+/// segment-start preference, `SegmentSeeker.swift:635-640`. That branch prefers
+/// the SEGMENT's start over a first word the DTW drifted more than half a second
+/// earlier, and clamps to `w0.end - constrained_median` — which for the last
+/// segment here is `1.51 - 0.70 = 0.81`, BELOW the `0.99` of the word in front
+/// of it.
+///
+/// The 0.70 median is `calculate_word_duration_constraints`' own ceiling
+/// (`median.min(0.7)`), which any speech whose median word runs 0.7 s or longer
+/// reaches.
+fn a_pipeline_result_with_a_backwards_start(
+  tokenizer: &crate::audio::whisper::tokenizer::WhisperTokenizer,
+) -> Vec<WordTiming> {
+  use crate::audio::whisper::{
+    result::TranscriptionSegment, segment::update_segments_with_word_timings,
+  };
+
+  let ids: Vec<u32> = [" A", " B", " C", " D"]
+    .iter()
+    .map(|text| tokenizer.encode(text).unwrap()[0])
+    .collect();
+  let plain = |tokens: Vec<u32>, start: f32, end: f32| {
+    let mut segment = TranscriptionSegment::new();
+    segment.set_tokens(tokens).set_start(start).set_end(end);
+    segment
+  };
+  let segments = [
+    plain(vec![ids[0]], 0.50, 0.70),
+    plain(vec![ids[1], ids[2]], 0.80, 0.99),
+    // The drifted one: the timestamp tokens put this segment at 1.50 while DTW
+    // put its first word at 0.99 — a 0.51 s disagreement, which is what opens
+    // `:635-640`.
+    plain(vec![ids[3]], 1.50, 1.60),
+  ];
+  let alignment = [
+    WordTiming::new(" A", vec![ids[0]], 0.50, 0.70, 0.9),
+    WordTiming::new(" B", vec![ids[1]], 0.80, 0.99, 0.9),
+    WordTiming::new(" C", vec![ids[2]], 0.99, 0.99, 0.9),
+    WordTiming::new(" D", vec![ids[3]], 0.99, 1.51, 0.9),
+  ];
+  assert!(
+    alignment
+      .windows(2)
+      .all(|pair| pair[0].end() <= pair[1].start() + 1e-4),
+    "the INPUT is what `find_alignment` guarantees: non-decreasing and \
+     non-overlapping. Everything backwards below is the post-processing's doing.",
+  );
+  update_segments_with_word_timings(&segments, &alignment, 0, 0.0, 0.70, 1.40, tokenizer)
+    .unwrap()
+    .iter()
+    .flat_map(TranscriptionSegment::words_slice)
+    .cloned()
+    .collect()
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word() {
+  // #94, codex round 7 on PR #95, finding 1. Rule W's SECOND postcondition —
+  // an advance may not push the watermark past a word of its own hypothesis it
+  // did not confirm — used to be free on an INTERIOR split, and the reason given
+  // was that "word starts inside one hypothesis are non-decreasing, so
+  // everything from `split` on is at or past the watermark". That premise is
+  // FALSE, and this test is the disproof: `update_segments_with_word_timings`
+  // emits `[0.50, 0.80, 0.99, 0.81]` from a strictly non-decreasing alignment.
+  //
+  // What the premise cost: the split lands at index 2 (`0.80 < 0.99` is a legal
+  // strict boundary), so the watermark used to be `" C"`'s own `0.99` — and
+  // `" D"` at `0.81`, a word this round CONFIRMED NOTHING about and is still
+  // holding back, falls below it. The next worded ingest filters it out of both
+  // hypotheses at once and `finalize` can never reach it again, after this
+  // round's own `finalize` has already published it. That is a RETRACTION on an
+  // interior split, outside the split-at-the-end exception the doc claimed was
+  // the only one.
+  //
+  // The repair is `sparing_watermark`, which the empty-holdback arm already had:
+  // the anchor drops to the earliest unconfirmed start it can still clear. Here
+  // that is `" D"`'s own `0.81`, which is above the `0.80` this round settled
+  // last, so nothing is stranded at all.
+  //
+  // Mutation proof: return `anchor` from `sparing_watermark` (drop the fold) and
+  // this reds with a `0.99` watermark and `" D"` unreachable.
+  let tokenizer = tiny_tokenizer();
+  let words = a_pipeline_result_with_a_backwards_start(&tokenizer);
+  let starts: Vec<f32> = words.iter().map(WordTiming::start).collect();
+  assert_eq!(
+    (
+      words.iter().map(WordTiming::word).collect::<Vec<_>>(),
+      starts[0],
+      starts[1],
+      starts[2],
+    ),
+    (vec![" A", " B", " C", " D"], 0.50, 0.80, 0.99),
+    "non-vacuous: the first three words are where the alignment put them",
+  );
+  assert!(
+    starts[3] < starts[2] && starts[3] > starts[1],
+    "THE FINDING: the pipeline's own post-processing put `\" D\"` at {} — behind \
+     `\" C\"`'s {} and ahead of `\" B\"`'s {}. Word starts inside one hypothesis \
+     are NOT non-decreasing.",
+    starts[3],
+    starts[2],
+    starts[1],
+  );
+
+  let offered = || result_with_words(words.clone());
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, which is the driver's own",
+  );
+  agreement.ingest_streamed(offered());
+  assert!(agreement.ingest_streamed(offered()).is_advanced());
+  assert_eq!(
+    (
+      confirmed_texts(&agreement),
+      held_back_texts(&agreement),
+      agreement.last_agreed_seconds(),
+    ),
+    (vec![" A", " B"], vec![" C", " D"], starts[3]),
+    "the watermark is the BACKWARDS word's own start, not the first held word's: \
+     an interior split may not pass a word it is still holding back. Before this \
+     repair it was {} — `\" C\"`'s start — and `\" D\"` was stranded below it.",
+    starts[2],
+  );
+
+  // The two postconditions, read on this round rather than argued about.
+  let settled_high = highest_start(agreement.confirmed_words_slice()).unwrap();
+  assert!(
+    settled_high < agreement.last_agreed_seconds(),
+    "FIRST postcondition: every confirmed word starts strictly before the \
+     watermark. Highest confirmed start {settled_high}, watermark {}",
+    agreement.last_agreed_seconds(),
+  );
+  let below: Vec<(&str, f32)> = agreement
+    .hypothesis_words
+    .iter()
+    .skip(agreement.confirmed_words_slice().len())
+    .filter(|word| word.start() < agreement.last_agreed_seconds())
+    .map(|word| (word.word(), word.start()))
+    .collect();
+  assert!(
+    below.is_empty(),
+    "SECOND postcondition: nothing this round left unconfirmed is below the \
+     watermark, so nothing was stranded: {below:?}",
+  );
+
+  // And the round trip: the very next hypothesis still carries `" D"`, which is
+  // the whole point — a stranded word disappears from BOTH hypotheses at once.
+  assert!(
+    LocalAgreement::watermark_filtered(&offered(), agreement.last_agreed_seconds())
+      .iter()
+      .any(|held| held.word() == " D"),
+    "`\" D\"` is still offerable, so a later hypothesis can still revise or \
+     corroborate it",
+  );
+  assert!(agreement.ingest_streamed(offered()).is_advanced());
+  assert!(
+    agreement
+      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+      .text()
+      .contains('D'),
+    "and it reaches the published transcript rather than being retracted out of \
+     it",
+  );
+}
+
+#[test]
+fn a_backwards_start_two_words_back_still_cannot_be_re_admitted() {
+  // THE SCOPE of the first postcondition, and the reason it is stated over the
+  // WHOLE confirmed list rather than over its last word (#94, codex round 7 on
+  // PR #95, finding 1).
+  //
+  // `split_at_a_strict_boundary` used to compare each candidate boundary
+  // against its ADJACENT predecessor, and the doc justified that with "word
+  // starts inside one hypothesis are non-decreasing, so an earlier confirmed
+  // word starts at or before the last one". `a_backward_start_from_the_segment_
+  // pipeline_does_not_strand_a_later_word` disproves the premise. This pins what
+  // the premise was carrying: with starts `[0.50, 1.15, 0.95, 1.10]` the
+  // adjacent test passes at index 3 (`0.95 < 1.10`), the advance confirms
+  // `" Q"` at `1.15`, and the watermark lands at `1.10` — so `" Q"` satisfies
+  // `watermark_filtered`'s own `start >= watermark` against its own confirmation
+  // and can head the next hypothesis. That is #94 itself, reached from the
+  // backwards side.
+  //
+  // REACHABILITY, stated rather than implied. This exact shape is NOT one
+  // `update_segments_with_word_timings` can emit: its only backwards mover is
+  // the `SegmentSeeker.swift:635-640` clamp, which needs `w0` to span more than
+  // 0.5 s and lowers it only to `w0.end - median`, and every word after it
+  // starts at or after `w0`'s own alignment END — which is at or after
+  // everything in front of it. So the word AFTER a backwards one cannot also
+  // duck below the word two back, which is what this shape needs. The check is
+  // therefore a STRENGTHENING that removes a premise rather than a repair for a
+  // demonstrated route: `ingest` is `pub(crate)` and residual 4 already records
+  // that an in-crate caller can order its calls freely, and re-deriving a new
+  // bound from the clamp's arithmetic is the kind of reasoning this issue has
+  // punished twice. The falsifier is hermetic because the input is.
+  //
+  // Mutation proof: restore the adjacent-predecessor test in
+  // `split_at_a_strict_boundary` (`common[at - 1].start()` for
+  // `settled_before[at]`) and this reds — alone, at 503 of 504 green.
+  let offered = || {
+    result_with_words(vec![
+      word(" P", 0.50, 0.60),
+      word(" Q", 1.15, 1.20),
+      word(" R", 0.95, 1.05),
+      word(" S", 1.10, 1.30),
+    ])
+  };
+  let mut agreement = LocalAgreement::new();
+  agreement.ingest_streamed(offered());
+  assert!(agreement.ingest_streamed(offered()).is_advanced());
+  assert_eq!(
+    (
+      confirmed_texts(&agreement),
+      held_back_texts(&agreement),
+      agreement.last_agreed_seconds(),
+    ),
+    (vec![" P"], vec![" Q", " R", " S"], 0.95),
+    "the forward search finds no boundary at or above the requested split -- \
+     both `0.95` and `1.10` are below the `1.15` already inside `common` -- so \
+     the back-off lands at index 1, and the watermark is the lowest unconfirmed \
+     start it can still clear",
+  );
+  for confirmed in agreement.confirmed_words_slice() {
+    assert!(
+      confirmed.start() < agreement.last_agreed_seconds(),
+      "EVERY confirmed word starts strictly before the {} s watermark, not just \
+       the last: {:?} at {}",
+      agreement.last_agreed_seconds(),
+      confirmed.word(),
+      confirmed.start(),
+    );
+  }
+  assert!(
+    LocalAgreement::watermark_filtered(&offered(), agreement.last_agreed_seconds())
+      .iter()
+      .all(|offered| offered.word() != " P"),
+    "and nothing confirmed can head the next hypothesis",
   );
 }

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -395,6 +395,120 @@ fn omitting_a_confirmed_tied_word_does_not_drop_provisional_words() {
 }
 
 #[test]
+fn the_split_never_cuts_at_a_tied_start() {
+  // RULE W's POSTCONDITION, swept rather than pinned to one fixture: whenever
+  // the holdback is non-empty, the last CONFIRMED word starts strictly before
+  // the watermark.
+  //
+  // That inequality is the whole of #94. `watermark_filtered_with` offers every
+  // hypothesis word whose `start >= watermark`, so a confirmed word that TIES
+  // the watermark passes that filter and can come back at the head of the next
+  // hypothesis -- and there it is byte-identical to the stream's own second
+  // occurrence of the same text, which is the issue's impossibility result.
+  // Every defeated rule in this module's ledger tried to DECIDE that state.
+  // Rule W refuses to create it: the split widens past a tie instead of cutting
+  // at one, so the state is unreachable and needs no decision.
+  //
+  // The sweep draws starts from a coarse grid whose repeats make consecutive
+  // words tie -- the `a=[0,0.5)/b=[0,1.0)` shape both #94 regressions are built
+  // from, generalized -- keeps them non-decreasing the way `find_alignment`
+  // guarantees (`segment::tests`: `w[i].end() <= w[i+1].start() + 1e-4`), and
+  // drives growing prefixes through `ingest_streamed`, the MARKED path the
+  // driver uses, so every advance carries the prefill premise the engine issues
+  // for itself. One stride in four omits the leading word, which is the rewrite
+  // `omitting_a_confirmed_tied_word_does_not_drop_provisional_words` is built
+  // from.
+  //
+  // Mutation proof: drop Rule W's widening loop from `ingest` (leaving the bare
+  // `budgeted_split`) and this reds on the first swept tie, reporting the
+  // confirmed word whose start equals the watermark.
+  const TEXTS: [&str; 4] = [" A", " B", " C", " D"];
+  // Repeated 0.0 entries are the ties; the rest keep the grid coarse enough for
+  // two words to share an instant often.
+  const STEPS: [f32; 6] = [0.0, 0.0, 0.0, 0.5, 0.5, 1.0];
+  // The 0.0 duration is a zero-length word, which is the one shape that could
+  // satisfy `start >= watermark` from inside the confirmed list without a tie
+  // between two distinct starts.
+  const DURATIONS: [f32; 4] = [0.0, 0.2, 0.5, 1.0];
+
+  fn postcondition(agreement: &LocalAgreement, trial: u32, stride: usize) -> bool {
+    if agreement.last_agreed_words_slice().is_empty() {
+      return false;
+    }
+    let Some(last) = agreement.confirmed_words_slice().last() else {
+      return false;
+    };
+    assert!(
+      last.start() < agreement.last_agreed_seconds(),
+      "trial {trial}, stride {stride}: the confirmed list {:?} ends on {:?} at \
+       {}, which is not strictly before the {} s watermark -- that word passes \
+       `watermark_filtered`'s own `start >= watermark` and can be re-admitted",
+      confirmed_texts(agreement),
+      last.word(),
+      last.start(),
+      agreement.last_agreed_seconds(),
+    );
+    true
+  }
+
+  let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+  let mut next = move || {
+    state ^= state << 13;
+    state ^= state >> 7;
+    state ^= state << 17;
+    state
+  };
+  let mut checked = 0u32;
+  let mut tied_truths = 0u32;
+
+  for trial in 0..256u32 {
+    let length = 4 + (next() % 5) as usize;
+    let mut truth: Vec<WordTiming> = Vec::with_capacity(length);
+    let mut start = 0.0f32;
+    for _ in 0..length {
+      let text = TEXTS[(next() % TEXTS.len() as u64) as usize];
+      start += STEPS[(next() % STEPS.len() as u64) as usize];
+      let end = start + DURATIONS[(next() % DURATIONS.len() as u64) as usize];
+      truth.push(word(text, start, end));
+    }
+    if truth
+      .windows(2)
+      .any(|pair| pair[0].start() >= pair[1].start())
+    {
+      tied_truths += 1;
+    }
+
+    let mut agreement = LocalAgreement::new();
+    for stride in 2..=truth.len() {
+      let omit_head = stride > 2 && next() % 4 == 0;
+      let offered = if omit_head {
+        truth[1..stride].to_vec()
+      } else {
+        truth[..stride].to_vec()
+      };
+      for _ in 0..2 {
+        agreement.ingest_streamed(result_with_words(offered.clone()));
+        if postcondition(&agreement, trial, stride) {
+          checked += 1;
+        }
+      }
+    }
+  }
+
+  // Non-vacuity, both halves: the sweep really did build tied truths, and the
+  // postcondition really was READ against a non-empty holdback and a non-empty
+  // confirmed list rather than skipped.
+  assert!(
+    tied_truths > 64,
+    "the sweep must actually produce tied starts: {tied_truths} of 256 trials",
+  );
+  assert!(
+    checked > 256,
+    "the postcondition must actually be reachable: {checked} observations",
+  );
+}
+
+#[test]
 fn a_dropped_disagreeing_hypothesiss_draw_survives_into_finalize() {
   // F1 (codex round 8). A three-hypothesis history where the MIDDLE hypothesis
   // disagrees and is dropped from `results` (`:395-400`, skipAppend) but is
@@ -846,14 +960,19 @@ fn a_revision_that_repeats_a_held_back_word_is_not_duplicated() {
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(settled());
   assert!(agreement.ingest_streamed(settled()).is_advanced());
-  assert_eq!(confirmed_texts(&agreement), vec![" A"]);
+  // Rule W (#94): the split may not cut at a tied start, so it widens past the
+  // tie -- one word moves from `last_agreed_words_slice()` into
+  // `confirmed_words_slice()` and the watermark moves to the first word past
+  // the tie. `confirmed ++ holdback` is unchanged, and the finalized text this
+  // test asserts is measured byte-identical either way.
+  assert_eq!(confirmed_texts(&agreement), vec![" A", " B"]);
   assert_eq!(
     agreement
       .last_agreed_words_slice()
       .iter()
       .map(WordTiming::word)
       .collect::<Vec<_>>(),
-    vec![" B", " C"],
+    vec![" C"],
   );
 
   let revision = || {
@@ -1023,14 +1142,19 @@ fn an_insertion_before_a_reproduced_confirmed_word_is_refused_with_it() {
       .ingest_streamed(result_with_words(vec![a(), b(), c()]))
       .is_advanced()
   );
+  // Rule W (#94): the split may not cut at a tied start, so it widens past the
+  // tie -- one word moves from `last_agreed_words_slice()` into
+  // `confirmed_words_slice()` and the watermark moves to the first word past
+  // the tie. `confirmed ++ holdback` is unchanged, and the finalized text this
+  // test asserts is measured byte-identical either way.
   assert_eq!(
     agreement
       .confirmed_words_slice()
       .iter()
       .map(WordTiming::word)
       .collect::<Vec<_>>(),
-    vec![" A"],
-    "confirmed [A], holding [B, C] at a 0.0 s watermark",
+    vec![" A", " B"],
+    "confirmed [A, B], holding [C] at a 1.0 s watermark",
   );
 
   agreement.ingest_streamed(result_with_words(vec![x(), a(), b(), c()]));
@@ -1076,13 +1200,18 @@ fn an_insertion_before_a_reproduced_confirmed_word_is_refused_on_the_advance() {
   agreement.ingest_streamed(result_with_words(vec![x(), a(), b(), c()]));
   agreement.ingest_streamed(result_with_words(vec![x(), a(), b(), c()]));
 
+  // Rule W (#94): the split may not cut at a tied start, so it widens past the
+  // tie -- one word moves from `last_agreed_words_slice()` into
+  // `confirmed_words_slice()` and the watermark moves to the first word past
+  // the tie. `confirmed ++ holdback` is unchanged, and the finalized text this
+  // test asserts is measured byte-identical either way.
   assert_eq!(
     agreement
       .confirmed_words_slice()
       .iter()
       .map(WordTiming::word)
       .collect::<Vec<_>>(),
-    vec![" A"],
+    vec![" A", " B"],
     "the advance path must not re-confirm A either",
   );
 }
@@ -1248,8 +1377,9 @@ fn tied_pair_confirmed() -> LocalAgreement {
       .iter()
       .map(WordTiming::word)
       .collect::<Vec<_>>(),
-    vec![" A", " B"],
-    "confirmed [A, B], holding [C, D] at a 0.0 s watermark",
+    vec![" A", " B", " C"],
+    "Rule W widens past the 0.0 s tie, so this is confirmed [A, B, C] holding \
+     [D] at a 1.0 s watermark -- `confirmed ++ holdback` unchanged",
   );
   agreement
 }
@@ -1318,8 +1448,9 @@ fn a_confirmed_tail_reproduced_without_its_head_is_still_refused_on_the_advance(
       .iter()
       .map(WordTiming::word)
       .collect::<Vec<_>>(),
-    vec![" A", " B"],
-    "the advance path must not re-confirm B either",
+    vec![" A", " B", " C"],
+    "the advance path must not re-confirm B either (\" C\" is Rule W's widening, \
+     not a re-admission)",
   );
 }
 
@@ -1391,8 +1522,9 @@ fn a_reproduction_behind_a_shorter_false_match_is_still_refused_on_the_advance()
       .iter()
       .map(WordTiming::word)
       .collect::<Vec<_>>(),
-    vec![" A", " B"],
-    "the advance path must not re-confirm A or B either",
+    vec![" A", " B", " C"],
+    "the advance path must not re-confirm A or B either (\" C\" is Rule W's \
+     widening, not a re-admission)",
   );
 }
 
@@ -1527,10 +1659,15 @@ fn a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream() {
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(stutter());
   assert!(agreement.ingest_streamed(stutter()).is_advanced());
+  // Rule W (#94): the split may not cut at a tied start, so it widens past the
+  // tie -- one word moves from `last_agreed_words_slice()` into
+  // `confirmed_words_slice()` and the watermark moves to the first word past
+  // the tie. `confirmed ++ holdback` is unchanged, and the finalized text this
+  // test asserts is measured byte-identical either way.
   assert_eq!(
     confirmed_texts(&agreement),
-    vec![" A"],
-    "the advance confirms the first A and holds the distinct second one",
+    vec![" A", " A"],
+    "the advance settles both stuttered A's rather than cutting between them",
   );
 
   // The stream CONTINUES past that advance -- which is exactly what
@@ -1591,10 +1728,15 @@ fn a_reproduction_shifted_off_the_watermark_is_still_refused() {
       .ingest_streamed(result_with_words(vec![a(), b(), c()]))
       .is_advanced()
   );
+  // Rule W (#94): the split may not cut at a tied start, so it widens past the
+  // tie -- one word moves from `last_agreed_words_slice()` into
+  // `confirmed_words_slice()` and the watermark moves to the first word past
+  // the tie. `confirmed ++ holdback` is unchanged, and the finalized text this
+  // test asserts is measured byte-identical either way.
   assert_eq!(
     confirmed_texts(&agreement),
-    vec![" A"],
-    "confirmed [A], holding [B, C] at a 0.0 s watermark",
+    vec![" A", " B"],
+    "confirmed [A, B], holding [C] at a 1.0 s watermark",
   );
 
   let shifted = || {
@@ -1609,9 +1751,9 @@ fn a_reproduction_shifted_off_the_watermark_is_still_refused() {
   agreement.ingest_streamed(shifted());
   assert_eq!(
     confirmed_texts(&agreement),
-    vec![" A"],
+    vec![" A", " B"],
     "the shifted reproduction must not reach the confirmed list on the advance \
-     path either",
+     path either (\" B\" is Rule W's widening, not the reproduction)",
   );
 
   let text = agreement

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -5005,3 +5005,111 @@ fn a_backward_start_beyond_common_backs_the_split_off_too() {
     published.text(),
   );
 }
+
+#[test]
+fn characterization_an_agreeing_round_returns_advanced_without_moving_the_watermark() {
+  // CHARACTERIZATION of what `AgreementOutcome::Advanced` reports TODAY, not a
+  // property that holds. The CORRECT answer is in the failure messages below.
+  //
+  // `Advanced`'s doc said "the confirmation watermark advanced and the result
+  // was kept", and `AwaitingAgreement`'s said "two hypotheses that AGREE always
+  // advance the watermark ... what this value reports is whether the watermark
+  // moved". Both were false, and neither is a rounding artifact.
+  //
+  // MEASURED, on the real tiny model: strides 7 and 9 of the shipping
+  // `jfk_simulated_stream_confirms_the_transcript` fixture return `Advanced`
+  // with `last_agreed_seconds` BIT-identical to the stride before (`0x3fb5c28f`
+  // and `0x3fb851ec`) and the confirmed prefix unchanged at `"and so my"`, while
+  // every stride that really moves changes the bits by ~0.02 s. Instrumenting
+  // the same 512-trial shape `the_split_never_cuts_at_a_tied_start` sweeps finds
+  // 1281 such rounds out of 4233 at this commit and 1128 out of 4233 on `main`,
+  // with the rounded-only count at ZERO on both. The behaviour predates this
+  // branch: the JFK trace is element-wise identical across `main`, `7b353b4`
+  // and `eb1e412`.
+  //
+  // WHY, and it is not the budget. An advance confirms `common[..split]` and
+  // holds `common[split..]`. Where the split is ZERO -- here the earliest
+  // boundary the budget floor allows, `budgeted_split(common, 0) == 0`, and a
+  // legal one -- the round confirms nothing, so `sparing_watermark` re-anchors on
+  // the first held-back word, which is the word the watermark already sat on.
+  // The EXHAUSTED-BUDGET arm is the opposite case and does move the watermark:
+  // it runs the split off the end of `common` and confirms all of it
+  // (`a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant`).
+  //
+  // Split > 0 cannot reach this state, which is why the pin is at split 0: every
+  // word of `common` clears the watermark by `watermark_filtered`, so confirming
+  // one raises `highest_start(confirmed_words)` to at least the watermark, and
+  // Rule W's first postcondition then puts the new watermark strictly past it.
+  //
+  // Mutation proof: make the third ingest disagree (change `" my"`'s text in
+  // `revised`) and the `is_advanced` row reds -- so the round asserted here is
+  // genuinely an AGREEING one and not a disagreement in disguise.
+  let and = || word(" and", 0.0, 0.4);
+  let so = || word(" so", 0.4, 0.7);
+  let my = || word(" my", 0.7, 1.0);
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, the only one the driver reaches",
+  );
+
+  agreement.ingest_streamed(result_with_words(vec![and(), so(), my()]));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(vec![
+        and(),
+        so(),
+        my(),
+        word(" fellow", 1.0, 1.5),
+      ]))
+      .is_advanced()
+  );
+  assert_eq!(
+    (
+      confirmed_texts(&agreement),
+      held_back_texts(&agreement),
+      agreement.last_agreed_seconds().to_bits(),
+    ),
+    (vec![" and"], vec![" so", " my"], 0.4f32.to_bits()),
+    "the SETUP round really advances: it confirms `\" and\"` and puts the \
+     watermark on the first held-back word",
+  );
+
+  // The steady state: this round re-agrees on exactly `agreement_count_needed`
+  // words and holds both, so its split is zero and it confirms nothing new.
+  let settled = agreement.last_agreed_seconds();
+  let revised = result_with_words(vec![so(), my(), word(" americans", 1.0, 1.6)]);
+  let outcome = agreement.ingest_streamed(revised);
+
+  assert!(
+    outcome.is_advanced(),
+    "non-vacuous: this round AGREED and its result was kept -- it is the \
+     `Advanced` path, not a disagreement",
+  );
+  assert_eq!(
+    agreement.last_agreed_seconds().to_bits(),
+    settled.to_bits(),
+    "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94): \
+     this pins that a round returning `{outcome}` moves the watermark NOWHERE \
+     -- left is the {} it holds now, right the {settled} it already held, \
+     compared as BITS so no rounding can be blamed either way. The CORRECT \
+     answer is that a caller can read `advanced` as \"something progressed\" \
+     and act on it: drive a \
+     progress indicator, decide a stream has stalled, or stop re-offering audio \
+     that will never be confirmed. Today it only says the round AGREED and its \
+     result was KEPT. Making the signal honest is tracked separately, because \
+     it changes what the JFK regression trace records and that trace must stay \
+     byte-identical on this branch.",
+    agreement.last_agreed_seconds(),
+  );
+  assert_eq!(
+    (confirmed_texts(&agreement), held_back_texts(&agreement)),
+    (vec![" and"], vec![" so", " my"]),
+    "and nothing else progressed either: the confirmed prefix is unchanged and \
+     the whole agreed prefix is still the holdback, which is what a zero split \
+     leaves behind. A caller polling `confirmed_words_slice()` on an `advanced` \
+     sees the same words it saw last round.",
+  );
+}

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -1581,7 +1581,8 @@ fn a_dropped_disagreeing_hypothesiss_draw_survives_into_finalize() {
   // R2 disagrees with R1 (no common prefix) AND drew from an unseeded sampler.
   let r2 = result_with_words(vec![word(" But", 0.0, 0.4), word(" then", 0.4, 0.7)])
     .with_task_facts(TaskFacts::observed_clean().with_drew_from_rng(true));
-  // R3 agrees with the retained R2 control hypothesis, advancing the watermark.
+  // R3 agrees with the retained R2 control hypothesis, so the round returns
+  // `Advanced` -- on a ZERO split, so it confirms nothing and the watermark holds.
   let r3 = result_with_words(vec![
     word(" But", 0.0, 0.4),
     word(" then", 0.4, 0.7),

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -8,6 +8,64 @@ fn word(text: &str, start: f32, end: f32) -> WordTiming {
   WordTiming::new(text, vec![start as u32 + 1], start, end, 0.9)
 }
 
+/// A word carrying `token_count` distinct plain-vocabulary token ids — for the
+/// prefill-budget cases, where what matters is how many TOKENS the holdback
+/// costs, not how many words it holds. Ids stay far below any Whisper
+/// vocabulary's `special_token_begin`, so `prefill_tokens`' other filter cannot
+/// confuse the measurement.
+fn word_of_tokens(text: &str, start: f32, end: f32, token_count: usize) -> WordTiming {
+  let first = start as u32 * 1000 + 1;
+  let tokens: Vec<u32> = (0..token_count as u32).map(|index| first + index).collect();
+  WordTiming::new(text, tokens, start, end, 0.9)
+}
+
+/// A word whose tokens `prefill_tokens` ERASES: every id is at or above
+/// [`MIN_SPECIAL_TOKEN_BEGIN`], so the filter drops the lot and the word
+/// contributes NOTHING to the initial prompt. `add_word_timestamps` never emits
+/// one — it strips exactly those ids and skips an alignment entry that has
+/// nothing left — so this is a hand-built shape, which is precisely the call
+/// shape [`LocalAgreement::ingest`]'s `decoded_under` parameter exists for.
+fn special_only_word(text: &str, start: f32, end: f32) -> WordTiming {
+  WordTiming::new(text, vec![MIN_SPECIAL_TOKEN_BEGIN], start, end, 0.9)
+}
+
+/// The tiny model's tokenizer — the same artifact `decode`'s own tests read, and
+/// the only way to assert what `decode_text` is actually handed rather than what
+/// [`DecodingOptions`] merely records.
+fn tiny_tokenizer() -> crate::audio::whisper::tokenizer::WhisperTokenizer {
+  let root = std::env::var_os("WHISPERKIT_TEST_MODELS").map_or_else(
+    || {
+      std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("Models")
+    },
+    std::path::PathBuf::from,
+  );
+  crate::audio::whisper::tokenizer::WhisperTokenizer::from_folder(
+    root.join("tokenizers/whisper-tiny"),
+  )
+  .unwrap()
+}
+
+/// The initial prompt `WhisperKit::transcribe` builds from `options`, exactly as
+/// it builds it (`transcribe/mod.rs:394-405`): `[<|startoftranscript|>]` unless
+/// [`DecodingOptions::use_prefill_prompt`] is set, in which case
+/// [`prefill_tokens`](crate::audio::whisper::decode::prefill_tokens) derives the
+/// whole thing. This is the layer the prefill contract has to be pinned at —
+/// `DecodingOptions::prefix_tokens` is only what the engine RECORDED, and
+/// `prefill_tokens` is free to trim and filter it before `decode_text` ever sees
+/// a token.
+fn initial_prompt_for(
+  options: &DecodingOptions,
+  tokenizer: &crate::audio::whisper::tokenizer::WhisperTokenizer,
+) -> Vec<u32> {
+  if options.use_prefill_prompt() {
+    crate::audio::whisper::decode::prefill_tokens(options, tokenizer, true)
+  } else {
+    vec![tokenizer.special_tokens().start_of_transcript_token()]
+  }
+}
+
 // NOTE: this task's own brief's literal snippet called `TranscriptionResult::
 // new()` with no arguments, then chained `.set_segments(...)`/
 // `.set_language(...)`. The shipped constructor is four-argument
@@ -16,6 +74,26 @@ fn word(text: &str, start: f32, end: f32) -> WordTiming {
 // defaults for these either") — same brief-vs-shipped-API fix as
 // `tests/pipeline.rs`'s `tiny_options`/`tests/parity_jfk.rs`. Both call sites
 // below pass the real values directly instead.
+/// Ingest the way [`LocalAgreementTranscriber::push_samples`] does: under the
+/// options the engine itself issued for its current state, so the prefill
+/// premise `LocalAgreement::watermark_filtered`'s ambiguity rule is decided by
+/// is ESTABLISHED rather than assumed.
+///
+/// Every test below that is modelling the streaming loop goes through this. The
+/// bare [`LocalAgreement::ingest`] is the UNMARKED path — a result decoded some
+/// other way — and the tests that mean that call it directly, with the options
+/// they mean.
+trait IngestStreamed {
+  fn ingest_streamed(&mut self, result: TranscriptionResult) -> AgreementOutcome;
+}
+
+impl IngestStreamed for LocalAgreement {
+  fn ingest_streamed(&mut self, result: TranscriptionResult) -> AgreementOutcome {
+    let options = self.decoding_options_for_next(&DecodingOptions::new());
+    self.ingest(result, &options)
+  }
+}
+
 fn result_with_words(words: Vec<WordTiming>) -> TranscriptionResult {
   let mut segment = TranscriptionSegment::new();
   segment
@@ -41,7 +119,7 @@ fn agreement_confirms_the_common_prefix_minus_the_agreed_tail() {
     word(" my", 0.7, 1.0),
   ]);
   assert!(
-    agreement.ingest(first).is_awaiting_agreement(),
+    agreement.ingest_streamed(first).is_awaiting_agreement(),
     "first result: nothing to agree with"
   );
   assert_eq!(
@@ -56,7 +134,7 @@ fn agreement_confirms_the_common_prefix_minus_the_agreed_tail() {
     word(" my", 0.7, 1.0),
     word(" fellow", 1.0, 1.5),
   ]);
-  assert!(agreement.ingest(second).is_advanced());
+  assert!(agreement.ingest_streamed(second).is_advanced());
   assert_eq!(agreement.results_slice().len(), 2);
   // common = [And, so, my]; last agreed = suffix(2) = [so, my];
   // confirmed += prefix(1) = [And]; watermark = " so".start.
@@ -76,12 +154,16 @@ fn agreement_confirms_the_common_prefix_minus_the_agreed_tail() {
 fn disagreement_skips_the_result_and_keeps_the_watermark() {
   // TranscribeCLI.swift:395-400 (skipAppend).
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![
+  agreement.ingest_streamed(result_with_words(vec![
     word(" And", 0.0, 0.4),
     word(" so", 0.4, 0.7),
   ]));
   let disagreeing = result_with_words(vec![word(" But", 0.0, 0.4), word(" then", 0.4, 0.7)]);
-  assert!(agreement.ingest(disagreeing).is_awaiting_agreement());
+  assert!(
+    agreement
+      .ingest_streamed(disagreeing)
+      .is_awaiting_agreement()
+  );
   assert_eq!(
     agreement.results_slice().len(),
     1,
@@ -98,7 +180,7 @@ fn wordless_results_are_flagged_but_still_appended() {
   let mut segment = TranscriptionSegment::new();
   segment.set_text("hi");
   let wordless = TranscriptionResult::new("hi", vec![segment], "en", TranscriptionTimings::new());
-  assert!(agreement.ingest(wordless).is_no_word_timings());
+  assert!(agreement.ingest_streamed(wordless).is_no_word_timings());
   assert_eq!(agreement.results_slice().len(), 1);
 }
 
@@ -106,12 +188,12 @@ fn wordless_results_are_flagged_but_still_appended() {
 fn finalize_appends_agreed_tail_plus_different_suffix_and_merges() {
   // TranscribeCLI.swift:418-421.
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![
+  agreement.ingest_streamed(result_with_words(vec![
     word(" And", 0.0, 0.4),
     word(" so", 0.4, 0.7),
     word(" my", 0.7, 1.0),
   ]));
-  agreement.ingest(result_with_words(vec![
+  agreement.ingest_streamed(result_with_words(vec![
     word(" And", 0.0, 0.4),
     word(" so", 0.4, 0.7),
     word(" my", 0.7, 1.0),
@@ -149,7 +231,7 @@ fn finalize_threads_options_so_dropped_ids_survive() {
     TranscriptionTimings::new(),
   );
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result);
+  agreement.ingest_streamed(result);
   assert_eq!(
     agreement.results_slice().len(),
     1,
@@ -177,11 +259,11 @@ fn agreement_count_needed_is_configurable() {
   // constructor/accessor plumbing.
   let mut agreement = LocalAgreement::new().with_agreement_count_needed(1);
   assert_eq!(agreement.agreement_count_needed(), 1);
-  agreement.ingest(result_with_words(vec![word(" And", 0.0, 0.4)]));
+  agreement.ingest_streamed(result_with_words(vec![word(" And", 0.0, 0.4)]));
   let second = result_with_words(vec![word(" And", 0.0, 0.4), word(" so", 0.4, 0.7)]);
   // A single-word common prefix ([And]) already meets a threshold of 1 —
   // it would NOT at the default threshold of 2.
-  assert!(agreement.ingest(second).is_advanced());
+  assert!(agreement.ingest_streamed(second).is_advanced());
   assert!(agreement.confirmed_words_slice().is_empty());
   assert_eq!(agreement.last_agreed_words_slice().len(), 1);
   assert_eq!(agreement.last_agreed_words_slice()[0].word(), " And");
@@ -198,9 +280,9 @@ fn agreement_count_needed_zero_is_clamped_to_one_and_never_panics() {
   // setter clamps instead.
   let mut agreement = LocalAgreement::new().with_agreement_count_needed(0);
   assert_eq!(agreement.agreement_count_needed(), 1);
-  agreement.ingest(result_with_words(vec![word(" And", 0.0, 0.4)]));
+  agreement.ingest_streamed(result_with_words(vec![word(" And", 0.0, 0.4)]));
   let second = result_with_words(vec![word(" And", 0.0, 0.4), word(" so", 0.4, 0.7)]);
-  agreement.ingest(second); // must not panic
+  agreement.ingest_streamed(second); // must not panic
 }
 
 #[test]
@@ -223,7 +305,7 @@ fn later_segment_words_satisfy_the_any_segment_gate() {
     TranscriptionTimings::new(),
   );
   let mut agreement = LocalAgreement::new();
-  let outcome = agreement.ingest(result);
+  let outcome = agreement.ingest_streamed(result);
   assert!(
     !outcome.is_no_word_timings(),
     "any-segment gate: later words count"
@@ -242,9 +324,9 @@ fn tied_word_starts_never_confirm_twice() {
   let d = || word(" D", 2.0, 3.0);
   let e = || word(" E", 3.0, 4.0);
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest(result_with_words(vec![a(), b(), c(), d()]));
-  agreement.ingest(result_with_words(vec![a(), b(), c(), d(), e()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c(), d()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c(), d(), e()]));
   let confirmed: Vec<&str> = agreement
     .confirmed_words_slice()
     .iter()
@@ -268,23 +350,27 @@ fn tied_word_starts_never_confirm_twice() {
 fn omitting_a_confirmed_tied_word_does_not_drop_provisional_words() {
   // Regression (phase-gate round 2): the count-based readmit skip dropped
   // B whenever a rewrite OMITTED confirmed A (tied start) and shifted the
-  // hypothesis left — `watermark_filtered_with`'s strip only removes words that
-  // ACTUALLY reproduce the confirmed tail, so a candidate the hypothesis does
-  // not reproduce costs nothing.
+  // hypothesis left. The frontier rule refuses only what the alignment
+  // ATTRIBUTES to the settled half, and a deletion costs it nothing beyond the
+  // match it forgoes, so a candidate the hypothesis does not reproduce costs
+  // nothing here either.
   //
-  // Mutation proof: replace that strip with the unconditional count-skip
-  // (`let strip = readmit_candidates.len().min(filtered.len());`) and B is never
-  // confirmed at all.
+  // Mutation proof: refuse nothing at all (a frontier of 0, Swift's bare
+  // timestamp filter at `:372`) and B is never confirmed -- the re-admitted A
+  // sits at the front of BOTH filtered lists, the prefix comparison lines up on
+  // it instead of on B, and `confirmed_words_slice()` reads back [" A"]. The
+  // same mutation costs `tied_word_starts_never_confirm_twice` its stability,
+  // reading back [" A", " A", " B"].
   let a = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0); // tied start with A
   let c = || word(" C", 1.0, 2.0);
   let d = || word(" D", 2.0, 3.0);
   let e = || word(" E", 3.0, 4.0);
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest(result_with_words(vec![a(), b(), c(), d()])); // confirms A, holds B,C
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c(), d()])); // confirms A, holds B,C
   // The rewrite omits A entirely: B must survive to be confirmed next.
-  agreement.ingest(result_with_words(vec![b(), c(), d(), e()]));
+  agreement.ingest_streamed(result_with_words(vec![b(), c(), d(), e()]));
   let confirmed: Vec<&str> = agreement
     .confirmed_words_slice()
     .iter()
@@ -292,7 +378,7 @@ fn omitting_a_confirmed_tied_word_does_not_drop_provisional_words() {
     .collect();
   assert!(
     confirmed.contains(&" B"),
-    "B lost to the positional skip: {confirmed:?}"
+    "B lost to the re-admission frontier: {confirmed:?}"
   );
   assert_eq!(
     confirmed.iter().filter(|w| **w == " B").count(),
@@ -334,13 +420,13 @@ fn a_dropped_disagreeing_hypothesiss_draw_survives_into_finalize() {
   .with_task_facts(TaskFacts::observed_clean());
 
   let mut agreement = LocalAgreement::new();
-  assert!(agreement.ingest(r1).is_awaiting_agreement());
+  assert!(agreement.ingest_streamed(r1).is_awaiting_agreement());
   assert!(
-    agreement.ingest(r2).is_awaiting_agreement(),
+    agreement.ingest_streamed(r2).is_awaiting_agreement(),
     "R2 disagrees with R1 and is dropped from results",
   );
   assert!(
-    agreement.ingest(r3).is_advanced(),
+    agreement.ingest_streamed(r3).is_advanced(),
     "R3 agrees with the retained R2 control hypothesis",
   );
 
@@ -419,13 +505,13 @@ fn finalize_keeps_the_earliest_ingested_language_over_a_later_survivor() {
   .with_task_facts(TaskFacts::observed_clean().with_observed_language(Some("fr".into())));
 
   let mut agreement = LocalAgreement::new();
-  assert!(agreement.ingest(r1).is_awaiting_agreement());
+  assert!(agreement.ingest_streamed(r1).is_awaiting_agreement());
   assert!(
-    agreement.ingest(r2).is_awaiting_agreement(),
+    agreement.ingest_streamed(r2).is_awaiting_agreement(),
     "R2 disagrees with R1 and is dropped from results",
   );
   assert!(
-    agreement.ingest(r3).is_advanced(),
+    agreement.ingest_streamed(r3).is_advanced(),
     "R3 agrees with the retained R2 control hypothesis",
   );
   assert_eq!(
@@ -475,13 +561,13 @@ fn finalize_reports_an_unknown_worker_schedule() {
   .with_task_facts(TaskFacts::observed_clean().with_worker(2));
 
   let mut agreement = LocalAgreement::new();
-  assert!(agreement.ingest(r1).is_awaiting_agreement());
+  assert!(agreement.ingest_streamed(r1).is_awaiting_agreement());
   assert!(
-    agreement.ingest(r2).is_awaiting_agreement(),
+    agreement.ingest_streamed(r2).is_awaiting_agreement(),
     "R2 disagrees with R1 and is dropped from results",
   );
   assert!(
-    agreement.ingest(r3).is_advanced(),
+    agreement.ingest_streamed(r3).is_advanced(),
     "R3 agrees with the retained R2 control hypothesis",
   );
   // The surviving results R1 (worker 0) and R3 (worker 2) carry a knowable [0, 2],
@@ -514,7 +600,7 @@ fn a_disagreeing_final_hypothesis_replaces_the_holdback_instead_of_duplicating_i
   let mut agreement = LocalAgreement::new();
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         word(" alpha", 0.0, 0.4),
         word(" bravo", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
@@ -524,7 +610,7 @@ fn a_disagreeing_final_hypothesis_replaces_the_holdback_instead_of_duplicating_i
   );
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         word(" alpha", 0.0, 0.4),
         word(" bravo", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
@@ -553,7 +639,7 @@ fn a_disagreeing_final_hypothesis_replaces_the_holdback_instead_of_duplicating_i
   // no common prefix with the previous one and is dropped from `results`.
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         word(" xray", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
       ]))
@@ -598,7 +684,7 @@ fn a_disagreeing_final_pair_keeps_the_words_both_hypotheses_agreed_on() {
   let mut agreement = LocalAgreement::new();
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         word(" and", 0.0, 0.4),
         word(" so", 0.4, 0.7),
       ]))
@@ -608,7 +694,7 @@ fn a_disagreeing_final_pair_keeps_the_words_both_hypotheses_agreed_on() {
   // disagrees even though both hypotheses produced " and".
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         word(" and", 0.0, 0.4),
         word(" then", 0.4, 0.7),
       ]))
@@ -637,14 +723,14 @@ fn a_final_hypothesis_with_nothing_past_the_watermark_keeps_the_holdback() {
   // `finalize`'s guard and this reads back " alpha" -- the held-back
   // " bravo charlie" silently lost.
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![
+  agreement.ingest_streamed(result_with_words(vec![
     word(" alpha", 0.0, 0.4),
     word(" bravo", 0.4, 0.7),
     word(" charlie", 0.7, 1.0),
   ]));
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         word(" alpha", 0.0, 0.4),
         word(" bravo", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
@@ -654,7 +740,7 @@ fn a_final_hypothesis_with_nothing_past_the_watermark_keeps_the_holdback() {
   assert!((agreement.last_agreed_seconds() - 0.4).abs() < 1e-6);
 
   // Words, but every one of them before the 0.4 s watermark.
-  let outcome = agreement.ingest(result_with_words(vec![word(" alpha", 0.0, 0.4)]));
+  let outcome = agreement.ingest_streamed(result_with_words(vec![word(" alpha", 0.0, 0.4)]));
   assert!(
     outcome.is_awaiting_agreement(),
     "words present, so NOT NoWordTimings -- it disagrees instead: {outcome}",
@@ -686,14 +772,14 @@ fn an_agreement_after_a_disagreement_restores_the_swift_shape() {
   // `..._repeats_a_held_back_word_...` tests do catch it, from a longer
   // history — this is the minimal one.)
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![
+  agreement.ingest_streamed(result_with_words(vec![
     word(" alpha", 0.0, 0.4),
     word(" bravo", 0.4, 0.7),
     word(" charlie", 0.7, 1.0),
   ]));
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         word(" alpha", 0.0, 0.4),
         word(" bravo", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
@@ -703,7 +789,7 @@ fn an_agreement_after_a_disagreement_restores_the_swift_shape() {
   // Revises the held-back " bravo": disagrees, dropped, holdback superseded.
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         word(" xray", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
         word(" delta", 1.0, 1.3),
@@ -714,7 +800,7 @@ fn an_agreement_after_a_disagreement_restores_the_swift_shape() {
   // " charlie delta", and the holdback is the final hypothesis's own again.
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         word(" xray", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
         word(" delta", 1.0, 1.3),
@@ -758,8 +844,8 @@ fn a_revision_that_repeats_a_held_back_word_is_not_duplicated() {
     ])
   };
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(settled());
-  assert!(agreement.ingest(settled()).is_advanced());
+  agreement.ingest_streamed(settled());
+  assert!(agreement.ingest_streamed(settled()).is_advanced());
   assert_eq!(confirmed_texts(&agreement), vec![" A"]);
   assert_eq!(
     agreement
@@ -781,7 +867,9 @@ fn a_revision_that_repeats_a_held_back_word_is_not_duplicated() {
     ])
   };
   assert!(
-    agreement.ingest(revision()).is_awaiting_agreement(),
+    agreement
+      .ingest_streamed(revision())
+      .is_awaiting_agreement(),
     "one shared word is short of the threshold of 2, so this disagrees",
   );
 
@@ -825,11 +913,11 @@ fn a_corroborated_revision_that_repeats_a_held_back_word_reaches_the_transcript(
     ])
   };
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(settled());
-  assert!(agreement.ingest(settled()).is_advanced());
-  agreement.ingest(revision());
+  agreement.ingest_streamed(settled());
+  assert!(agreement.ingest_streamed(settled()).is_advanced());
+  agreement.ingest_streamed(revision());
   assert!(
-    agreement.ingest(revision()).is_advanced(),
+    agreement.ingest_streamed(revision()).is_advanced(),
     "the revision corroborates itself",
   );
 
@@ -852,72 +940,87 @@ fn a_corroborated_revision_that_repeats_a_held_back_word_reaches_the_transcript(
 }
 
 // ---------------------------------------------------------------------
-// The re-admission ledger: CHARACTERIZATIONS of a defect that is OPEN
+// The re-admission ledger: the sequences that closed #94
 // ---------------------------------------------------------------------
 //
-// `watermark_filtered`'s strip only catches a reproduction the hypothesis puts
-// at the very FRONT of its post-watermark list. Every test below is a sequence
-// that slides past it and confirms a settled word a second time (or, in the last
-// one, deletes a word the stream genuinely produced).
+// Every test below is a sequence that slid past `watermark_filtered`'s old
+// leading-run strip and confirmed a settled word a second time -- or, in the
+// last one, DELETED a word the stream genuinely produced. Each was a
+// CHARACTERIZATION while <https://github.com/findit-studio/coremlit/issues/94>
+// was open: it asserted the wrong answer the strip produced and carried the
+// right one in its failure message. The frontier rule
+// (`LocalAgreement::watermark_filtered`) replaced that strip, so each now
+// asserts the property its name states, at exactly the value its old failure
+// message specified.
 //
-// Each one asserts WHAT THE CODE DOES TODAY -- the wrong answer -- and carries
-// the CORRECT expectation in its failure message. They are green on this tree,
-// and they go RED the day someone fixes
-// <https://github.com/findit-studio/coremlit/issues/94>, handing the fixer the
-// value to change the expectation to. Run the whole module, both halves at
+// They belong beside the constraints in the next section: these pin what the
+// rule must now DO, those pin what it must still NOT do. Run both halves at
 // once:
 //
 //     cargo test -p coremlit --features whisper --lib -- \
 //         audio::whisper::stream::agreement::tests::
 //
-// WHY CHARACTERIZATION RATHER THAN `#[ignore]`. An earlier revision marked
-// these ten `#[ignore]` and called them "red on purpose". That is the wrong
-// marker, for two independent reasons -- do not revert to it:
+// NOT `#[ignore]`. An early revision of this ledger marked its ten entries
+// `#[ignore]` and called them "red on purpose". That is the wrong marker and
+// must not be restored, for two independent reasons:
 //
 //   - libtest's `--ignored` is ignored-ONLY, not skip-the-ignored: it SELECTS
 //     every ignored test in the target and runs it. This repository's model
 //     gates (.github/workflows/ci.yml, the `whisper|@all` row) and its sharded
 //     coverage legs (.github/workflows/coverage.yml, the same row) both invoke
-//     `-- --ignored`, so an `#[ignore]`d test is not parked -- it is scheduled,
-//     and ten deliberately-red tests turn every one of those runs red.
+//     `-- --ignored`, so an `#[ignore]`d test is not parked -- it is scheduled.
 //   - An ignored test never executes, so it rots silently as the code moves
-//     under it. A characterization test runs on every push: it pins today's
-//     behaviour exactly, it cannot drift unnoticed, and its going red is the
-//     signal that the defect is gone.
+//     under it.
 //
 // `#[ignore]` here marks a test CI cannot run unconditionally: it needs an
 // artifact this checkout may not have (a staged model, a tokenizer sidecar, a
 // fixture tree), or one specific host, or a cost CI will not pay. What it must
 // never mean is "this test is expected to fail" -- `--ignored` runs it.
 //
-// Four adversarial-review rounds established that no predicate over (confirmed
-// list, offered list, watermark) can decide these: occurrence identity is not
-// recoverable from what the rule sees. The argument, the three defeated
-// approaches and the recommended direction are in the issue.
+// Four adversarial-review rounds each defeated a different predicate over
+// (confirmed list, offered list, watermark) before establishing that NO such
+// predicate can decide these: two runs reach byte-identical triples and need
+// opposite answers, so occurrence identity is not recoverable from those three.
+// What separates those two runs is the HOLDBACK -- which is why the rule that
+// closed them aligns `settled ++ holdback` as a whole instead of scanning the
+// offered list for a text match. The four defeated approaches and the
+// falsifier that killed each are in the issue.
 
 #[test]
-fn an_insertion_before_a_reproduced_confirmed_word_reconfirms_it_today() {
-  // OPEN (codex round 2; the round-4 F1 "all tied at the watermark" variant).
-  // `watermark_filtered_with` zips the confirmed tail against the offered list
-  // from BOTH fronts, so it only removes a reproduction the hypothesis puts at
-  // the very FRONT of its post-watermark list. Insert a word at that same
-  // instant AHEAD of the reproduction and the zip mismatches at offset 0, strips
-  // nothing, and the already-confirmed " A" rides through into
-  // `hypothesis_words` -- which `finalize` then appends wholesale.
+fn an_insertion_before_a_reproduced_confirmed_word_is_refused_with_it() {
+  // #94 (codex round 2; also the round-4 F1 "all tied at the watermark"
+  // variant). The old leading-run strip zipped the confirmed tail against the
+  // offered list from BOTH fronts, so it only removed a reproduction the
+  // hypothesis put at the very FRONT of its post-watermark list. An insertion at
+  // that same instant AHEAD of the reproduction mismatched at offset 0, stripped
+  // nothing, and the already-confirmed " A" rode through into `hypothesis_words`
+  // -- which `finalize` then appended wholesale, reading back " A X A B C".
+  //
+  // The frontier rule aligns the span as a whole: `settled ++ holdback` is
+  // [A, B, C] against the offered [X, A, B, C], and the only optimal alignment
+  // matches A, B and C at offsets 1, 2 and 3 -- so the seam sits at offset 1 and
+  // " X" is refused WITH the reproduction it hides behind. That is forced rather
+  // than incidental: the settled " A" is already in the caller's hands and
+  // `confirmed_words_slice()` is append-only, so " X" can go neither before it
+  // nor after it. Take the reproduction away and the choice disappears, which is
+  // what `an_insertion_that_reproduces_nothing_confirmed_keeps_its_word` pins
+  // from the other side.
   //
   //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
-  //   ingest    [X@0.0, A@0.0, B@0.0, C@1.0]
-  //   TODAY     " A X A B C"   <- " A" confirmed twice; asserted below
-  //   CORRECT   " A B C"
+  //   ingest    [X@0.0, A@0.0, B@0.0, C@1.0]  ->  " A B C", " A" once
+  //
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back " A X A B C" -- the answer the ledger recorded while #94 was open.
   let a = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0); // tied start with A
   let c = || word(" C", 1.0, 2.0);
   let x = || word(" X", 0.0, 0.3); // an insertion at that same instant
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
   assert!(
     agreement
-      .ingest(result_with_words(vec![a(), b(), c()]))
+      .ingest_streamed(result_with_words(vec![a(), b(), c()]))
       .is_advanced()
   );
   assert_eq!(
@@ -930,49 +1033,48 @@ fn an_insertion_before_a_reproduced_confirmed_word_reconfirms_it_today() {
     "confirmed [A], holding [B, C] at a 0.0 s watermark",
   );
 
-  agreement.ingest(result_with_words(vec![x(), a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![x(), a(), b(), c()]));
 
   let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
   assert_eq!(
     final_result.text(),
-    " A X A B C",
-    "CHARACTERIZATION of open defect #94, not a requirement -- this is what the \
-     re-admission rule produces today. CORRECT is \" A B C\": the settled A wins \
-     the instant it was confirmed at, and the insertion is not smuggled in \
-     beside it. RED here means you fixed #94 -- change this expectation to \
-     \" A B C\" and the count below to 1.",
+    " A B C",
+    "the settled A wins the instant it was confirmed at, and the insertion is \
+     not smuggled in beside it",
   );
   assert_eq!(
     final_result.text().matches('A').count(),
-    2,
-    "CHARACTERIZATION of open defect #94: \" A\" reaches the transcript TWICE \
-     today. CORRECT is 1. Text: {:?}",
+    1,
+    "\" A\" reaches the transcript exactly once. Text: {:?}",
     final_result.text(),
   );
 }
 
 #[test]
-fn an_insertion_before_a_reproduced_confirmed_word_reconfirms_it_on_the_advance_today() {
-  // OPEN. The same defect WITHOUT `finalize`: `ingest`'s advance folds
+fn an_insertion_before_a_reproduced_confirmed_word_is_refused_on_the_advance() {
+  // #94, the same defect WITHOUT `finalize`. `ingest`'s advance folds
   // `common[..split]` -- a slice of `hypothesis_words` -- straight into
-  // `confirmed_words`. Two consecutive hypotheses that both insert ahead of the
-  // reproduced confirmed word agree on the whole insertion, so the duplicate
-  // reaches `confirmed_words_slice()` on the streaming path a caller reads
-  // between pushes, not only in the finalized text. Fixing `finalize` alone
-  // would not reach this one.
+  // `confirmed_words`, so two consecutive hypotheses that both insert ahead of
+  // the reproduced confirmed word used to agree on the whole insertion and put
+  // the duplicate into `confirmed_words_slice()`, the face a streaming caller
+  // reads between pushes. Fixing `finalize` alone would never have reached this
+  // one, which is why the ledger pins both paths.
+  //
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back [" A", " X", " A"] -- the answer the ledger recorded while #94 was open.
   //
   //   ingest [A,B,C] [A,B,C] [X,A,B,C] [X,A,B,C]  (all tied at 0.0 but C)
-  //   TODAY     confirmed_words_slice() == [" A", " X", " A"]
-  //   CORRECT   [" A"]
+  //   confirmed_words_slice() == [" A"]
   let a = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0);
   let c = || word(" C", 1.0, 2.0);
   let x = || word(" X", 0.0, 0.3);
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest(result_with_words(vec![x(), a(), b(), c()]));
-  agreement.ingest(result_with_words(vec![x(), a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![x(), a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![x(), a(), b(), c()]));
 
   assert_eq!(
     agreement
@@ -980,75 +1082,86 @@ fn an_insertion_before_a_reproduced_confirmed_word_reconfirms_it_on_the_advance_
       .iter()
       .map(WordTiming::word)
       .collect::<Vec<_>>(),
-    vec![" A", " X", " A"],
-    "CHARACTERIZATION of open defect #94, not a requirement -- no finalize \
-     involved, so fixing `finalize` alone would not reach this one. CORRECT is \
-     [\" A\"]: the advance path must not re-confirm A either. RED here means you \
-     fixed #94 -- change this expectation to vec![\" A\"].",
+    vec![" A"],
+    "the advance path must not re-confirm A either",
   );
 }
 
 #[test]
-fn a_holdback_over_a_reproduced_confirmed_word_reconfirms_it_today() {
-  // OPEN. The sibling at `finalize`'s OTHER append: `confirmed_words.append(&mut
+fn a_holdback_over_a_reproduced_confirmed_word_keeps_the_settled_span() {
+  // #94 at `finalize`'s OTHER append: `confirmed_words.append(&mut
   // last_agreed_words)`. `last_agreed_words` is `common[split..]`, itself a
-  // slice of `hypothesis_words`, so an already-confirmed word the strip missed
-  // reaches `confirmed_words` through the HOLDBACK rather than through the
-  // divergence branch. With `split == 0` nothing is confirmed at the advance and
-  // the whole agreed prefix -- insertion and re-admitted " A" alike -- is held
-  // back, then flushed by `finalize`.
+  // slice of `hypothesis_words`, so an already-confirmed word the old strip
+  // missed reached `confirmed_words` through the HOLDBACK rather than through
+  // the `holdback_superseded` branch: with `split == 0` nothing is confirmed at
+  // the advance and the whole agreed prefix -- insertion and re-admitted " A"
+  // alike -- was held back and then flushed, reading back " A X A" and losing
+  // " B C" with it.
+  //
+  // Under the frontier rule these two hypotheses offer NOTHING past the seam:
+  // aligning [A, B, C] against [X, A] matches only the A at offset 1, so the
+  // seam is at offset 2 and `hypothesis_words` is empty. They therefore disagree
+  // with the holdback, and an empty `hypothesis_words` is exactly the case
+  // `a_final_hypothesis_with_nothing_past_the_watermark_keeps_the_holdback`
+  // guards: nothing supersedes the holdback, so it is still flushed.
   //
   //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
-  //   ingest    [X@0.0, A@0.0] twice -- they agree on [X, A], split is 0
-  //   TODAY     " A X A"       <- " A" confirmed twice, " B C" lost with it
-  //   CORRECT   " A B C"
+  //
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back " A X A" -- the answer the ledger recorded while #94 was open.
+  //   ingest    [X@0.0, A@0.0] twice  ->  " A B C"
   let a = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0);
   let c = || word(" C", 1.0, 2.0);
   let x = || word(" X", 0.0, 0.3);
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
-  // Two hypotheses that agree on exactly [X, A]: `split` is 0, so the pair lands
-  // in the holdback rather than in `confirmed_words`.
-  agreement.ingest(result_with_words(vec![x(), a()]));
-  agreement.ingest(result_with_words(vec![x(), a()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![x(), a()]));
+  agreement.ingest_streamed(result_with_words(vec![x(), a()]));
 
   let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
   assert_eq!(
     final_result.text(),
-    " A X A",
-    "CHARACTERIZATION of open defect #94, not a requirement -- this is what the \
-     holdback flushes today. CORRECT is \" A B C\": the holdback must not flush a \
-     second copy of the confirmed A, and it must not lose \" B C\" doing it. RED \
-     here means you fixed #94 -- change this expectation to \" A B C\".",
+    " A B C",
+    "the holdback must not flush a second copy of the confirmed A, and it must \
+     not lose \" B C\" doing it",
   );
 }
 
 #[test]
-fn a_different_suffix_over_a_reproduced_confirmed_word_reconfirms_it_today() {
-  // OPEN. The sibling at `finalize`'s THIRD append: `find_longest_different_suffix(
-  // &prev_words, &hypothesis_words)`, also a slice of `hypothesis_words`. Here
-  // the re-admitted " A" sits PAST the common prefix -- two hypotheses agree on
-  // an inserted [P, Q] and then diverge, and the newer one's reproduction of the
-  // confirmed " A" rides in on the differing suffix.
+fn a_different_suffix_over_a_reproduced_confirmed_word_keeps_the_settled_span() {
+  // #94 at `finalize`'s THIRD append: `find_longest_different_suffix(&prev_words,
+  // &hypothesis_words)`, also a slice of `hypothesis_words`. Here the
+  // re-admitted " A" sat PAST the common prefix -- two hypotheses agree on an
+  // inserted [P, Q] and then diverge, and the newer one's reproduction of the
+  // confirmed " A" rode in on the differing suffix, reading back " A P Q A".
+  //
+  // The frontier rule refuses [P, Q, A] wholesale: aligning [A, B, C] against
+  // [P, Q, A] matches only the A at offset 2, so the seam is at offset 3.
+  // Refusing " P" and " Q" is the same forced choice as
+  // `an_insertion_before_a_reproduced_confirmed_word_is_refused_with_it` -- they
+  // sit ahead of a reproduction of a word the caller already holds.
   //
   //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
-  //   ingest    [P@0.0, Q@0.0, Z@0.0] then [P@0.0, Q@0.0, A@0.0]
-  //   TODAY     " A P Q A"     <- " A" confirmed twice
-  //   CORRECT   " A B C"
+  //
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back " A P Q A" -- the answer the ledger recorded while #94 was open.
+  //   ingest    [P@0.0, Q@0.0, Z@0.0] then [P@0.0, Q@0.0, A@0.0]  ->  " A B C"
   let a = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0);
   let c = || word(" C", 1.0, 2.0);
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest(result_with_words(vec![
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![
     word(" P", 0.0, 0.1),
     word(" Q", 0.0, 0.2),
     word(" Z", 0.0, 0.3),
   ]));
-  agreement.ingest(result_with_words(vec![
+  agreement.ingest_streamed(result_with_words(vec![
     word(" P", 0.0, 0.1),
     word(" Q", 0.0, 0.2),
     a(),
@@ -1057,11 +1170,8 @@ fn a_different_suffix_over_a_reproduced_confirmed_word_reconfirms_it_today() {
   let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
   assert_eq!(
     final_result.text(),
-    " A P Q A",
-    "CHARACTERIZATION of open defect #94, not a requirement -- this is what the \
-     differing suffix flushes today. CORRECT is \" A B C\": the differing suffix \
-     must not flush a second copy of the confirmed A. RED here means you fixed \
-     #94 -- change this expectation to \" A B C\".",
+    " A B C",
+    "the differing suffix must not flush a second copy of the confirmed A",
   );
 }
 
@@ -1077,10 +1187,14 @@ fn a_later_re_use_of_a_confirmed_word_is_not_mistaken_for_a_re_admission() {
   // " C" down with it. That is the failure mode a stricter replacement rule has
   // to avoid, which is why this pin is green rather than ignored.
   //
-  // Mutation proof: scan the whole offered list for the last text match
+  // Mutation proof: drop the HOLDBACK from the alignment (align `settled`
+  // alone) and this reads back " A D E" -- " B" and " C", agreed by both
+  // hypotheses, gone. Without the holdback to score against, matching the
+  // settled " A" at offset 2 is the alignment's whole objective, so the seam
+  // lands behind it. That is the identical answer the naive rposition scan gave
   // (`filtered.iter().rposition(|w| candidates.contains(&normalized(w.word())))
-  // .map_or(0, |i| i + 1)`) and this reads back " A D E" -- " B" and " C",
-  // agreed by both hypotheses, gone.
+  // .map_or(0, |i| i + 1)`), which is the point: what keeps the frontier off
+  // the later occurrence is the holdback, not the search.
   let a0 = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0); // tied start with the confirmed A
   let c = || word(" C", 1.0, 2.0);
@@ -1088,10 +1202,10 @@ fn a_later_re_use_of_a_confirmed_word_is_not_mistaken_for_a_re_admission() {
   let d = || word(" D", 3.0, 3.5);
   let e = || word(" E", 4.0, 4.5);
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![a0(), b(), c()]));
-  agreement.ingest(result_with_words(vec![a0(), b(), c()]));
-  agreement.ingest(result_with_words(vec![b(), c(), a2(), d()]));
-  agreement.ingest(result_with_words(vec![b(), c(), a2(), d(), e()]));
+  agreement.ingest_streamed(result_with_words(vec![a0(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a0(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![b(), c(), a2(), d()]));
+  agreement.ingest_streamed(result_with_words(vec![b(), c(), a2(), d(), e()]));
 
   let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
   assert_eq!(
@@ -1112,7 +1226,7 @@ fn a_later_re_use_of_a_confirmed_word_is_not_mistaken_for_a_re_admission() {
 /// still at or past it.
 fn tied_pair_confirmed() -> LocalAgreement {
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![
+  agreement.ingest_streamed(result_with_words(vec![
     tied_a(),
     tied_b(),
     tied_c(),
@@ -1120,7 +1234,7 @@ fn tied_pair_confirmed() -> LocalAgreement {
   ]));
   assert!(
     agreement
-      .ingest(result_with_words(vec![
+      .ingest_streamed(result_with_words(vec![
         tied_a(),
         tied_b(),
         tied_c(),
@@ -1154,71 +1268,83 @@ fn tied_d() -> WordTiming {
 }
 
 #[test]
-fn a_confirmed_tail_reproduced_without_its_head_is_reconfirmed_today() {
-  // OPEN (codex round 2, counterexample 1) -- the CONFIRMED-TAIL OMISSION.
-  // `watermark_filtered_with` compares the confirmed tail from ITS OWN front, so
-  // a hypothesis that OMITS " A" and reproduces only " B" mismatches at offset 0,
-  // strips nothing, and " B" rides through into `hypothesis_words`.
+fn a_confirmed_tail_reproduced_without_its_head_is_still_refused() {
+  // #94 (codex round 2, counterexample 1) -- the CONFIRMED-TAIL OMISSION. The
+  // old strip compared the confirmed tail from ITS OWN front, so a hypothesis
+  // that OMITS " A" and reproduces only " B" mismatched at offset 0, stripped
+  // nothing, and " B" rode through into `hypothesis_words` for " A B B C D".
+  //
+  // A deletion costs the frontier alignment nothing beyond the match it forgoes:
+  // [A, B, C, D] against [B, C, D] simply drops the A, matches B/C/D at offsets
+  // 0/1/2, and puts the seam after offset 0. The reproduction is refused even
+  // though it does not start where the confirmed tail does.
   //
   //   confirmed [A@0.0, B@0.0], holding [C@0.0, D@1.0], watermark 0.0
-  //   ingest    [B@0.0, C@0.0, D@1.0]
-  //   TODAY     " A B B C D"   <- " B" confirmed twice
-  //   CORRECT   " A B C D"
+  //
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back " A B B C D" -- the answer the ledger recorded while #94 was open.
+  //   ingest    [B@0.0, C@0.0, D@1.0]  ->  " A B C D"
   let mut agreement = tied_pair_confirmed();
-  agreement.ingest(result_with_words(vec![tied_b(), tied_c(), tied_d()]));
+  agreement.ingest_streamed(result_with_words(vec![tied_b(), tied_c(), tied_d()]));
   let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
   assert_eq!(
     final_result.text(),
-    " A B B C D",
-    "CHARACTERIZATION of open defect #94, not a requirement -- this is what the \
-     confirmed-tail omission produces today. CORRECT is \" A B C D\": the \
-     confirmed B must not be confirmed a second time by a reproduction that \
-     skipped A. RED here means you fixed #94 -- change this expectation to \
-     \" A B C D\".",
+    " A B C D",
+    "the confirmed B must not be confirmed a second time by a reproduction \
+     that skipped A",
   );
 }
 
 #[test]
-fn a_confirmed_tail_reproduced_without_its_head_is_reconfirmed_on_the_advance_today() {
-  // OPEN. The same omission WITHOUT `finalize`. Repeating the hypothesis makes
-  // the two agree, and `ingest`'s advance folds `common[..split]` -- which still
-  // carries the reproduced " B" -- straight into the caller-visible
-  // `confirmed_words_slice()` a streaming caller reads between pushes.
+fn a_confirmed_tail_reproduced_without_its_head_is_still_refused_on_the_advance() {
+  // #94, the same omission WITHOUT `finalize`. Repeating the hypothesis makes
+  // the two agree, and `ingest`'s advance folds `common[..split]` straight into
+  // the caller-visible `confirmed_words_slice()` a streaming caller reads
+  // between pushes -- so this path needs its own pin.
+  //
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back [" A", " B", " B"] -- the answer the ledger recorded while #94 was open.
   //
   //   ingest [B,C,D] twice on top of the same history
-  //   TODAY     confirmed_words_slice() == [" A", " B", " B"]
-  //   CORRECT   [" A", " B"]
+  //   confirmed_words_slice() == [" A", " B"]
   let mut agreement = tied_pair_confirmed();
-  agreement.ingest(result_with_words(vec![tied_b(), tied_c(), tied_d()]));
-  agreement.ingest(result_with_words(vec![tied_b(), tied_c(), tied_d()]));
+  agreement.ingest_streamed(result_with_words(vec![tied_b(), tied_c(), tied_d()]));
+  agreement.ingest_streamed(result_with_words(vec![tied_b(), tied_c(), tied_d()]));
   assert_eq!(
     agreement
       .confirmed_words_slice()
       .iter()
       .map(WordTiming::word)
       .collect::<Vec<_>>(),
-    vec![" A", " B", " B"],
-    "CHARACTERIZATION of open defect #94, not a requirement -- no finalize \
-     involved, so fixing `finalize` alone would not reach this one. CORRECT is \
-     [\" A\", \" B\"]: the advance path must not re-confirm B either. RED here \
-     means you fixed #94 -- change this expectation to vec![\" A\", \" B\"].",
+    vec![" A", " B"],
+    "the advance path must not re-confirm B either",
   );
 }
 
 #[test]
-fn a_reproduction_behind_a_shorter_false_match_is_reconfirmed_today() {
-  // OPEN (codex round 2, counterexample 2) -- the PARTIAL FRONT MATCH.
-  // `watermark_filtered_with` zips the confirmed tail [A, B] against the offered
-  // list, matches " A" at offset 0, mismatches " B" against the inserted " X",
-  // and stops -- so it strips one word and lets the real, longer " A B"
-  // reproduction sitting at offset 2 ride through.
+fn a_reproduction_behind_a_shorter_false_match_is_still_refused() {
+  // #94 (codex round 2, counterexample 2) -- the PARTIAL FRONT MATCH. The old
+  // strip zipped the confirmed tail [A, B] against the offered list, matched
+  // " A" at offset 0, mismatched " B" against the inserted " X", and stopped --
+  // stripping one word and letting the real, longer " A B" reproduction at
+  // offset 2 ride through, for " A B X A B C D".
+  //
+  // The frontier alignment has no front to be trapped at. [A, B, C, D] against
+  // [A, X, A, B, C, D] scores four matches only by taking B at offset 3 (there
+  // is no other B), so every optimal alignment puts the seam after it: the
+  // frontier is 4 and the false match, the insertion and the real reproduction
+  // are all refused together.
   //
   //   confirmed [A@0.0, B@0.0], holding [C@0.0, D@1.0], watermark 0.0
-  //   ingest    [A@0.0, X@0.0, A@0.0, B@0.0, C@0.0, D@1.0]
-  //   TODAY     " A B X A B C D"   <- " A" and " B" confirmed twice
-  //   CORRECT   " A B C D"
+  //
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back " A B X A B C D" -- the answer the ledger recorded while #94 was open.
+  //   ingest    [A@0.0, X@0.0, A@0.0, B@0.0, C@0.0, D@1.0]  ->  " A B C D"
   let mut agreement = tied_pair_confirmed();
-  agreement.ingest(result_with_words(vec![
+  agreement.ingest_streamed(result_with_words(vec![
     tied_a(),
     word(" X", 0.0, 0.3),
     tied_a(),
@@ -1229,22 +1355,23 @@ fn a_reproduction_behind_a_shorter_false_match_is_reconfirmed_today() {
   let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
   assert_eq!(
     final_result.text(),
-    " A B X A B C D",
-    "CHARACTERIZATION of open defect #94, not a requirement -- this is what the \
-     partial front match produces today. CORRECT is \" A B C D\": the longer \
-     reproduction behind the false match must still be stripped. RED here means \
-     you fixed #94 -- change this expectation to \" A B C D\".",
+    " A B C D",
+    "the longer reproduction behind the false match is stripped too",
   );
 }
 
 #[test]
-fn a_reproduction_behind_a_shorter_false_match_is_reconfirmed_on_the_advance_today() {
-  // OPEN. The same partial front match WITHOUT `finalize` -- two hypotheses that
-  // agree on the whole `[A, X, A, B]` run advance, and `common[..split]` carries
-  // both already-confirmed words into `confirmed_words_slice()`.
+fn a_reproduction_behind_a_shorter_false_match_is_still_refused_on_the_advance() {
+  // #94, the same partial front match WITHOUT `finalize` -- two hypotheses that
+  // agree on the whole `[A, X, A, B]` run used to advance, carrying both
+  // already-confirmed words into `confirmed_words_slice()`.
   //
-  //   TODAY     confirmed_words_slice() == [" A", " B", " X", " A", " B"]
-  //   CORRECT   [" A", " B"]
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back [" A", " B", " X", " A", " B"] -- the answer the ledger recorded while
+  // #94 was open.
+  //
+  //   confirmed_words_slice() == [" A", " B"]
   let hypothesis = || {
     result_with_words(vec![
       tied_a(),
@@ -1256,20 +1383,16 @@ fn a_reproduction_behind_a_shorter_false_match_is_reconfirmed_on_the_advance_tod
     ])
   };
   let mut agreement = tied_pair_confirmed();
-  agreement.ingest(hypothesis());
-  agreement.ingest(hypothesis());
+  agreement.ingest_streamed(hypothesis());
+  agreement.ingest_streamed(hypothesis());
   assert_eq!(
     agreement
       .confirmed_words_slice()
       .iter()
       .map(WordTiming::word)
       .collect::<Vec<_>>(),
-    vec![" A", " B", " X", " A", " B"],
-    "CHARACTERIZATION of open defect #94, not a requirement -- no finalize \
-     involved, so fixing `finalize` alone would not reach this one. CORRECT is \
-     [\" A\", \" B\"]: the advance path must not re-confirm A or B either. RED \
-     here means you fixed #94 -- change this expectation to \
-     vec![\" A\", \" B\"].",
+    vec![" A", " B"],
+    "the advance path must not re-confirm A or B either",
   );
 }
 
@@ -1277,20 +1400,21 @@ fn a_reproduction_behind_a_shorter_false_match_is_reconfirmed_on_the_advance_tod
 // What the re-admission rule must NOT break
 // ---------------------------------------------------------------------
 //
-// The three pins below are green on this tree AND on `main`: they are the
-// constraints any replacement rule has to keep satisfying, recorded next to the
-// characterizations above so a future fix is measured against both halves at
-// once -- the ten go RED when #94 is fixed, these three must STAY green.
-// Deleting a word the stream genuinely produced is the failure mode a
-// stricter rule falls into, and it is worse than the duplication above --
-// `tests/whisper/streaming.rs`'s portable prefix property tolerates a
-// truncation and forbids a rewrite.
+// The pins below were green on `main` and on every defeated candidate rule, and
+// they are green on the frontier rule: they are the constraints a replacement
+// has to keep satisfying, recorded next to the ledger above so any future change
+// is measured against both halves at once. Deleting a word the stream genuinely
+// produced is the failure mode a stricter rule falls into, and it is worse than
+// the duplication the ledger records -- `tests/whisper/streaming.rs`'s portable
+// prefix property tolerates a truncation and forbids a rewrite. That asymmetry
+// is why the frontier rule breaks an ambiguous seam toward KEEPING: it refuses
+// only the offered prefix every optimal alignment settles.
 
 #[test]
 fn a_stutter_at_the_watermark_keeps_both_occurrences() {
-  // Codex round 3, finding 2, first half -- the half `watermark_filtered` gets
-  // right, kept green so the characterized second half
-  // (`a_distinct_repetition_of_a_confirmed_word_is_deleted_by_the_continuing_stream_today`)
+  // Codex round 3, finding 2, first half -- the half every candidate rule got
+  // right, kept green so the second half
+  // (`a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream`)
   // is pinned from both ends. A hypothesis that STUTTERS at the watermark's own
   // instant -- " A" twice, same text, same start, same end -- straddles the
   // advance's split: the first " A" is confirmed, the second is held back, and
@@ -1298,9 +1422,10 @@ fn a_stutter_at_the_watermark_keeps_both_occurrences() {
   // reproduction of the word just confirmed, which is why the rule must not run
   // a second time over words a first pass already cleared.
   //
-  // Mutation proof: re-run `watermark_filtered_with`'s strip over `finalize`'s
-  // flushed words (the tempting "defence in depth") and this reads back " A B",
-  // one " A" short.
+  // Mutation proof: run `settled_frontier` a second time over `finalize`'s
+  // flushed holdback (the tempting "defence in depth") and this reads back
+  // " A B", one " A" short -- the frontier must be taken once, on the offered
+  // list, and never again on words a first pass already cleared.
   let hypothesis = || {
     result_with_words(vec![
       word(" A", 0.0, 0.5),
@@ -1309,8 +1434,8 @@ fn a_stutter_at_the_watermark_keeps_both_occurrences() {
     ])
   };
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(hypothesis());
-  assert!(agreement.ingest(hypothesis()).is_advanced());
+  agreement.ingest_streamed(hypothesis());
+  assert!(agreement.ingest_streamed(hypothesis()).is_advanced());
   assert_eq!(
     agreement
       .finalize(&crate::audio::whisper::options::DecodingOptions::new())
@@ -1331,35 +1456,77 @@ fn confirmed_texts(agreement: &LocalAgreement) -> Vec<&str> {
     .collect()
 }
 
+/// `pending_words_slice()` as text — the agreed-but-not-yet-irrevocable head of
+/// the holdback. Always read in the SAME assertion as `confirmed_texts`, so the
+/// boundary between the two is pinned rather than implied: a mutation that moves
+/// a word across it fails the pair even though the concatenation is unchanged.
+fn pending_texts(agreement: &LocalAgreement) -> Vec<&str> {
+  agreement
+    .pending_words_slice()
+    .iter()
+    .map(WordTiming::word)
+    .collect()
+}
+
 #[test]
-fn a_distinct_repetition_of_a_confirmed_word_is_deleted_by_the_continuing_stream_today() {
-  // OPEN (codex round 3, finding 2) -- the ledger's OTHER face, a DELETION
-  // rather than a duplication, and the reason a stricter text-matching rule is
-  // not the fix. A hypothesis that STUTTERS at the watermark's own instant
-  // straddles the advance: the first " A" is confirmed and the second -- a
-  // DISTINCT occurrence with identical text, start and end -- is held back.
-  // Every later hypothesis correctly omits the confirmed one and re-offers the
-  // held-back one; `watermark_filtered_with` reads that survivor as a
-  // reproduction (it IS a front-of-list text match) and strips it on every
-  // filter, and the next advance moves the watermark past it.
+fn a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream() {
+  // #94 (codex round 3, finding 2) -- the ledger's OTHER face, a DELETION rather
+  // than a duplication, and the reason a stricter TEXT-MATCHING rule was never
+  // the fix. A hypothesis that STUTTERS at the watermark's own instant straddles
+  // the advance: the first " A" is confirmed and the second -- a DISTINCT
+  // occurrence with identical text, start and end -- is held back. Every later
+  // hypothesis correctly omits the confirmed one and re-offers the held-back
+  // one; the old strip read that survivor as a reproduction (it IS a
+  // front-of-list text match) and stripped it on every filter, and the next
+  // advance moved the watermark past it.
   //
-  // This is the two-run construction from the issue, live: a run of ` A A B` and
-  // a run of ` A B C` reach byte-identical (confirmed, offered, watermark) here
-  // and need OPPOSITE answers, so no predicate over those three can be right.
+  // This is the issue's two-run construction, live: a run of ` A A B` and a run
+  // of ` A B C` reach byte-identical (confirmed, offered, watermark) and need
+  // OPPOSITE answers, so no predicate over those three can be right. What
+  // separates them is the HOLDBACK -- `[A, B]` here against `[B, C]` there --
+  // and the frontier rule reads it, because it aligns `settled ++ holdback` as a
+  // whole. [A, A, B] against [A, B, C, D] scores two matches with the seam at
+  // either offset 0 or offset 1, so the seam is AMBIGUOUS; taking the smallest
+  // keeps the leading " A", which is the stream's own second occurrence.
+  //
+  // Round 5, finding 1 re-reported THIS sequence -- the same two ingests, the
+  // same two optimal seams, the same [" A", " A", " B"] -- and argued the other
+  // reading: that the offered " A" is the SETTLED one coming back and the
+  // provisional " A" was deleted, so seam 1 is right and the minimum rule
+  // duplicates a word. That reading is refuted by how the offered list is
+  // produced, not by this bias. `decoding_options_for_next` prefills the decoder
+  // with the holdback's own tokens and `decode_text` forces every prompt
+  // position, so a hypothesis decoded from those options BEGINS with the
+  // provisional " A"; deleting it would mean dropping a token the decoder was
+  // fed rather than asked for. The minimum seam is that reading.
+  // `the_next_strides_prefill_is_the_holdback_verbatim` pins the contract, and
+  // `LocalAgreement::watermark_filtered`'s "Ambiguity rule" carries why blocking
+  // on the tie instead would deadlock this exact shape on every stride.
+  //
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back [" A", " B"] -- the answer the ledger recorded while #94 was open.
+  // Two more, for the two halves of the rule this one turns on. Take the
+  // LARGEST optimal seam instead of the smallest and it reads back [" A", " B"]
+  // again -- the ambiguity is real, and the direction the tie breaks IS the
+  // answer. Drop the holdback from the alignment (align `settled` alone) and it
+  // reads back [" A", " B"] once more, because the holdback is the only thing
+  // that separates this run from the one in the issue's table. That same
+  // mutation takes the sibling pin
+  // `a_later_re_use_of_a_confirmed_word_is_not_mistaken_for_a_re_admission`
+  // down to " A D E" -- the naive-scan failure, from the other direction.
   //
   //   ingest    [A@0.0, A@0.0, B@1.0] twice -> confirmed [A], holding [A, B]
   //   then      [A@0.0, B@1.0, C@2.0, D@3.0] twice
-  //   TODAY     confirmed_words_slice() == [" A", " B"]
-  //             <- the stream's second " A" is deleted; text " A B C D"
-  //   CORRECT   [" A", " A", " B"], text " A A B C D"
+  //   confirmed_words_slice() == [" A", " A", " B"], text " A A B C D"
   let a = || word(" A", 0.0, 0.5);
   let b = || word(" B", 1.0, 1.5);
   let c = || word(" C", 2.0, 2.5);
   let d = || word(" D", 3.0, 3.5);
   let stutter = || result_with_words(vec![a(), a(), b()]);
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(stutter());
-  assert!(agreement.ingest(stutter()).is_advanced());
+  agreement.ingest_streamed(stutter());
+  assert!(agreement.ingest_streamed(stutter()).is_advanced());
   assert_eq!(
     confirmed_texts(&agreement),
     vec![" A"],
@@ -1368,53 +1535,60 @@ fn a_distinct_repetition_of_a_confirmed_word_is_deleted_by_the_continuing_stream
 
   // The stream CONTINUES past that advance -- which is exactly what
   // `a_stutter_at_the_watermark_keeps_both_occurrences` does not do, and why
-  // that green pin cannot see this.
+  // that pin cannot see this.
   let onward = || result_with_words(vec![a(), b(), c(), d()]);
-  agreement.ingest(onward());
-  assert!(agreement.ingest(onward()).is_advanced());
+  agreement.ingest_streamed(onward());
+  assert!(agreement.ingest_streamed(onward()).is_advanced());
   assert_eq!(
     confirmed_texts(&agreement),
-    vec![" A", " B"],
-    "CHARACTERIZATION of open defect #94, not a requirement -- the stream's own \
-     second \" A\" is DELETED today, the ledger's other face. CORRECT is \
-     [\" A\", \" A\", \" B\"]: the held-back A is the stream's own second \
-     occurrence, not a re-offer of the confirmed first one. RED here means you \
-     fixed #94 -- change this expectation to vec![\" A\", \" A\", \" B\"].",
+    vec![" A", " A", " B"],
+    "the held-back A is the stream's own second occurrence, not a re-offer of \
+     the confirmed first one",
   );
 
   assert_eq!(
     agreement
       .finalize(&crate::audio::whisper::options::DecodingOptions::new())
       .text(),
-    " A B C D",
-    "CHARACTERIZATION of open defect #94, not a requirement. CORRECT is \
-     \" A A B C D\" -- both occurrences the stream produced. RED here means you \
-     fixed #94 -- change this expectation to \" A A B C D\".",
+    " A A B C D",
+    "both occurrences the stream produced",
   );
 }
 
 #[test]
-fn a_reproduction_shifted_off_the_watermark_is_reconfirmed_today() {
-  // OPEN (codex round 3, finding 1; re-reported verbatim as ROUND 4, FINDING 1
-  // -- "F1 as reported" in the round-4 measurement, where `main` and the
+fn a_reproduction_shifted_off_the_watermark_is_still_refused() {
+  // #94 (codex round 3, finding 1; re-reported verbatim as ROUND 4, FINDING 1 --
+  // "F1 as reported" in the round-4 three-tree measurement, where `main` and the
   // apparatus branch were byte-identical at every ingest). The re-decode nudges
   // every word a hair PAST the 0.0 s watermark and inserts " X" ahead of the
-  // reproduced " A", so nothing the hypothesis offers matches the confirmed tail
-  // at offset 0 and the strip is 0. Two such hypotheses agree with each other
-  // and confirm [X, A] on top of the settled A.
+  // reproduced " A", so nothing the hypothesis offered matched the confirmed
+  // tail at offset 0, the old strip was 0, and two such hypotheses agreed with
+  // each other and confirmed [X, A] on top of the settled A.
+  //
+  // This is also why the frontier rule reads TEXT and not timestamps. The
+  // defeated approach 3 drew a match window from the watermark, and this exact
+  // sequence escaped it by sitting a hundredth of a second outside; a re-decode
+  // is free to move every timestamp it emits, so timings are evidence about the
+  // span, not about occurrence identity within it. The alignment of [A, B, C]
+  // against [X, A, B, C] does not care where the words landed: its only optimal
+  // reading matches A/B/C at offsets 1/2/3, seam at 1.
   //
   //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
+  //
+  // Mutation proof: put the old leading-run strip back in place of the frontier
+  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
+  // back [" A", " X", " A"] -- the answer the ledger recorded while #94 was open.
+  //
   //   ingest    [X@0.01, A@0.02, B@1.0, C@2.0] twice
-  //   TODAY     confirmed_words_slice() == [" A", " X", " A"], text " A X A B C"
-  //   CORRECT   [" A"], text " A B C"
+  //   confirmed_words_slice() == [" A"], text " A B C"
   let a = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0); // tied start with A: the watermark stays 0.0
   let c = || word(" C", 1.0, 2.0);
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
   assert!(
     agreement
-      .ingest(result_with_words(vec![a(), b(), c()]))
+      .ingest_streamed(result_with_words(vec![a(), b(), c()]))
       .is_advanced()
   );
   assert_eq!(
@@ -1431,32 +1605,24 @@ fn a_reproduction_shifted_off_the_watermark_is_reconfirmed_today() {
       word(" C", 2.0, 2.5),
     ])
   };
-  agreement.ingest(shifted());
-  agreement.ingest(shifted());
+  agreement.ingest_streamed(shifted());
+  agreement.ingest_streamed(shifted());
   assert_eq!(
     confirmed_texts(&agreement),
-    vec![" A", " X", " A"],
-    "CHARACTERIZATION of open defect #94, not a requirement -- this is what the \
-     shifted reproduction reaches the confirmed list as today. CORRECT is \
-     [\" A\"]: it must not reach the confirmed list on the advance path either. \
-     RED here means you fixed #94 -- change this expectation to vec![\" A\"].",
+    vec![" A"],
+    "the shifted reproduction must not reach the confirmed list on the advance \
+     path either",
   );
 
   let text = agreement
     .finalize(&crate::audio::whisper::options::DecodingOptions::new())
     .text()
     .to_string();
-  assert_eq!(
-    text, " A X A B C",
-    "CHARACTERIZATION of open defect #94, not a requirement. CORRECT is \
-     \" A B C\". RED here means you fixed #94 -- change this expectation to \
-     \" A B C\" and the count below to 1.",
-  );
+  assert_eq!(text, " A B C");
   assert_eq!(
     text.matches('A').count(),
-    2,
-    "CHARACTERIZATION of open defect #94: \" A\" reaches the transcript TWICE \
-     today. CORRECT is 1. Text: {text:?}",
+    1,
+    "\" A\" reaches the transcript exactly once. Text: {text:?}",
   );
 }
 
@@ -1471,28 +1637,33 @@ fn an_insertion_that_reproduces_nothing_confirmed_keeps_its_word() {
   // refusing " X" would be an unforced deletion. Here two hypotheses insert " X"
   // ahead of the held-back [B, C] and reproduce nothing confirmed.
   //
-  // Mutation proof: replace the strip with the unconditional count-skip
-  // (`let strip = readmit_candidates.len().min(filtered.len());`) and
-  // `confirmed_words_slice()` reads back [" A", " B"] -- " X", agreed on by both
-  // hypotheses and contradicting nothing, gone. Same mutation as
-  // `omitting_a_confirmed_tied_word_does_not_drop_provisional_words`, from the
-  // opposite direction: that one loses a word to an OMISSION shifting the
-  // hypothesis left, this one to an INSERTION shifting it right.
+  // This is also the direct falsifier for the frontier's TIE-BREAK. The seam
+  // here is ambiguous -- " X" matches nothing settled, so an optimal alignment
+  // may put it on either side -- and the smallest admissible seam keeps it.
+  //
+  // Mutation proof: take the LARGEST optimal seam instead of the smallest
+  // (`.rev()` on `settled_frontier`'s final `find`) and `confirmed_words_slice()`
+  // reads back [" A", " B"] -- " X", agreed on by both hypotheses and
+  // contradicting nothing, gone. That is the deletion the bias exists to
+  // avoid, and it is the same loss
+  // `omitting_a_confirmed_tied_word_does_not_drop_provisional_words` records
+  // from the opposite direction: that one loses a word to an OMISSION shifting
+  // the hypothesis left, this one to an INSERTION shifting it right.
   let a = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0); // tied start with A
   let c = || word(" C", 1.0, 2.0);
   let mut agreement = LocalAgreement::new();
-  agreement.ingest(result_with_words(vec![a(), b(), c()]));
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
   assert!(
     agreement
-      .ingest(result_with_words(vec![a(), b(), c()]))
+      .ingest_streamed(result_with_words(vec![a(), b(), c()]))
       .is_advanced()
   );
   assert_eq!(confirmed_texts(&agreement), vec![" A"]);
 
   let inserted = || result_with_words(vec![word(" X", 0.0, 0.3), b(), c(), word(" D", 2.0, 2.5)]);
-  agreement.ingest(inserted());
-  assert!(agreement.ingest(inserted()).is_advanced());
+  agreement.ingest_streamed(inserted());
+  assert!(agreement.ingest_streamed(inserted()).is_advanced());
   assert_eq!(
     confirmed_texts(&agreement),
     vec![" A", " X", " B"],
@@ -1503,5 +1674,2724 @@ fn an_insertion_that_reproduces_nothing_confirmed_keeps_its_word() {
       .finalize(&crate::audio::whisper::options::DecodingOptions::new())
       .text(),
     " A X B C D",
+  );
+}
+
+#[test]
+fn a_confirmed_word_from_before_the_watermark_is_out_of_the_alignment() {
+  // The third constraint, and the SCOPE of `settled`: only the trailing run of
+  // the confirmed list whose extent REACHES the watermark is aligned against the
+  // offered words. Confirmed words that end before it have another word's audio,
+  // or silence, between them and the re-decoded span, and putting them in the
+  // alignment would let them match a genuinely later re-use of the same text --
+  // taking the provisional words behind it down too, exactly the scan-based
+  // failure `a_later_re_use_of_a_confirmed_word_is_not_mistaken_for_a_re_admission`
+  // pins. That sibling cannot see this, because there the watermark is still
+  // 0.0 s and the trailing run IS the whole confirmed list; here the watermark
+  // has moved past " A" and the clip says " A" again at the new frontier.
+  //
+  // The GAPS below are load-bearing, and were not when this test was written:
+  // " B" ends at 0.9 with the watermark at 1.0, so it is out of scope by 0.1 s.
+  // Its sibling `a_re_utterance_separated_from_the_watermark_keeps_its_word`
+  // re-utters " B" rather than " A" and so pins that boundary directly; this
+  // one pins the word two places back, which stays out however the run's near
+  // end is drawn.
+  //
+  // Mutation proof: widen `settled` to the whole confirmed list
+  // (`let settled_len = confirmed.len();`) and the alignment matches the
+  // re-used " A" at offset 0 against the confirmed " A" at 0.0 s, putting the
+  // seam behind it -- `confirmed_words_slice()` reads back [" A", " B", " C"],
+  // the stream's second " A" deleted. Every other test in this module stays
+  // green under that mutation.
+  let a0 = || word(" A", 0.0, 0.4);
+  let b = || word(" B", 0.5, 0.9);
+  let c0 = || word(" C", 1.0, 1.4);
+  let d0 = || word(" D", 1.5, 1.9);
+  let mut agreement = LocalAgreement::new();
+  agreement.ingest_streamed(result_with_words(vec![a0(), b(), c0(), d0()]));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(vec![a0(), b(), c0(), d0()]))
+      .is_advanced()
+  );
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A", " B"],
+    "confirmed [A@0.0, B@0.5], holding [C@1.0, D@1.5] at a 1.0 s watermark",
+  );
+  assert!((agreement.last_agreed_seconds() - 1.0).abs() < 1e-6);
+
+  // The clip says " A" again, at the watermark itself -- a different word at a
+  // different instant, with the confirmed one two words behind the watermark.
+  let re_used = || {
+    result_with_words(vec![
+      word(" A", 1.0, 1.05),
+      word(" C", 1.1, 1.4),
+      word(" D", 1.5, 1.9),
+      word(" E", 2.0, 2.4),
+    ])
+  };
+  agreement.ingest_streamed(re_used());
+  assert!(agreement.ingest_streamed(re_used()).is_advanced());
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A", " B", " A", " C"],
+    "the later \" A\" is the stream's own, and costs nothing that follows it",
+  );
+  assert_eq!(
+    agreement
+      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+      .text(),
+    " A B A C D E",
+  );
+}
+
+// ---------------------------------------------------------------------
+// What the frontier rule deliberately LEAVES
+// ---------------------------------------------------------------------
+//
+// A documented residual with a test, rather than a claim of totality. See
+// `LocalAgreement::watermark_filtered`'s "What this deliberately leaves".
+
+#[test]
+fn an_unaccounted_repeat_of_a_settled_word_is_kept_as_the_streams_own() {
+  // RESIDUAL of #94, held open on purpose. The frontier rule aligns
+  // `settled ++ holdback` -- the engine's whole record of the span at and past
+  // the watermark -- against the offered words. When the offered list carries
+  // MORE copies of a settled word than that record accounts for, the surplus
+  // copy matches nothing on the settled side, no alignment can attribute it
+  // there, and it is kept: the transcript ends up with the settled " A" twice.
+  //
+  // That is not a missed case, it is the tie broken deliberately. The engine
+  // holds `settled = [A]`, `holdback = [B, C]`, offered `[A, A, B, C]`; the clip
+  // stuttering (" A A B C" is right) and the decode duplicating (" A B C" is
+  // right) produce byte-identical inputs, down to every `WordTiming` field. The
+  // holdback separates the issue's two-run construction, but it cannot separate
+  // THIS one -- the holdbacks are equal too. With nothing left to decide on, the
+  // rule keeps: `tests/whisper/streaming.rs`'s portable prefix property
+  // tolerates a truncation and forbids a rewrite, so a duplicate is the
+  // recoverable error and a deletion is not.
+  //
+  // Its mirror image is
+  // `a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream`:
+  // there the offered list carries FEWER copies than the record, the same tie is
+  // broken the same way, and keeping is the RIGHT answer. One rule, one bias,
+  // two truths -- which is exactly why the boundary is undecidable here and the
+  // bias is the whole of the answer.
+  //
+  // Refusing to advance instead would not help: this shape reproduces on every
+  // subsequent stride, `settled` and `holdback` only move on an advance, so the
+  // stream would stall forever rather than for a stride.
+  //
+  //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
+  //
+  // Mutation proof: take the LARGEST optimal seam instead of the smallest and
+  // this reads back [" A"] -- the surplus copy refused, which is the deletion
+  // this bias exists to avoid. Drop the refusal entirely (a frontier of 0,
+  // Swift's bare timestamp filter at `:372`) and it reads back
+  // [" A", " A", " A"] -- three copies, so the rule is doing real work here
+  // even though it cannot do all of it.
+  //
+  //   ingest    [A@0.0, A@0.0, B@0.0, C@1.0] twice
+  //   confirmed_words_slice() == [" A", " A"], text " A A B C"
+  let a = || word(" A", 0.0, 0.5);
+  let b = || word(" B", 0.0, 1.0); // tied start with A
+  let c = || word(" C", 1.0, 2.0);
+  let mut agreement = LocalAgreement::new();
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(vec![a(), b(), c()]))
+      .is_advanced()
+  );
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A"],
+    "confirmed [A], holding [B, C] at a 0.0 s watermark",
+  );
+
+  let repeated = || result_with_words(vec![a(), a(), b(), c()]);
+  agreement.ingest_streamed(repeated());
+  assert!(agreement.ingest_streamed(repeated()).is_advanced());
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A", " A"],
+    "the surplus A is kept and confirmed -- the documented residual, not a \
+     regression of the ledger above",
+  );
+  assert_eq!(
+    agreement
+      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+      .text(),
+    " A A B C",
+  );
+}
+
+// ---------------------------------------------------------------------
+// The scope of `settled`: which EDGE of a confirmed word faces the span
+// ---------------------------------------------------------------------
+
+#[test]
+fn a_word_whose_extent_reaches_the_watermark_is_in_the_alignment() {
+  // #94 round 5, finding 2 -- CROSS-WATERMARK DRIFT, which bypassed the
+  // alignment entirely rather than losing an argument inside it. `settled` was
+  // the trailing run of confirmed words with `start >= watermark`; here the
+  // confirmed " A" ENDS at the watermark and starts a hundredth of a second
+  // before it, so the run was EMPTY, `watermark_filtered_with` took its
+  // `settled_len == 0` fast path, and the whole offered list came back
+  // unfiltered. Two such hypotheses then agreed and confirmed " A" a second
+  // time. Nothing in the frontier rule ever ran.
+  //
+  // The endpoint was the bug. Each list is tested against the watermark on the
+  // edge that FACES the span -- `offered` on `start`, `settled` on `end` -- and
+  // testing `start` on both asked whether a confirmed word BEGINS inside the
+  // span, which a word straddling the boundary never does. The last confirmed
+  // word straddles it on essentially every advance: DTW word timings abut, so
+  // `confirmed.last().end() == holdback[0].start() == watermark` (measured in
+  // `jfk_tiny_words_golden.json`: 20 of its 21 consecutive word pairs share an
+  // instant exactly, the one exception a 0.5 s silence). Under the old rule that
+  // word was in scope only in the degenerate tie where it ALSO had a zero-length
+  // overlap with the holdback -- which is why `tied_word_starts_never_confirm_twice`
+  // passed while this did not.
+  //
+  //   confirmed [A@0.99-1.00], holding [B@1.00, C@1.50], watermark 1.00
+  //   ingest    [A@1.01, B@1.11, C@1.61, D@2.20] twice
+  //
+  // The alignment then has a UNIQUE optimum -- [A] ++ [B, C] against
+  // [A, B, C, D] matches all three with the seam at 1, and no other seam scores
+  // 3 -- so unlike the ambiguous shapes above, nothing here is a tie-break.
+  //
+  // Mutation proof: put the endpoint back (`take_while(|word| word.start() >=
+  // watermark)`) and both assertions below red at once, to [" A", " A", " B"]
+  // and " A A B C D" -- the finding as reported. Dropping the fast path's early
+  // return instead changes nothing, which is the point: the fast path was never
+  // wrong, its INPUT was.
+  let a = || word(" A", 0.99, 1.0);
+  let b = || word(" B", 1.0, 1.5);
+  let c = || word(" C", 1.5, 2.0);
+  let mut agreement = LocalAgreement::new();
+  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(vec![a(), b(), c()]))
+      .is_advanced()
+  );
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A"],
+    "confirmed [A@0.99], holding [B@1.00, C@1.50] at a 1.00 s watermark",
+  );
+  assert!((agreement.last_agreed_seconds() - 1.0).abs() < 1e-6);
+
+  // The re-decode moves every timestamp it emits, and " A" lands PAST the
+  // watermark it used to end on.
+  let drifted = || {
+    result_with_words(vec![
+      word(" A", 1.01, 1.1),
+      word(" B", 1.11, 1.6),
+      word(" C", 1.61, 2.1),
+      word(" D", 2.2, 2.5),
+    ])
+  };
+  agreement.ingest_streamed(drifted());
+  assert!(agreement.ingest_streamed(drifted()).is_advanced());
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A", " B"],
+    "the drifted reproduction is refused; only the words past it advance",
+  );
+  assert_eq!(
+    agreement
+      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+      .text(),
+    " A B C D",
+    "\" A\" reaches the transcript exactly once",
+  );
+}
+
+#[test]
+fn a_re_utterance_separated_from_the_watermark_keeps_its_word() {
+  // The COST BOUNDARY of the scope above, and the reason it is `end >=
+  // watermark` rather than "always take the last confirmed word". This is
+  // `a_word_whose_extent_reaches_the_watermark_is_in_the_alignment`'s mirror,
+  // byte-identical in shape -- one word ahead of a full reproduction of the
+  // holdback, whose text is a confirmed word's -- and it needs the OPPOSITE
+  // answer, because here the stream genuinely says " B" again.
+  //
+  // What separates them is the only evidence there is: the confirmed " B" ENDS
+  // 0.1 s before the watermark, with another word's audio (or silence) between
+  // it and the re-decoded span, while the sibling's " A" ends ON it. The gap is
+  // load-bearing. Widen the scope past it -- to the whole confirmed list, or by
+  // an unconditional `.max(1)` on the run length -- and this reads back
+  // [" A", " B", " C"], the stream's second " B" deleted, while the sibling
+  // still passes. Both mutations were run. `.max(1)` reds exactly this test in
+  // this module; the whole-list widening reds this one and
+  // `a_confirmed_word_from_before_the_watermark_is_out_of_the_alignment`, which
+  // is the pair of them bounding the run's near and far ends.
+  //
+  //   confirmed [A@0.0-0.4, B@0.5-0.9], holding [C@1.0, D@1.5], watermark 1.0
+  //   ingest    [B@1.0, C@1.1, D@1.5, E@2.0] twice
+  let a0 = || word(" A", 0.0, 0.4);
+  let b0 = || word(" B", 0.5, 0.9);
+  let c0 = || word(" C", 1.0, 1.4);
+  let d0 = || word(" D", 1.5, 1.9);
+  let mut agreement = LocalAgreement::new();
+  agreement.ingest_streamed(result_with_words(vec![a0(), b0(), c0(), d0()]));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(vec![a0(), b0(), c0(), d0()]))
+      .is_advanced()
+  );
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A", " B"],
+    "confirmed [A@0.0, B@0.5], holding [C@1.0, D@1.5] at a 1.0 s watermark",
+  );
+
+  let re_uttered = || {
+    result_with_words(vec![
+      word(" B", 1.0, 1.05),
+      word(" C", 1.1, 1.4),
+      word(" D", 1.5, 1.9),
+      word(" E", 2.0, 2.4),
+    ])
+  };
+  agreement.ingest_streamed(re_uttered());
+  assert!(agreement.ingest_streamed(re_uttered()).is_advanced());
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A", " B", " B", " C"],
+    "the later \" B\" is the stream's own, and costs nothing that follows it",
+  );
+  assert_eq!(
+    agreement
+      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+      .text(),
+    " A B B C D E",
+  );
+}
+
+#[test]
+fn the_next_strides_prefill_is_the_holdback_verbatim() {
+  // What decides the ambiguity rule, pinned as the fact it is. The smallest
+  // optimal seam attributes a disputed offered head to the HOLDBACK rather than
+  // to `settled`, and the justification is not that keeping errs safe -- it is
+  // that the engine WROTE the holdback into the next hypothesis. This asserts
+  // the two halves of that contract that live in this module:
+  //
+  //   * `prefix_tokens` is the holdback's own tokens, in order, concatenated --
+  //     not a count, not a summary. `decode::prefill_tokens` appends them to the
+  //     initial prompt and `decode::decode_text` forces every prompt position
+  //     (`next_token = current_tokens[token_index]`), so they are copied into
+  //     the hypothesis rather than predicted by it.
+  //   * `use_prefill_prompt` is SET, because `WhisperKit::transcribe` calls
+  //     `prefill_tokens` only when it is -- without it the tokens above are
+  //     silently inert and the retargeting is a no-op.
+  //
+  // The prefill BUDGET is deliberately NOT asserted here: with the default
+  // two-word agreement the prefix is two tokens, so `len() <=
+  // MAX_HOLDBACK_PREFILL_TOKENS` would hold whatever the code did -- true by
+  // construction is a gap, not a pass. It is pinned where it can fail instead,
+  // by `an_over_budget_holdback_is_capped_rather_than_silently_truncated`.
+  //
+  // THESE ARE THE OPTIONS-LAYER FACTS ONLY -- what the engine RECORDED. What
+  // `decode_text` is actually handed, after `prefill_tokens`' trim and
+  // special-id filter, is pinned by
+  // `the_prefill_reaches_decode_text_as_the_whole_holdback`, which needs the
+  // tokenizer artifact and so runs under `--ignored` (codex round 6, finding 2:
+  // this test alone was checking the wrong layer). Both are kept: this one is
+  // hermetic and runs everywhere.
+  //
+  // Mutation proof: drop `.with_use_prefill_prompt()` from
+  // `decoding_options_for_next` and the flag assertion reds. Prefill
+  // `confirmed_words` instead of `last_agreed_words` and the token assertion
+  // reds. Both were run.
+  let mut agreement = LocalAgreement::new();
+  let words = vec![
+    word(" And", 0.0, 0.4),
+    word(" so", 0.4, 0.8),
+    word(" my", 0.8, 1.2),
+  ];
+  agreement.ingest_streamed(result_with_words(words.clone()));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(words))
+      .is_advanced()
+  );
+
+  // The base has the prompt turned OFF, which is what makes the flag assertion
+  // below non-vacuous: on the default base it would hold with no code at all.
+  let base = crate::audio::whisper::options::DecodingOptions::new().maybe_use_prefill_prompt(false);
+  assert!(!base.use_prefill_prompt());
+  let next = agreement.decoding_options_for_next(&base);
+  assert!(
+    next.use_prefill_prompt(),
+    "without this the prefix tokens below never reach the decoder",
+  );
+  assert_eq!(
+    next.clip_timestamps_slice(),
+    &[agreement.last_agreed_seconds()]
+  );
+
+  let holdback_tokens: Vec<u32> = agreement
+    .last_agreed_words_slice()
+    .iter()
+    .flat_map(|word| word.tokens_slice().iter().copied())
+    .collect();
+  assert_eq!(
+    next.prefix_tokens_slice(),
+    holdback_tokens.as_slice(),
+    "the prefill IS the holdback, token for token",
+  );
+  assert!(
+    !holdback_tokens.is_empty(),
+    "non-vacuous: an empty holdback would satisfy the equality above trivially",
+  );
+}
+
+// ---------------------------------------------------------------------
+// The unmarked path: no prefill premise, so the other reading of the seam
+// ---------------------------------------------------------------------
+
+#[test]
+fn a_direct_ingest_with_no_prefill_refuses_the_disputed_head() {
+  // #94 (codex round 6, finding 1). THE SAME SEQUENCE as
+  // `a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream`,
+  // with the opposite PROVENANCE -- and it must reach the opposite answer.
+  //
+  // There, the continuing results are decoded under the engine's own retarget,
+  // so the decoder was FORCED to emit the holdback and the disputed leading " A"
+  // can only be the holdback's own first word. Here the caller decoded some
+  // other way: no clip retarget, no forced prefill. Nothing then says whether
+  // that " A" is the held-back second occurrence coming back or the SETTLED
+  // first one being re-offered while the held one was dropped -- and
+  // `confirmed_words_slice()` is append-only, so guessing "held" and being wrong
+  // confirms a settled word a second time with no way to retract it. The
+  // unattributable reading refuses it.
+  //
+  // Mutation proof: read `seams.prefilled` on the unmarked path too (the single
+  // policy this replaced) and BOTH faces below read back the marked path's
+  // answers -- [" A", " A", " B"] and " A A B C D".
+  //
+  //   ingest_streamed [A@0.0, A@0.0, B@1.0] twice -> confirmed [A], holding [A, B]
+  //   then BARE ingest [A@0.0, B@1.0, C@2.0, D@3.0] twice, caller's own options
+  //   confirmed_words_slice() == [" A", " B"], text " A B C D"
+  let a = || word(" A", 0.0, 0.5);
+  let b = || word(" B", 1.0, 1.5);
+  let c = || word(" C", 2.0, 2.5);
+  let d = || word(" D", 3.0, 3.5);
+  let stutter = || result_with_words(vec![a(), a(), b()]);
+  let mut agreement = LocalAgreement::new();
+  agreement.ingest_streamed(stutter());
+  assert!(agreement.ingest_streamed(stutter()).is_advanced());
+  assert_eq!(confirmed_texts(&agreement), vec![" A"]);
+
+  // The caller's OWN options: whatever it decoded with, it was not this engine's
+  // retarget. `DecodingOptions::new()` already fails the premise on two clauses
+  // at once -- no `clip_timestamps` at the watermark, no `prefix_tokens` at all.
+  let unmarked = DecodingOptions::new();
+  assert_ne!(
+    unmarked.clip_timestamps_slice(),
+    &[agreement.last_agreed_seconds()],
+    "non-vacuous: these options are NOT the retarget",
+  );
+  let onward = || result_with_words(vec![a(), b(), c(), d()]);
+  agreement.ingest(onward(), &unmarked);
+  assert!(agreement.ingest(onward(), &unmarked).is_advanced());
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A", " B"],
+    "the disputed leading A could be the settled one coming back, so it is not \
+     confirmed a second time",
+  );
+
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A B C D",
+    "the finalized face of the same refusal",
+  );
+}
+
+#[test]
+fn a_stale_retarget_does_not_buy_the_prefilled_reading() {
+  // The premise is checked against the CURRENT state, not against "these look
+  // like retarget options". A caller that keeps re-offering the options the
+  // engine issued a watermark ago has not prefilled the decoder with THIS
+  // holdback, so it gets the unattributable reading -- the same answer as a
+  // caller with no retarget at all.
+  //
+  // Mutation proof: drop the `clip_timestamps`/`prefix_tokens` clauses from
+  // `prefill_reproduces_holdback` (check only `use_prefill_prompt`) and the
+  // stale options buy the prefilled reading, reading back [" A", " A", " B"].
+  let a = || word(" A", 0.0, 0.5);
+  let b = || word(" B", 1.0, 1.5);
+  let c = || word(" C", 2.0, 2.5);
+  let d = || word(" D", 3.0, 3.5);
+  let mut agreement = LocalAgreement::new();
+  // Captured BEFORE the advance: at this point the holdback is empty and the
+  // watermark is 0.0, so these are the FIRST stride's options.
+  let stale = agreement.decoding_options_for_next(&DecodingOptions::new());
+  let stutter = || result_with_words(vec![a(), a(), b()]);
+  agreement.ingest_streamed(stutter());
+  assert!(agreement.ingest_streamed(stutter()).is_advanced());
+  assert!(
+    !agreement.last_agreed_words_slice().is_empty(),
+    "non-vacuous: the state moved on from what `stale` targets",
+  );
+
+  let onward = || result_with_words(vec![a(), b(), c(), d()]);
+  agreement.ingest(onward(), &stale);
+  assert!(agreement.ingest(onward(), &stale).is_advanced());
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A", " B"],
+    "options that prefill an EMPTY holdback cannot make the offered head the \
+     holdback's own reproduction",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A B C D"
+  );
+}
+
+#[test]
+fn an_unmarked_results_frontier_is_not_re_read_under_a_later_marked_one() {
+  // #94 (codex round 7, finding 1). THE UNMARKED REFUSAL MUST OUTLIVE THE CALL
+  // THAT MADE IT. `prev_result` is stored RAW and re-filtered on the next
+  // ingest; if that re-filter reads the frontier under the NEXT result's
+  // provenance, an unmarked result whose disputed head was refused gets that
+  // head handed back one call later, on nothing more than the next caller
+  // decoding honestly.
+  //
+  // Nobody lies here. The unmarked result really was decoded some other way, and
+  // the marked one really was decoded under the retarget. Each is entitled to
+  // its own frontier -- and re-reading the stored one under a foreign premise
+  // manufactures an agreement neither hypothesis actually offered:
+  // `find_longest_common_prefix` returns elements of the CURRENT hypothesis, but
+  // its LENGTH is set by both sides, and `prev_words` read too permissively
+  // makes that length LONGER, not shorter. Length is what decides whether the
+  // watermark advances and how much lands in the append-only
+  // `confirmed_words_slice()`.
+  //
+  // Mutation proof: filter `prev_result` with the CURRENT result's flag (the
+  // shape this replaced -- pass `prefilled` where the stored provenance is read)
+  // and both faces red: the fourth ingest reads back `Advanced` with
+  // [" A", " A", " B"] confirmed, and the transcript becomes " A A B C D" --
+  // " B" confirmed irrevocably on an agreement that never happened, so the
+  // genuine later revision " Z" can never be applied.
+  let a = || word(" A", 0.0, 0.5);
+  let b = || word(" B", 1.0, 1.5);
+  let c = || word(" C", 2.0, 2.5);
+  let d = || word(" D", 3.0, 3.5);
+  // " Z" revises the held-back " B", at " B"'s own extent.
+  let z = || word(" Z", 1.0, 1.5);
+
+  let mut agreement = LocalAgreement::new();
+  let stutter = || result_with_words(vec![a(), a(), b()]);
+  agreement.ingest_streamed(stutter());
+  assert!(agreement.ingest_streamed(stutter()).is_advanced());
+  assert_eq!(confirmed_texts(&agreement), vec![" A"]);
+  assert_eq!(
+    agreement
+      .last_agreed_words_slice()
+      .iter()
+      .map(WordTiming::word)
+      .collect::<Vec<_>>(),
+    vec![" A", " B"],
+    "the disputed shape: one settled \" A\", and a holdback that starts with \
+     another",
+  );
+
+  // (1) UNMARKED. The head is unattributable, so it is cut -- the answer
+  // `a_direct_ingest_with_no_prefill_refuses_the_disputed_head` pins. This
+  // result is now `prev_result`, stored raw.
+  let unmarked = DecodingOptions::new();
+  let onward = || result_with_words(vec![a(), b(), c(), d()]);
+  assert!(
+    agreement
+      .ingest(onward(), &unmarked)
+      .is_awaiting_agreement(),
+    "[B, C, D] against the stutter's [A, B] shares no prefix",
+  );
+
+  // (2) MARKED, and the very same words. Its OWN frontier is the prefilled one
+  // -- but the raw result stored at (1) keeps the unmarked frontier it arrived
+  // with, so the two lists still disagree and nothing is confirmed.
+  assert!(
+    agreement.ingest_streamed(onward()).is_awaiting_agreement(),
+    "the stored result's head is still refused, so [B, C, D] against \
+     [A, B, C, D] still shares no prefix",
+  );
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A"],
+    "the streaming face: the unmarked refusal is not undone one call later",
+  );
+
+  // (3) The cost of getting (2) wrong, one revision later. " B" is still HELD,
+  // so a hypothesis that revises it to " Z" supersedes it; had (2) confirmed
+  // " B" the watermark would already be past " Z" and the revision could never
+  // be applied at all.
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(vec![a(), z(), c(), d()]))
+      .is_awaiting_agreement(),
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A A Z C D",
+    "the finalized face: the revision reaches the transcript because the word it \
+     revises was never confirmed on a manufactured agreement",
+  );
+}
+
+#[test]
+fn a_recurring_ambiguity_would_never_clear_on_the_unmarked_path() {
+  // THE REFUTATION of "block on an ambiguous frontier, since without the
+  // prefill nothing re-creates the ambiguity every stride". The prefill is not
+  // what re-creates it. The disputed columns' scores are a function of
+  // `(settled, holdback, offered)` alone; `settled` and `holdback` move only on
+  // an advance -- which is exactly what a block prevents -- and growing the
+  // offered list at the TAIL leaves the disputed columns tied, because
+  // `before[j]` is untouched there and `after[j]` rises for every `j` at once.
+  //
+  // So a caller re-decoding a growing window off unchanged audio re-offers the
+  // same head every stride whether or not it prefills: a deterministic decoder
+  // does not need to be forced to repeat itself. A block would re-arm on every
+  // one of the strides below and the stream would never confirm another word --
+  // trading one forgone repetition for the entire rest of the transcript.
+  //
+  // Mutation proof: this is an assertion about `settled_seams` itself, so its
+  // falsifier is the claim's negation -- assert the seams CONVERGE at some
+  // stride and every row below reds.
+  let settled = [word(" A", 0.0, 0.5)];
+  let holdback = [word(" A", 0.0, 0.5), word(" B", 1.0, 1.5)];
+  let mut offered = vec![word(" A", 0.0, 0.5), word(" B", 1.0, 1.5)];
+  for stride in 0..6usize {
+    let seams = settled_seams(&settled, &holdback, &offered);
+    assert_eq!(
+      (seams.prefilled, seams.unattributed),
+      (0, 1),
+      "stride {stride}: the seam is still ambiguous with {} offered words, so a \
+       blocking policy re-arms here too",
+      offered.len(),
+    );
+    // The stream grows at the tail, which is the only way it CAN grow while the
+    // watermark is pinned by the block.
+    let next = 2.0 + stride as f32;
+    offered.push(word(&format!(" W{stride}"), next, next + 0.5));
+  }
+
+  // Liveness, for contrast: the unattributable reading advances on this exact
+  // shape rather than stalling on it -- see
+  // `a_direct_ingest_with_no_prefill_refuses_the_disputed_head`, whose stream
+  // reaches `Advanced` and confirms " B" while a block would still be waiting.
+}
+
+// ---------------------------------------------------------------------
+// The prefill budget
+// ---------------------------------------------------------------------
+
+/// Nine abutting 30-token words: `[w0 .. w8]`, `wN` spanning `[N, N+1)`.
+/// 30 tokens apiece puts four of them (120) over
+/// [`MAX_HOLDBACK_PREFILL_TOKENS`] and three (90) under, so a five-word holdback
+/// request straddles the budget.
+fn budget_words() -> Vec<WordTiming> {
+  (0..9u32)
+    .map(|index| word_of_tokens(&format!(" w{index}"), index as f32, index as f32 + 1.0, 30))
+    .collect()
+}
+
+#[test]
+fn an_over_budget_holdback_is_capped_rather_than_silently_truncated() {
+  // #94 (codex round 6, finding 2). `agreement_count_needed` has no upper bound
+  // and `prefill_tokens` keeps only the last `MAX_TOKEN_CONTEXT / 2` prefix
+  // tokens, so a wide enough agreement asks for a holdback the decoder will
+  // never be given whole. The head of such a holdback is then neither reproduced
+  // (the decoder never sees those tokens) nor confirmed (the next advance
+  // REPLACES the holdback with the new `common[split..]`) -- it just vanishes.
+  //
+  // Holding back only what the prefill can carry, and confirming the rest, is
+  // what closes it: `common` is already the prefix two consecutive hypotheses
+  // agreed on, so those words meet LocalAgreement-2's whole criterion, and a
+  // word outside the prefill budget is one no third hypothesis could revise
+  // anyway.
+  //
+  // Mutation proof: make `budgeted_split` return its `requested` argument
+  // unchanged and both faces red -- the confirmed list stalls at two words
+  // instead of four, and the finalized text loses " w2 w3" entirely. The empty
+  // PENDING half has its own falsifier: relax the advance's `word.end() >
+  // self.last_agreed_seconds` to `>=` and " w3" is deferred instead of
+  // confirmed, though nothing offered can ever overlap it.
+  let words = budget_words();
+  let mut agreement = LocalAgreement::new().with_agreement_count_needed(5);
+
+  let first = || result_with_words(words[..7].to_vec());
+  agreement.ingest_streamed(first());
+  assert!(agreement.ingest_streamed(first()).is_advanced());
+
+  let requested: usize = agreement
+    .last_agreed_words_slice()
+    .iter()
+    .map(|word| word.tokens_slice().len())
+    .sum();
+  assert!(
+    requested <= MAX_HOLDBACK_PREFILL_TOKENS,
+    "the holdback must fit the prefill budget: {requested} tokens",
+  );
+  assert_eq!(
+    agreement.last_agreed_words_slice().len(),
+    3,
+    "five words were asked for; three is what 112 tokens can carry",
+  );
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" w0", " w1", " w2", " w3"], Vec::<&str>::new()),
+    "the two words that could not be held are CONFIRMED, not dropped -- and \
+     confirmed OUTRIGHT, not left pending: both end at or before the watermark, \
+     so no word the engine will ever be offered again can overlap them (codex \
+     round 12, finding 1)",
+  );
+  // The face that matters to the decoder: what the next stride will prefill.
+  assert_eq!(
+    agreement
+      .decoding_options_for_next(&DecodingOptions::new())
+      .prefix_tokens_slice()
+      .len(),
+    90,
+    "the whole prefix survives `prefill_tokens`' 112-token trim",
+  );
+
+  // The stream continues, and the next hypotheses begin at the holdback -- which
+  // is exactly what a prefill the decoder receives WHOLE produces, and what a
+  // truncated one does not.
+  let onward = || result_with_words(words[4..].to_vec());
+  agreement.ingest_streamed(onward());
+  assert!(agreement.ingest_streamed(onward()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (
+      vec![" w0", " w1", " w2", " w3", " w4", " w5"],
+      Vec::<&str>::new()
+    ),
+    "confirmation kept moving, and nothing was retracted",
+  );
+
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " w0 w1 w2 w3 w4 w5 w6 w7 w8",
+    "every word the stream produced reaches the transcript",
+  );
+}
+
+#[test]
+fn a_prefill_over_the_budget_does_not_buy_the_prefilled_reading() {
+  // A caller assembling its own options can present a prefix that ENDS with the
+  // holdback behind a head of its own. `prefill_tokens` keeps the last
+  // `MAX_HOLDBACK_PREFILL_TOKENS` of it, so `decode_text` is forced to emit that
+  // head too and the hypothesis does NOT begin with the holdback -- the premise
+  // the smallest-seam reading rests on is simply false. Equality is what refuses
+  // it, and equality is what the premise needs.
+  //
+  // Mutation proof: weaken the comparison in `prefill_reproduces_holdback` to
+  // `decoded_under.prefix_tokens_slice().ends_with(...)` -- the plausible
+  // mistake, since the decoder does receive the holdback at the tail -- and the
+  // over-budget options below buy the prefilled reading, reading back
+  // [" A", " A", " B"] / " A A B C D".
+  //
+  // ROUND 7 CORRECTION: this test used to record its falsifier as dropping the
+  // `holdback.len() <= MAX_HOLDBACK_PREFILL_TOKENS` clause. That mutation reds
+  // NOTHING, here or anywhere -- the padded prefix differs from the holdback in
+  // LENGTH as well as content, so the equality already refuses it and the length
+  // clause never decided this case. It cannot decide any case now: the clause
+  // read the ENGINE's holdback, which `budgeted_split` keeps inside the budget
+  // after every advance, so it was a conjunct that could not be false. It is
+  // gone, and this is the mutation that actually falsifies what is left.
+  let a = || word(" A", 0.0, 0.5);
+  let b = || word(" B", 1.0, 1.5);
+  let c = || word(" C", 2.0, 2.5);
+  let d = || word(" D", 3.0, 3.5);
+  let mut agreement = LocalAgreement::new();
+  let stutter = || result_with_words(vec![a(), a(), b()]);
+  agreement.ingest_streamed(stutter());
+  assert!(agreement.ingest_streamed(stutter()).is_advanced());
+
+  // The engine's own retarget, then the prefix swapped for an over-budget one
+  // that still ENDS with the holdback -- so `prefill_tokens` would hand
+  // `decode_text` a tail that reproduces it, but nothing forces the head.
+  let honest = agreement.decoding_options_for_next(&DecodingOptions::new());
+  let mut padded: Vec<u32> = (10_000..10_000 + MAX_HOLDBACK_PREFILL_TOKENS as u32).collect();
+  padded.extend_from_slice(honest.prefix_tokens_slice());
+  assert!(padded.len() > MAX_HOLDBACK_PREFILL_TOKENS);
+  let over_budget = honest.clone().with_prefix_tokens(padded);
+
+  let onward = || result_with_words(vec![a(), b(), c(), d()]);
+  agreement.ingest(onward(), &over_budget);
+  assert!(agreement.ingest(onward(), &over_budget).is_advanced());
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" A", " B"],
+    "a prefix the decoder will trim is not a reproduction of the holdback",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A B C D"
+  );
+}
+
+#[test]
+fn a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held() {
+  // #94 (codex round 7, finding 2). THE CAP MUST ALWAYS CAP. `budgeted_split`
+  // moved the split later until the holdback fit -- but stopped while one word
+  // was still left, so a single word whose OWN tokens exceed
+  // `MAX_HOLDBACK_PREFILL_TOKENS` was held anyway and the cap silently did not
+  // cap. `decoding_options_for_next` then issued a prefix `prefill_tokens`
+  // trims, the decoder was fed the word's TAIL, and the hypothesis came back
+  // with a word that is not the held one.
+  //
+  // The unmarked seam does not repair that: it is the right frontier for a
+  // hypothesis the engine did not write, and it cannot put back a token the
+  // engine itself dropped. What follows is DATA LOSS, not a stall -- the
+  // truncated hypothesis disagrees, `holdback_superseded` fires, and `finalize`
+  // replaces the intact held word with the truncation.
+  //
+  // Holding it is what cannot be done; CONFIRMING it always can. `common` is
+  // already the prefix two consecutive hypotheses agreed on -- LocalAgreement-2's
+  // whole criterion -- and a word outside the prefill budget is one no third
+  // hypothesis could revise, being behind both the forced prefill and the clip
+  // window. So the split runs all the way to `common.len()` when it has to, and
+  // the holdback the advance leaves can be EMPTY.
+  //
+  // Mutation proof: stop `budgeted_split`'s loop one word early again
+  // (`split + 1 < common.len()`) and every assertion below reds -- the oversized
+  // word is held instead of confirmed, the issued prefix is 113 tokens against a
+  // 112-token budget, and the transcript reads " A Htail X" with the intact
+  // " H" gone. The empty PENDING half: make the advance's
+  // `self.last_agreed_words.is_empty()` arm DEFER (`0` in place of
+  // `widened.len()`) and both words wait for an anchor that can never arrive.
+  let a = || word_of_tokens(" A", 1.0, 2.0, 1);
+  let huge = || word_of_tokens(" H", 2.0, 3.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
+  assert!(
+    huge().tokens_slice().len() > MAX_HOLDBACK_PREFILL_TOKENS,
+    "non-vacuous: one word, and it alone cannot fit the prefill budget",
+  );
+
+  let mut agreement = LocalAgreement::new();
+  let pair = || result_with_words(vec![a(), huge()]);
+  agreement.ingest_streamed(pair());
+  assert!(agreement.ingest_streamed(pair()).is_advanced());
+
+  // The streaming face, read between pushes: both agreed words are settled,
+  // because the second one is a word the engine can never hand a decoder whole.
+  // Settled OUTRIGHT rather than left pending -- the watermark is " H"'s own
+  // end, so the still-open span starts where " H" stops and can never overlap
+  // it (codex round 12, finding 1).
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A", " H"], Vec::<&str>::new()),
+    "a word the prefill cannot carry is CONFIRMED, never held",
+  );
+  assert!(
+    agreement.last_agreed_words_slice().is_empty(),
+    "and the holdback is empty rather than over budget",
+  );
+
+  // The face the decoder sees: whatever the engine issues, `prefill_tokens`
+  // keeps ALL of it. This is the postcondition the cap now actually has.
+  let next = agreement.decoding_options_for_next(&DecodingOptions::new());
+  assert!(
+    next.prefix_tokens_slice().len() <= MAX_HOLDBACK_PREFILL_TOKENS,
+    "the issued prefix is {} tokens against a {MAX_HOLDBACK_PREFILL_TOKENS}-token \
+     budget",
+    next.prefix_tokens_slice().len(),
+  );
+  assert_eq!(
+    agreement.last_agreed_seconds(),
+    3.0,
+    "with nothing held back, the still-open span starts where the confirmed one \
+     ends",
+  );
+
+  // The continuation a truncated prefill would produce: fed " H"'s last 112
+  // tokens, the decoder emits some other word over that same extent. Under the
+  // cap that word is outside the clip window and outside the offered span
+  // entirely, so it cannot displace the settled " H".
+  let truncated = || {
+    result_with_words(vec![
+      word_of_tokens(" Htail", 2.0, 3.0, MAX_HOLDBACK_PREFILL_TOKENS),
+      word_of_tokens(" X", 3.0, 4.0, 1),
+    ])
+  };
+  assert!(
+    agreement
+      .ingest_streamed(truncated())
+      .is_awaiting_agreement()
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A H X",
+    "the finalized face: an intact confirmed word is not replaced by a \
+     truncation of itself",
+  );
+}
+
+#[test]
+fn a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held() {
+  // #94 (codex round 8, finding 1). THE CAP MUST CAP THE OTHER FILTER TOO.
+  // `prefill_tokens` reduces `prefix_tokens` twice on its way to the decoder: it
+  // keeps only the last `MAX_HOLDBACK_PREFILL_TOKENS` ids, AND it drops every id
+  // at or above the vocabulary's `special_token_begin`. `budgeted_split` bounded
+  // only the first, and `prefill_reproduces_holdback` proves the caller's prefix
+  // EQUALS the holdback -- which is exactly as true for a holdback whose tokens
+  // the second filter erases. So a hand-built stream can settle a word, hold a
+  // word made of ids the decoder never receives, pass the retarget
+  // `decoding_options_for_next` just issued, and have `ProvenancedResult` record
+  // `prefilled = true` for a hypothesis the engine did NOT write the holdback
+  // into.
+  //
+  // REACHABILITY, since round 3 classified this half unreachable. That
+  // classification's evidence is correct -- `update_segments_with_word_timings`
+  // strips `id >= special_token_begin` from every `WordTiming` and emits no word
+  // at all for an all-special entry, so this crate's pipeline never produces
+  // one. What it does not cover is `ingest` itself, which is public, takes a
+  // hand-built `TranscriptionResult`, and sets `last_agreed_words` to
+  // `common[split..]` -- elements of the caller's own hypothesis, tokens
+  // included. `WordTiming::new` takes the token vector directly. Nothing between
+  // there and `holdback_prefill_tokens` looks at an id.
+  //
+  // NEITHER SEAM IS THE REPAIR, which is why the fix is in the split. Read the
+  // arithmetic of this very stream three ways:
+  //
+  //   - held and read MARKED (the defect): " S" is never confirmed, the
+  //     re-offer supersedes the holdback that carried it, and the transcript
+  //     loses it -- " A A Y C".
+  //   - held and read UNATTRIBUTED (refuse the marked reading): the offered head
+  //     is cut as well, so the stream loses " S" AND the " A" that replaced it --
+  //     " A Y C". Refusing is not the conservative choice here; the state is the
+  //     defect, not the reading of it.
+  //   - CONFIRMED instead of held (this fix): " A S A Y C", every word two
+  //     hypotheses agreed on, and the later revision still applied.
+  //
+  // Confirming is no weaker a claim than any other confirmation carries --
+  // `common` is the prefix two consecutive hypotheses agreed on, LocalAgreement-2's
+  // entire criterion -- and holding buys nothing, because whatever the next
+  // hypothesis produces over that extent was decoded from a prefix the held word
+  // is not in, so it is neither a corroboration of it nor a revision of it.
+  //
+  // Mutation proof: drop `budgeted_split`'s `rposition` floor (equivalently,
+  // weaken `prefill_carries_whole` to `true`) and every assertion below reds --
+  // " S" is held rather than confirmed, the issued prefix carries the id the
+  // filter erases, and the transcript reads " A A Y C" with " S" gone. The two
+  // guards have their own falsifiers, named where they stand: widen
+  // `prefill_carries_whole` to `false` for every word and the issued prefill goes
+  // EMPTY, and take the plain maximum seam and the ambiguity pin reads (0, 3).
+  let a0 = || word(" A", 0.5, 1.0);
+  let s = || special_only_word(" S", 1.0, 1.5);
+  let a1 = || word(" A", 1.5, 2.0);
+  let b = || word(" B", 2.0, 2.5);
+  let c = || word(" C", 2.5, 3.0);
+  // " Y" revises " B", at " B"'s own extent.
+  let y = || word(" Y", 2.0, 2.5);
+  assert!(
+    s()
+      .tokens_slice()
+      .iter()
+      .all(|&id| id >= MIN_SPECIAL_TOKEN_BEGIN),
+    "non-vacuous: the held word is made only of ids `prefill_tokens` drops",
+  );
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![a0(), s(), a1()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+
+  // The streaming face, read between pushes: the word the prefill cannot carry
+  // is SETTLED, and the holdback is the one word that survives the filter whole.
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A", " S"], Vec::<&str>::new()),
+    "a word the decoder can never be given is CONFIRMED, never held -- and \
+     outright, since \" S\" ends exactly where the watermark starts and no \
+     offered word can overlap it (codex round 12, finding 1)",
+  );
+  assert_eq!(
+    agreement
+      .last_agreed_words_slice()
+      .iter()
+      .map(WordTiming::word)
+      .collect::<Vec<_>>(),
+    vec![" A"],
+    "and the holdback keeps only what the prefill reproduces",
+  );
+  assert_eq!(
+    agreement.last_agreed_seconds(),
+    1.5,
+    "the watermark moves to the first word still held",
+  );
+
+  // The face the decoder sees: every id the engine issues survives BOTH of
+  // `prefill_tokens`'s reductions, so the equality
+  // `prefill_reproduces_holdback` checks really does establish that the
+  // hypothesis was written to begin with the whole holdback.
+  let next = agreement.decoding_options_for_next(&DecodingOptions::new());
+  assert!(
+    next
+      .prefix_tokens_slice()
+      .iter()
+      .all(|&id| id < MIN_SPECIAL_TOKEN_BEGIN),
+    "the issued prefix carries an id the decoder's filter erases: {:?}",
+    next.prefix_tokens_slice(),
+  );
+  assert!(
+    !next.prefix_tokens_slice().is_empty(),
+    "and it is not empty, so there is something for the decoder to reproduce",
+  );
+
+  // The AMBIGUOUS frontier this fix makes unreachable, stated as the shape it
+  // is: had " S" stayed in the holdback, a re-offer of the settled word's text
+  // would have left the seam genuinely disputed, and the marked reading would
+  // have taken column 0 on a premise the decoder never established.
+  let re_offer = || result_with_words(vec![a1(), b(), c()]);
+  assert_eq!(
+    {
+      let seams = settled_seams(&[a0()], &[s(), a1()], &[a1(), b(), c()]);
+      (seams.prefilled, seams.unattributed)
+    },
+    (0, 1),
+    "non-vacuous: the state the fix removes really was an ambiguous frontier",
+  );
+
+  // The continuation. The re-offer reproduces the one held word and carries the
+  // stream on; the pair agrees on the next stride and settles it. Outcome and
+  // settled span are read TOGETHER at each step, so the step itself has a
+  // falsifier rather than only the state after it.
+  assert_eq!(
+    (
+      agreement.ingest_streamed(re_offer()),
+      confirmed_texts(&agreement)
+    ),
+    (AgreementOutcome::AwaitingAgreement, vec![" A", " S"]),
+    "one reproduced word is short of `agreement_count_needed`, so nothing new \
+     settles here",
+  );
+  assert_eq!(
+    (
+      agreement.ingest_streamed(re_offer()),
+      confirmed_texts(&agreement)
+    ),
+    (AgreementOutcome::Advanced, vec![" A", " S", " A"]),
+    "the settled span grows over the word the prefill could not carry, never \
+     through it",
+  );
+
+  // The genuine later revision, which must still be applied: " B" is only HELD,
+  // so a hypothesis that revises it to " Y" supersedes it.
+  let revised = agreement.ingest_streamed(result_with_words(vec![y(), c()]));
+  assert_eq!(
+    (
+      revised,
+      agreement
+        .finalize(&DecodingOptions::new())
+        .text()
+        .to_string()
+    ),
+    (
+      AgreementOutcome::AwaitingAgreement,
+      " A S A Y C".to_string()
+    ),
+    "the finalized face: the unreproducible word survives BECAUSE it was \
+     confirmed, and the later revision is still free to land",
+  );
+}
+
+#[test]
+fn the_split_holds_back_exactly_what_the_prefill_carries_whole() {
+  // The postcondition `budgeted_split` now has, and its MINIMALITY -- written out
+  // longhand rather than through `prefill_carries_whole`, so a mutation of that
+  // predicate cannot mutate its own falsifier along with it.
+  //
+  // Four things a row here pins that the end-to-end counterexample does not: a
+  // word with NO tokens at all (it contributes nothing to `prefix_tokens`, so the
+  // decoder is never given it either -- the same defect, with no vocabulary
+  // knowledge required to see it); a filtered word BEHIND a carriable one, which
+  // is why the floor reads `rposition` and not `position` (the FIRST such word is
+  // not the one the split has to clear); the two reductions side by side, so
+  // neither is enforced only by cancelling the other; and the id filter read
+  // against a THRESHOLD rather than against the constant, rows 6 and 7 differing
+  // in nothing else (codex round 12, finding 2).
+  //
+  // Mutation proof, every row enumerated by running it: drop `!tokens.is_empty()`
+  // and row 1 reds; use `position` for the floor and row 3 reds; drop the floor
+  // entirely and rows 0-3 and 6 red on the postcondition; make `budgeted_split`
+  // the identity and rows 0-4 and 6 do; return `common.len()` unconditionally and
+  // rows 0, 1, 3, 4, 5, 6 and 7 red on the MINIMALITY clause instead; read
+  // `MIN_SPECIAL_TOKEN_BEGIN` in `budgeted_split` instead of the threshold it is
+  // given and row 6 reds alone.
+  let plain =
+    |text: &str, start: f32, count: usize| word_of_tokens(text, start, start + 1.0, count);
+  let filtered = |text: &str, start: f32| special_only_word(text, start, start + 1.0);
+  let tokenless =
+    |text: &str, start: f32| WordTiming::new(text, Vec::new(), start, start + 1.0, 0.9);
+  // An id BELOW `MIN_SPECIAL_TOKEN_BEGIN` and so carriable under the floor, but
+  // at or above the lower threshold rows 6/7 configure -- the artifact shape
+  // codex round 12, finding 2 is about.
+  let below_floor =
+    |text: &str, start: f32| WordTiming::new(text, vec![45_000], start, start + 1.0, 0.9);
+
+  // `(common, requested, special_token_begin)`.
+  let cases: Vec<(Vec<WordTiming>, usize, u32)> = vec![
+    // 0: the counterexample's own shape -- a filtered word at the holdback head.
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        filtered(" S", 1.0),
+        plain(" B", 2.0, 1),
+      ],
+      1,
+      MIN_SPECIAL_TOKEN_BEGIN,
+    ),
+    // 1: no tokens at all, in the same position.
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        tokenless(" S", 1.0),
+        plain(" B", 2.0, 1),
+      ],
+      1,
+      MIN_SPECIAL_TOKEN_BEGIN,
+    ),
+    // 2: a filtered word at the holdback TAIL -- the split has to clear that one
+    //    too, so the holdback comes back empty.
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        plain(" B", 1.0, 1),
+        filtered(" S", 2.0),
+      ],
+      1,
+      MIN_SPECIAL_TOKEN_BEGIN,
+    ),
+    // 3: a carriable word BETWEEN two filtered ones. `position` stops at the
+    //    first and leaves the second held; `rposition` clears both.
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        filtered(" S", 1.0),
+        plain(" B", 2.0, 1),
+        filtered(" T", 3.0),
+        plain(" C", 4.0, 1),
+      ],
+      1,
+      MIN_SPECIAL_TOKEN_BEGIN,
+    ),
+    // 4: the length reduction, unchanged by any of the above.
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        plain(" B", 1.0, MAX_HOLDBACK_PREFILL_TOKENS),
+        plain(" C", 2.0, MAX_HOLDBACK_PREFILL_TOKENS),
+      ],
+      1,
+      MIN_SPECIAL_TOKEN_BEGIN,
+    ),
+    // 5: nothing to do -- every word carriable, the whole holdback in budget.
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        plain(" B", 1.0, 1),
+        plain(" C", 2.0, 1),
+      ],
+      1,
+      MIN_SPECIAL_TOKEN_BEGIN,
+    ),
+    // 6: an id the FLOOR calls carriable and a lower-threshold vocabulary
+    //    filters. The split must clear it against the threshold it was GIVEN,
+    //    not against the constant (codex round 12, finding 2).
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        below_floor(" S", 1.0),
+        plain(" B", 2.0, 1),
+      ],
+      1,
+      40_000,
+    ),
+    // 7: row 6's own control -- the same three words under the default floor,
+    //    where the same id IS carriable and nothing needs clearing. Rows 6 and 7
+    //    differ only in the threshold, so a split that ignored it would fail one
+    //    of them whatever it returned.
+    (
+      vec![
+        plain(" A", 0.0, 1),
+        below_floor(" S", 1.0),
+        plain(" B", 2.0, 1),
+      ],
+      1,
+      MIN_SPECIAL_TOKEN_BEGIN,
+    ),
+  ];
+
+  let holdable = |words: &[WordTiming], special_token_begin: u32| {
+    words.iter().all(|word| {
+      !word.tokens_slice().is_empty()
+        && word
+          .tokens_slice()
+          .iter()
+          .all(|&id| id < special_token_begin)
+    }) && words
+      .iter()
+      .map(|word| word.tokens_slice().len())
+      .sum::<usize>()
+      <= MAX_HOLDBACK_PREFILL_TOKENS
+  };
+
+  for (row, (common, requested, special_token_begin)) in cases.iter().enumerate() {
+    let split = budgeted_split(common, *requested, *special_token_begin);
+    let texts: Vec<&str> = common.iter().map(WordTiming::word).collect();
+    assert!(
+      (*requested..=common.len()).contains(&split),
+      "row {row} ({texts:?}): split {split} left the requested-to-end range",
+    );
+    assert!(
+      holdable(&common[split..], *special_token_begin),
+      "row {row} ({texts:?}): the holdback at {split} is not one the prefill \
+       carries whole",
+    );
+    for earlier in *requested..split {
+      assert!(
+        !holdable(&common[earlier..], *special_token_begin),
+        "row {row} ({texts:?}): split {split} confirms more than it has to -- \
+         {earlier} already holds only carriable words within budget",
+      );
+    }
+  }
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn the_prefill_token_ceiling_is_below_the_vocabularys_special_range() {
+  // `MIN_SPECIAL_TOKEN_BEGIN` is the bound `budgeted_split` tests against with no
+  // tokenizer in hand, and it is only sound while it is at or below the LOADED
+  // vocabulary's own `special_token_begin` -- otherwise an id `prefill_tokens`
+  // filters would be held anyway. Asserted against the real artifact rather than
+  // argued from the constant's doc.
+  //
+  // Mutation proof: raise the constant above the shipped vocabulary's threshold
+  // (`50_258`) and this reds.
+  let special_token_begin = tiny_tokenizer().special_tokens().special_token_begin();
+  assert!(
+    special_token_begin >= MIN_SPECIAL_TOKEN_BEGIN,
+    "the vocabulary reserves ids from {special_token_begin}, below the \
+     {MIN_SPECIAL_TOKEN_BEGIN} the holdback rule assumes",
+  );
+}
+
+#[test]
+fn with_nothing_held_back_both_frontiers_are_the_same_column() {
+  // The property `prefill_reproduces_holdback`'s vacuous `true` now rests on.
+  // Before `budgeted_split` could leave an EMPTY holdback, an empty holdback
+  // implied an empty `confirmed_words` too, so `watermark_filtered` took its
+  // `settled_len == 0` fast path and no frontier was read at all -- the premise
+  // could not matter because nothing consulted it. It can now be empty beside a
+  // NON-empty settled set, so a frontier IS read; it still cannot matter,
+  // because with no holdback the two policies name the same column.
+  //
+  // With an empty holdback `after[j]` is identically zero (`settled_seams`'
+  // second DP runs its outer loop over an empty pattern), so `score(j) ==
+  // before[j]`, which is non-decreasing. `best == before[len]`; the smallest
+  // optimal seam is the first column to reach it; and every larger column has
+  // `before[j] == before[j - 1]`, so none of them is match-SUPPORTED.
+  //
+  // Mutation proof: take the plain maximum for `unattributed` (drop the
+  // `before[j] > before[j - 1]` clause) and the rows whose settled word matches
+  // nothing red -- the plain maximum is `offered.len()` there, against a
+  // smallest seam of 0.
+  let settled = [word(" A", 0.0, 0.5)];
+  for offered in [
+    Vec::new(),
+    vec![word(" A", 0.0, 0.5)],
+    vec![word(" X", 0.0, 0.5), word(" Y", 1.0, 1.5)],
+    vec![word(" A", 0.0, 0.5), word(" X", 1.0, 1.5)],
+    vec![
+      word(" X", 0.0, 0.5),
+      word(" A", 1.0, 1.5),
+      word(" A", 2.0, 2.5),
+    ],
+  ] {
+    let seams = settled_seams(&settled, &[], &offered);
+    assert_eq!(
+      seams.unattributed,
+      seams.prefilled,
+      "with an empty holdback the premise cannot change the frontier: {:?}",
+      offered.iter().map(WordTiming::word).collect::<Vec<_>>(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------
+// The prompt itself, at the layer the decoder reads it
+// ---------------------------------------------------------------------
+
+#[test]
+fn the_first_strides_options_keep_the_callers_prefill_flag() {
+  // #94 (codex round 6, finding 3). Before the first advance the engine holds no
+  // holdback, so there is no premise to enforce and no frontier to read -- and
+  // forcing `use_prefill_prompt` there would silently swap the caller's bare
+  // `<|startoftranscript|>` prompt for the full multilingual prefill.
+  //
+  // Mutation proof: force the flag unconditionally (the single
+  // `.with_use_prefill_prompt()` this replaced) and the first assertion reds;
+  // never force it and the last one reds.
+  let base = DecodingOptions::new().maybe_use_prefill_prompt(false);
+  assert!(!base.use_prefill_prompt());
+
+  let mut agreement = LocalAgreement::new();
+  let first = agreement.decoding_options_for_next(&base);
+  assert!(
+    !first.use_prefill_prompt(),
+    "nothing is held back yet, so the caller's own flag stands",
+  );
+  assert!(
+    first.prefix_tokens_slice().is_empty(),
+    "and there is nothing for the prompt to have carried anyway",
+  );
+  assert_eq!(
+    first.clip_timestamps_slice(),
+    &[0.0],
+    "the clip retarget is unconditional -- Swift `:364-367` sets it too",
+  );
+
+  let words = vec![
+    word(" And", 0.0, 0.4),
+    word(" so", 0.4, 0.8),
+    word(" my", 0.8, 1.2),
+  ];
+  agreement.ingest_streamed(result_with_words(words.clone()));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(words))
+      .is_advanced()
+  );
+  assert!(
+    agreement
+      .decoding_options_for_next(&base)
+      .use_prefill_prompt(),
+    "once there IS a holdback the flag is forced, or the prefix is inert and \
+     the frontier's tie-break has nothing behind it",
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn the_first_strides_prompt_is_the_bare_start_of_transcript() {
+  // The decoder-layer face of the test above: not what `DecodingOptions`
+  // records, but the `initial_prompt` `WhisperKit::transcribe` builds from it
+  // (`transcribe/mod.rs:394-405`) and hands to `decode_text`.
+  //
+  // Mutation proof: force `use_prefill_prompt` unconditionally in
+  // `decoding_options_for_next` and the first prompt below becomes the
+  // four-token multilingual prefill -- the very divergence this pins against.
+  let tokenizer = tiny_tokenizer();
+  let special = *tokenizer.special_tokens();
+  let base = DecodingOptions::new().maybe_use_prefill_prompt(false);
+
+  let agreement = LocalAgreement::new();
+  let first = agreement.decoding_options_for_next(&base);
+  assert_eq!(
+    initial_prompt_for(&first, &tokenizer),
+    vec![special.start_of_transcript_token()],
+    "the caller asked for a bare SOT and the first stride still gives it one",
+  );
+  // Non-vacuous: this IS a different prompt, not the same tokens by luck.
+  assert_eq!(
+    crate::audio::whisper::decode::prefill_tokens(&first, &tokenizer, true),
+    vec![
+      special.start_of_transcript_token(),
+      special.english_token(),
+      special.transcribe_token(),
+      special.time_token_begin(),
+    ],
+    "what the caller would have been given instead",
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn the_prefill_reaches_decode_text_as_the_whole_holdback() {
+  // The contract `LocalAgreement::watermark_filtered`'s ambiguity rule rests on,
+  // pinned at the layer that decides it. `DecodingOptions::prefix_tokens` is
+  // only what the engine RECORDED; `prefill_tokens` keeps just the last
+  // `MAX_TOKEN_CONTEXT / 2` of them and drops every id at or above
+  // `special_token_begin` before `decode_text` sees a single token. What the
+  // tie-break needs is that the WHOLE holdback survives that -- so this asserts
+  // the assembled initial prompt ENDS with the holdback's tokens, in order.
+  //
+  // Mutation proof: prefill `confirmed_words` instead of `last_agreed_words` and
+  // the tail below stops matching; make `budgeted_split` return `requested`
+  // unchanged and the over-budget half loses its head tokens to the trim.
+  let tokenizer = tiny_tokenizer();
+
+  let mut agreement = LocalAgreement::new();
+  let words = vec![
+    word(" And", 0.0, 0.4),
+    word(" so", 0.4, 0.8),
+    word(" my", 0.8, 1.2),
+  ];
+  agreement.ingest_streamed(result_with_words(words.clone()));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(words))
+      .is_advanced()
+  );
+
+  let holdback_tokens: Vec<u32> = agreement
+    .last_agreed_words_slice()
+    .iter()
+    .flat_map(|word| word.tokens_slice().iter().copied())
+    .collect();
+  assert!(!holdback_tokens.is_empty(), "non-vacuous");
+  let prompt = initial_prompt_for(
+    &agreement.decoding_options_for_next(&DecodingOptions::new()),
+    &tokenizer,
+  );
+  assert!(
+    prompt.ends_with(&holdback_tokens),
+    "decode_text is forced through the whole holdback: prompt {prompt:?} must \
+     end with {holdback_tokens:?}",
+  );
+
+  // The wide-agreement case, where the budget is genuinely in play: five words
+  // were asked for, and every token of what is actually held still lands.
+  let budget = budget_words();
+  let mut wide = LocalAgreement::new().with_agreement_count_needed(5);
+  let first = || result_with_words(budget[..7].to_vec());
+  wide.ingest_streamed(first());
+  assert!(wide.ingest_streamed(first()).is_advanced());
+  let wide_holdback: Vec<u32> = wide
+    .last_agreed_words_slice()
+    .iter()
+    .flat_map(|word| word.tokens_slice().iter().copied())
+    .collect();
+  assert_eq!(
+    wide_holdback.len(),
+    90,
+    "non-vacuous: a real multi-word prefill"
+  );
+  let wide_prompt = initial_prompt_for(
+    &wide.decoding_options_for_next(&DecodingOptions::new()),
+    &tokenizer,
+  );
+  assert!(
+    wide_prompt.ends_with(&wide_holdback),
+    "no token of the held-back words is left behind by the 112-token trim",
+  );
+}
+
+#[test]
+fn an_unmarked_hypothesis_that_reproduces_nothing_settled_is_kept_whole() {
+  // The other half of the unattributable reading, and the reason it is the
+  // largest MATCH-SUPPORTED optimal seam rather than the largest one. When
+  // `settled` matches nothing in the offered list, every seam scores the same
+  // and the plain maximum is `offered.len()` -- the entire hypothesis refused,
+  // on a stream that re-admitted nothing at all. Repeat that each stride and the
+  // engine never confirms another word: a permanent stall wearing caution's
+  // clothes. Requiring the word before the seam to be matched to a settled word
+  // pins the frontier at 0 here, and the stream keeps moving.
+  //
+  // Mutation proof: drop the `frontier == 0 || before[frontier] >
+  // before[frontier - 1]` conjunct from `settled_seams` (take the plain maximum)
+  // and both faces red -- the confirmed list stops at [" A"] and the transcript
+  // loses " X Y Z".
+  let mut agreement = LocalAgreement::new();
+  let settled = || {
+    result_with_words(vec![
+      word(" A", 0.0, 1.0),
+      word(" B", 1.0, 2.0),
+      word(" C", 2.0, 3.0),
+    ])
+  };
+  agreement.ingest_streamed(settled());
+  assert!(agreement.ingest_streamed(settled()).is_advanced());
+  assert_eq!(confirmed_texts(&agreement), vec![" A"]);
+  assert_eq!(
+    agreement
+      .last_agreed_words_slice()
+      .iter()
+      .map(WordTiming::word)
+      .collect::<Vec<_>>(),
+    vec![" B", " C"],
+    "non-vacuous: `settled` is [\" A\"] and REACHES the watermark, so the \
+     alignment is live -- this is not the settled_len == 0 fast path",
+  );
+
+  // Wholly different text, decoded some other way: nothing here can be a
+  // settled word coming back, and nothing may be refused as one.
+  let unmarked = DecodingOptions::new();
+  let onward = || {
+    result_with_words(vec![
+      word(" X", 1.0, 2.0),
+      word(" Y", 2.0, 3.0),
+      word(" Z", 3.0, 4.0),
+    ])
+  };
+  agreement.ingest(onward(), &unmarked);
+  assert!(
+    agreement.ingest(onward(), &unmarked).is_advanced(),
+    "the unmarked path must still make progress, not stall on unrelated text",
+  );
+  assert_eq!(confirmed_texts(&agreement), vec![" A", " X"]);
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A X Y Z",
+  );
+}
+
+#[test]
+fn a_widened_word_is_not_confirmed_before_an_unmarked_continuation_can_revise_it() {
+  // #94 (codex round 12, finding 1). THE WIDENING'S OWN PREMISE IS ABOUT THE
+  // NEXT RESULT, AND THE SPLIT RUNS BEFORE IT EXISTS. `budgeted_split` widens
+  // past a word the prefill cannot carry, and round 8's argument for settling it
+  // on the spot -- "whatever the next hypothesis produces over that extent was
+  // decoded from a prefix the word is not in, and from audio the clip excludes"
+  // -- is true of a MARKED continuation and of nothing else. A caller that does
+  // not use `decoding_options_for_next` is subject to neither reduction: its
+  // decoder saw that audio and can revise the word. Confirming at the advance
+  // strands the stale reading beside the revision, which is the exact defect
+  // `finalize`'s `holdback_superseded` branch exists to prevent -- reached one
+  // word earlier and through the append-only list, where nothing can take it
+  // back.
+  //
+  // The split still has to widen: with " S" left in the holdback the retarget
+  // would prefill " B" while clipping at " S"'s own start, so a marked
+  // continuation would be forced to contradict the audio it was given and would
+  // disagree every stride (round 8's arithmetic). What is deferrable is the
+  // widened-past word's DESTINATION, not the split, so it goes to
+  // `pending_words` and `ingest` settles it on the first hypothesis whose window
+  // starts at the watermark.
+  //
+  // " S" is tokenless, so `budgeted_split` widens past it; " B" ties with it at
+  // 1.0, so the watermark stays at 1.0 and " S" OVERLAPS the still-open span --
+  // which is what leaves it revisable at all (see the advance's own `end >
+  // watermark` split, and `the_split_settles_a_widened_word_the_span_can_never_
+  // reach` for the other side of that line).
+  //
+  // Mutation proof, both faces: put the widened-past words straight into
+  // `confirmed_words` at the advance (`extend_from_slice(&common[..split])`,
+  // with no `pending_words`) and the state reads back ([" A", " S"], []) and the
+  // transcript " A S Y B C" -- " S" and its own replacement " Y" side by side.
+  // The transcript face has a second falsifier of its own: append
+  // `pending_words` ahead of `hypothesis_words` on `finalize`'s superseded path
+  // instead of dropping them, and the same " A S Y B C" comes back.
+  let a = || word(" A", 0.0, 1.0);
+  let s = || special_only_word(" S", 1.0, 1.5);
+  let b = || word(" B", 1.0, 1.5);
+  // " Y" revises " S", at " S"'s own extent.
+  let y = || word(" Y", 1.0, 1.5);
+  let c = || word(" C", 1.5, 2.0);
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![a(), s(), b()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+
+  // The streaming face, read between pushes: " S" is agreed and out of the
+  // holdback, but NOT yet irrevocable.
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A"], vec![" S"]),
+    "the widened-past word waits for the provenance that decides it",
+  );
+  assert_eq!(
+    agreement
+      .last_agreed_words_slice()
+      .iter()
+      .map(WordTiming::word)
+      .collect::<Vec<_>>(),
+    vec![" B"],
+    "non-vacuous: the split really did widen -- \" S\" is out of the holdback, \
+     so the prefill below carries no id the decoder's filter erases",
+  );
+  assert!(
+    agreement
+      .decoding_options_for_next(&DecodingOptions::new())
+      .prefix_tokens_slice()
+      .iter()
+      .all(|&id| id < MIN_SPECIAL_TOKEN_BEGIN),
+    "and the retarget is the widened one, unchanged by the deferral",
+  );
+  // Finalized HERE, with nothing having superseded it, the pending word is still
+  // in the transcript: deferring is not dropping. (Mutation: delete
+  // `finalize`'s Swift-shaped `append(&mut self.pending_words)` and this reads
+  // " A B".)
+  assert_eq!(
+    agreement.clone().finalize(&DecodingOptions::new()).text(),
+    " A S B",
+    "nothing superseded it, so it is still the only estimate for its span",
+  );
+
+  // The continuation the widening's premise does not cover: decoded some other
+  // way, so it saw " S"'s audio and revised it.
+  let unmarked = DecodingOptions::new();
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![y(), b(), c()]), &unmarked)
+      .is_awaiting_agreement(),
+    "the revision disagrees with the hypothesis it revises",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A Y B C",
+    "the finalized face: the revision replaces the word it revises rather than \
+     landing beside it",
+  );
+}
+
+#[test]
+fn a_marked_continuation_settles_the_widened_word_it_could_not_have_revised() {
+  // The other half of the pair above, and the reason the deferral is not a
+  // regression on round 8's fix: a hypothesis decoded under the retarget could
+  // not have revised the widened-past word (no prefill token of it, and its
+  // audio outside the clip), so the word settles the moment one arrives -- one
+  // ingest later than round 8 settled it, and irrevocably from then on.
+  //
+  // Mutation proof: delete the promotion drain from `ingest` and the SECOND
+  // assertion reads back ([" A"], [" S"]) -- the word never settles, and the
+  // stream that could not have revised it is treated as though it might.
+  let a = || word(" A", 0.0, 1.0);
+  let s = || special_only_word(" S", 1.0, 1.5);
+  let b = || word(" B", 1.0, 1.5);
+  let c = || word(" C", 1.5, 2.0);
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![a(), s(), b()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A"], vec![" S"]),
+    "non-vacuous: there is a pending word for the next stride to settle",
+  );
+
+  // `ingest_streamed` decodes under the engine's own retarget, so its window
+  // starts at the watermark.
+  agreement.ingest_streamed(result_with_words(vec![b(), c()]));
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A", " S"], Vec::<&str>::new()),
+    "a hypothesis clipped at the watermark settles it",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A S B C",
+    "and it stays in the transcript, exactly as round 8 required",
+  );
+}
+
+#[test]
+fn an_empty_holdback_leaves_nothing_pending_because_nothing_could_ever_clear_it() {
+  // The second half of the advance's reachability split, and the reason the
+  // promotion above can read `prefill_reproduces_holdback` without ever reading
+  // it VACUOUSLY. That predicate answers TRUE for anything when the holdback is
+  // empty -- a state `budgeted_split` reaches by design (round 7, finding 2) --
+  // and its vacuity was only ever justified for the FRONTIER, where both
+  // readings name the same column
+  // (`with_nothing_held_back_both_frontiers_are_the_same_column`).
+  //
+  // Rather than bolt a clause on for a state that must not arise, the state is
+  // removed: a pending word waits for a hypothesis this engine ANCHORED, and
+  // with nothing held back no future result can ever be one. Waiting would be an
+  // indefinite hold, and `finalize`'s superseded path would end it by deleting a
+  // word the stream produced -- exactly the loss round 7 finding 2 removed. So
+  // the whole widened-past run is settled at the advance, and
+  // `pending_words` non-empty implies `last_agreed_words` non-empty for good.
+  //
+  // The shape: " L" runs 1.0..5.0 and " B" 2.0..3.0, so the budget forces the
+  // split to the end (an empty holdback, watermark at 3.0) and " L" OVERLAPS the
+  // still-open span -- the one case the overlap test alone would defer. Word ends
+  // inside a hypothesis are not monotone, which is also why the advance takes a
+  // `position` prefix.
+  //
+  // Mutation proof, one face each, and the second one is codex round 13 finding
+  // 1's recommendation run end to end. Dropping the
+  // `self.last_agreed_words.is_empty()` arm from the advance's second split reds
+  // the STATE face at ([], [" L", " B"]) -- and stops there: the transcript
+  // survives, because `prefill_reproduces_holdback` answers the unanchored
+  // continuation below TRUE vacuously and the promotion puts both words back.
+  // (Round 12 recorded that mutation as reaching the transcript too; it does
+  // not, and the vacuity is why.) Add the other two clauses that finding asks
+  // for -- promote only on a NON-VACUOUS anchor (`&& !self.last_agreed_words
+  // .is_empty()`), and read `seams.unattributed` while the holdback is empty --
+  // and the transcript face reds at " Y Z": " L" and " B" deleted, which is
+  // round 7 finding 2's loss returning. Nothing else in this module reds with
+  // all three applied, so that deletion is the whole of what the
+  // recommendation buys.
+  let long = || word_of_tokens(" L", 1.0, 5.0, 1);
+  let big = || word_of_tokens(" B", 2.0, 3.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
+  let y = || word(" Y", 3.0, 5.0);
+  let z = || word(" Z", 5.0, 6.0);
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![long(), big()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert!(
+    agreement.last_agreed_words_slice().is_empty(),
+    "non-vacuous: the budget left NOTHING held back, so there is no anchor a \
+     later result could be checked against",
+  );
+  assert_eq!(agreement.last_agreed_seconds(), 3.0);
+  assert!(
+    long().end() > agreement.last_agreed_seconds(),
+    "non-vacuous: \" L\" DOES overlap the still-open span, so the overlap test \
+     alone would have deferred it",
+  );
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" L", " B"], Vec::<&str>::new()),
+    "with no anchor to wait for, the widened-past run is settled at the advance",
+  );
+
+  // And it stays settled through a continuation the engine did not write.
+  let unmarked = DecodingOptions::new();
+  assert!(
+    agreement.prefill_reproduces_holdback(&unmarked),
+    "non-vacuous: these options satisfy the prefill premise VACUOUSLY -- the \
+     answer that would have been read had anything been left pending",
+  );
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![y(), z()]), &unmarked)
+      .is_awaiting_agreement()
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " L B Y Z",
+    "the finalized face: nothing the stream agreed on was dropped by the wait \
+     it never took",
+  );
+}
+
+#[test]
+fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
+  // #94 (codex round 13, finding 1), REFUTED HERE RATHER THAN FIXED, and this is
+  // the row that says why. The finding reads the empty-holdback arm of the
+  // advance's second split as a NEW hazard: `overlapping` is forced to
+  // `widened.len()`, so a widened-past word whose `end` is past the watermark is
+  // confirmed even though a later unanchored decode could re-read its audio, and
+  // `an_empty_holdback_leaves_nothing_pending_because_nothing_could_ever_clear_
+  // it` is offered as the counterexample (" L" 1.0..5.0 confirmed, then " Y"
+  // 3.0..5.0 landing beside it).
+  //
+  // That reading of the state IS what that test asserts. What makes it not a
+  // defect is this row: `common[..requested]` -- the MAINLINE confirmation, the
+  // one Swift has and this port has never touched -- appends with no overlap
+  // test of any kind, and lands in exactly the same place. Word ends inside a
+  // hypothesis are not monotone, so an agreed word can extend past the first
+  // held-back word's start; here " P" runs 0.0..5.0 while the watermark lands at
+  // " Q"'s 1.0, and the unmarked " Y" that follows re-reads 1.0..5.0. Both are
+  // in the transcript, overlapping.
+  //
+  // So "a confirmed word overlaps a later hypothesis's word" is not a property
+  // the empty-holdback arm introduces; it is the LocalAgreement-2 contract, which
+  // confirms on agreement between two consecutive hypotheses and is append-only.
+  // The frontier is what decides whether an offered word is a settled one coming
+  // BACK (`settled_seams`), and it decides that by alignment; it said " Y" is not
+  // " P". The alternative the finding proposes -- hold the word until an anchor
+  // certifies it -- has no terminating condition when the holdback is empty, and
+  // ends in the deletion round 7 finding 2 removed. See that test's own comment.
+  //
+  // Mutation proof: this row's whole point is that no mutation of the
+  // empty-holdback arm can red it -- the arm is not on this path. The mutation
+  // that DOES red it is the finding's own recommendation carried to its logical
+  // end: take the same `position(|word| word.end() > self.last_agreed_seconds)`
+  // prefix of `common[..requested]` that the widened run takes, and the state
+  // below reads back ([], []) -- " P" never reaches `confirmed_words_slice()` at
+  // all. Eighteen other rows in this module red with it, which is the measure of
+  // how much of the port that recommendation actually moves.
+  let p = || word(" P", 0.0, 5.0);
+  let q = || word(" Q", 1.0, 2.0);
+  let r = || word(" R", 2.0, 3.0);
+  let y = || word(" Y", 1.0, 5.0);
+  let z = || word(" Z", 5.0, 6.0);
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![p(), q(), r()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(agreement.last_agreed_seconds(), 1.0);
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" P"], Vec::<&str>::new()),
+    "non-vacuous: \" P\" came from `common[..requested]`, not from the widened \
+     run -- nothing was ever pending here",
+  );
+  assert!(
+    p().end() > agreement.last_agreed_seconds(),
+    "non-vacuous: the mainline path confirmed a word that OVERLAPS the \
+     still-open span, with no overlap test anywhere on it",
+  );
+
+  let unmarked = DecodingOptions::new();
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![y(), z()]), &unmarked)
+      .is_awaiting_agreement()
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " P Y Z",
+    "the overlapping confirmed word and the later re-reading of its audio are \
+     BOTH in the transcript -- the append-only contract, reached without the \
+     empty-holdback arm being involved at all",
+  );
+}
+
+#[test]
+fn a_retarget_with_a_foreign_prefix_does_not_settle_a_pending_word() {
+  // The promotion's premise is the whole prefill contract, not the clip half of
+  // it. A caller can clip exactly where the engine asked and still hand the
+  // decoder a prefix of its own -- and then nothing forces the hypothesis to
+  // BEGIN with the holdback, so it is free to put a word in front of that
+  // reproduction, over the very span the pending word occupies. (Here " S" runs
+  // 1.0..1.5 and the clip is at 1.0, so its audio is inside that window: the
+  // clip alone excludes nothing.)
+  //
+  // Mutation proof, both faces: promote on the clip clause alone
+  // (`decoded_under.clip_timestamps_slice() == [self.last_agreed_seconds]`,
+  // threaded in beside `decoded_under`) and the state reads back
+  // ([" A", " S"], []) and the transcript " A S Y B C".
+  let a = || word(" A", 0.0, 1.0);
+  let s = || special_only_word(" S", 1.0, 1.5);
+  let b = || word(" B", 1.0, 1.5);
+  let y = || word(" Y", 1.0, 1.5);
+  let c = || word(" C", 1.5, 2.0);
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![a(), s(), b()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A"], vec![" S"]),
+    "non-vacuous: there is a pending word for the retarget to settle or not",
+  );
+
+  // The engine's own clip, with someone else's prefix.
+  let honest = agreement.decoding_options_for_next(&DecodingOptions::new());
+  let foreign = honest.clone().with_prefix_tokens(vec![9_001, 9_002]);
+  assert_eq!(
+    foreign.clip_timestamps_slice(),
+    [agreement.last_agreed_seconds()],
+    "non-vacuous: the clip clause alone IS satisfied",
+  );
+  assert!(
+    !agreement.prefill_reproduces_holdback(&foreign),
+    "and the contract as a whole is not",
+  );
+  assert!(
+    s().start() < agreement.last_agreed_seconds() + 0.001
+      && s().end() > agreement.last_agreed_seconds(),
+    "non-vacuous: the pending word's audio straddles the clip point, so the \
+     clip excludes none of it",
+  );
+
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![y(), b(), c()]), &foreign)
+      .is_awaiting_agreement()
+  );
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A"], vec![" S"]),
+    "the retarget settled nothing -- the word is still revisable, and the \
+     disagreement leaves `finalize` to say what became of it",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A Y B C",
+    "and there it is superseded by the hypothesis that re-covered its span",
+  );
+}
+
+#[test]
+fn a_late_clipped_disagreement_does_not_supersede_the_span_it_never_decoded() {
+  // #94 (codex round 13, finding 2). THE ENGINE ASSUMED EVERY RESULT SAW THE
+  // AUDIO IT WAS JUDGING. `finalize`'s `holdback_superseded` branch replaces the
+  // engine's own provisional record of the still-open span -- `pending_words`
+  // then `last_agreed_words` -- with the final hypothesis's own post-watermark
+  // words, on the premise that hypothesis RE-COVERED that span carrying a
+  // revision. For a marked continuation the clip guarantees it; for an unmarked
+  // one it was simply assumed, and `ingest` documents no requirement that an
+  // unmarked result's window reach the watermark at all.
+  //
+  // A window that begins AFTER the words it supersedes falsifies it outright.
+  // " S" and " B" both run 1.0..1.5 and this decode's `clip_timestamps` begin at
+  // 1.5, so it shares no instant with either: it produced no revision of them,
+  // it produced nothing over their span at all, and the branch's whole
+  // justification -- prefer the revision to the reading it replaced -- has no
+  // referent. Dropping them deletes two words the stream agreed on and nothing
+  // contradicted.
+  //
+  // The fact was already in hand: `decoded_under` carries `clip_timestamps`, and
+  // `ProvenancedResult` already pairs a result with what was known when it
+  // arrived, so the window travels with the result exactly as its prefill
+  // premise does (`ProvenancedResult::window`).
+  //
+  // Mutation proof, the finalized face: make `finalize` drop the whole record
+  // regardless (pass `0` where it passes `open_record_split`) and the first row
+  // reads back " A C" -- " S" and " B" gone. The second row is the falsifier for
+  // how the declared window is READ: `clip_timestamps` holds `(start, end)`
+  // pairs, and reading only the last point as a start (`[2.0, ..)`) refuses a
+  // window that plainly covered the span.
+  let a = || word(" A", 0.0, 1.0);
+  let s = || special_only_word(" S", 1.0, 1.5);
+  let b = || word(" B", 1.0, 1.5);
+  let c = || word(" C", 1.5, 2.0);
+
+  let settled = || {
+    let mut agreement = LocalAgreement::new();
+    let opening = || result_with_words(vec![a(), s(), b()]);
+    agreement.ingest_streamed(opening());
+    assert!(agreement.ingest_streamed(opening()).is_advanced());
+    assert_eq!(
+      (confirmed_texts(&agreement), pending_texts(&agreement)),
+      (vec![" A"], vec![" S"]),
+      "non-vacuous: there is a pending word AND a holdback for the branch to \
+       drop",
+    );
+    assert_eq!(agreement.last_agreed_seconds(), 1.0);
+    agreement
+  };
+
+  for (clip, expected, why) in [
+    // Honest options for a decoder that resumed at 1.5 -- STRICTLY past the
+    // watermark, and at or past the end of every word the branch would drop.
+    (
+      vec![1.5],
+      " A S B C",
+      "a decode that never covered the span does not get to replace the only \
+       estimate it has",
+    ),
+    // A whole `(start, end)` pair whose START precedes the record: this window
+    // DID cover 1.0..1.5, so the branch fires exactly as it always did.
+    (
+      vec![0.5, 2.0],
+      " A C",
+      "a window that covered the span still supersedes it -- the guard is a \
+       coverage test, not a blanket refusal of unmarked results",
+    ),
+  ] {
+    let mut agreement = settled();
+    let late = DecodingOptions::new().with_clip_timestamps(clip.clone());
+    assert!(
+      !agreement.prefill_reproduces_holdback(&late),
+      "non-vacuous: unmarked, so nothing is promoted on arrival and the pending \
+       word is still there to be dropped ({clip:?})",
+    );
+    assert!(
+      agreement
+        .ingest(result_with_words(vec![c()]), &late)
+        .is_awaiting_agreement(),
+      "it disagrees, so `holdback_superseded` fires ({clip:?})",
+    );
+    // The streaming face is unmoved on both rows -- the decision is
+    // `finalize`'s alone, and this pins that the ingest above neither promoted
+    // nor dropped anything.
+    assert_eq!(
+      (confirmed_texts(&agreement), pending_texts(&agreement)),
+      (vec![" A"], vec![" S"]),
+      "{clip:?}",
+    );
+    assert_eq!(
+      agreement.finalize(&DecodingOptions::new()).text(),
+      expected,
+      "the finalized face, clipped at {clip:?}: {why}",
+    );
+  }
+  assert!(
+    s().end() <= 1.5 && b().end() <= 1.5,
+    "non-vacuous: the refusing row's window shares NO instant with either word \
+     it would supersede",
+  );
+}
+
+#[test]
+fn the_still_open_span_begins_where_the_engines_own_record_does() {
+  // Round 13, finding 2's span, from both ends. `open_record_split` scans the
+  // record the engine would DROP, and that record is `pending_words ++
+  // last_agreed_words` -- so it begins at the pending head whenever anything is
+  // pending, and at the holdback otherwise. Reading only one of the two is a
+  // live hole in each direction, and neither is visible in the shapes above,
+  // where the pending word and the holdback tie at the same start.
+  //
+  // The FIRST case is also round 14 finding 2's boundary seen from the pending
+  // side: the window opens at 2.0, which is inside " S1" (1.5..3.0) and at the
+  // head of " B" (2.0..3.0), so the record splits between them -- the pending
+  // head is preserved because no clip re-read it whole, and the holdback is
+  // superseded because one did. A verdict applied to the whole record cannot
+  // express that in either direction.
+  //
+  // Mutation proof, one per case, each mutating `open_record` AND
+  // `open_record_len` together -- moving only one of them leaves the split
+  // arithmetic inconsistent and the mutation self-cancelling, which is how the
+  // first attempt at this pair passed. Make the record the HOLDBACK alone and
+  // the FIRST case reads back " A S0 C": " S1" is no longer in the record, so
+  // nothing protects it and it goes with " B". Make it PENDING alone and the
+  // SECOND case reads back " P D": nothing is pending, so the record is empty,
+  // every word of it is vacuously re-read, and the holdback goes.
+
+  // A pending word that starts STRICTLY before the holdback -- the shape
+  // `the_split_settles_a_widened_word_the_span_can_never_reach` builds, where
+  // the split widens past two words and only the straddling one stays pending.
+  let a = || word(" A", 0.0, 1.0);
+  let s0 = || special_only_word(" S0", 1.0, 2.0);
+  let s1 = || special_only_word(" S1", 1.5, 3.0);
+  let b = || word(" B", 2.0, 3.0);
+  let c = || word(" C", 3.0, 4.0);
+
+  let mut agreement = LocalAgreement::new().with_agreement_count_needed(3);
+  let opening = || result_with_words(vec![a(), s0(), s1(), b()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A", " S0"], vec![" S1"]),
+    "non-vacuous: the record's head is PENDING, and it starts at 1.5 while the \
+     holdback starts at 2.0",
+  );
+  assert_eq!(agreement.last_agreed_seconds(), 2.0);
+
+  // Exactly at the watermark, which is exactly where the holdback begins -- so
+  // measuring the holdback alone would call this covering. It is not: " S1"
+  // runs from 1.5.
+  let at_the_holdback = DecodingOptions::new().with_clip_timestamps(vec![2.0]);
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![c()]), &at_the_holdback)
+      .is_awaiting_agreement()
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A S0 S1 C",
+    "the pending head is part of the record and no clip re-read it whole, so it \
+     survives a window that superseded the holdback behind it",
+  );
+
+  // The other end: nothing pending at all, so the holdback IS the record.
+  let p = || word(" P", 0.0, 1.0);
+  let q = || word(" Q", 1.0, 2.0);
+  let r = || word(" R", 2.0, 3.0);
+  let d = || word(" D", 3.5, 4.5);
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![p(), q(), r()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" P"], Vec::<&str>::new()),
+    "non-vacuous: NOTHING is pending, so the holdback is the whole record",
+  );
+  assert_eq!(agreement.last_agreed_seconds(), 1.0);
+
+  let past_the_holdback = DecodingOptions::new().with_clip_timestamps(vec![3.5]);
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![d()]), &past_the_holdback)
+      .is_awaiting_agreement()
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " P Q R D",
+    "with nothing pending the holdback is still a record to protect, not an \
+     absent one",
+  );
+}
+
+#[test]
+fn a_late_clipped_agreement_confirms_the_span_it_could_not_re_read() {
+  // Round 13, finding 2's OTHER consumer, and the reason the coverage fact is a
+  // property of the result rather than a clause bolted onto `finalize`. The
+  // advance replaces the same provisional record -- `pending_words.clear()` and
+  // `last_agreed_words = common[split..]` -- on the same unchecked premise, and
+  // its own comment stated it outright ("this hypothesis saw its audio"). Two
+  // consecutive late-clipped hypotheses agree on " C D" at 1.5 onwards; `common`
+  // is their words, not a re-reading of 1.0..1.5, so replacing " S" and " B"
+  // with it deletes them -- and here it deletes them from the STREAMING face
+  // too, where nothing downstream can put them back.
+  //
+  // Confirming is what is left, and it is the same claim every other confirmed
+  // word carries: two consecutive hypotheses agreed on them, and no hypothesis
+  // that could see their audio has contradicted them since. Holding them instead
+  // has no terminating condition -- the watermark has moved past them, so no
+  // future result can be offered over their span at all.
+  //
+  // Mutation proof, both faces: drop the `covers` guard from the advance's
+  // replacement and the streaming face reads back ([" A"], []) and the
+  // transcript " A C D".
+  let a = || word(" A", 0.0, 1.0);
+  let s = || special_only_word(" S", 1.0, 1.5);
+  let b = || word(" B", 1.0, 1.5);
+  let c = || word(" C", 1.5, 2.0);
+  let d = || word(" D", 2.0, 2.5);
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![a(), s(), b()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A"], vec![" S"]),
+    "non-vacuous: there is a pending word AND a holdback for the advance to \
+     replace",
+  );
+
+  let late = DecodingOptions::new().with_clip_timestamps(vec![1.5]);
+  let resumed = || result_with_words(vec![c(), d()]);
+  assert!(
+    agreement.ingest(resumed(), &late).is_awaiting_agreement(),
+    "the first one has nothing to agree with over this span",
+  );
+  assert!(
+    agreement.ingest(resumed(), &late).is_advanced(),
+    "the second corroborates it: an advance whose `common` is entirely past 1.5",
+  );
+
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A", " S", " B"], Vec::<&str>::new()),
+    "the streaming face: what the advance could not re-read, it confirms rather \
+     than drops",
+  );
+  assert_eq!(
+    agreement
+      .last_agreed_words_slice()
+      .iter()
+      .map(WordTiming::word)
+      .collect::<Vec<_>>(),
+    vec![" C", " D"],
+    "and the holdback is the agreeing pair's own words, as always",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A S B C D",
+    "the finalized face: nothing the stream agreed on was lost to a window that \
+     excluded it",
+  );
+}
+
+#[test]
+fn a_gap_between_clip_ranges_does_not_supersede_the_span_no_range_reached() {
+  // #94 (codex round 14, finding 1). COVERAGE IS A SET OF INTERVALS, NOT A
+  // SINGLE HALF-LINE. Round 13 recorded the window a result arrived under as its
+  // FIRST `clip_timestamps` entry and read it as `[decoded_from, ..)`.
+  // `clip_timestamps` is not a start: its own doc says "Explicit `(start, end)`-pair
+  // timestamps ... to split the audio into segments before transcription", and
+  // `WhisperKit::transcribe` hands it straight to `chunker::prepare_seek_clips`,
+  // which pairs the points and decodes each pair as its own clip.
+  //
+  // `[0.0, 0.5, 3.0]` therefore decodes `[0.0, 0.5)` and `[3.0, end)` and NOTHING
+  // between them. The still-open record here is " S1" (1.5..3.0) then " B"
+  // (2.0..3.0), which sits entirely inside that gap -- yet the half-line reading
+  // starts the window at 0.0 and calls the record covered, so a word from the
+  // SECOND range supersedes a span the decoder demonstrably never saw. Two words
+  // the stream agreed on, deleted for a revision that does not exist.
+  // Mutation proof, one per row. Read the first clip point as a half-line
+  // (`clip_timestamps.first()`, then `[start, ..)`, which is what round 13 did)
+  // and ROW 1 reads back " A S0 C" -- " S1" and " B" gone. Make the trailing
+  // comparison STRICT (`word.end() < end`) and ROW 2 reads back
+  // " A S0 S1 B Y": a clip ending exactly where the record does stops covering
+  // it. Test only the word's START against the clip end
+  // (`start <= word.start() && word.start() <= end`) and ROW 3 reads back
+  // " A S0 Y" -- half a word inside the clip counted as re-read. Full OVERLAP
+  // (`start <= word.end() && word.start() <= end`) reds row 1 first, " A S0 C",
+  // because the `[3.0, ..)` clip then touches both record words at the instant
+  // 3.0, and reds five other tests besides.
+  //
+  // The three rows below also pin the two ENDS of a clip against each other. A
+  // range is half-open and a word is covered by CONTAINMENT in ONE of them, so
+  // the trailing comparison is non-strict at a clip that ends exactly where the
+  // record does (row 2) and refuses a clip that ends one word short of it (row
+  // 3) -- overlap would have accepted both, and a strict end would have refused
+  // both. Rows 2 and 3 differ in NOTHING but that clip end.
+  let a = || word(" A", 0.0, 1.0);
+  let s0 = || special_only_word(" S0", 1.0, 2.0);
+  let s1 = || special_only_word(" S1", 1.5, 3.0);
+  let b = || word(" B", 2.0, 3.0);
+  let c = || word(" C", 3.0, 4.0);
+  let y = || word(" Y", 2.0, 2.5);
+
+  let settled = || {
+    let mut agreement = LocalAgreement::new().with_agreement_count_needed(3);
+    let opening = || result_with_words(vec![a(), s0(), s1(), b()]);
+    agreement.ingest_streamed(opening());
+    assert!(agreement.ingest_streamed(opening()).is_advanced());
+    assert_eq!(
+      (confirmed_texts(&agreement), pending_texts(&agreement)),
+      (vec![" A", " S0"], vec![" S1"]),
+      "non-vacuous: the record spans both buckets -- a pending head and a \
+       holdback",
+    );
+    assert_eq!(agreement.last_agreed_seconds(), 2.0);
+    agreement
+  };
+
+  assert_eq!(
+    crate::audio::whisper::audio::chunker::prepare_seek_clips(&[0.0, 0.5, 3.0], 16_000 * 10)
+      .unwrap(),
+    vec![(0, 8_000), (48_000, 160_000)],
+    "non-vacuous: the crate's own range derivation reads these three points as \
+     two disjoint clips, and 1.5..3.0 is in neither",
+  );
+  assert!(
+    s1().start() >= 0.5 && b().end() <= 3.0,
+    "non-vacuous: the whole record lies strictly inside the gap",
+  );
+
+  for (clip, hypothesis, expected, why) in [
+    // The gap. Every word of the record is between the two clips, and the only
+    // word offered comes out of the SECOND one.
+    (
+      vec![0.0, 0.5, 3.0],
+      vec![c()],
+      " A S0 S1 B C",
+      "a word decoded in the range AFTER the gap supersedes nothing inside it",
+    ),
+    // One clip containing the whole record, ending EXACTLY where it ends. The
+    // branch fires as it always did -- this is a coverage test, not a blanket
+    // refusal of a `(start, end)` pair.
+    (
+      vec![0.0, 3.0],
+      vec![y()],
+      " A S0 Y",
+      "a clip that ends exactly where the record does still decoded it whole",
+    ),
+    // The same clip half a second shorter, so it stops between the record's two
+    // words' starts and their shared end. Neither word was decoded WHOLE, so
+    // neither is superseded.
+    (
+      vec![0.0, 2.5],
+      vec![y()],
+      " A S0 S1 B Y",
+      "a clip that only reaches PART of each held word re-read neither of them",
+    ),
+  ] {
+    let mut agreement = settled();
+    let clipped = DecodingOptions::new().with_clip_timestamps(clip.clone());
+    assert!(
+      !agreement.prefill_reproduces_holdback(&clipped),
+      "non-vacuous: unmarked, so nothing is promoted on arrival ({clip:?})",
+    );
+    assert!(
+      agreement
+        .ingest(result_with_words(hypothesis), &clipped)
+        .is_awaiting_agreement(),
+      "it disagrees, so `holdback_superseded` fires ({clip:?})",
+    );
+    assert_eq!(
+      (confirmed_texts(&agreement), pending_texts(&agreement)),
+      (vec![" A", " S0"], vec![" S1"]),
+      "the streaming face is unmoved -- the decision is `finalize`'s alone \
+       ({clip:?})",
+    );
+    assert_eq!(
+      agreement.finalize(&DecodingOptions::new()).text(),
+      expected,
+      "the finalized face, clipped at {clip:?}: {why}",
+    );
+  }
+  assert!(
+    y().start() >= 2.0 && y().end() <= 2.5,
+    "non-vacuous: the offered word is inside BOTH of the last two rows' clips, \
+     so the rows differ only in what the clip reached of the RECORD",
+  );
+}
+
+#[test]
+fn an_agreement_from_past_a_clip_gap_confirms_the_span_no_range_reached() {
+  // #94 (codex round 14, finding 1), the advance's face. Same gapped schedule,
+  // same record, and the same deletion reached without `finalize` at all: two
+  // consecutive hypotheses whose every word comes from the `[3.0, end)` range
+  // agree, and the advance installs `common` over `pending_words` and
+  // `last_agreed_words`. `common` is not a re-reading of 1.5..3.0 -- no decode
+  // in this schedule ever looked there -- so the record is deleted from the
+  // STREAMING face, where nothing downstream can put it back.
+  //
+  // Mutation proof: read the first clip point as a half-line and the streaming
+  // face reads back ([" A", " S0"], []) with the transcript " A S0 C E F". The
+  // two halves of the confirmed prefix have their own falsifiers -- drop the
+  // holdback half of `confirm_the_unread_prefix_and_drop_the_rest` and it reads
+  // ([" A", " S0", " S1"], []); drop the pending half and it reads
+  // ([" A", " S0", " B"], []), which also pins their ORDER.
+  let a = || word(" A", 0.0, 1.0);
+  let s0 = || special_only_word(" S0", 1.0, 2.0);
+  let s1 = || special_only_word(" S1", 1.5, 3.0);
+  let b = || word(" B", 2.0, 3.0);
+  let c = || word(" C", 3.0, 4.0);
+  let e = || word(" E", 4.0, 5.0);
+  let f = || word(" F", 5.0, 6.0);
+
+  let mut agreement = LocalAgreement::new().with_agreement_count_needed(3);
+  let opening = || result_with_words(vec![a(), s0(), s1(), b()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A", " S0"], vec![" S1"]),
+    "non-vacuous: there is a pending word AND a holdback for the advance to \
+     replace",
+  );
+
+  let gapped = DecodingOptions::new().with_clip_timestamps(vec![0.0, 0.5, 3.0]);
+  let resumed = || result_with_words(vec![c(), e(), f()]);
+  assert!(
+    agreement.ingest(resumed(), &gapped).is_awaiting_agreement(),
+    "the first one has nothing to agree with over this span",
+  );
+  assert!(
+    agreement.ingest(resumed(), &gapped).is_advanced(),
+    "the second corroborates it: an advance whose `common` is entirely past the \
+     gap",
+  );
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A", " S0", " S1", " B"], Vec::<&str>::new()),
+    "the streaming face: what no clip in the schedule could re-read, the advance \
+     confirms rather than drops",
+  );
+  assert_eq!(
+    agreement
+      .last_agreed_words_slice()
+      .iter()
+      .map(WordTiming::word)
+      .collect::<Vec<_>>(),
+    vec![" C", " E", " F"],
+    "and the holdback is the agreeing pair's own words, as always",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A S0 S1 B C E F",
+    "the finalized face: nothing the stream agreed on was lost to a schedule \
+     that skipped it",
+  );
+}
+
+#[test]
+fn a_window_that_opens_inside_the_record_replaces_only_the_part_it_re_read() {
+  // #94 (codex round 14, finding 2). ONE VERDICT FOR A WHOLE RECORD IS WRONG IN
+  // BOTH DIRECTIONS. Round 13 asked whether the window reached the record's
+  // FIRST word and applied that answer to every word in it. Here " Q" (1.0..2.0)
+  // and " R" (2.0..3.0) are held and the continuation clips at exactly 2.0: " Q"
+  // is outside its window and " R" is wholly inside it. The head-only reading
+  // answers "not covered" and CONFIRMS both -- so " R" becomes irrevocable on the
+  // streaming face at the very moment a hypothesis that did re-read it says it is
+  // " X" instead, and the transcript carries the stale " R" beside its own
+  // revision.
+  //
+  // That is the exact mirror of round 13's finding: there a late-clipped result
+  // was allowed to supersede a record it never saw; here the same conservatism
+  // confirms the portion it DID see and revise. The record splits at the
+  // coverage boundary instead: the uncovered prefix is preserved (or, on the
+  // advance, confirmed) and only the covered suffix is replaced.
+  //
+  // Mutation proof, four ways and both faces. Make the leading comparison STRICT
+  // (`start < word.start()`) and the finalized row reads back " P Q R X D" --
+  // the round-13 answer, and the reason that comparison cannot be tightened.
+  // Make `finalize` drop the whole record (pass `0` where it passes
+  // `open_record_split`) and it reads " P X D"; make the ADVANCE do the same and
+  // the streaming face reads ([" P"], []). Read the first clip point as a
+  // half-line, or test only the word's START, or scan FORWARD for the first
+  // covered word (`position`) instead of back over the covered suffix, and the
+  // last row reads back " P Y" -- " Q" and " R" both replaced, the second of
+  // them from behind a word no clip reached.
+  let p = || word(" P", 0.0, 1.0);
+  let q = || word(" Q", 1.0, 2.0);
+  let r = || word(" R", 2.0, 3.0);
+  let x = || word(" X", 2.0, 3.0);
+  let d = || word(" D", 3.0, 4.0);
+
+  let settled = || {
+    let mut agreement = LocalAgreement::new();
+    let opening = || result_with_words(vec![p(), q(), r()]);
+    agreement.ingest_streamed(opening());
+    assert!(agreement.ingest_streamed(opening()).is_advanced());
+    assert_eq!(
+      (confirmed_texts(&agreement), pending_texts(&agreement)),
+      (vec![" P"], Vec::<&str>::new()),
+      "non-vacuous: TWO words are held, and the window below opens between them",
+    );
+    assert_eq!(agreement.last_agreed_seconds(), 1.0);
+    agreement
+  };
+
+  // Exactly the second held word's start, which is strictly past the record's
+  // own head. `" R"` is wholly inside `[2.0, ..)`; `" Q"` is wholly outside it.
+  let inside = || DecodingOptions::new().with_clip_timestamps(vec![2.0]);
+  assert!(
+    q().start() < 2.0 && r().start() >= 2.0,
+    "non-vacuous: the window opens strictly inside the record",
+  );
+
+  // The finalized face: one disagreeing hypothesis.
+  let mut agreement = settled();
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![x(), d()]), &inside())
+      .is_awaiting_agreement(),
+    "it disagrees, so `holdback_superseded` fires",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " P Q X D",
+    "the revised half is replaced by its revision and the unreachable half is \
+     kept -- not both readings of 2.0..3.0 side by side",
+  );
+
+  // The streaming face: two agreeing hypotheses, so the advance decides.
+  let mut agreement = settled();
+  let resumed = || result_with_words(vec![x(), d()]);
+  assert!(
+    agreement
+      .ingest(resumed(), &inside())
+      .is_awaiting_agreement()
+  );
+  assert!(agreement.ingest(resumed(), &inside()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" P", " Q"], Vec::<&str>::new()),
+    "the streaming face: only the half the pair could not re-read is made \
+     irrevocable -- confirming \" R\" here would strand it against its own \
+     revision",
+  );
+  assert_eq!(
+    agreement
+      .last_agreed_words_slice()
+      .iter()
+      .map(WordTiming::word)
+      .collect::<Vec<_>>(),
+    vec![" X", " D"],
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " P Q X D",
+    "and the transcript agrees with the streaming face word for word",
+  );
+
+  // THE OTHER DIRECTION, and why the split is the start of the longest COVERED
+  // SUFFIX rather than the first covered word. A clip that CLOSES inside the
+  // record re-read " Q" and not " R", so the covered word is the one in FRONT.
+  // Replacing from it would take " R" with it -- a deletion, from behind a word
+  // the window never reached -- so the boundary moves past both and the whole
+  // record is preserved. The cost is the erring-wide one this rule is drawn to
+  // pay: " Q" reaches the transcript beside its own revision " Y". A repetition,
+  // not a deletion, and the same direction the advance's `position` split takes
+  // for the same reason.
+  let closing_inside = DecodingOptions::new().with_clip_timestamps(vec![0.0, 2.0]);
+  let y = || word(" Y", 1.0, 2.0);
+  assert!(
+    q().end() <= 2.0 && r().end() > 2.0,
+    "non-vacuous: the clip contains the FIRST held word whole and the second \
+     only in part",
+  );
+  let mut agreement = settled();
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![y()]), &closing_inside)
+      .is_awaiting_agreement(),
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " P Q R Y",
+    "a covered word in front of an uncovered one is kept, so the uncovered one \
+     is never replaced out from behind it",
+  );
+}
+
+#[test]
+fn a_final_pair_that_agreed_past_an_unreachable_record_keeps_what_they_agreed_on() {
+  // #94 (codex round 14). The record and the TAIL are two questions, and only
+  // the record's half belongs to coverage. Round 13's `finalize` guard made
+  // "this hypothesis re-read the record" decide both at once; round 14's split
+  // answers the record's half by itself -- a record nothing re-read gets
+  // `open_record_split == len` and is kept whole either way -- leaving the guard
+  // deciding only whether the tail is `hypothesis_words` or Swift's
+  // `findLongestDifferentSuffix(prevWords, hypothesisWords)`.
+  //
+  // Nothing in the suite could tell the two apart, and every shape that CAN
+  // makes the subtraction wrong. Here two consecutive late-clipped hypotheses
+  // both produce " M" at 3.0..4.0 -- a one-word common prefix, short of the
+  // threshold of 2, so it disagrees and " M" is never confirmed. Swift subtracts
+  // it on the premise that `lastAgreedWords` supplies it; `lastAgreedWords` is
+  // " Q R" at 1.0..3.0, which has nothing to do with " M", so subtracting drops
+  // a word BOTH hypotheses produced and nothing puts it back. That is
+  // `a_disagreeing_final_pair_keeps_the_words_both_hypotheses_agreed_on`'s
+  // defect reached with a NON-empty holdback.
+  //
+  // Mutation proof: restore the conjunct (`&& (record_len == 0 ||
+  // open_record_split < record_len)`, with `record_len` re-derived from
+  // `open_record_len()`) and this reads back " P Q R Z" -- " M" gone.
+  let p = || word(" P", 0.0, 1.0);
+  let q = || word(" Q", 1.0, 2.0);
+  let r = || word(" R", 2.0, 3.0);
+  let m = || word(" M", 3.0, 4.0);
+  let n = || word(" N", 4.0, 5.0);
+  let z = || word(" Z", 4.0, 5.0);
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![p(), q(), r()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" P"], Vec::<&str>::new()),
+    "non-vacuous: the holdback is NON-empty, which is what separates this from \
+     the empty-holdback face of the same defect",
+  );
+
+  // Strictly past every word of the record, so nothing in it is re-read and the
+  // record survives whichever tail is taken.
+  let late = DecodingOptions::new().with_clip_timestamps(vec![3.0]);
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![m(), n()]), &late)
+      .is_awaiting_agreement()
+  );
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![m(), z()]), &late)
+      .is_awaiting_agreement(),
+    "a ONE-word common prefix is short of the threshold, so this disagrees too",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " P Q R M Z",
+    "the unreachable record is kept whole AND the word both hypotheses produced \
+     survives -- the subtraction has no holdback to justify it here",
+  );
+}
+
+#[test]
+fn the_split_settles_a_widened_word_the_span_can_never_reach() {
+  // The line the advance's second split draws, asserted from both sides in one
+  // stream. `budgeted_split` widens past BOTH " S" words here; the still-open
+  // span begins at " B"'s start, and only the word whose extent crosses that
+  // point is still in play. The other one is settled outright -- every word the
+  // engine will ever be offered again starts at or after the watermark, so
+  // nothing can overlap it, and no provenance can change that.
+  //
+  // Deferring it anyway would be strictly worse than the round-8 behaviour it
+  // replaces: `finalize`'s superseded branch would drop a word the stream
+  // produced and nothing revised.
+  //
+  // Mutation proof: relax the advance's `word.end() > self.last_agreed_seconds`
+  // to `>=` and the first assertion reads back ([" A"], [" S0", " S1"]); test
+  // `word.start() >= self.last_agreed_seconds` instead -- the plausible mistake,
+  // since `offered` is filtered on `start` -- and it reads
+  // ([" A", " S0", " S1"], []), which the second half then falsifies too: the
+  // unmarked revision lands beside " S1" rather than replacing it,
+  // " A S0 S1 Y B C".
+  //
+  // `agreement_count_needed` is 3 so that BOTH " S" words fall inside
+  // `common[requested..split]`: at the default 2 the first of them would be
+  // confirmed by `common[..requested]` regardless, and the boundary under test
+  // would decide nothing.
+  let a = || word(" A", 0.0, 1.0);
+  // Ends exactly where the still-open span begins: unreachable from inside it.
+  let s0 = || special_only_word(" S0", 1.0, 2.0);
+  // STRADDLES that point -- starts before it, ends after it -- so an offered
+  // word can overlap it and it is still in play.
+  let s1 = || special_only_word(" S1", 1.5, 3.0);
+  let b = || word(" B", 2.0, 3.0);
+  let y = || word(" Y", 2.0, 3.0);
+  let c = || word(" C", 3.0, 4.0);
+
+  let mut agreement = LocalAgreement::new().with_agreement_count_needed(3);
+  let opening = || result_with_words(vec![a(), s0(), s1(), b()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(agreement.last_agreed_seconds(), 2.0);
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A", " S0"], vec![" S1"]),
+    "the widened-past words split again, on whether the still-open span can \
+     reach them",
+  );
+
+  let unmarked = DecodingOptions::new();
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![y(), b(), c()]), &unmarked)
+      .is_awaiting_agreement()
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A S0 Y B C",
+    "the unreachable word survives the revision; the reachable one is replaced \
+     by it",
+  );
+}
+
+#[test]
+fn the_holdback_filter_reads_the_configured_special_range_not_the_floor() {
+  // #94 (codex round 12, finding 2). THE FLOOR IS AN ASSUMPTION, NOT AN
+  // INVARIANT. `MIN_SPECIAL_TOKEN_BEGIN` is correct for the 50256/50257
+  // families, but `WhisperTokenizer::from_folder` loads any parseable
+  // `tokenizer.json` and probes `<|endoftext|>` for that artifact's OWN
+  // threshold, rejecting nothing below the floor. For such an artifact the
+  // engine calls an id carriable that `prefill_tokens` erases, the equality
+  // `prefill_reproduces_holdback` checks is satisfied by a prefix the decoder is
+  // given only part of, and round 8's defect is back with no caller lying.
+  //
+  // Threading the real value closes it where the value is known and costs
+  // nothing where it is not: the default is exactly the floor, so no existing
+  // caller moves, and `LocalAgreementTranscriber` sets it from the very
+  // tokenizer whose `prefill_tokens` will apply the filter (see
+  // `the_driver_takes_its_special_range_from_the_loaded_vocabulary`). Rejecting
+  // the artifact at load instead would refuse a vocabulary this crate otherwise
+  // decodes correctly, over a premise only the streaming engine has a stake in.
+  //
+  // Mutation proof, both faces: read `MIN_SPECIAL_TOKEN_BEGIN` in
+  // `budgeted_split` instead of the threshold it is given and the configured
+  // engine's holdback reads back [" S", " B"] carrying id 40005 -- an id the
+  // artifact's own filter erases.
+  const LOW: u32 = 40_000;
+  let a = || word(" A", 0.0, 0.5);
+  // Below the floor, so carriable under the default; at or above LOW, so not
+  // carriable for an artifact that reserves ids from there.
+  let s = || WordTiming::new(" S", vec![LOW + 5], 0.5, 1.0, 0.9);
+  let b = || word(" B", 1.0, 1.5);
+  assert!(
+    s()
+      .tokens_slice()
+      .iter()
+      .all(|&id| id < MIN_SPECIAL_TOKEN_BEGIN),
+    "non-vacuous: the floor calls every one of these ids carriable",
+  );
+
+  let run = |engine: LocalAgreement| {
+    let mut engine = engine;
+    let opening = || result_with_words(vec![a(), s(), b()]);
+    engine.ingest_streamed(opening());
+    assert!(engine.ingest_streamed(opening()).is_advanced());
+    let holdback: Vec<String> = engine
+      .last_agreed_words_slice()
+      .iter()
+      .map(|word| word.word().to_string())
+      .collect();
+    let prefill = engine
+      .decoding_options_for_next(&DecodingOptions::new())
+      .prefix_tokens_slice()
+      .to_vec();
+    (holdback, prefill)
+  };
+
+  // The default engine: the floor, and the artifact's filter erases what it
+  // issues.
+  let engine = LocalAgreement::new();
+  assert_eq!(engine.special_token_begin(), MIN_SPECIAL_TOKEN_BEGIN);
+  let (holdback, prefill) = run(engine);
+  assert_eq!(holdback, vec![" S".to_string(), " B".to_string()]);
+  assert!(
+    prefill.iter().any(|&id| id >= LOW),
+    "non-vacuous: this is the defect -- the issued prefix {prefill:?} carries \
+     an id a vocabulary reserving from {LOW} drops",
+  );
+
+  // Told the artifact's own threshold: the same word is widened past instead,
+  // and every id the engine issues survives that vocabulary's filter.
+  let engine = LocalAgreement::new().with_special_token_begin(LOW);
+  assert_eq!(engine.special_token_begin(), LOW);
+  let (holdback, prefill) = run(engine);
+  assert_eq!(
+    holdback,
+    vec![" B".to_string()],
+    "the holdback keeps only what THAT vocabulary's prefill carries whole",
+  );
+  assert!(
+    !prefill.is_empty() && prefill.iter().all(|&id| id < LOW),
+    "and the issued prefix {prefill:?} survives its filter intact",
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn the_driver_takes_its_special_range_from_the_loaded_vocabulary() {
+  // The path that needs nothing remembered: the driver holds the very tokenizer
+  // whose `prefill_tokens` applies the filter `budgeted_split` is standing in
+  // for, so it hands the engine the exact threshold instead of the floor. Read
+  // off the real artifact rather than argued from the constant.
+  //
+  // Mutation proof: drop the `with_special_token_begin(...)` from
+  // `LocalAgreementTranscriber::new` and this reads back
+  // `MIN_SPECIAL_TOKEN_BEGIN`.
+  let tokenizer = tiny_tokenizer();
+  let vocabulary = tokenizer.special_tokens().special_token_begin();
+  assert_ne!(
+    vocabulary, MIN_SPECIAL_TOKEN_BEGIN,
+    "non-vacuous: the shipped vocabulary's threshold is not the floor, so the \
+     two answers are distinguishable",
+  );
+
+  let kit = crate::audio::whisper::transcribe::WhisperKit::with_backend(
+    crate::audio::whisper::backend::mock::MockBackend::new(),
+    tokenizer,
+  );
+  let streamer = kit.local_agreement_transcriber(DecodingOptions::new());
+  assert_eq!(
+    streamer.agreement().special_token_begin(),
+    vocabulary,
+    "the driver's engine reads the loaded vocabulary, not the floor",
+  );
+}
+
+#[test]
+fn an_unmarked_hypothesis_may_re_agree_a_pending_word_because_it_is_not_confirmed() {
+  // Where the pending words sit in the ALIGNMENT, pinned by the case that can
+  // tell. They are not confirmed, so they belong to `settled_seams`' revisable
+  // half beside the holdback: an offered word that re-covers one is a
+  // reproduction the engine WANTS -- a second hypothesis agreeing over that span
+  // is how the word earns its place. Filing them in the settled half instead
+  // would refuse exactly that reproduction, which is the right treatment for a
+  // word already in the caller's hands and the wrong one for a word that is not.
+  //
+  // Mutation proof: put `pending` in `watermark_filtered_with`'s settled half
+  // (concatenate it onto `confirmed` and leave `revisable` as the holdback) and
+  // both faces red -- the outcome becomes `awaiting_agreement`, the state
+  // ([" A"], [" S"]) survives for the wrong reason, and the transcript loses
+  // " S" entirely (" A B C"). Separately, drop `self.pending_words.clear()` from
+  // the advance and the state reads back ([" A"], [" S", " S"]).
+  let a = || word(" A", 0.0, 1.0);
+  let s = || special_only_word(" S", 1.0, 1.5);
+  let b = || word(" B", 1.0, 1.5);
+  let c = || word(" C", 1.5, 2.0);
+
+  let mut agreement = LocalAgreement::new();
+  let opening = || result_with_words(vec![a(), s(), b()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A"], vec![" S"]),
+    "non-vacuous: there is a pending word for the re-offer to re-agree",
+  );
+
+  // Decoded some other way, and reproducing the pending word rather than
+  // revising it.
+  let unmarked = DecodingOptions::new();
+  assert!(
+    agreement
+      .ingest(result_with_words(vec![s(), b(), c()]), &unmarked)
+      .is_advanced(),
+    "the re-offer agrees with the hypothesis that produced the pending word",
+  );
+  assert_eq!(
+    (confirmed_texts(&agreement), pending_texts(&agreement)),
+    (vec![" A"], vec![" S"]),
+    "and the re-agreement leaves it pending, not doubled and not dropped: it is \
+     still a word the prefill cannot carry",
+  );
+  assert_eq!(
+    agreement.finalize(&DecodingOptions::new()).text(),
+    " A S B C",
   );
 }

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -1083,9 +1083,10 @@ fn the_split_never_cuts_at_a_tied_start() {
         let confirmed_high_before = highest_start(agreement.confirmed_words_slice());
         let outcome = agreement.ingest_streamed(result_with_words(offered));
         // THE HONEST SIGNAL, asserted on every round of every trial: an
-        // agreeing round says `progressed` exactly when one of the two things a
-        // caller can observe moved, and `stationary` exactly when neither did;
-        // a round that did not agree moves neither.
+        // agreeing round says `progressed` exactly when one of the two SETTLED
+        // channels moved -- the watermark and the confirmed prefix, not
+        // everything a caller can observe -- and `stationary` exactly when
+        // neither did; a round that did not agree moves neither.
         //
         // Mutation proof, and the reason this rides the sweep rather than only
         // the two hand-built pairs: decide progress by `split != 0` instead of
@@ -1443,8 +1444,9 @@ fn an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant() {
   // an ALL-ZERO alignment matrix -- the zero-fill
   // `add_word_timestamps_zero_pads_missing_rows` pins -- because DTW's tie-break
   // walks the path down column 0 and every text-index step there records the
-  // same boundary time. Measured on that stack: 130 words, all at 0.0, all
-  // zero-duration, one token each.
+  // same boundary time: every word lands at 0.0, zero-duration, one token each.
+  // The COUNT is whatever the gathered tokens supply, so the 113 this test uses
+  // is its own construction rather than a measurement of that stack.
   //
   // WHY IT IS ACCEPTED. To a timestamp filter a genuinely new word at the run's
   // instant and a re-offer of the run's own last word are the same value, which
@@ -3761,9 +3763,13 @@ fn a_tied_run_above_the_budget_floor_advances_instead_of_stalling() {
   // the split runs off the END of `common`. A repeated hypothesis grows nothing,
   // so the state is the same again next round and the round after.
   // `add_word_timestamps` produces exactly that shape from an ALL-ZERO alignment
-  // matrix (`add_word_timestamps_zero_pads_missing_rows`; measured at 130 such
-  // words), which is why this is the reachability answer for the finding rather
-  // than the shape above.
+  // matrix -- DTW's tie-break walks the path down column 0, so every text-index
+  // step records the same boundary time -- which is why this is the reachability
+  // answer for the finding rather than the shape above. The zero-fill that makes
+  // such a matrix reachable is pinned by
+  // `add_word_timestamps_zero_pads_missing_rows` in `segment/tests.rs`; the
+  // WIDTH of the run is this test's own 113, built here, and no fixture in this
+  // repository measures a different one.
   //
   // Nothing is stranded on the FIRST half: `beyond_common` is EMPTY, so the
   // watermark filters nothing away that any hypothesis had produced, and BOTH of
@@ -5096,13 +5102,20 @@ fn an_agreeing_round_that_moves_nothing_reports_stationary() {
   // Was `characterization_an_agreeing_round_returns_advanced_without_moving_the_
   // watermark`, which PINNED the dishonest signal and named the correct answer
   // in its own failure message. This asserts that answer instead: a round that
-  // agreed, kept its result and moved NOTHING says so.
+  // agreed, kept its result and moved neither the watermark nor the confirmed
+  // prefix says so. Not "moved nothing" -- its holdback is replaced wholesale,
+  // which is observable and is deliberately not a progress channel.
   //
-  // WHY IT MATTERS, measured rather than argued. On the pathological input
-  // `the_split_never_cuts_at_a_tied_start` builds, 399 of 400 rounds are this
-  // one. While both agreeing cases shared a single `Advanced`, a caller with a
-  // stall watchdog keyed on the outcome saw 399 consecutive reports of progress
-  // and could not tell the stall from a working stream.
+  // WHY IT MATTERS, measured rather than argued -- and measured on fixtures
+  // THIS REPOSITORY RUNS, so every figure here is reproducible by running them.
+  // `a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forever`
+  // reaches this state on 110 CONSECUTIVE rounds of its 120, asserted there
+  // against a floor of 100. `the_split_never_cuts_at_a_tied_start`'s 512-trial
+  // sweep reaches it on 1281 of its 2965 agreeing rounds, 4233 rounds in all,
+  // asserted there against a floor of 256. While both agreeing cases shared a
+  // single `Advanced`, a caller with a stall watchdog keyed on the outcome read
+  // every one of those as progress -- 110 in an unbroken run -- and could not
+  // tell the stall from a working stream.
   //
   // The MINIMAL PAIR is
   // `an_agreeing_round_with_a_zero_split_and_drifting_timings_progresses`: the

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -430,8 +430,9 @@ fn the_split_never_cuts_at_a_tied_start() {
   // budget, and that could not build the AGGREGATE trigger (codex round 3 on
   // PR #95): a TIED RUN of ordinary words whose TOTAL exceeds the budget, where
   // the floor lands inside the run, every reachable boundary ties, and the split
-  // runs off the end of `common`. Measured on the shape this test had before:
-  // 25 such rounds of 1662 observations, all of them reached through the
+  // runs off the end of `common`. Measured on the shape this test had before
+  // (at `4b259ef`): 25 such rounds of 1662 observations, all of them reached
+  // through the
   // oversized word rather than through a run, and none of them DISTINGUISHED.
   // `aggregate_fallbacks` is that half's own non-vacuity proof, and it counts
   // the ROUTE rather than the arm: a fallback round in which no word of `common`
@@ -443,7 +444,8 @@ fn the_split_never_cuts_at_a_tied_start() {
   // an advance may not push the watermark past a word of its own hypothesis it
   // did not confirm; the state that tests it is the FORCED arm reached with a
   // live suffix beyond `common`, and offering every stride TWICE could not build
-  // it -- measured at 0 rounds of 1353. `repeats` below offers a stride once in
+  // it -- measured at 0 rounds of 1353 (at `c6fc2e1`). `repeats` below offers a
+  // stride once in
   // three, which leaves the next stride's first ingest comparing consecutive
   // GROWING lists, and `forced_strands` is that half's non-vacuity proof.
   //
@@ -538,11 +540,13 @@ fn the_split_never_cuts_at_a_tied_start() {
   // legality predicate makes the back-off run on backwards starts as well as on
   // ties, so the sweep now visits split positions it never reached before.
   // Delete the back-off arm outright and `avoidable_backward_strands` reds at 3
-  // of 5 -- every one of them a round whose forward search found nothing and
-  // whose only remaining position was off the end. It used to red NOTHING here,
+  // of 5 (at `eb1e412`) -- every one of them a round whose forward search found
+  // nothing and whose only remaining position was off the end. It used to red
+  // NOTHING here,
   // the empty-holdback anchor holding the first postcondition on that path, and
   // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count` was
-  // the sole falsifier at 384 of 385 green; that test still reds, now alongside
+  // the sole falsifier at 384 of 385 green (at `4b259ef`); that test still reds,
+  // now alongside
   // 5 others. Read the boundary against the ADJACENT predecessor rather than the
   // running maximum and the FIRST postcondition reds at trial 65, on a confirmed
   // list reaching a 1 s watermark -- where it used to leave
@@ -559,7 +563,8 @@ fn the_split_never_cuts_at_a_tied_start() {
   // again, on the word the round declined to settle. Drop the suffix-minimum
   // conjunct from `split_at_a_strict_boundary`'s predicate -- the half-predicate
   // codex round 8 found -- and the postcondition itself stays GREEN while
-  // `avoidable_backward_strands` reds at 2 of 4, which is why the oracle is
+  // `avoidable_backward_strands` reds at 2 of 4 (at `eb1e412`), which is why the
+  // oracle is
   // here: the exception's own wording admitted those strands. Seed that suffix
   // minimum with `f32::INFINITY` instead of the minimum over the words beyond
   // `common` and this sweep stays green too, the beyond-`common` half being
@@ -570,10 +575,12 @@ fn the_split_never_cuts_at_a_tied_start() {
   // round 8 removed the interior route rather than the gate.
   //
   // The SHAPE rows, each forced off and re-measured. `aggregate` off:
-  // `aggregate_fallbacks` reds at `0 of 134`, the tied-run route to the empty
+  // `aggregate_fallbacks` reds at `0 of 134` (at `4b259ef`), the tied-run route
+  // to the empty
   // holdback being unreachable while the oversized-word route still supplies
   // 134. `retiming` off: `drifted_advances` reds at `0 rounds`. `alternating`
-  // off: `contradictions` reds at `18 rounds` against its floor of 128 -- but
+  // off: `contradictions` reds at `18 rounds` (at `4b259ef`) against its floor
+  // of 128 -- but
   // only with `nothing_the_stream_still_says_is_erased` neutralized first, since
   // that helper fires at trial 92 on a re-timing its `offered` membership test
   // cannot tell from an erasure (the transcript keeps one `(" A", 0.5)` and the
@@ -989,7 +996,8 @@ fn the_split_never_cuts_at_a_tied_start() {
       // so `common` is the whole filtered list with nothing beyond it, and where
       // that list ENDS on the over-budget word the forced arm confirms it there
       // -- one stride BEFORE the growth that would have given it a suffix.
-      // Measured on the two-everywhere shape: 0 such rounds in 256 trials.
+      // Measured on the two-everywhere shape: 0 such rounds in 256 trials (at
+      // `c6fc2e1`).
       //
       // Offering a stride once leaves the next stride's FIRST ingest comparing
       // `truth[..s]` against `truth[..s + 1]`, so `common` ends on `truth[s - 1]`
@@ -4623,7 +4631,8 @@ fn a_backwards_start_two_words_back_still_cannot_be_re_admitted() {
   //
   // Mutation proof: restore the adjacent-predecessor test in
   // `split_at_a_strict_boundary` (`common[at - 1].start()` for
-  // `settled_before[at]`) and this reds — alone, at 503 of 504 green.
+  // `settled_before[at]`) and this reds — alone, at 503 of 504 green
+  // (at `7b353b4`).
   let offered = || {
     result_with_words(vec![
       word(" P", 0.50, 0.60),
@@ -4997,7 +5006,7 @@ fn a_backward_start_beyond_common_backs_the_split_off_too() {
   // minimum over `beyond_common` in `split_at_a_strict_boundary` and this reds
   // (measured: this test and
   // `a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forever`
-  // are that mutation's only two falsifiers, 42 of 44 still green).
+  // are that mutation's only two falsifiers, 42 of 44 still green, at `eb1e412`).
   const CONSTRAINED_MEDIAN: f32 = 0.70;
   const LAST_SEGMENT_START: f32 = 2.88;
   /// `find_alignment`'s own output, `(start, end)` per word -- the seventh being

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -430,9 +430,21 @@ fn the_split_never_cuts_at_a_tied_start() {
   // it -- measured at 0 rounds of 1353. `repeats` below offers a stride once in
   // three, which leaves the next stride's first ingest comparing consecutive
   // GROWING lists, and `forced_strands` is that half's non-vacuity proof.
-  // Measured on the shape below, at 512 trials: 491 tied truths, 2736
-  // observations, 265 empty holdbacks, 231 deferrals, 12 forced-arm rounds with
-  // a live suffix.
+  //
+  // A FOURTH shape change reaches the DEFERRAL's own liveness (codex round 4 on
+  // PR #95). Everything above offers PREFIXES, so every hypothesis is a prefix
+  // of the next, `common` grows on every round, and a deferral is always
+  // relieved by waiting -- the assumption the deferral's own liveness argument
+  // made, and the reason this sweep could not see the stall. `alternating`
+  // rewrites the LAST offered word on every other offering, which pins `common`
+  // in front of it; `contradictions` is that half's non-vacuity proof, `escapes`
+  // proves the bound fires, and `tie_strands` proves the second postcondition's
+  // one exception is reached rather than merely written down. Measured on the
+  // shape below, at 512 trials: 489 tied truths, 2292 observations, 268 empty
+  // holdbacks, 176 deferrals, 37 forced-arm rounds with a live suffix, 1221
+  // contradicting rounds, 79 escapes, 12 of which stranded at the settled
+  // instant. (On the shape before this change: 491, 2736, 265, 231, 12, and no
+  // escape reachable at all.)
   //
   // The sweep draws starts from a coarse grid whose repeats make consecutive
   // words tie -- the `a=[0,0.5)/b=[0,1.0)` shape both #94 regressions are built
@@ -454,10 +466,12 @@ fn the_split_never_cuts_at_a_tied_start() {
   // the back-off has its own falsifier in
   // `a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count`
   // rather than being asserted here. Restoring the widen-off-the-end fallback
-  // (`.or(Some(common.len()))` after the back-off) reds only the `deferrals`
-  // clause below, at `0 deferred rounds`, for the same reason: the postcondition
-  // survives that fallback, and what it costs is the DELETION its own falsifier
-  // pins.
+  // (`.or(Some(common.len()))` after the back-off) reds the SECOND postcondition
+  // now that the alternation half below builds a stranding round for it --
+  // `[(" Z", 1.5)]` stranded on a round that did not escape -- and with that
+  // clause's `escaped` gate removed it falls through to the `deferrals` clause
+  // at `21 deferred rounds`. It used to red only the latter, the sweep having no
+  // shape that could strand.
   //
   // The SECOND postcondition has its own rows. Hand
   // `split_at_a_strict_boundary` an empty `beyond_common` at the call site --
@@ -465,6 +479,24 @@ fn the_split_never_cuts_at_a_tied_start() {
   // `nothing_unconfirmed_falls_below_the_watermark` reds on a swept forced-arm
   // round; return `repeats` to a constant 2 and `forced_strands` reds at
   // `0 rounds` instead, the state being unreachable rather than unguarded.
+  //
+  // The LIVENESS rows: force `alternating` to `false` and `contradictions` reds
+  // at `14 rounds` against its floor of 128 -- the state the prefix-only shape
+  // could not build. Drop the sparing FOLD from `empty_holdback_watermark`
+  // (return `past_the_confirmed_start`) and the second postcondition reds on a
+  // swept round whose strand is BEYOND the settled instant; drop only its filter
+  // (fold over every start) and the FIRST postcondition reds, the watermark
+  // having landed on the confirmed word's own start.
+  //
+  // The exception's two clauses red nothing when mutated ALONE, because on a
+  // correct engine neither state they reject is reachable -- an ordinary advance
+  // never strands, and an escape never strands beyond the settled instant. Each
+  // is the sole discriminator for one engine mutation, and that is where they
+  // are pinned: drop the `escaped` gate and the widen-off-the-end fallback above
+  // stops reding the second postcondition, falling through to `deferrals`
+  // instead; drop the tie clause and the no-sparing-fold mutation above stops
+  // reding it. Neither is dead -- they are conditional on mutants, not on
+  // inputs.
   const TEXTS: [&str; 4] = [" A", " B", " C", " D"];
   // Repeated 0.0 entries are the ties; the rest keep the grid coarse enough for
   // two words to share an instant often.
@@ -509,28 +541,58 @@ fn the_split_never_cuts_at_a_tied_start() {
   ///
   /// `appended` is measured across the call rather than read off a split, so
   /// this cannot be satisfied by the same arithmetic that produced it.
+  ///
+  /// IT HAS ONE EXCEPTION since the deferral was bounded (codex round 4 on
+  /// PR #95), and the exception is as narrow as the impossibility that forces
+  /// it: on a round that ESCAPED a repeating deferral, a stranded word may sit
+  /// at the last confirmed word's OWN start. There no instant serves both --
+  /// every watermark strictly past that start (which the first postcondition
+  /// requires) filters the strand, and every watermark that spares the strand
+  /// re-admits the settled word. It is this module's residual 1 reached one
+  /// round earlier than its own route. `escaped` gates it, so an ordinary
+  /// advance may not use it, and `empty_holdback_watermark`'s sparing fold is
+  /// what keeps every other overlap out of it. Returns whether the exception was
+  /// taken, which is the non-vacuity proof that the escape really strands
+  /// something somewhere.
   fn nothing_unconfirmed_falls_below_the_watermark(
     agreement: &LocalAgreement,
     appended: usize,
+    escaped: bool,
     trial: u32,
     stride: usize,
-  ) {
-    let below: Vec<&str> = agreement
+  ) -> bool {
+    let below: Vec<(&str, f32)> = agreement
       .hypothesis_words
       .iter()
       .filter(|word| word.start() < agreement.last_agreed_seconds())
-      .map(WordTiming::word)
+      .map(|word| (word.word(), word.start()))
       .collect();
+    if below.len() <= appended {
+      return false;
+    }
+    let settled = agreement
+      .confirmed_words_slice()
+      .last()
+      .map(WordTiming::start);
+    let stranded = &below[appended..];
     assert!(
-      below.len() <= appended,
+      escaped
+        && stranded
+          .iter()
+          .all(|(_, start)| settled.is_some_and(|settled| *start <= settled)),
       "trial {trial}, stride {stride}: {} words of the hypothesis are below \
        the {} s watermark ({below:?}) but only {appended} were confirmed this \
-       round -- the rest are STRANDED: the next worded ingest filters them out \
-       of both hypotheses at once and `finalize` can no longer reach them, \
-       after this round's own `finalize` already published them",
+       round -- {stranded:?} are STRANDED: the next worded ingest filters them \
+       out of both hypotheses at once and `finalize` can no longer reach them, \
+       after this round's own `finalize` already published them. Only an \
+       ESCAPE round (this one escaped: {escaped}) may strand, and only at or \
+       before the settled start {settled:?} -- with starts non-decreasing \
+       inside one hypothesis that is the exact TIE, where no watermark serves \
+       both",
       below.len(),
       agreement.last_agreed_seconds(),
     );
+    true
   }
 
   let mut state: u64 = 0x2545_F491_4F6C_DD1D;
@@ -545,6 +607,9 @@ fn the_split_never_cuts_at_a_tied_start() {
   let mut tied_truths = 0u32;
   let mut deferrals = 0u32;
   let mut forced_strands = 0u32;
+  let mut contradictions = 0u32;
+  let mut escapes = 0u32;
+  let mut tie_strands = 0u32;
 
   for trial in 0..512u32 {
     let length = 4 + (next() % 5) as usize;
@@ -596,6 +661,8 @@ fn the_split_never_cuts_at_a_tied_start() {
     // advance, 2 is the driver's own `DEFAULT_AGREEMENT_COUNT_NEEDED`.
     let mut agreement =
       LocalAgreement::new().with_agreement_count_needed(1 + (next() % 2) as usize);
+    let alternating = next() % 2 == 0;
+    let mut offering = 0u32;
     for stride in 2..=truth.len() {
       let omit_head = stride > 2 && next() % 4 == 0;
       let offered = if omit_head {
@@ -617,19 +684,71 @@ fn the_split_never_cuts_at_a_tied_start() {
       // whenever the over-budget word lands on that boundary.
       let repeats = if next() % 3 == 0 { 1 } else { 2 };
       for _ in 0..repeats {
+        // ALTERNATION, the shape codex round 4 on PR #95 needed and neither
+        // half above could build. Growing prefixes and re-offered strides make
+        // every hypothesis a PREFIX of the next, so `common` grows on every
+        // round and a deferral is always relieved by waiting -- which is
+        // precisely the assumption the deferral's own liveness argument made.
+        // Rewriting the LAST offered word on every other offering instead makes
+        // two consecutive hypotheses CONTRADICT each other there, which pins
+        // `common` at everything in front of it for as long as the rewriting
+        // continues. `contradictions` below is this half's non-vacuity proof,
+        // and `escapes` is the proof that the bound actually fires.
+        let mut offered = offered.clone();
+        if alternating
+          && offering % 2 == 1
+          && let Some(last) = offered.last_mut()
+        {
+          *last = WordTiming::new(
+            " Z",
+            last.tokens_slice().to_vec(),
+            last.start(),
+            last.end(),
+            last.probability(),
+          );
+        }
+        offering += 1;
         let before = agreement.confirmed_words_slice().len();
-        agreement.ingest_streamed(result_with_words(offered.clone()));
+        // Captured BEFORE the call, since `ingest` overwrites both: they are
+        // the two inputs the escape decision is actually made from.
+        let deferred_before = agreement.deferred_common_len;
+        let confirmed_last_before = agreement
+          .confirmed_words_slice()
+          .last()
+          .map(WordTiming::start);
+        agreement.ingest_streamed(result_with_words(offered));
         // Read straight off the engine: a deferral returns
         // `AwaitingAgreement`, which a disagreement returns too, so the outcome
         // cannot tell them apart.
-        deferrals += u32::from(agreement.split_deferred);
+        deferrals += u32::from(agreement.deferred_common_len.is_some());
         forced_strands += u32::from(forced_arm_with_a_live_suffix(&agreement));
-        nothing_unconfirmed_falls_below_the_watermark(
+        let common_len = common_prefix_len(&agreement);
+        contradictions += u32::from(
+          common_len >= agreement.agreement_count_needed()
+            && common_len < agreement.prev_words.len()
+            && common_len < agreement.hypothesis_words.len(),
+        );
+        // EXACT, rather than inferred from the outcome: re-ask
+        // `split_at_a_strict_boundary` what it would have answered WITHOUT the
+        // bound, from the same inputs the engine handed it.
+        let escaped = common_len >= agreement.agreement_count_needed()
+          && deferred_before.is_some_and(|deferred| common_len <= deferred)
+          && split_at_a_strict_boundary(
+            &agreement.hypothesis_words[..common_len],
+            &agreement.hypothesis_words[common_len..],
+            common_len - agreement.agreement_count_needed(),
+            confirmed_last_before,
+            false,
+          )
+          .is_none();
+        escapes += u32::from(escaped);
+        tie_strands += u32::from(nothing_unconfirmed_falls_below_the_watermark(
           &agreement,
           agreement.confirmed_words_slice().len() - before,
+          escaped,
           trial,
           stride,
-        );
+        ));
         if let Some(empty) = postcondition(&agreement, trial, stride) {
           checked += 1;
           empty_holdbacks += u32::from(empty);
@@ -666,6 +785,24 @@ fn the_split_never_cuts_at_a_tied_start() {
     "and the FORCED arm must be reached with a live suffix beyond `common` -- \
      the state the second postcondition above speaks about, and the one an \
      unconditional forced advance strands: {forced_strands} rounds",
+  );
+  assert!(
+    contradictions > 128,
+    "and two consecutive hypotheses must actually CONTRADICT each other past \
+     `common` -- growing prefixes alone make every hypothesis a prefix of the \
+     next, which is the assumption the deferral's liveness argument made: \
+     {contradictions} rounds",
+  );
+  assert!(
+    escapes > 8,
+    "and the deferral's BOUND must actually fire -- a repeating deferral that \
+     takes the empty holdback instead of waiting again: {escapes} rounds",
+  );
+  assert!(
+    tie_strands > 0,
+    "and the second postcondition's one exception must be reached rather than \
+     merely written down -- an escape that strands at the settled instant, \
+     which is the only strand any watermark leaves: {tie_strands} rounds",
   );
 }
 #[test]
@@ -805,6 +942,12 @@ fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
   // either way) -- the divergence is entirely in what LATER ingests can still
   // see.
   //
+  // This wait is the FIRST one, and TAIL growth really does relieve it here:
+  // both rounds after the deferral grow `common`, so the bound in
+  // `split_at_a_strict_boundary`'s arm 3 never fires. What happens when growth
+  // does NOT arrive is
+  // `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`.
+  //
   // Mutation proof, every row run: restore the widen-off-the-end fallback
   // (`.or(Some(common.len()))` after the back-off) and the deferral assertion
   // below reds reading `(113, 0, 2.0000002, 0, 2)`; with that assertion
@@ -814,9 +957,11 @@ fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
   // floor bites at all (`if floor > 0 { return None }`) and the deadlock clause
   // below reds -- along with
   // `an_over_budget_holdback_is_capped_rather_than_silently_truncated`, which is
-  // the ordinary budget path this may not swallow. Never CLEAR the flag
-  // (`|=` for `=` in `ingest`) and the finalized face reds, the advance's own
-  // Swift shape replaced by the hypothesis. Make `word` emit two tokens and the
+  // the ordinary budget path this may not swallow. Make the bound fire on EVERY
+  // round (`deferral_gained_nothing = true`) and the deferral assertion reds, the
+  // first wait taken away; record `usize::MAX` rather than `common.len()`, or
+  // never clear the record, and it reds the same way -- the advance's own Swift
+  // shape replaced by the hypothesis. Make `word` emit two tokens and the
   // non-vacuity row reds at `(113, 226, false)`.
   //
   // The `finalize` half has its own two rows at its own assertions below.
@@ -881,9 +1026,9 @@ fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
   // ++ differentSuffix(prev, hypothesis)`, and on a deferred round the holdback
   // is an EARLIER agreement's -- here it does not exist at all -- so the sum
   // drops every word the two hypotheses agreed on. A deferred round therefore
-  // finalizes from the latest hypothesis instead (`split_deferred`).
+  // finalizes from the latest hypothesis instead (`deferred_common_len`).
   //
-  // Mutation proof for that clause alone: drop `|| self.split_deferred` from
+  // Mutation proof for that clause alone: drop `|| self.deferred_common_len.is_some()` from
   // `finalize`'s guard and this reads `" x0 x1"` -- the whole 113-word run gone,
   // exactly the `commonPrefix.count` leading words the Swift expression cannot
   // account for once the holdback is not the round's own.
@@ -1657,20 +1802,28 @@ fn a_stutter_at_the_watermark_keeps_both_occurrences() {
 /// calling `budgeted_split` or `empty_holdback_watermark`, so a mutation to
 /// either cannot mutate this counter along with them:
 ///
+/// `find_longest_common_prefix`'s answer for the round the engine has just
+/// finished, recomputed from the two word lists it left behind. The sweep's
+/// alphabet is five distinct plain texts, so `normalized` comparison is text
+/// equality and this is the engine's own `common.len()`.
+fn common_prefix_len(agreement: &LocalAgreement) -> usize {
+  agreement
+    .prev_words
+    .iter()
+    .zip(&agreement.hypothesis_words)
+    .take_while(|(previous, current)| previous.word() == current.word())
+    .count()
+}
+
 /// - `budgeted_split(common, 0) == common.len()` is exactly "`common`'s last
 ///   word alone exceeds `MAX_HOLDBACK_PREFILL_TOKENS`". The loop subtracts words
 ///   from the front while the holdback is over budget, so it can only run off
 ///   the end from `split == common.len() - 1`, where the holdback is that one
 ///   word.
-/// - the sweep's alphabet is four distinct plain texts, so
+/// - the sweep's alphabet is five distinct plain texts, so
 ///   `find_longest_common_prefix`'s `normalized` comparison is text equality.
 fn forced_arm_with_a_live_suffix(agreement: &LocalAgreement) -> bool {
-  let common_len = agreement
-    .prev_words
-    .iter()
-    .zip(&agreement.hypothesis_words)
-    .take_while(|(previous, current)| previous.word() == current.word())
-    .count();
+  let common_len = common_prefix_len(agreement);
   if common_len < agreement.agreement_count_needed() {
     return false;
   }
@@ -2740,16 +2893,30 @@ fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
   // post-`common` words and defers the forced advance exactly while one of them
   // starts before the watermark that advance would set.
   //
+  // This wait is the FIRST one, and it is the one worth taking: what ENDS it is
+  // the bound in `split_at_a_strict_boundary`'s arm 3, whose own falsifiers are
+  // `an_alternating_suffix_escapes_the_deferral_instead_of_stalling` and
+  // `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`.
+  // The two rounds after the deferral here GROW `common`, so the bound never
+  // fires in this test -- which is exactly what it must not do.
+  //
   // Mutation proof, every row run: pass an empty `beyond_common` at the call
   // site (the pre-repair information state) and the deferred-state row reds
   // reading `([" A", " H"], [], 1.0000001)`; with that row neutralized the
   // RETRACTION row reds at `" A H Y"`, `" X"` gone from a transcript that had
   // already published it. Defer the forced arm unconditionally (drop the
-  // `beyond_common` test) and
+  // `beyond_common` test, keeping the bound) and
   // `a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held`
-  // reds -- the anchor that can never arrive. Drop `|| self.split_deferred`
-  // from `finalize`'s guard and the IMMEDIATE row reds at `" X"`, the deferred
-  // round's own transcript reduced to the differing suffix.
+  // reds -- the anchor that can never arrive, and the bound does not rescue it,
+  // since that shape never defers twice. Make the bound fire on EVERY round
+  // (`deferral_gained_nothing = true`) and this test's deferred-state row reds
+  // instead; record `usize::MAX` rather than `common.len()` and it reds the same
+  // way, the LENGTH being what makes the measurement a measurement, and so does
+  // never clearing the record
+  // (`self.deferred_common_len = deferred.or(self.deferred_common_len)`). Drop
+  // `|| self.deferred_common_len.is_some()` from `finalize`'s guard and the
+  // IMMEDIATE row reds at `" X"`, the deferred round's own transcript reduced to
+  // the differing suffix.
   let a = || word(" A", 0.0, 1.0);
   let over = || word_of_tokens(" H", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   let tied = || word(" X", 1.0, 1.0);
@@ -2860,6 +3027,465 @@ fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
     "and \" X\" is confirmed exactly once, by the ordinary interior split",
   );
 }
+/// One round of the STREAMING face — the outcome a caller reads back plus the
+/// three pieces of engine state it can see between pushes. Built as a value so a
+/// whole run of rounds compares in ONE assertion: a stall is a face that repeats,
+/// and a repeating face is only visible across rounds.
+fn streaming_face(
+  outcome: AgreementOutcome,
+  agreement: &LocalAgreement,
+) -> (String, Vec<String>, Vec<String>, f32) {
+  (
+    outcome.to_string(),
+    confirmed_texts(agreement)
+      .into_iter()
+      .map(str::to_string)
+      .collect(),
+    held_back_texts(agreement)
+      .into_iter()
+      .map(str::to_string)
+      .collect(),
+    agreement.last_agreed_seconds(),
+  )
+}
+
+#[test]
+fn an_alternating_suffix_escapes_the_deferral_instead_of_stalling() {
+  // #94, codex round 4 on PR #95 -- the DEFERRAL's own liveness, and the first
+  // finding on this branch that is not a correctness hole.
+  //
+  // Rule W's deferral is a WAIT for tail growth: `common` grows, and a boundary
+  // the split may legally take appears. Nothing bounded that wait. Hypotheses
+  // that ALTERNATE past the agreed prefix -- `[A, H, X]` then `[A, H, Y]` then
+  // `[A, H, X]` -- pin `common` at `[A, H]` forever: the forced arm sees the
+  // same over-budget `" H"` at the end of the same `common` every round, the
+  // same live suffix beyond it, and returns `None` every round. The watermark
+  // never moves, nothing is ever confirmed, the caller reads
+  // `awaiting_agreement` forever, and in the driver the clip keeps re-decoding
+  // from a boundary that never advances while the buffer grows past it.
+  //
+  // The earlier liveness argument -- "one word starting strictly later opens a
+  // boundary" -- is about a suffix that STABILIZES, and does not reach this
+  // state: `" T"` and `" U"` below DO start strictly later, and they never help,
+  // because they can only join `common` once the words in front of them agree.
+  //
+  // THE BOUND: a deferral over a `common` no longer than the one the previous
+  // round already deferred over is that round again. It is a measurement of the
+  // wait that has already happened, not a prediction about the next one, and it
+  // costs at most one round. Round 1 defers; round 2 finds `common` no longer
+  // and takes the empty holdback instead.
+  //
+  // WHAT THAT TRADES, stated in the direction that costs something. `" X"` and
+  // `" Y"` sit at `" H"`'s own instant, so no watermark strictly past `" H"`'s
+  // start can spare them (`empty_holdback_watermark` lowers the anchor as far as
+  // it can, and here it cannot lower it at all) -- this module's residual 1,
+  // reached one round earlier than the residual's own route. A stream that ENDS
+  // inside the stall keeps the disputed word, since a deferred round finalizes
+  // `confirmed ++ hypothesis_words`; a stream that CONTINUES gets a transcript
+  // instead of a frozen one. Both are asserted below. The disputed word is also
+  // the one thing the deferral could never have delivered: `find_longest_common_
+  // prefix` stops at it by construction, so it is uncorroborated on every round
+  // it is offered, and `finalize` already published a DIFFERENT one each round.
+  //
+  // Mutation proof, every row run: drop `deferral_gained_nothing` from the
+  // forced arm's test (`if empty_holdback_strands()`) and the face reds with
+  // eight `awaiting_agreement` rounds at watermark 0 -- the stall itself.
+  // Compare with `<` instead of `<=` in `deferral_gained_nothing` and it reds
+  // the same way, `common.len()` being EQUAL rather than smaller here. Record
+  // `usize::MAX` instead of `common.len()` and this goes GREEN while
+  // `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` and
+  // `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix` red, which
+  // is the same statement from the other side: what makes the bound a
+  // MEASUREMENT rather than a one-round cap is the length. Make the escape
+  // unconditional (`deferral_gained_nothing = true`) and those same two red --
+  // the FIRST wait is the one that is worth taking.
+  let a = || word(" A", 0.0, 1.0);
+  let over = || word_of_tokens(" H", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
+  let x = || word(" X", 1.0, 1.0);
+  let y = || word(" Y", 1.0, 1.0);
+  // Two words the deferral's own liveness argument would call relief. They start
+  // strictly later, they are in every hypothesis, and they cannot reach `common`
+  // while the words in front of them disagree.
+  let tail = || vec![word(" T", 2.0, 3.0), word(" U", 3.0, 4.0)];
+  let odd = || result_with_words([vec![a(), over(), x()], tail()].concat());
+  let even = || result_with_words([vec![a(), over(), y()], tail()].concat());
+
+  assert_eq!(
+    (
+      over().tokens_slice().len() > MAX_HOLDBACK_PREFILL_TOKENS,
+      x().start() == over().start(),
+      y().start() == over().start(),
+      x().word() == y().word(),
+      tail()[0].start() > over().start(),
+    ),
+    (true, true, true, false, true),
+    "non-vacuous: ONE word over the budget (the forced arm's own condition), \
+     two DIFFERENT words alternating at its exact instant, and a tail that does \
+     start strictly later",
+  );
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, the only one the driver reaches",
+  );
+
+  const ROUNDS: usize = 8;
+  let mut face = Vec::with_capacity(ROUNDS);
+  let mut forced_arm = Vec::with_capacity(ROUNDS);
+  let mut stalled_transcript = String::new();
+  for round in 0..ROUNDS {
+    let outcome = agreement.ingest_streamed(if round % 2 == 0 { odd() } else { even() });
+    face.push(streaming_face(outcome, &agreement));
+    forced_arm.push(forced_arm_with_a_live_suffix(&agreement));
+    if round == 1 {
+      stalled_transcript = agreement
+        .clone()
+        .finalize(&DecodingOptions::new())
+        .text()
+        .to_string();
+    }
+  }
+
+  // NON-VACUOUS, per round: the forced arm really is the arm being driven, with
+  // a live suffix beyond `common`, on BOTH the round that defers and the round
+  // that escapes. Without this the face below could be produced by an engine
+  // that never reached the state at all.
+  assert_eq!(
+    forced_arm,
+    vec![false, true, true, false, false, false, false, false],
+    "the deferring round and the escaping round must both BE the forced arm \
+     with a live suffix; round 0 has no previous hypothesis and rounds 3+ have \
+     advanced past the over-budget word",
+  );
+
+  let awaiting = |confirmed: &[&str], held: &[&str], watermark: f32| {
+    (
+      "awaiting_agreement".to_string(),
+      confirmed.iter().map(|w| (*w).to_string()).collect(),
+      held.iter().map(|w| (*w).to_string()).collect(),
+      watermark,
+    )
+  };
+  let advanced = |confirmed: &[&str], held: &[&str], watermark: f32| {
+    (
+      "advanced".to_string(),
+      confirmed.iter().map(|w| (*w).to_string()).collect(),
+      held.iter().map(|w| (*w).to_string()).collect(),
+      watermark,
+    )
+  };
+  assert_eq!(
+    face,
+    vec![
+      // No previous hypothesis to agree with.
+      awaiting(&[], &[], 0.0),
+      // THE WAIT, worth taking once: `common` may yet grow past `" H"`.
+      awaiting(&[], &[], 0.0),
+      // THE ESCAPE. `common` is `[" A", " H"]` again, so the wait bought
+      // nothing; the empty holdback is taken at the only instant that clears
+      // `" H"`'s own start.
+      advanced(&[" A", " H"], &[], 1.0f32.next_up()),
+      // And the stream is a stream again: the tail the alternation was blocking
+      // reaches `common` and is held back under an ordinary interior split.
+      advanced(&[" A", " H"], &[" T", " U"], 2.0),
+      advanced(&[" A", " H"], &[" T", " U"], 2.0),
+      advanced(&[" A", " H"], &[" T", " U"], 2.0),
+      advanced(&[" A", " H"], &[" T", " U"], 2.0),
+      advanced(&[" A", " H"], &[" T", " U"], 2.0),
+    ],
+    "the alternation must not freeze the stream",
+  );
+
+  // THE TRADE, both directions, so neither can be reported as free. A stream
+  // that ENDS inside the wait publishes the disputed word; one that CONTINUES
+  // past it does not, and gets everything after it instead.
+  assert_eq!(
+    (
+      stalled_transcript.as_str(),
+      agreement
+        .finalize(&DecodingOptions::new())
+        .text()
+        .to_string()
+        .as_str(),
+    ),
+    (" A H Y T U", " A H T U"),
+    "the escape drops the word at the settled instant -- residual 1, one round \
+     earlier than its own route -- and keeps the transcript moving",
+  );
+}
+
+#[test]
+fn a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling() {
+  // #94, codex round 4 on PR #95 -- the SAME unbounded wait on the OTHER
+  // deferral arm, and the one this crate's own pipeline can actually reach.
+  //
+  // The alternating shape above needs a single word carrying more than
+  // `MAX_HOLDBACK_PREFILL_TOKENS` tokens. This one needs no over-budget word, no
+  // alternation, and nothing beyond `common` at all: 113 ORDINARY one-token
+  // words sharing one instant, offered UNCHANGED on every stride. Their SUM puts
+  // the budget floor strictly inside the run, every boundary at or above it
+  // ties, and the back-off may not cross the floor -- so `split_at_a_strict_
+  // boundary` returns `None`, and it returns `None` again next round because a
+  // repeated hypothesis grows nothing. `add_word_timestamps` produces exactly
+  // that shape from an ALL-ZERO alignment matrix (`add_word_timestamps_zero_
+  // pads_missing_rows`; measured at 130 such words), which is why this is the
+  // reachability answer for the finding rather than the shape above.
+  //
+  // Nothing is stranded here: `beyond_common` is EMPTY, so the escape's
+  // watermark filters nothing away that any hypothesis had produced, and BOTH of
+  // Rule W's postconditions hold across it unweakened. What the wait was
+  // protecting is the HOLDBACK -- the tied run stays revisable and the next
+  // stride keeps its prefill anchor -- and that is worth exactly one round.
+  //
+  // The SECOND half drives the same arm with a suffix that ALTERNATES at the
+  // run's own instant, which is where a strand-conditional escape would have
+  // gone on deferring forever. Both halves are here because they are one arm
+  // and one bound; splitting them would let a repair pass on the half it
+  // happened to cover.
+  //
+  // Mutation proof, every row run: delete the escape arm outright (the final
+  // `.or_else` in `split_at_a_strict_boundary`) and the STABLE face reds with six
+  // `awaiting_agreement` rounds at watermark 0. Re-introduce a
+  // `!empty_holdback_strands()` guard beside `deferral_gained_nothing` -- the
+  // shape that exempts the arm's own strand from its own bound -- and the
+  // ALTERNATING face reds the same way while the stable one stays green, which
+  // is why both halves are here. Make the escape unconditional
+  // (`.or(Some(common.len()))`) and
+  // `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix`,
+  // `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` and the
+  // sweep red, the first wait taken away.
+  const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
+  let tied: Vec<WordTiming> = (0..RUN)
+    .map(|index| word(&format!(" w{index:03}"), 2.0, 2.0))
+    .collect();
+  assert_eq!(
+    (
+      tied.len(),
+      tied.iter().all(|word| word.tokens_slice().len() == 1),
+      tied
+        .iter()
+        .map(|word| word.tokens_slice().len())
+        .sum::<usize>()
+        > MAX_HOLDBACK_PREFILL_TOKENS,
+      tied.iter().all(|word| word.start() == 2.0),
+    ),
+    (113, true, true, true),
+    "non-vacuous: ORDINARY one-token words, no single one over budget, and it \
+     is their SUM at ONE instant that puts the floor inside the run",
+  );
+  let stable = || result_with_words(tied.clone());
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, the only one the driver reaches",
+  );
+
+  const ROUNDS: usize = 6;
+  let mut face = Vec::with_capacity(ROUNDS);
+  for _ in 0..ROUNDS {
+    let outcome = agreement.ingest_streamed(stable());
+    face.push((
+      outcome.to_string(),
+      confirmed_texts(&agreement).len(),
+      held_back_texts(&agreement).len(),
+      agreement.last_agreed_seconds(),
+      // Nothing this hypothesis produced falls below the watermark that is not
+      // confirmed: the SECOND postcondition, read on every round of this shape
+      // rather than swept, since the escape is where it could have broken.
+      LocalAgreement::watermark_filtered(&stable(), agreement.last_agreed_seconds()).len()
+        + agreement.confirmed_words_slice().len(),
+    ));
+  }
+  assert_eq!(
+    face,
+    vec![
+      ("awaiting_agreement".to_string(), 0, 0, 0.0, RUN),
+      // THE WAIT: `common` may yet grow past the tie.
+      ("awaiting_agreement".to_string(), 0, 0, 0.0, RUN),
+      // THE ESCAPE, at the only instant that clears the run's own.
+      ("advanced".to_string(), RUN, 0, 2.0f32.next_up(), RUN),
+      // The run is behind the watermark now, so a hypothesis that keeps
+      // repeating it offers nothing -- which is the input being degenerate, not
+      // the engine stalling: every word it has is at one instant.
+      (
+        "awaiting_agreement".to_string(),
+        RUN,
+        0,
+        2.0f32.next_up(),
+        RUN
+      ),
+      (
+        "awaiting_agreement".to_string(),
+        RUN,
+        0,
+        2.0f32.next_up(),
+        RUN
+      ),
+      (
+        "awaiting_agreement".to_string(),
+        RUN,
+        0,
+        2.0f32.next_up(),
+        RUN
+      ),
+    ],
+    "a hypothesis that simply REPEATS must not freeze the stream, and the \
+     escape must strand nothing: every word is either still offerable or \
+     confirmed",
+  );
+
+  let text = agreement
+    .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+    .text()
+    .to_string();
+  assert_eq!(
+    text.split_whitespace().count(),
+    RUN,
+    "and the whole run reaches the transcript, each word once: {text:?}",
+  );
+
+  // ── SECOND HALF: the same arm, with a live strand at the run's own instant.
+  //
+  // Two words alternate past the run, both at the run's instant, so the escape
+  // cannot spare either -- and a bound that refused to fire while a strand
+  // existed would defer here forever, which is the state it exists to leave.
+  let x0 = || word(" x0", 2.0, 2.0);
+  let x1 = || word(" x1", 2.0, 2.0);
+  let odd = || result_with_words([tied.clone(), vec![x0()]].concat());
+  let even = || result_with_words([tied.clone(), vec![x1()]].concat());
+  assert_eq!(
+    (
+      x0().start() == tied[RUN - 1].start(),
+      x0().word() == x1().word()
+    ),
+    (true, false),
+    "non-vacuous: two DIFFERENT words alternating at the run's own instant,      which no watermark strictly past that instant can spare",
+  );
+
+  let mut alternating = LocalAgreement::new();
+  let mut alternating_face = Vec::with_capacity(ROUNDS);
+  for round in 0..ROUNDS {
+    let outcome = alternating.ingest_streamed(if round % 2 == 0 { odd() } else { even() });
+    alternating_face.push((
+      outcome.to_string(),
+      confirmed_texts(&alternating).len(),
+      held_back_texts(&alternating).len(),
+      alternating.last_agreed_seconds(),
+    ));
+  }
+  assert_eq!(
+    alternating_face,
+    vec![
+      ("awaiting_agreement".to_string(), 0, 0, 0.0),
+      ("awaiting_agreement".to_string(), 0, 0, 0.0),
+      ("advanced".to_string(), RUN, 0, 2.0f32.next_up()),
+      ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
+      ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
+      ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
+    ],
+    "an alternating suffix at the run's own instant must not freeze this arm      either -- the run is confirmed and the disputed words at its instant are      the residual, not the reason to wait",
+  );
+}
+
+#[test]
+fn a_strand_starting_strictly_later_lowers_the_watermark_instead_of_deferring() {
+  // #94, codex round 4 on PR #95 -- the NARROWING that keeps the escape above
+  // from having to strand anything it does not have to.
+  //
+  // The forced empty holdback used to anchor at `common.last().end()` flatly,
+  // and defer whenever a word the hypothesis had produced beyond `common`
+  // started before it. But word ENDS inside a hypothesis are not monotone
+  // (`an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too`), so
+  // `end` can reach past a word that is already there -- and nothing needs it
+  // to. All the watermark owes #94 is to clear the last CONFIRMED word's START.
+  // So `empty_holdback_watermark` lowers the anchor to the earliest such word's
+  // start when that still clears it, the round advances, and the word stays
+  // offerable instead of being waited for.
+  //
+  // What that leaves the deferral is the EXACT TIE alone, which is the case no
+  // instant serves: `an_alternating_suffix_escapes_the_deferral_instead_of_
+  // stalling` is that half.
+  //
+  // Mutation proof, every row run: drop the `fold` and return
+  // `past_the_confirmed_start` and this reds -- round 1 reads
+  // `("awaiting_agreement", [], [], 0.0)`, the deferral this narrowing removes.
+  // Keep the fold but drop its `*start > last.start()` filter and this stays
+  // green while `the_split_never_cuts_at_a_tied_start` reds on a swept exact tie
+  // (`" C" at 1.5, which is not strictly before the 1.5 s watermark`) -- the
+  // filter is postcondition ONE, asserted where it is swept.
+  let a = || word(" A", 0.0, 1.0);
+  let over = || word_of_tokens(" H", 1.0, 3.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
+  let strand = || word(" X", 2.0, 2.5);
+  let tail = || word(" T", 3.5, 4.0);
+  assert_eq!(
+    (
+      over().tokens_slice().len() > MAX_HOLDBACK_PREFILL_TOKENS,
+      over().start() < strand().start(),
+      strand().start() < over().end(),
+    ),
+    (true, true, true),
+    "non-vacuous: the forced arm's own condition, and a word beyond `common` \
+     that starts strictly AFTER the last agreed word's start and strictly \
+     BEFORE its end -- the overlap the flat anchor used to defer over",
+  );
+
+  let older = || result_with_words(vec![a(), over()]);
+  let newer = || result_with_words(vec![a(), over(), strand(), tail()]);
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, the only one the driver reaches",
+  );
+  let mut face = Vec::new();
+  for round in 0..3u32 {
+    let outcome = agreement.ingest_streamed(if round == 0 { older() } else { newer() });
+    face.push(streaming_face(outcome, &agreement));
+  }
+  assert_eq!(
+    face,
+    vec![
+      (
+        "awaiting_agreement".to_string(),
+        Vec::new(),
+        Vec::new(),
+        0.0
+      ),
+      // The round that used to DEFER: it advances, and the anchor is the
+      // strand's own start rather than `" H"`'s far edge.
+      (
+        "advanced".to_string(),
+        vec![" A".to_string(), " H".to_string()],
+        Vec::new(),
+        2.0,
+      ),
+      // And `" X"` was never filtered away, so it is held back like any other
+      // agreed word one round later.
+      (
+        "advanced".to_string(),
+        vec![" A".to_string(), " H".to_string()],
+        vec![" X".to_string(), " T".to_string()],
+        2.0,
+      ),
+    ],
+    "a strand that starts strictly later is SPARED by lowering the anchor, not \
+     waited for",
+  );
+
+  assert_eq!(
+    agreement
+      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+      .text(),
+    " A H X T",
+    "and nothing is lost",
+  );
+}
+
 #[test]
 fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
   // #94 (codex round 13, finding 1), REFUTED RATHER THAN FIXED, and this is the

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -495,6 +495,84 @@ fn the_split_never_cuts_at_a_tied_start() {
 }
 
 #[test]
+fn the_split_widens_past_a_tie_with_the_confirmed_list_itself() {
+  // RULE W's BASE CASE, which `the_split_never_cuts_at_a_tied_start`'s sweep
+  // cannot reach. When the split has moved past nothing (`split == 0`, i.e.
+  // `common.len() == agreement_count_needed` and the budget widened nothing),
+  // there is no `common[split - 1]` to anchor against and the rule falls back to
+  // the engine's own last CONFIRMED word -- the word the watermark would
+  // otherwise sit beside.
+  //
+  // The sweep never gets here because the fallback is inert while the
+  // postcondition already holds: `confirmed.last().start() < watermark` and
+  // every offered word starts at or past the watermark, so `anchor >=
+  // common[0].start()` is false by induction. The one state that breaks the
+  // induction is the documented residual
+  // (`an_empty_holdback_leaves_a_zero_duration_word_at_the_watermark`): with an
+  // EMPTY holdback the watermark anchors at `common.last().end()`, so a
+  // zero-duration word there leaves `confirmed.last().start() == watermark`, and
+  // the NEXT advance is the only place that can repair it.
+  //
+  //   agreement_count_needed 1
+  //   ingest [A@0.0-1.0, Z@1.0-1.0 (over budget)] twice
+  //     -> confirmed [A, Z], holdback EMPTY, watermark 1.0 == Z's own start
+  //   ingest [W@1.0-2.0] twice
+  //     -> common [W], requested 0, budget widens nothing, so split == 0
+  //     -> the fallback sees Z@1.0 >= W@1.0 and widens to 1
+  //
+  // Mutation proof: seed the anchor with `None` instead of
+  // `self.confirmed_words.last().map(WordTiming::start)` and this reds -- the
+  // split stays at 0, `" W"` is held back at a 1.0 s watermark, and `" Z"` is
+  // left confirmed at exactly that instant, where it passes
+  // `watermark_filtered`'s own `start >= watermark` and can be re-admitted.
+  // Nothing else in this module reds with that mutation, which is why this test
+  // exists.
+  let a = || word(" A", 0.0, 1.0);
+  let zero = || word_of_tokens(" Z", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
+  let w = || word(" W", 1.0, 2.0);
+
+  let mut agreement = LocalAgreement::new().with_agreement_count_needed(1);
+  let opening = || result_with_words(vec![a(), zero()]);
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    (
+      confirmed_texts(&agreement),
+      agreement.last_agreed_words_slice().len(),
+      agreement.last_agreed_seconds()
+    ),
+    (vec![" A", " Z"], 0, 1.0),
+    "non-vacuous setup: the budget emptied the holdback and left the last \
+     confirmed word starting exactly at the watermark -- the only state from \
+     which the base case below has anything to repair",
+  );
+
+  // Two ingests: the first disagrees (so `prev_result` becomes this hypothesis
+  // without advancing), the second agrees with it on the single word " W".
+  let onward = || result_with_words(vec![w()]);
+  assert!(agreement.ingest_streamed(onward()).is_awaiting_agreement());
+  assert!(agreement.ingest_streamed(onward()).is_advanced());
+  assert_eq!(
+    (confirmed_texts(&agreement), agreement.last_agreed_seconds()),
+    (vec![" A", " Z", " W"], 2.0),
+    "the split had moved past nothing, so Rule W anchored on the confirmed \
+     list itself and widened past the tie -- restoring the postcondition the \
+     empty-holdback watermark had broken",
+  );
+  let last = agreement
+    .confirmed_words_slice()
+    .last()
+    .expect("the confirmed list is non-empty");
+  assert!(
+    last.start() < agreement.last_agreed_seconds(),
+    "the postcondition is repaired: {:?} starts at {} against a {} s watermark",
+    last.word(),
+    last.start(),
+    agreement.last_agreed_seconds(),
+  );
+}
+
+#[test]
 fn a_dropped_disagreeing_hypothesiss_draw_survives_into_finalize() {
   // F1 (codex round 8). A three-hypothesis history where the MIDDLE hypothesis
   // disagrees and is dropped from `results` (`:395-400`, skipAppend) but is

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -5201,7 +5201,8 @@ fn an_agreeing_round_that_moves_nothing_reports_stationary() {
     "so the round must REPORT that, and it reports `{outcome}`. A caller may \
      read `progressed` as \"something moved\" and act on it -- drive a progress \
      indicator, decide a stream has stalled, stop re-offering audio that will \
-     never be confirmed -- and this round moved nothing.",
+     never be confirmed -- and this round moved neither the watermark nor the \
+     confirmed prefix.",
   );
 }
 

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -76,8 +76,8 @@ fn initial_prompt_for(
 // below pass the real values directly instead.
 /// Ingest the way [`LocalAgreementTranscriber::push_samples`] does: under the
 /// options the engine itself issued for its current state, so the prefill
-/// premise `LocalAgreement::watermark_filtered`'s ambiguity rule is decided by
-/// is ESTABLISHED rather than assumed.
+/// premise `LocalAgreement::prefill_reproduces_holdback` checks is ESTABLISHED
+/// rather than assumed.
 ///
 /// Every test below that is modelling the streaming loop goes through this. The
 /// bare [`LocalAgreement::ingest`] is the UNMARKED path — a result decoded some
@@ -350,17 +350,18 @@ fn tied_word_starts_never_confirm_twice() {
 fn omitting_a_confirmed_tied_word_does_not_drop_provisional_words() {
   // Regression (phase-gate round 2): the count-based readmit skip dropped
   // B whenever a rewrite OMITTED confirmed A (tied start) and shifted the
-  // hypothesis left. The frontier rule refuses only what the alignment
-  // ATTRIBUTES to the settled half, and a deletion costs it nothing beyond the
-  // match it forgoes, so a candidate the hypothesis does not reproduce costs
-  // nothing here either.
+  // hypothesis left. Rule W keeps the tie out of the offered list in the first
+  // place -- it widens the split past the tie, so the watermark is 1.0 and
+  // neither A nor B is ever re-offered -- so there is nothing here for a
+  // rewrite to shift into.
   //
-  // Mutation proof: refuse nothing at all (a frontier of 0, Swift's bare
-  // timestamp filter at `:372`) and B is never confirmed -- the re-admitted A
-  // sits at the front of BOTH filtered lists, the prefix comparison lines up on
-  // it instead of on B, and `confirmed_words_slice()` reads back [" A"]. The
-  // same mutation costs `tied_word_starts_never_confirm_twice` its stability,
-  // reading back [" A", " A", " B"].
+  // Mutation proof: delete Rule W's widening loop (the `while split <
+  // common.len()` in `ingest`'s advance) and B is never confirmed -- the
+  // re-admitted A sits at the front of BOTH filtered lists, the prefix
+  // comparison lines up on it instead of on B, and `confirmed_words_slice()`
+  // reads back [" A"]. The same mutation costs
+  // `tied_word_starts_never_confirm_twice` its stability, reading back
+  // [" A", " A", " B"].
   let a = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0); // tied start with A
   let c = || word(" C", 1.0, 2.0);
@@ -378,7 +379,7 @@ fn omitting_a_confirmed_tied_word_does_not_drop_provisional_words() {
     .collect();
   assert!(
     confirmed.contains(&" B"),
-    "B lost to the re-admission frontier: {confirmed:?}"
+    "B lost to a re-admitted tied word: {confirmed:?}"
   );
   assert_eq!(
     confirmed.iter().filter(|w| **w == " B").count(),
@@ -400,7 +401,7 @@ fn the_split_never_cuts_at_a_tied_start() {
   // the holdback is non-empty, the last CONFIRMED word starts strictly before
   // the watermark.
   //
-  // That inequality is the whole of #94. `watermark_filtered_with` offers every
+  // That inequality is the whole of #94. `watermark_filtered` offers every
   // hypothesis word whose `start >= watermark`, so a confirmed word that TIES
   // the watermark passes that filter and can come back at the head of the next
   // hypothesis -- and there it is byte-identical to the stream's own second
@@ -1064,13 +1065,15 @@ fn a_corroborated_revision_that_repeats_a_held_back_word_reaches_the_transcript(
 //
 // Every test below is a sequence that slid past `watermark_filtered`'s old
 // leading-run strip and confirmed a settled word a second time -- or, in the
-// last one, DELETED a word the stream genuinely produced. Each was a
+// last two, DELETED a word the stream genuinely produced. Each was a
 // CHARACTERIZATION while <https://github.com/findit-studio/coremlit/issues/94>
 // was open: it asserted the wrong answer the strip produced and carried the
-// right one in its failure message. The frontier rule
-// (`LocalAgreement::watermark_filtered`) replaced that strip, so each now
-// asserts the property its name states, at exactly the value its old failure
-// message specified.
+// right one in its failure message. RULE W (`LocalAgreement::ingest`'s advance)
+// closed the class at its source -- the split never cuts at a tied start, so a
+// confirmed word can never pass the offered filter -- and `watermark_filtered`
+// went back to Swift's bare `:372` line. The two `rule_w_deletes_*` entries are
+// the cost of that trade and stay CHARACTERIZATION; the rest now assert the
+// property their names state.
 //
 // They belong beside the constraints in the next section: these pin what the
 // rule must now DO, those pin what it must still NOT do. Run both halves at
@@ -1100,230 +1103,33 @@ fn a_corroborated_revision_that_repeats_a_held_back_word_reaches_the_transcript(
 // (confirmed list, offered list, watermark) before establishing that NO such
 // predicate can decide these: two runs reach byte-identical triples and need
 // opposite answers, so occurrence identity is not recoverable from those three.
-// What separates those two runs is the HOLDBACK -- which is why the rule that
-// closed them aligns `settled ++ holdback` as a whole instead of scanning the
-// offered list for a text match. The four defeated approaches and the
-// falsifier that killed each are in the issue.
-
-#[test]
-fn an_insertion_before_a_reproduced_confirmed_word_is_refused_with_it() {
-  // #94 (codex round 2; also the round-4 F1 "all tied at the watermark"
-  // variant). The old leading-run strip zipped the confirmed tail against the
-  // offered list from BOTH fronts, so it only removed a reproduction the
-  // hypothesis put at the very FRONT of its post-watermark list. An insertion at
-  // that same instant AHEAD of the reproduction mismatched at offset 0, stripped
-  // nothing, and the already-confirmed " A" rode through into `hypothesis_words`
-  // -- which `finalize` then appended wholesale, reading back " A X A B C".
-  //
-  // The frontier rule aligns the span as a whole: `settled ++ holdback` is
-  // [A, B, C] against the offered [X, A, B, C], and the only optimal alignment
-  // matches A, B and C at offsets 1, 2 and 3 -- so the seam sits at offset 1 and
-  // " X" is refused WITH the reproduction it hides behind. That is forced rather
-  // than incidental: the settled " A" is already in the caller's hands and
-  // `confirmed_words_slice()` is append-only, so " X" can go neither before it
-  // nor after it. Take the reproduction away and the choice disappears, which is
-  // what `an_insertion_that_reproduces_nothing_confirmed_keeps_its_word` pins
-  // from the other side.
-  //
-  //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
-  //   ingest    [X@0.0, A@0.0, B@0.0, C@1.0]  ->  " A B C", " A" once
-  //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back " A X A B C" -- the answer the ledger recorded while #94 was open.
-  let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 0.0, 1.0); // tied start with A
-  let c = || word(" C", 1.0, 2.0);
-  let x = || word(" X", 0.0, 0.3); // an insertion at that same instant
-  let mut agreement = LocalAgreement::new();
-  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
-  assert!(
-    agreement
-      .ingest_streamed(result_with_words(vec![a(), b(), c()]))
-      .is_advanced()
-  );
-  // Rule W (#94): the split may not cut at a tied start, so it widens past the
-  // tie -- one word moves from `last_agreed_words_slice()` into
-  // `confirmed_words_slice()` and the watermark moves to the first word past
-  // the tie. `confirmed ++ holdback` is unchanged, and the finalized text this
-  // test asserts is measured byte-identical either way.
-  assert_eq!(
-    agreement
-      .confirmed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" A", " B"],
-    "confirmed [A, B], holding [C] at a 1.0 s watermark",
-  );
-
-  agreement.ingest_streamed(result_with_words(vec![x(), a(), b(), c()]));
-
-  let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
-  assert_eq!(
-    final_result.text(),
-    " A B C",
-    "the settled A wins the instant it was confirmed at, and the insertion is \
-     not smuggled in beside it",
-  );
-  assert_eq!(
-    final_result.text().matches('A').count(),
-    1,
-    "\" A\" reaches the transcript exactly once. Text: {:?}",
-    final_result.text(),
-  );
-}
-
-#[test]
-fn an_insertion_before_a_reproduced_confirmed_word_is_refused_on_the_advance() {
-  // #94, the same defect WITHOUT `finalize`. `ingest`'s advance folds
-  // `common[..split]` -- a slice of `hypothesis_words` -- straight into
-  // `confirmed_words`, so two consecutive hypotheses that both insert ahead of
-  // the reproduced confirmed word used to agree on the whole insertion and put
-  // the duplicate into `confirmed_words_slice()`, the face a streaming caller
-  // reads between pushes. Fixing `finalize` alone would never have reached this
-  // one, which is why the ledger pins both paths.
-  //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back [" A", " X", " A"] -- the answer the ledger recorded while #94 was open.
-  //
-  //   ingest [A,B,C] [A,B,C] [X,A,B,C] [X,A,B,C]  (all tied at 0.0 but C)
-  //   confirmed_words_slice() == [" A"]
-  let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 0.0, 1.0);
-  let c = || word(" C", 1.0, 2.0);
-  let x = || word(" X", 0.0, 0.3);
-  let mut agreement = LocalAgreement::new();
-  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest_streamed(result_with_words(vec![x(), a(), b(), c()]));
-  agreement.ingest_streamed(result_with_words(vec![x(), a(), b(), c()]));
-
-  // Rule W (#94): the split may not cut at a tied start, so it widens past the
-  // tie -- one word moves from `last_agreed_words_slice()` into
-  // `confirmed_words_slice()` and the watermark moves to the first word past
-  // the tie. `confirmed ++ holdback` is unchanged, and the finalized text this
-  // test asserts is measured byte-identical either way.
-  assert_eq!(
-    agreement
-      .confirmed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" A", " B"],
-    "the advance path must not re-confirm A either",
-  );
-}
-
-#[test]
-fn a_holdback_over_a_reproduced_confirmed_word_keeps_the_settled_span() {
-  // #94 at `finalize`'s OTHER append: `confirmed_words.append(&mut
-  // last_agreed_words)`. `last_agreed_words` is `common[split..]`, itself a
-  // slice of `hypothesis_words`, so an already-confirmed word the old strip
-  // missed reached `confirmed_words` through the HOLDBACK rather than through
-  // the `holdback_superseded` branch: with `split == 0` nothing is confirmed at
-  // the advance and the whole agreed prefix -- insertion and re-admitted " A"
-  // alike -- was held back and then flushed, reading back " A X A" and losing
-  // " B C" with it.
-  //
-  // Under the frontier rule these two hypotheses offer NOTHING past the seam:
-  // aligning [A, B, C] against [X, A] matches only the A at offset 1, so the
-  // seam is at offset 2 and `hypothesis_words` is empty. They therefore disagree
-  // with the holdback, and an empty `hypothesis_words` is exactly the case
-  // `a_final_hypothesis_with_nothing_past_the_watermark_keeps_the_holdback`
-  // guards: nothing supersedes the holdback, so it is still flushed.
-  //
-  //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
-  //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back " A X A" -- the answer the ledger recorded while #94 was open.
-  //   ingest    [X@0.0, A@0.0] twice  ->  " A B C"
-  let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 0.0, 1.0);
-  let c = || word(" C", 1.0, 2.0);
-  let x = || word(" X", 0.0, 0.3);
-  let mut agreement = LocalAgreement::new();
-  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest_streamed(result_with_words(vec![x(), a()]));
-  agreement.ingest_streamed(result_with_words(vec![x(), a()]));
-
-  let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
-  assert_eq!(
-    final_result.text(),
-    " A B C",
-    "the holdback must not flush a second copy of the confirmed A, and it must \
-     not lose \" B C\" doing it",
-  );
-}
-
-#[test]
-fn a_different_suffix_over_a_reproduced_confirmed_word_keeps_the_settled_span() {
-  // #94 at `finalize`'s THIRD append: `find_longest_different_suffix(&prev_words,
-  // &hypothesis_words)`, also a slice of `hypothesis_words`. Here the
-  // re-admitted " A" sat PAST the common prefix -- two hypotheses agree on an
-  // inserted [P, Q] and then diverge, and the newer one's reproduction of the
-  // confirmed " A" rode in on the differing suffix, reading back " A P Q A".
-  //
-  // The frontier rule refuses [P, Q, A] wholesale: aligning [A, B, C] against
-  // [P, Q, A] matches only the A at offset 2, so the seam is at offset 3.
-  // Refusing " P" and " Q" is the same forced choice as
-  // `an_insertion_before_a_reproduced_confirmed_word_is_refused_with_it` -- they
-  // sit ahead of a reproduction of a word the caller already holds.
-  //
-  //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
-  //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back " A P Q A" -- the answer the ledger recorded while #94 was open.
-  //   ingest    [P@0.0, Q@0.0, Z@0.0] then [P@0.0, Q@0.0, A@0.0]  ->  " A B C"
-  let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 0.0, 1.0);
-  let c = || word(" C", 1.0, 2.0);
-  let mut agreement = LocalAgreement::new();
-  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
-  agreement.ingest_streamed(result_with_words(vec![
-    word(" P", 0.0, 0.1),
-    word(" Q", 0.0, 0.2),
-    word(" Z", 0.0, 0.3),
-  ]));
-  agreement.ingest_streamed(result_with_words(vec![
-    word(" P", 0.0, 0.1),
-    word(" Q", 0.0, 0.2),
-    a(),
-  ]));
-
-  let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
-  assert_eq!(
-    final_result.text(),
-    " A B C",
-    "the differing suffix must not flush a second copy of the confirmed A",
-  );
-}
+// A fifth -- a longest-common-subsequence alignment of `settled ++ holdback`
+// against the offered list -- decided them, and deleted the words BETWEEN two
+// occurrences of a recurring phrase while doing it
+// (`a_recurring_phrase_does_not_delete_the_words_between_its_occurrences`).
+// Rule W stops trying to decide the state and refuses to create it. The
+// defeated approaches and the falsifier that killed each are in the issue.
 
 #[test]
 fn a_later_re_use_of_a_confirmed_word_is_not_mistaken_for_a_re_admission() {
-  // The BOUND on `watermark_filtered_with`'s strip, and phase-gate round 2's
-  // rule restated for it: a candidate the hypothesis does not reproduce must
-  // cost nothing. " A" is confirmed at 0.0 s and the clip says " A" again at
-  // 2.0 s — a different word at a different instant, with two provisional words
-  // in front of it. Zipping the confirmed tail against the offered list from
-  // both fronts stops at the first mismatch, so the later " A" is out of reach;
-  // a rule that SCANS for a text match instead would find it and take " B" and
-  // " C" down with it. That is the failure mode a stricter replacement rule has
-  // to avoid, which is why this pin is green rather than ignored.
+  // THE STANDING BOUND on any re-admission rule, and phase-gate round 2's rule
+  // restated for it: a word the stream genuinely re-utters must cost nothing.
+  // " A" is confirmed at 0.0 s and the clip says " A" again at 2.0 s -- a
+  // different word at a different instant, with provisional words in front of
+  // it. Under Rule W nothing looks for it at all: the watermark is 1.0 s, the
+  // offered filter is Swift's bare `start >= watermark`, and a rule that SCANS
+  // the offered list for a confirmed word's TEXT would find the 2.0 s " A" and
+  // take the words in front of it down too. Kept green as the constraint any
+  // future change is measured against, not because the current code has a
+  // branch that could get it wrong.
   //
-  // Mutation proof: drop the HOLDBACK from the alignment (align `settled`
-  // alone) and this reads back " A D E" -- " B" and " C", agreed by both
-  // hypotheses, gone. Without the holdback to score against, matching the
-  // settled " A" at offset 2 is the alignment's whole objective, so the seam
-  // lands behind it. That is the identical answer the naive rposition scan gave
-  // (`filtered.iter().rposition(|w| candidates.contains(&normalized(w.word())))
-  // .map_or(0, |i| i + 1)`), which is the point: what keeps the frontier off
-  // the later occurrence is the holdback, not the search.
+  // Mutation proof: put a text SCAN back in front of the agreement comparison
+  // (`hypothesis_words.rposition(|w| confirmed texts contain normalized(w))`,
+  // then strip through it -- the naive rule phase-gate round 2 defeated) and
+  // this reads back " A B D E": " C" and the re-uttered " A", both agreed by two
+  // consecutive hypotheses, gone. Measured, and it reds five other pins with it
+  // (`a_recurring_phrase_does_not_delete_the_words_between_its_occurrences`
+  // among them).
   let a0 = || word(" A", 0.0, 0.5);
   let b = || word(" B", 0.0, 1.0); // tied start with the confirmed A
   let c = || word(" C", 1.0, 2.0);
@@ -1345,202 +1151,18 @@ fn a_later_re_use_of_a_confirmed_word_is_not_mistaken_for_a_re_admission() {
 }
 
 // ---------------------------------------------------------------------
-// The ledger, continued: two shapes with TWO confirmed words tied at the
-// watermark
-// ---------------------------------------------------------------------
-
-/// The shared history for the two ledger entries below: two identical hypotheses
-/// whose first THREE words tie at 0.0 s, so the advance confirms `[A, B]`,
-/// holds `[C, D]`, and leaves the watermark at 0.0 s with TWO confirmed words
-/// still at or past it.
-fn tied_pair_confirmed() -> LocalAgreement {
-  let mut agreement = LocalAgreement::new();
-  agreement.ingest_streamed(result_with_words(vec![
-    tied_a(),
-    tied_b(),
-    tied_c(),
-    tied_d(),
-  ]));
-  assert!(
-    agreement
-      .ingest_streamed(result_with_words(vec![
-        tied_a(),
-        tied_b(),
-        tied_c(),
-        tied_d()
-      ]))
-      .is_advanced(),
-  );
-  assert_eq!(
-    agreement
-      .confirmed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" A", " B", " C"],
-    "Rule W widens past the 0.0 s tie, so this is confirmed [A, B, C] holding \
-     [D] at a 1.0 s watermark -- `confirmed ++ holdback` unchanged",
-  );
-  agreement
-}
-
-fn tied_a() -> WordTiming {
-  word(" A", 0.0, 0.5)
-}
-fn tied_b() -> WordTiming {
-  word(" B", 0.0, 0.6)
-}
-fn tied_c() -> WordTiming {
-  word(" C", 0.0, 0.7)
-}
-fn tied_d() -> WordTiming {
-  word(" D", 1.0, 1.5)
-}
-
-#[test]
-fn a_confirmed_tail_reproduced_without_its_head_is_still_refused() {
-  // #94 (codex round 2, counterexample 1) -- the CONFIRMED-TAIL OMISSION. The
-  // old strip compared the confirmed tail from ITS OWN front, so a hypothesis
-  // that OMITS " A" and reproduces only " B" mismatched at offset 0, stripped
-  // nothing, and " B" rode through into `hypothesis_words` for " A B B C D".
-  //
-  // A deletion costs the frontier alignment nothing beyond the match it forgoes:
-  // [A, B, C, D] against [B, C, D] simply drops the A, matches B/C/D at offsets
-  // 0/1/2, and puts the seam after offset 0. The reproduction is refused even
-  // though it does not start where the confirmed tail does.
-  //
-  //   confirmed [A@0.0, B@0.0], holding [C@0.0, D@1.0], watermark 0.0
-  //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back " A B B C D" -- the answer the ledger recorded while #94 was open.
-  //   ingest    [B@0.0, C@0.0, D@1.0]  ->  " A B C D"
-  let mut agreement = tied_pair_confirmed();
-  agreement.ingest_streamed(result_with_words(vec![tied_b(), tied_c(), tied_d()]));
-  let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
-  assert_eq!(
-    final_result.text(),
-    " A B C D",
-    "the confirmed B must not be confirmed a second time by a reproduction \
-     that skipped A",
-  );
-}
-
-#[test]
-fn a_confirmed_tail_reproduced_without_its_head_is_still_refused_on_the_advance() {
-  // #94, the same omission WITHOUT `finalize`. Repeating the hypothesis makes
-  // the two agree, and `ingest`'s advance folds `common[..split]` straight into
-  // the caller-visible `confirmed_words_slice()` a streaming caller reads
-  // between pushes -- so this path needs its own pin.
-  //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back [" A", " B", " B"] -- the answer the ledger recorded while #94 was open.
-  //
-  //   ingest [B,C,D] twice on top of the same history
-  //   confirmed_words_slice() == [" A", " B"]
-  let mut agreement = tied_pair_confirmed();
-  agreement.ingest_streamed(result_with_words(vec![tied_b(), tied_c(), tied_d()]));
-  agreement.ingest_streamed(result_with_words(vec![tied_b(), tied_c(), tied_d()]));
-  assert_eq!(
-    agreement
-      .confirmed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" A", " B", " C"],
-    "the advance path must not re-confirm B either (\" C\" is Rule W's widening, \
-     not a re-admission)",
-  );
-}
-
-#[test]
-fn a_reproduction_behind_a_shorter_false_match_is_still_refused() {
-  // #94 (codex round 2, counterexample 2) -- the PARTIAL FRONT MATCH. The old
-  // strip zipped the confirmed tail [A, B] against the offered list, matched
-  // " A" at offset 0, mismatched " B" against the inserted " X", and stopped --
-  // stripping one word and letting the real, longer " A B" reproduction at
-  // offset 2 ride through, for " A B X A B C D".
-  //
-  // The frontier alignment has no front to be trapped at. [A, B, C, D] against
-  // [A, X, A, B, C, D] scores four matches only by taking B at offset 3 (there
-  // is no other B), so every optimal alignment puts the seam after it: the
-  // frontier is 4 and the false match, the insertion and the real reproduction
-  // are all refused together.
-  //
-  //   confirmed [A@0.0, B@0.0], holding [C@0.0, D@1.0], watermark 0.0
-  //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back " A B X A B C D" -- the answer the ledger recorded while #94 was open.
-  //   ingest    [A@0.0, X@0.0, A@0.0, B@0.0, C@0.0, D@1.0]  ->  " A B C D"
-  let mut agreement = tied_pair_confirmed();
-  agreement.ingest_streamed(result_with_words(vec![
-    tied_a(),
-    word(" X", 0.0, 0.3),
-    tied_a(),
-    tied_b(),
-    tied_c(),
-    tied_d(),
-  ]));
-  let final_result = agreement.finalize(&crate::audio::whisper::options::DecodingOptions::new());
-  assert_eq!(
-    final_result.text(),
-    " A B C D",
-    "the longer reproduction behind the false match is stripped too",
-  );
-}
-
-#[test]
-fn a_reproduction_behind_a_shorter_false_match_is_still_refused_on_the_advance() {
-  // #94, the same partial front match WITHOUT `finalize` -- two hypotheses that
-  // agree on the whole `[A, X, A, B]` run used to advance, carrying both
-  // already-confirmed words into `confirmed_words_slice()`.
-  //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back [" A", " B", " X", " A", " B"] -- the answer the ledger recorded while
-  // #94 was open.
-  //
-  //   confirmed_words_slice() == [" A", " B"]
-  let hypothesis = || {
-    result_with_words(vec![
-      tied_a(),
-      word(" X", 0.0, 0.3),
-      tied_a(),
-      tied_b(),
-      tied_c(),
-      tied_d(),
-    ])
-  };
-  let mut agreement = tied_pair_confirmed();
-  agreement.ingest_streamed(hypothesis());
-  agreement.ingest_streamed(hypothesis());
-  assert_eq!(
-    agreement
-      .confirmed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" A", " B", " C"],
-    "the advance path must not re-confirm A or B either (\" C\" is Rule W's \
-     widening, not a re-admission)",
-  );
-}
-
-// ---------------------------------------------------------------------
 // What the re-admission rule must NOT break
 // ---------------------------------------------------------------------
 //
 // The pins below were green on `main` and on every defeated candidate rule, and
-// they are green on the frontier rule: they are the constraints a replacement
-// has to keep satisfying, recorded next to the ledger above so any future change
-// is measured against both halves at once. Deleting a word the stream genuinely
+// they are green under Rule W: they are the constraints a replacement has to
+// keep satisfying, recorded next to the ledger above so any future change is
+// measured against both halves at once. Deleting a word the stream genuinely
 // produced is the failure mode a stricter rule falls into, and it is worse than
 // the duplication the ledger records -- `tests/whisper/streaming.rs`'s portable
-// prefix property tolerates a truncation and forbids a rewrite. That asymmetry
-// is why the frontier rule breaks an ambiguous seam toward KEEPING: it refuses
-// only the offered prefix every optimal alignment settles.
+// prefix property tolerates a truncation and forbids a rewrite. Rule W pays
+// exactly that cost on two tied fixtures, which is why those two are
+// characterization tests carrying the correct answer rather than pins.
 
 #[test]
 fn a_stutter_at_the_watermark_keeps_both_occurrences() {
@@ -1554,10 +1176,12 @@ fn a_stutter_at_the_watermark_keeps_both_occurrences() {
   // reproduction of the word just confirmed, which is why the rule must not run
   // a second time over words a first pass already cleared.
   //
-  // Mutation proof: run `settled_frontier` a second time over `finalize`'s
-  // flushed holdback (the tempting "defence in depth") and this reads back
-  // " A B", one " A" short -- the frontier must be taken once, on the offered
-  // list, and never again on words a first pass already cleared.
+  // Mutation proof: make the offered filter STRICT (`start > watermark` in
+  // `watermark_filtered`) and the advance never happens -- both stuttered A's
+  // sit exactly at the 0.0 s watermark, the hypothesis comes back as the single
+  // word " B", and `is_advanced()` is false. The non-strict endpoint is what
+  // lets a hypothesis re-offer the instant the watermark sits on, which is the
+  // whole of what Rule W then has to keep safe.
   let hypothesis = || {
     result_with_words(vec![
       word(" A", 0.0, 0.5),
@@ -1614,39 +1238,24 @@ fn a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream() {
   //
   // This is the issue's two-run construction, live: a run of ` A A B` and a run
   // of ` A B C` reach byte-identical (confirmed, offered, watermark) and need
-  // OPPOSITE answers, so no predicate over those three can be right. What
-  // separates them is the HOLDBACK -- `[A, B]` here against `[B, C]` there --
-  // and the frontier rule reads it, because it aligns `settled ++ holdback` as a
-  // whole. [A, A, B] against [A, B, C, D] scores two matches with the seam at
-  // either offset 0 or offset 1, so the seam is AMBIGUOUS; taking the smallest
-  // keeps the leading " A", which is the stream's own second occurrence.
+  // OPPOSITE answers, so no predicate over those three can be right. Round 5,
+  // finding 1 re-reported THIS sequence and argued the other reading -- that the
+  // offered " A" is the SETTLED one coming back, so a rule that keeps it
+  // duplicates a word. Rule W answers neither reading: the stutter is a start
+  // TIE (both A's at 0.0 s), so the split widens past both instead of cutting
+  // between them. They are confirmed together, the watermark lands on " B" at
+  // 1.0 s, and no later hypothesis can offer either one back -- the state the
+  // two readings disagreed about is never created.
   //
-  // Round 5, finding 1 re-reported THIS sequence -- the same two ingests, the
-  // same two optimal seams, the same [" A", " A", " B"] -- and argued the other
-  // reading: that the offered " A" is the SETTLED one coming back and the
-  // provisional " A" was deleted, so seam 1 is right and the minimum rule
-  // duplicates a word. That reading is refuted by how the offered list is
-  // produced, not by this bias. `decoding_options_for_next` prefills the decoder
-  // with the holdback's own tokens and `decode_text` forces every prompt
-  // position, so a hypothesis decoded from those options BEGINS with the
-  // provisional " A"; deleting it would mean dropping a token the decoder was
-  // fed rather than asked for. The minimum seam is that reading.
-  // `the_next_strides_prefill_is_the_holdback_verbatim` pins the contract, and
-  // `LocalAgreement::watermark_filtered`'s "Ambiguity rule" carries why blocking
-  // on the tie instead would deadlock this exact shape on every stride.
-  //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back [" A", " B"] -- the answer the ledger recorded while #94 was open.
-  // Two more, for the two halves of the rule this one turns on. Take the
-  // LARGEST optimal seam instead of the smallest and it reads back [" A", " B"]
-  // again -- the ambiguity is real, and the direction the tie breaks IS the
-  // answer. Drop the holdback from the alignment (align `settled` alone) and it
-  // reads back [" A", " B"] once more, because the holdback is the only thing
-  // that separates this run from the one in the issue's table. That same
-  // mutation takes the sibling pin
-  // `a_later_re_use_of_a_confirmed_word_is_not_mistaken_for_a_re_admission`
-  // down to " A D E" -- the naive-scan failure, from the other direction.
+  // Mutation proof: delete Rule W's widening loop (the `while split <
+  // common.len()` in `ingest`'s advance) and this reads back [" A"] instead of
+  // [" A", " A"] at the first checkpoint -- the split cuts between the two
+  // stuttered A's, the second is held back at a watermark tied to the first, and
+  // the sequence is back in the undecidable state. Measured; the same mutation
+  // reds `tied_word_starts_never_confirm_twice`,
+  // `omitting_a_confirmed_tied_word_does_not_drop_provisional_words`,
+  // `the_split_never_cuts_at_a_tied_start` and both `rule_w_deletes_*`
+  // characterizations.
   //
   //   ingest    [A@0.0, A@0.0, B@1.0] twice -> confirmed [A], holding [A, B]
   //   then      [A@0.0, B@1.0, C@2.0, D@3.0] twice
@@ -1693,33 +1302,33 @@ fn a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream() {
 }
 
 #[test]
-fn a_reproduction_shifted_off_the_watermark_is_still_refused() {
-  // #94 (codex round 3, finding 1; re-reported verbatim as ROUND 4, FINDING 1 --
-  // "F1 as reported" in the round-4 three-tree measurement, where `main` and the
-  // apparatus branch were byte-identical at every ingest). The re-decode nudges
-  // every word a hair PAST the 0.0 s watermark and inserts " X" ahead of the
-  // reproduced " A", so nothing the hypothesis offered matched the confirmed
-  // tail at offset 0, the old strip was 0, and two such hypotheses agreed with
-  // each other and confirmed [X, A] on top of the settled A.
+fn rule_w_deletes_a_tied_insertion_that_reproduces_nothing_confirmed() {
+  // CHARACTERIZATION of Rule W, not a property that holds. This pins what the
+  // engine does TODAY on a tied fixture; the CORRECT answer is in the failure
+  // message below, so the day the trade is revisited this test goes red and
+  // hands the next author the expectation.
   //
-  // This is also why the frontier rule reads TEXT and not timestamps. The
-  // defeated approach 3 drew a match window from the watermark, and this exact
-  // sequence escaped it by sitting a hundredth of a second outside; a re-decode
-  // is free to move every timestamp it emits, so timings are evidence about the
-  // span, not about occurrence identity within it. The alignment of [A, B, C]
-  // against [X, A, B, C] does not care where the words landed: its only optimal
-  // reading matches A/B/C at offsets 1/2/3, seam at 1.
+  // TRIGGER: two adjacent agreed words with EQUAL starts -- here `" A"@[0.0,0.5)`
+  // and `" B"@[0.0,1.0)`. On words this crate's own pipeline produces that
+  // needs a zero-duration word, since `find_alignment` guarantees
+  // `w[i].end() <= w[i + 1].start() + 1e-4` (see
+  // `crate::audio::whisper::segment`'s tests); `LocalAgreementTranscriber`
+  // never reaches it, and the committed jfk golden carries no start tie at all.
   //
-  //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
+  // WHAT MOVES: Rule W widens the first advance's split past the tie, so `" B"`
+  // is confirmed a round early and the watermark lands at 1.0 s instead of
+  // 0.0 s. The later insertion `" X"@[0.0,0.3)` then falls BEFORE the watermark
+  // and `watermark_filtered` drops it from every hypothesis -- it is never
+  // offered, never held, never confirmed. Finalized `" A X B C D"` becomes
+  // `" A B C D"`.
   //
-  // Mutation proof: put the old leading-run strip back in place of the frontier
-  // (`settled.iter().zip(&offered).take_while(text-equal).count()`) and this reads
-  // back [" A", " X", " A"] -- the answer the ledger recorded while #94 was open.
-  //
-  //   ingest    [X@0.01, A@0.02, B@1.0, C@2.0] twice
-  //   confirmed_words_slice() == [" A"], text " A B C"
+  // WHY IT WAS ACCEPTED: the alignment frontier Rule W replaced deleted words
+  // on PHRASE RECURRENCE -- a shape real transcripts produce, and present at two
+  // watermark positions of this crate's own canonical jfk phrase -- while this
+  // deletes only inside a degenerate tie the driver cannot reach. Recorded as a
+  // behaviour change in this module's `Documented deviations`.
   let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 0.0, 1.0); // tied start with A: the watermark stays 0.0
+  let b = || word(" B", 0.0, 1.0); // tied start with A -- the trigger
   let c = || word(" C", 1.0, 2.0);
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
@@ -1728,163 +1337,49 @@ fn a_reproduction_shifted_off_the_watermark_is_still_refused() {
       .ingest_streamed(result_with_words(vec![a(), b(), c()]))
       .is_advanced()
   );
-  // Rule W (#94): the split may not cut at a tied start, so it widens past the
-  // tie -- one word moves from `last_agreed_words_slice()` into
-  // `confirmed_words_slice()` and the watermark moves to the first word past
-  // the tie. `confirmed ++ holdback` is unchanged, and the finalized text this
-  // test asserts is measured byte-identical either way.
   assert_eq!(
     confirmed_texts(&agreement),
     vec![" A", " B"],
-    "confirmed [A, B], holding [C] at a 1.0 s watermark",
+    "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94): \
+     Rule W widened this advance's split past the tie between \" A\"@[0.0,0.5) \
+     and \" B\"@[0.0,1.0), so \" B\" is confirmed here and the watermark is 1.0 \
+     rather than 0.0. Without the rule the split stops at 1 and this reads \
+     [\" A\"]. If you changed the rule, that is the expectation -- assert \
+     [\" A\"] and re-check the insertion below.",
   );
-
-  let shifted = || {
-    result_with_words(vec![
-      word(" X", 0.01, 0.3),
-      word(" A", 0.02, 0.5),
-      word(" B", 1.0, 1.5),
-      word(" C", 2.0, 2.5),
-    ])
-  };
-  agreement.ingest_streamed(shifted());
-  agreement.ingest_streamed(shifted());
   assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A", " B"],
-    "the shifted reproduction must not reach the confirmed list on the advance \
-     path either (\" B\" is Rule W's widening, not the reproduction)",
+    agreement.last_agreed_seconds(),
+    1.0,
+    "the watermark is the tie's far side, which is what deletes the insertion \
+     below",
   );
-
-  let text = agreement
-    .finalize(&crate::audio::whisper::options::DecodingOptions::new())
-    .text()
-    .to_string();
-  assert_eq!(text, " A B C");
-  assert_eq!(
-    text.matches('A').count(),
-    1,
-    "\" A\" reaches the transcript exactly once. Text: {text:?}",
-  );
-}
-
-#[test]
-fn an_insertion_that_reproduces_nothing_confirmed_keeps_its_word() {
-  // The second constraint on any replacement rule: an insertion that reproduces
-  // NOTHING confirmed must keep its word. Refusing what sits ahead of a
-  // reproduction is a forced choice -- the settled " A" is already in the
-  // caller's hands, so an " X" put BEFORE a reproduction of it can go neither
-  // before " A" (the list is append-only) nor after it (that would rewrite the
-  // confirmed prefix). Take the reproduction away and the choice disappears, so
-  // refusing " X" would be an unforced deletion. Here two hypotheses insert " X"
-  // ahead of the held-back [B, C] and reproduce nothing confirmed.
-  //
-  // This is also the direct falsifier for the frontier's TIE-BREAK. The seam
-  // here is ambiguous -- " X" matches nothing settled, so an optimal alignment
-  // may put it on either side -- and the smallest admissible seam keeps it.
-  //
-  // Mutation proof: take the LARGEST optimal seam instead of the smallest
-  // (`.rev()` on `settled_frontier`'s final `find`) and `confirmed_words_slice()`
-  // reads back [" A", " B"] -- " X", agreed on by both hypotheses and
-  // contradicting nothing, gone. That is the deletion the bias exists to
-  // avoid, and it is the same loss
-  // `omitting_a_confirmed_tied_word_does_not_drop_provisional_words` records
-  // from the opposite direction: that one loses a word to an OMISSION shifting
-  // the hypothesis left, this one to an INSERTION shifting it right.
-  let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 0.0, 1.0); // tied start with A
-  let c = || word(" C", 1.0, 2.0);
-  let mut agreement = LocalAgreement::new();
-  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
-  assert!(
-    agreement
-      .ingest_streamed(result_with_words(vec![a(), b(), c()]))
-      .is_advanced()
-  );
-  assert_eq!(confirmed_texts(&agreement), vec![" A"]);
 
   let inserted = || result_with_words(vec![word(" X", 0.0, 0.3), b(), c(), word(" D", 2.0, 2.5)]);
   agreement.ingest_streamed(inserted());
   assert!(agreement.ingest_streamed(inserted()).is_advanced());
   assert_eq!(
     confirmed_texts(&agreement),
-    vec![" A", " X", " B"],
-    "nothing confirmed is re-offered, so the insertion costs nothing",
-  );
-  assert_eq!(
-    agreement
-      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
-      .text(),
-    " A X B C D",
-  );
-}
-
-#[test]
-fn a_confirmed_word_from_before_the_watermark_is_out_of_the_alignment() {
-  // The third constraint, and the SCOPE of `settled`: only the trailing run of
-  // the confirmed list whose extent REACHES the watermark is aligned against the
-  // offered words. Confirmed words that end before it have another word's audio,
-  // or silence, between them and the re-decoded span, and putting them in the
-  // alignment would let them match a genuinely later re-use of the same text --
-  // taking the provisional words behind it down too, exactly the scan-based
-  // failure `a_later_re_use_of_a_confirmed_word_is_not_mistaken_for_a_re_admission`
-  // pins. That sibling cannot see this, because there the watermark is still
-  // 0.0 s and the trailing run IS the whole confirmed list; here the watermark
-  // has moved past " A" and the clip says " A" again at the new frontier.
-  //
-  // The GAPS below are load-bearing, and were not when this test was written:
-  // " B" ends at 0.9 with the watermark at 1.0, so it is out of scope by 0.1 s.
-  // Its sibling `a_re_utterance_separated_from_the_watermark_keeps_its_word`
-  // re-utters " B" rather than " A" and so pins that boundary directly; this
-  // one pins the word two places back, which stays out however the run's near
-  // end is drawn.
-  //
-  // Mutation proof: widen `settled` to the whole confirmed list
-  // (`let settled_len = confirmed.len();`) and the alignment matches the
-  // re-used " A" at offset 0 against the confirmed " A" at 0.0 s, putting the
-  // seam behind it -- `confirmed_words_slice()` reads back [" A", " B", " C"],
-  // the stream's second " A" deleted. Every other test in this module stays
-  // green under that mutation.
-  let a0 = || word(" A", 0.0, 0.4);
-  let b = || word(" B", 0.5, 0.9);
-  let c0 = || word(" C", 1.0, 1.4);
-  let d0 = || word(" D", 1.5, 1.9);
-  let mut agreement = LocalAgreement::new();
-  agreement.ingest_streamed(result_with_words(vec![a0(), b(), c0(), d0()]));
-  assert!(
-    agreement
-      .ingest_streamed(result_with_words(vec![a0(), b(), c0(), d0()]))
-      .is_advanced()
-  );
-  assert_eq!(
-    confirmed_texts(&agreement),
     vec![" A", " B"],
-    "confirmed [A@0.0, B@0.5], holding [C@1.0, D@1.5] at a 1.0 s watermark",
+    "\" X\"@[0.0,0.3) starts before the 1.0 s watermark, so it never reaches a \
+     hypothesis at all",
   );
-  assert!((agreement.last_agreed_seconds() - 1.0).abs() < 1e-6);
-
-  // The clip says " A" again, at the watermark itself -- a different word at a
-  // different instant, with the confirmed one two words behind the watermark.
-  let re_used = || {
-    result_with_words(vec![
-      word(" A", 1.0, 1.05),
-      word(" C", 1.1, 1.4),
-      word(" D", 1.5, 1.9),
-      word(" E", 2.0, 2.4),
-    ])
-  };
-  agreement.ingest_streamed(re_used());
-  assert!(agreement.ingest_streamed(re_used()).is_advanced());
+  let text = agreement
+    .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+    .text()
+    .to_string();
   assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A", " B", " A", " C"],
-    "the later \" A\" is the stream's own, and costs nothing that follows it",
-  );
-  assert_eq!(
-    agreement
-      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
-      .text(),
-    " A B A C D E",
+    text, " A B C D",
+    "CHARACTERIZATION, and a DELETION -- this module's non-preferred direction. \
+     The CORRECT answer is \" A X B C D\": \" X\" reproduces nothing confirmed, \
+     both hypotheses agreed on it, and nothing contradicted it, so no rule may \
+     drop it. It is dropped because Rule W moved the watermark past \" X\"'s \
+     span one advance earlier. Accepted at \
+     https://github.com/findit-studio/coremlit/issues/94 as the price of the \
+     postcondition (`confirmed.last().start() < last_agreed_seconds` strictly, \
+     which makes re-admission unrepresentable): the rule it replaced deleted \
+     words on phrase recurrence, which real transcripts produce, while this \
+     needs a zero-duration word the driver never emits. If that trade was \
+     revisited, assert \" A X B C D\" here and delete this message.",
   );
 }
 
@@ -1896,12 +1391,14 @@ fn a_recurring_phrase_does_not_delete_the_words_between_its_occurrences() {
   // one decode window, which is the shape Whisper's repetition loop manufactures
   // and which the crate's own canonical phrase contains twice.
   //
-  // The frontier aligns `settled ++ holdback` as a WHOLE, and a globally optimal
-  // alignment is free to explain the settled word by an EARLIER occurrence and
-  // the whole holdback by a LATER one. The seam then cuts past both, and every
-  // word BETWEEN the two occurrences is refused -- never confirmed, never held,
-  // and never re-offerable, because the advance that follows moves the watermark
-  // past them.
+  // The frontier ALIGNED `settled ++ holdback` as a WHOLE, and a globally
+  // optimal alignment is free to explain the settled word by an EARLIER
+  // occurrence and the whole holdback by a LATER one. The seam then cut past
+  // both, and every word BETWEEN the two occurrences was refused -- never
+  // confirmed, never held, and never re-offerable, because the advance that
+  // follows moves the watermark past them. This test was RED at 8f30eda and is
+  // green now that the frontier is gone; it is the falsifier that decided the
+  // rule had to be deleted rather than repaired.
   //
   //   settled  [" the"]                       confirmed, end == watermark
   //   holdback [" cat", " sat"]               forced into the next decode
@@ -1965,55 +1462,42 @@ fn a_recurring_phrase_does_not_delete_the_words_between_its_occurrences() {
 }
 
 // ---------------------------------------------------------------------
-// What the frontier rule deliberately LEAVES
+// What Rule W deliberately LEAVES, and what it costs
 // ---------------------------------------------------------------------
 //
-// A documented residual with a test, rather than a claim of totality. See
-// `LocalAgreement::watermark_filtered`'s "What this deliberately leaves".
+// Documented residuals and accepted costs, each with a test, rather than a
+// claim of totality. See `LocalAgreement::watermark_filtered` and this
+// module's `Documented deviations`.
 
 #[test]
-fn an_unaccounted_repeat_of_a_settled_word_is_kept_as_the_streams_own() {
-  // RESIDUAL of #94, held open on purpose. The frontier rule aligns
-  // `settled ++ holdback` -- the engine's whole record of the span at and past
-  // the watermark -- against the offered words. When the offered list carries
-  // MORE copies of a settled word than that record accounts for, the surplus
-  // copy matches nothing on the settled side, no alignment can attribute it
-  // there, and it is kept: the transcript ends up with the settled " A" twice.
+fn rule_w_deletes_an_unaccounted_repeat_of_a_settled_word() {
+  // CHARACTERIZATION of Rule W, not a property that holds. The CORRECT answer
+  // is in the failure message below.
   //
-  // That is not a missed case, it is the tie broken deliberately. The engine
-  // holds `settled = [A]`, `holdback = [B, C]`, offered `[A, A, B, C]`; the clip
-  // stuttering (" A A B C" is right) and the decode duplicating (" A B C" is
-  // right) produce byte-identical inputs, down to every `WordTiming` field. The
-  // holdback separates the issue's two-run construction, but it cannot separate
-  // THIS one -- the holdbacks are equal too. With nothing left to decide on, the
-  // rule keeps: `tests/whisper/streaming.rs`'s portable prefix property
-  // tolerates a truncation and forbids a rewrite, so a duplicate is the
-  // recoverable error and a deletion is not.
+  // This sequence is the issue's own two-run construction with the HOLDBACKS
+  // equal too: the engine holds `confirmed = [A]`, `holdback = [B, C]`, and is
+  // offered `[A, A, B, C]`. The clip stuttering (" A A B C" is right) and the
+  // decode duplicating (" A B C" is right) produce byte-identical inputs, down
+  // to every `WordTiming` field, so nothing the engine holds can separate them.
+  // The adjudicated bias was to KEEP: `tests/whisper/streaming.rs`'s portable
+  // prefix property tolerates a truncation and forbids a rewrite, so a
+  // duplicate is the recoverable error and a deletion is not.
   //
-  // Its mirror image is
-  // `a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream`:
-  // there the offered list carries FEWER copies than the record, the same tie is
-  // broken the same way, and keeping is the RIGHT answer. One rule, one bias,
-  // two truths -- which is exactly why the boundary is undecidable here and the
-  // bias is the whole of the answer.
+  // TRIGGER: the same tie as
+  // `rule_w_deletes_a_tied_insertion_that_reproduces_nothing_confirmed` --
+  // `" A"@[0.0,0.5)` and `" B"@[0.0,1.0)` share a start, which on this crate's
+  // own words needs a zero-duration word and which
+  // `LocalAgreementTranscriber` never produces.
   //
-  // Refusing to advance instead would not help: this shape reproduces on every
-  // subsequent stride, `settled` and `holdback` only move on an advance, so the
-  // stream would stall forever rather than for a stride.
-  //
-  //   confirmed [A@0.0], holding [B@0.0, C@1.0], watermark 0.0
-  //
-  // Mutation proof: take the LARGEST optimal seam instead of the smallest and
-  // this reads back [" A"] -- the surplus copy refused, which is the deletion
-  // this bias exists to avoid. Drop the refusal entirely (a frontier of 0,
-  // Swift's bare timestamp filter at `:372`) and it reads back
-  // [" A", " A", " A"] -- three copies, so the rule is doing real work here
-  // even though it cannot do all of it.
-  //
-  //   ingest    [A@0.0, A@0.0, B@0.0, C@1.0] twice
-  //   confirmed_words_slice() == [" A", " A"], text " A A B C"
+  // WHAT MOVES: Rule W widens the first advance past the tie, so the watermark
+  // is 1.0 s and BOTH copies of `" A"@[0.0,0.5)` -- the settled one and the
+  // stream's surplus one -- fall behind it. The surplus copy is filtered out
+  // rather than kept, the repeated hypothesis carries only `" C"`, which is one
+  // word short of `agreement_count_needed`, so the pair never agrees again and
+  // `finalize` takes its `holdback_superseded` path. Finalized `" A A B C"`
+  // becomes `" A B C"`.
   let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 0.0, 1.0); // tied start with A
+  let b = || word(" B", 0.0, 1.0); // tied start with A -- the trigger
   let c = || word(" C", 1.0, 2.0);
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
@@ -2023,109 +1507,52 @@ fn an_unaccounted_repeat_of_a_settled_word_is_kept_as_the_streams_own() {
       .is_advanced()
   );
   assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A"],
-    "confirmed [A], holding [B, C] at a 0.0 s watermark",
+    (confirmed_texts(&agreement), agreement.last_agreed_seconds()),
+    (vec![" A", " B"], 1.0),
+    "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94): \
+     Rule W widened past the tie, so \" B\" is confirmed here and the watermark \
+     is 1.0. Without the rule this reads ([\" A\"], 0.0) and the surplus repeat \
+     below is still visible to the engine.",
   );
 
   let repeated = || result_with_words(vec![a(), a(), b(), c()]);
-  agreement.ingest_streamed(repeated());
-  assert!(agreement.ingest_streamed(repeated()).is_advanced());
   assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A", " A"],
-    "the surplus A is kept and confirmed -- the documented residual, not a \
-     regression of the ledger above",
+    (
+      agreement.ingest_streamed(repeated()),
+      agreement.ingest_streamed(repeated())
+    ),
+    (
+      AgreementOutcome::AwaitingAgreement,
+      AgreementOutcome::AwaitingAgreement
+    ),
+    "both copies of \" A\" and \" B\" are behind the 1.0 s watermark, so each \
+     hypothesis is the single word \" C\" -- short of `agreement_count_needed`, \
+     so neither pair advances",
   );
   assert_eq!(
     agreement
       .finalize(&crate::audio::whisper::options::DecodingOptions::new())
       .text(),
-    " A A B C",
+    " A B C",
+    "CHARACTERIZATION, and a DELETION -- this module's non-preferred direction, \
+     taken here against its own adjudicated bias. The CORRECT answer is \
+     \" A A B C\": nothing the engine holds can tell a stuttering clip from a \
+     duplicating decode, and the standing bias is to KEEP the surplus copy \
+     because a duplicate is recoverable through the portable prefix property \
+     and a deletion is not. It is deleted because Rule W put the watermark past \
+     both copies one advance earlier. Accepted at \
+     https://github.com/findit-studio/coremlit/issues/94 as the price of the \
+     postcondition (`confirmed.last().start() < last_agreed_seconds` strictly): \
+     the alignment frontier it replaced deleted words on phrase recurrence, \
+     which real transcripts produce, while this needs a zero-duration word the \
+     driver never emits. If that trade was revisited, assert \" A A B C\" here \
+     and delete this message.",
   );
 }
 
 // ---------------------------------------------------------------------
 // The scope of `settled`: which EDGE of a confirmed word faces the span
 // ---------------------------------------------------------------------
-
-#[test]
-fn a_word_whose_extent_reaches_the_watermark_is_in_the_alignment() {
-  // #94 round 5, finding 2 -- CROSS-WATERMARK DRIFT, which bypassed the
-  // alignment entirely rather than losing an argument inside it. `settled` was
-  // the trailing run of confirmed words with `start >= watermark`; here the
-  // confirmed " A" ENDS at the watermark and starts a hundredth of a second
-  // before it, so the run was EMPTY, `watermark_filtered_with` took its
-  // `settled_len == 0` fast path, and the whole offered list came back
-  // unfiltered. Two such hypotheses then agreed and confirmed " A" a second
-  // time. Nothing in the frontier rule ever ran.
-  //
-  // The endpoint was the bug. Each list is tested against the watermark on the
-  // edge that FACES the span -- `offered` on `start`, `settled` on `end` -- and
-  // testing `start` on both asked whether a confirmed word BEGINS inside the
-  // span, which a word straddling the boundary never does. The last confirmed
-  // word straddles it on essentially every advance: DTW word timings abut, so
-  // `confirmed.last().end() == holdback[0].start() == watermark` (measured in
-  // `jfk_tiny_words_golden.json`: 20 of its 21 consecutive word pairs share an
-  // instant exactly, the one exception a 0.5 s silence). Under the old rule that
-  // word was in scope only in the degenerate tie where it ALSO had a zero-length
-  // overlap with the holdback -- which is why `tied_word_starts_never_confirm_twice`
-  // passed while this did not.
-  //
-  //   confirmed [A@0.99-1.00], holding [B@1.00, C@1.50], watermark 1.00
-  //   ingest    [A@1.01, B@1.11, C@1.61, D@2.20] twice
-  //
-  // The alignment then has a UNIQUE optimum -- [A] ++ [B, C] against
-  // [A, B, C, D] matches all three with the seam at 1, and no other seam scores
-  // 3 -- so unlike the ambiguous shapes above, nothing here is a tie-break.
-  //
-  // Mutation proof: put the endpoint back (`take_while(|word| word.start() >=
-  // watermark)`) and both assertions below red at once, to [" A", " A", " B"]
-  // and " A A B C D" -- the finding as reported. Dropping the fast path's early
-  // return instead changes nothing, which is the point: the fast path was never
-  // wrong, its INPUT was.
-  let a = || word(" A", 0.99, 1.0);
-  let b = || word(" B", 1.0, 1.5);
-  let c = || word(" C", 1.5, 2.0);
-  let mut agreement = LocalAgreement::new();
-  agreement.ingest_streamed(result_with_words(vec![a(), b(), c()]));
-  assert!(
-    agreement
-      .ingest_streamed(result_with_words(vec![a(), b(), c()]))
-      .is_advanced()
-  );
-  assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A"],
-    "confirmed [A@0.99], holding [B@1.00, C@1.50] at a 1.00 s watermark",
-  );
-  assert!((agreement.last_agreed_seconds() - 1.0).abs() < 1e-6);
-
-  // The re-decode moves every timestamp it emits, and " A" lands PAST the
-  // watermark it used to end on.
-  let drifted = || {
-    result_with_words(vec![
-      word(" A", 1.01, 1.1),
-      word(" B", 1.11, 1.6),
-      word(" C", 1.61, 2.1),
-      word(" D", 2.2, 2.5),
-    ])
-  };
-  agreement.ingest_streamed(drifted());
-  assert!(agreement.ingest_streamed(drifted()).is_advanced());
-  assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A", " B"],
-    "the drifted reproduction is refused; only the words past it advance",
-  );
-  assert_eq!(
-    agreement
-      .finalize(&crate::audio::whisper::options::DecodingOptions::new())
-      .text(),
-    " A B C D",
-    "\" A\" reaches the transcript exactly once",
-  );
-}
 
 #[test]
 fn a_re_utterance_separated_from_the_watermark_keeps_its_word() {
@@ -2191,11 +1618,11 @@ fn a_re_utterance_separated_from_the_watermark_keeps_its_word() {
 
 #[test]
 fn the_next_strides_prefill_is_the_holdback_verbatim() {
-  // What decides the ambiguity rule, pinned as the fact it is. The smallest
-  // optimal seam attributes a disputed offered head to the HOLDBACK rather than
-  // to `settled`, and the justification is not that keeping errs safe -- it is
-  // that the engine WROTE the holdback into the next hypothesis. This asserts
-  // the two halves of that contract that live in this module:
+  // THE PREMISE, pinned as the fact it is: the engine WRITES the holdback into
+  // the next hypothesis rather than asking for it. That is what makes a marked
+  // continuation unable to put anything in front of the holdback, which is what
+  // `prefill_reproduces_holdback` and the pending promotion rest on. This
+  // asserts the two halves of that contract that live in this module:
   //
   //   * `prefix_tokens` is the holdback's own tokens, in order, concatenated --
   //     not a count, not a summary. `decode::prefill_tokens` appends them to the
@@ -2265,245 +1692,6 @@ fn the_next_strides_prefill_is_the_holdback_verbatim() {
     !holdback_tokens.is_empty(),
     "non-vacuous: an empty holdback would satisfy the equality above trivially",
   );
-}
-
-// ---------------------------------------------------------------------
-// The unmarked path: no prefill premise, so the other reading of the seam
-// ---------------------------------------------------------------------
-
-#[test]
-fn a_direct_ingest_with_no_prefill_refuses_the_disputed_head() {
-  // #94 (codex round 6, finding 1). THE SAME SEQUENCE as
-  // `a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream`,
-  // with the opposite PROVENANCE -- and it must reach the opposite answer.
-  //
-  // There, the continuing results are decoded under the engine's own retarget,
-  // so the decoder was FORCED to emit the holdback and the disputed leading " A"
-  // can only be the holdback's own first word. Here the caller decoded some
-  // other way: no clip retarget, no forced prefill. Nothing then says whether
-  // that " A" is the held-back second occurrence coming back or the SETTLED
-  // first one being re-offered while the held one was dropped -- and
-  // `confirmed_words_slice()` is append-only, so guessing "held" and being wrong
-  // confirms a settled word a second time with no way to retract it. The
-  // unattributable reading refuses it.
-  //
-  // Mutation proof: read `seams.prefilled` on the unmarked path too (the single
-  // policy this replaced) and BOTH faces below read back the marked path's
-  // answers -- [" A", " A", " B"] and " A A B C D".
-  //
-  //   ingest_streamed [A@0.0, A@0.0, B@1.0] twice -> confirmed [A], holding [A, B]
-  //   then BARE ingest [A@0.0, B@1.0, C@2.0, D@3.0] twice, caller's own options
-  //   confirmed_words_slice() == [" A", " B"], text " A B C D"
-  let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 1.0, 1.5);
-  let c = || word(" C", 2.0, 2.5);
-  let d = || word(" D", 3.0, 3.5);
-  let stutter = || result_with_words(vec![a(), a(), b()]);
-  let mut agreement = LocalAgreement::new();
-  agreement.ingest_streamed(stutter());
-  assert!(agreement.ingest_streamed(stutter()).is_advanced());
-  assert_eq!(confirmed_texts(&agreement), vec![" A"]);
-
-  // The caller's OWN options: whatever it decoded with, it was not this engine's
-  // retarget. `DecodingOptions::new()` already fails the premise on two clauses
-  // at once -- no `clip_timestamps` at the watermark, no `prefix_tokens` at all.
-  let unmarked = DecodingOptions::new();
-  assert_ne!(
-    unmarked.clip_timestamps_slice(),
-    &[agreement.last_agreed_seconds()],
-    "non-vacuous: these options are NOT the retarget",
-  );
-  let onward = || result_with_words(vec![a(), b(), c(), d()]);
-  agreement.ingest(onward(), &unmarked);
-  assert!(agreement.ingest(onward(), &unmarked).is_advanced());
-  assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A", " B"],
-    "the disputed leading A could be the settled one coming back, so it is not \
-     confirmed a second time",
-  );
-
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A B C D",
-    "the finalized face of the same refusal",
-  );
-}
-
-#[test]
-fn a_stale_retarget_does_not_buy_the_prefilled_reading() {
-  // The premise is checked against the CURRENT state, not against "these look
-  // like retarget options". A caller that keeps re-offering the options the
-  // engine issued a watermark ago has not prefilled the decoder with THIS
-  // holdback, so it gets the unattributable reading -- the same answer as a
-  // caller with no retarget at all.
-  //
-  // Mutation proof: drop the `clip_timestamps`/`prefix_tokens` clauses from
-  // `prefill_reproduces_holdback` (check only `use_prefill_prompt`) and the
-  // stale options buy the prefilled reading, reading back [" A", " A", " B"].
-  let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 1.0, 1.5);
-  let c = || word(" C", 2.0, 2.5);
-  let d = || word(" D", 3.0, 3.5);
-  let mut agreement = LocalAgreement::new();
-  // Captured BEFORE the advance: at this point the holdback is empty and the
-  // watermark is 0.0, so these are the FIRST stride's options.
-  let stale = agreement.decoding_options_for_next(&DecodingOptions::new());
-  let stutter = || result_with_words(vec![a(), a(), b()]);
-  agreement.ingest_streamed(stutter());
-  assert!(agreement.ingest_streamed(stutter()).is_advanced());
-  assert!(
-    !agreement.last_agreed_words_slice().is_empty(),
-    "non-vacuous: the state moved on from what `stale` targets",
-  );
-
-  let onward = || result_with_words(vec![a(), b(), c(), d()]);
-  agreement.ingest(onward(), &stale);
-  assert!(agreement.ingest(onward(), &stale).is_advanced());
-  assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A", " B"],
-    "options that prefill an EMPTY holdback cannot make the offered head the \
-     holdback's own reproduction",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A B C D"
-  );
-}
-
-#[test]
-fn an_unmarked_results_frontier_is_not_re_read_under_a_later_marked_one() {
-  // #94 (codex round 7, finding 1). THE UNMARKED REFUSAL MUST OUTLIVE THE CALL
-  // THAT MADE IT. `prev_result` is stored RAW and re-filtered on the next
-  // ingest; if that re-filter reads the frontier under the NEXT result's
-  // provenance, an unmarked result whose disputed head was refused gets that
-  // head handed back one call later, on nothing more than the next caller
-  // decoding honestly.
-  //
-  // Nobody lies here. The unmarked result really was decoded some other way, and
-  // the marked one really was decoded under the retarget. Each is entitled to
-  // its own frontier -- and re-reading the stored one under a foreign premise
-  // manufactures an agreement neither hypothesis actually offered:
-  // `find_longest_common_prefix` returns elements of the CURRENT hypothesis, but
-  // its LENGTH is set by both sides, and `prev_words` read too permissively
-  // makes that length LONGER, not shorter. Length is what decides whether the
-  // watermark advances and how much lands in the append-only
-  // `confirmed_words_slice()`.
-  //
-  // Mutation proof: filter `prev_result` with the CURRENT result's flag (the
-  // shape this replaced -- pass `prefilled` where the stored provenance is read)
-  // and both faces red: the fourth ingest reads back `Advanced` with
-  // [" A", " A", " B"] confirmed, and the transcript becomes " A A B C D" --
-  // " B" confirmed irrevocably on an agreement that never happened, so the
-  // genuine later revision " Z" can never be applied.
-  let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 1.0, 1.5);
-  let c = || word(" C", 2.0, 2.5);
-  let d = || word(" D", 3.0, 3.5);
-  // " Z" revises the held-back " B", at " B"'s own extent.
-  let z = || word(" Z", 1.0, 1.5);
-
-  let mut agreement = LocalAgreement::new();
-  let stutter = || result_with_words(vec![a(), a(), b()]);
-  agreement.ingest_streamed(stutter());
-  assert!(agreement.ingest_streamed(stutter()).is_advanced());
-  assert_eq!(confirmed_texts(&agreement), vec![" A"]);
-  assert_eq!(
-    agreement
-      .last_agreed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" A", " B"],
-    "the disputed shape: one settled \" A\", and a holdback that starts with \
-     another",
-  );
-
-  // (1) UNMARKED. The head is unattributable, so it is cut -- the answer
-  // `a_direct_ingest_with_no_prefill_refuses_the_disputed_head` pins. This
-  // result is now `prev_result`, stored raw.
-  let unmarked = DecodingOptions::new();
-  let onward = || result_with_words(vec![a(), b(), c(), d()]);
-  assert!(
-    agreement
-      .ingest(onward(), &unmarked)
-      .is_awaiting_agreement(),
-    "[B, C, D] against the stutter's [A, B] shares no prefix",
-  );
-
-  // (2) MARKED, and the very same words. Its OWN frontier is the prefilled one
-  // -- but the raw result stored at (1) keeps the unmarked frontier it arrived
-  // with, so the two lists still disagree and nothing is confirmed.
-  assert!(
-    agreement.ingest_streamed(onward()).is_awaiting_agreement(),
-    "the stored result's head is still refused, so [B, C, D] against \
-     [A, B, C, D] still shares no prefix",
-  );
-  assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A"],
-    "the streaming face: the unmarked refusal is not undone one call later",
-  );
-
-  // (3) The cost of getting (2) wrong, one revision later. " B" is still HELD,
-  // so a hypothesis that revises it to " Z" supersedes it; had (2) confirmed
-  // " B" the watermark would already be past " Z" and the revision could never
-  // be applied at all.
-  assert!(
-    agreement
-      .ingest_streamed(result_with_words(vec![a(), z(), c(), d()]))
-      .is_awaiting_agreement(),
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A A Z C D",
-    "the finalized face: the revision reaches the transcript because the word it \
-     revises was never confirmed on a manufactured agreement",
-  );
-}
-
-#[test]
-fn a_recurring_ambiguity_would_never_clear_on_the_unmarked_path() {
-  // THE REFUTATION of "block on an ambiguous frontier, since without the
-  // prefill nothing re-creates the ambiguity every stride". The prefill is not
-  // what re-creates it. The disputed columns' scores are a function of
-  // `(settled, holdback, offered)` alone; `settled` and `holdback` move only on
-  // an advance -- which is exactly what a block prevents -- and growing the
-  // offered list at the TAIL leaves the disputed columns tied, because
-  // `before[j]` is untouched there and `after[j]` rises for every `j` at once.
-  //
-  // So a caller re-decoding a growing window off unchanged audio re-offers the
-  // same head every stride whether or not it prefills: a deterministic decoder
-  // does not need to be forced to repeat itself. A block would re-arm on every
-  // one of the strides below and the stream would never confirm another word --
-  // trading one forgone repetition for the entire rest of the transcript.
-  //
-  // Mutation proof: this is an assertion about `settled_seams` itself, so its
-  // falsifier is the claim's negation -- assert the seams CONVERGE at some
-  // stride and every row below reds.
-  let settled = [word(" A", 0.0, 0.5)];
-  let holdback = [word(" A", 0.0, 0.5), word(" B", 1.0, 1.5)];
-  let mut offered = vec![word(" A", 0.0, 0.5), word(" B", 1.0, 1.5)];
-  for stride in 0..6usize {
-    let seams = settled_seams(&settled, &holdback, &offered);
-    assert_eq!(
-      (seams.prefilled, seams.unattributed),
-      (0, 1),
-      "stride {stride}: the seam is still ambiguous with {} offered words, so a \
-       blocking policy re-arms here too",
-      offered.len(),
-    );
-    // The stream grows at the tail, which is the only way it CAN grow while the
-    // watermark is pinned by the block.
-    let next = 2.0 + stride as f32;
-    offered.push(word(&format!(" W{stride}"), next, next + 0.5));
-  }
-
-  // Liveness, for contrast: the unattributable reading advances on this exact
-  // shape rather than stalling on it -- see
-  // `a_direct_ingest_with_no_prefill_refuses_the_disputed_head`, whose stream
-  // reaches `Advanced` and confirms " B" while a block would still be waiting.
 }
 
 // ---------------------------------------------------------------------
@@ -2603,61 +1791,6 @@ fn an_over_budget_holdback_is_capped_rather_than_silently_truncated() {
 }
 
 #[test]
-fn a_prefill_over_the_budget_does_not_buy_the_prefilled_reading() {
-  // A caller assembling its own options can present a prefix that ENDS with the
-  // holdback behind a head of its own. `prefill_tokens` keeps the last
-  // `MAX_HOLDBACK_PREFILL_TOKENS` of it, so `decode_text` is forced to emit that
-  // head too and the hypothesis does NOT begin with the holdback -- the premise
-  // the smallest-seam reading rests on is simply false. Equality is what refuses
-  // it, and equality is what the premise needs.
-  //
-  // Mutation proof: weaken the comparison in `prefill_reproduces_holdback` to
-  // `decoded_under.prefix_tokens_slice().ends_with(...)` -- the plausible
-  // mistake, since the decoder does receive the holdback at the tail -- and the
-  // over-budget options below buy the prefilled reading, reading back
-  // [" A", " A", " B"] / " A A B C D".
-  //
-  // ROUND 7 CORRECTION: this test used to record its falsifier as dropping the
-  // `holdback.len() <= MAX_HOLDBACK_PREFILL_TOKENS` clause. That mutation reds
-  // NOTHING, here or anywhere -- the padded prefix differs from the holdback in
-  // LENGTH as well as content, so the equality already refuses it and the length
-  // clause never decided this case. It cannot decide any case now: the clause
-  // read the ENGINE's holdback, which `budgeted_split` keeps inside the budget
-  // after every advance, so it was a conjunct that could not be false. It is
-  // gone, and this is the mutation that actually falsifies what is left.
-  let a = || word(" A", 0.0, 0.5);
-  let b = || word(" B", 1.0, 1.5);
-  let c = || word(" C", 2.0, 2.5);
-  let d = || word(" D", 3.0, 3.5);
-  let mut agreement = LocalAgreement::new();
-  let stutter = || result_with_words(vec![a(), a(), b()]);
-  agreement.ingest_streamed(stutter());
-  assert!(agreement.ingest_streamed(stutter()).is_advanced());
-
-  // The engine's own retarget, then the prefix swapped for an over-budget one
-  // that still ENDS with the holdback -- so `prefill_tokens` would hand
-  // `decode_text` a tail that reproduces it, but nothing forces the head.
-  let honest = agreement.decoding_options_for_next(&DecodingOptions::new());
-  let mut padded: Vec<u32> = (10_000..10_000 + MAX_HOLDBACK_PREFILL_TOKENS as u32).collect();
-  padded.extend_from_slice(honest.prefix_tokens_slice());
-  assert!(padded.len() > MAX_HOLDBACK_PREFILL_TOKENS);
-  let over_budget = honest.clone().with_prefix_tokens(padded);
-
-  let onward = || result_with_words(vec![a(), b(), c(), d()]);
-  agreement.ingest(onward(), &over_budget);
-  assert!(agreement.ingest(onward(), &over_budget).is_advanced());
-  assert_eq!(
-    confirmed_texts(&agreement),
-    vec![" A", " B"],
-    "a prefix the decoder will trim is not a reproduction of the holdback",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A B C D"
-  );
-}
-
-#[test]
 fn a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held() {
   // #94 (codex round 7, finding 2). THE CAP MUST ALWAYS CAP. `budgeted_split`
   // moved the split later until the holdback fit -- but stopped while one word
@@ -2667,11 +1800,9 @@ fn a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held() {
   // trims, the decoder was fed the word's TAIL, and the hypothesis came back
   // with a word that is not the held one.
   //
-  // The unmarked seam does not repair that: it is the right frontier for a
-  // hypothesis the engine did not write, and it cannot put back a token the
-  // engine itself dropped. What follows is DATA LOSS, not a stall -- the
-  // truncated hypothesis disagrees, `holdback_superseded` fires, and `finalize`
-  // replaces the intact held word with the truncation.
+  // What follows is DATA LOSS, not a stall -- the truncated hypothesis
+  // disagrees, `holdback_superseded` fires, and `finalize` replaces the intact
+  // held word with the truncation.
   //
   // Holding it is what cannot be done; CONFIRMING it always can. `common` is
   // already the prefix two consecutive hypotheses agreed on -- LocalAgreement-2's
@@ -2799,10 +1930,10 @@ fn a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held() {
   // Mutation proof: drop `budgeted_split`'s `rposition` floor (equivalently,
   // weaken `prefill_carries_whole` to `true`) and every assertion below reds --
   // " S" is held rather than confirmed, the issued prefix carries the id the
-  // filter erases, and the transcript reads " A A Y C" with " S" gone. The two
-  // guards have their own falsifiers, named where they stand: widen
-  // `prefill_carries_whole` to `false` for every word and the issued prefill goes
-  // EMPTY, and take the plain maximum seam and the ambiguity pin reads (0, 3).
+  // filter erases, and the transcript reads " A A Y C" with " S" gone. The
+  // opposite mutation has its own falsifier where it stands: widen
+  // `prefill_carries_whole` to `false` for every word and the issued prefill
+  // goes EMPTY.
   let a0 = || word(" A", 0.5, 1.0);
   let s = || special_only_word(" S", 1.0, 1.5);
   let a1 = || word(" A", 1.5, 2.0);
@@ -2865,19 +1996,7 @@ fn a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held() {
     "and it is not empty, so there is something for the decoder to reproduce",
   );
 
-  // The AMBIGUOUS frontier this fix makes unreachable, stated as the shape it
-  // is: had " S" stayed in the holdback, a re-offer of the settled word's text
-  // would have left the seam genuinely disputed, and the marked reading would
-  // have taken column 0 on a premise the decoder never established.
   let re_offer = || result_with_words(vec![a1(), b(), c()]);
-  assert_eq!(
-    {
-      let seams = settled_seams(&[a0()], &[s(), a1()], &[a1(), b(), c()]);
-      (seams.prefilled, seams.unattributed)
-    },
-    (0, 1),
-    "non-vacuous: the state the fix removes really was an ambiguous frontier",
-  );
 
   // The continuation. The re-offer reproduces the one held word and carries the
   // stream on; the pair agrees on the next stride and settles it. Outcome and
@@ -3104,48 +2223,6 @@ fn the_prefill_token_ceiling_is_below_the_vocabularys_special_range() {
   );
 }
 
-#[test]
-fn with_nothing_held_back_both_frontiers_are_the_same_column() {
-  // The property `prefill_reproduces_holdback`'s vacuous `true` now rests on.
-  // Before `budgeted_split` could leave an EMPTY holdback, an empty holdback
-  // implied an empty `confirmed_words` too, so `watermark_filtered` took its
-  // `settled_len == 0` fast path and no frontier was read at all -- the premise
-  // could not matter because nothing consulted it. It can now be empty beside a
-  // NON-empty settled set, so a frontier IS read; it still cannot matter,
-  // because with no holdback the two policies name the same column.
-  //
-  // With an empty holdback `after[j]` is identically zero (`settled_seams`'
-  // second DP runs its outer loop over an empty pattern), so `score(j) ==
-  // before[j]`, which is non-decreasing. `best == before[len]`; the smallest
-  // optimal seam is the first column to reach it; and every larger column has
-  // `before[j] == before[j - 1]`, so none of them is match-SUPPORTED.
-  //
-  // Mutation proof: take the plain maximum for `unattributed` (drop the
-  // `before[j] > before[j - 1]` clause) and the rows whose settled word matches
-  // nothing red -- the plain maximum is `offered.len()` there, against a
-  // smallest seam of 0.
-  let settled = [word(" A", 0.0, 0.5)];
-  for offered in [
-    Vec::new(),
-    vec![word(" A", 0.0, 0.5)],
-    vec![word(" X", 0.0, 0.5), word(" Y", 1.0, 1.5)],
-    vec![word(" A", 0.0, 0.5), word(" X", 1.0, 1.5)],
-    vec![
-      word(" X", 0.0, 0.5),
-      word(" A", 1.0, 1.5),
-      word(" A", 2.0, 2.5),
-    ],
-  ] {
-    let seams = settled_seams(&settled, &[], &offered);
-    assert_eq!(
-      seams.unattributed,
-      seams.prefilled,
-      "with an empty holdback the premise cannot change the frontier: {:?}",
-      offered.iter().map(WordTiming::word).collect::<Vec<_>>(),
-    );
-  }
-}
-
 // ---------------------------------------------------------------------
 // The prompt itself, at the layer the decoder reads it
 // ---------------------------------------------------------------------
@@ -3153,7 +2230,7 @@ fn with_nothing_held_back_both_frontiers_are_the_same_column() {
 #[test]
 fn the_first_strides_options_keep_the_callers_prefill_flag() {
   // #94 (codex round 6, finding 3). Before the first advance the engine holds no
-  // holdback, so there is no premise to enforce and no frontier to read -- and
+  // holdback, so there is no premise to enforce -- and
   // forcing `use_prefill_prompt` there would silently swap the caller's bare
   // `<|startoftranscript|>` prompt for the full multilingual prefill.
   //
@@ -3195,7 +2272,7 @@ fn the_first_strides_options_keep_the_callers_prefill_flag() {
       .decoding_options_for_next(&base)
       .use_prefill_prompt(),
     "once there IS a holdback the flag is forced, or the prefix is inert and \
-     the frontier's tie-break has nothing behind it",
+     the engine's own retarget promises text the decoder was never given",
   );
 }
 
@@ -3236,8 +2313,8 @@ fn the_first_strides_prompt_is_the_bare_start_of_transcript() {
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn the_prefill_reaches_decode_text_as_the_whole_holdback() {
-  // The contract `LocalAgreement::watermark_filtered`'s ambiguity rule rests on,
-  // pinned at the layer that decides it. `DecodingOptions::prefix_tokens` is
+  // The contract `LocalAgreement::prefill_reproduces_holdback` rests on, pinned
+  // at the layer that decides it. `DecodingOptions::prefix_tokens` is
   // only what the engine RECORDED; `prefill_tokens` keeps just the last
   // `MAX_TOKEN_CONTEXT / 2` of them and drops every id at or above
   // `special_token_begin` before `decode_text` sees a single token. What the
@@ -3306,214 +2383,11 @@ fn the_prefill_reaches_decode_text_as_the_whole_holdback() {
 }
 
 #[test]
-fn an_unmarked_hypothesis_that_reproduces_nothing_settled_is_kept_whole() {
-  // The other half of the unattributable reading, and the reason it is the
-  // largest MATCH-SUPPORTED optimal seam rather than the largest one. When
-  // `settled` matches nothing in the offered list, every seam scores the same
-  // and the plain maximum is `offered.len()` -- the entire hypothesis refused,
-  // on a stream that re-admitted nothing at all. Repeat that each stride and the
-  // engine never confirms another word: a permanent stall wearing caution's
-  // clothes. Requiring the word before the seam to be matched to a settled word
-  // pins the frontier at 0 here, and the stream keeps moving.
-  //
-  // Mutation proof: drop the `frontier == 0 || before[frontier] >
-  // before[frontier - 1]` conjunct from `settled_seams` (take the plain maximum)
-  // and both faces red -- the confirmed list stops at [" A"] and the transcript
-  // loses " X Y Z".
-  let mut agreement = LocalAgreement::new();
-  let settled = || {
-    result_with_words(vec![
-      word(" A", 0.0, 1.0),
-      word(" B", 1.0, 2.0),
-      word(" C", 2.0, 3.0),
-    ])
-  };
-  agreement.ingest_streamed(settled());
-  assert!(agreement.ingest_streamed(settled()).is_advanced());
-  assert_eq!(confirmed_texts(&agreement), vec![" A"]);
-  assert_eq!(
-    agreement
-      .last_agreed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" B", " C"],
-    "non-vacuous: `settled` is [\" A\"] and REACHES the watermark, so the \
-     alignment is live -- this is not the settled_len == 0 fast path",
-  );
-
-  // Wholly different text, decoded some other way: nothing here can be a
-  // settled word coming back, and nothing may be refused as one.
-  let unmarked = DecodingOptions::new();
-  let onward = || {
-    result_with_words(vec![
-      word(" X", 1.0, 2.0),
-      word(" Y", 2.0, 3.0),
-      word(" Z", 3.0, 4.0),
-    ])
-  };
-  agreement.ingest(onward(), &unmarked);
-  assert!(
-    agreement.ingest(onward(), &unmarked).is_advanced(),
-    "the unmarked path must still make progress, not stall on unrelated text",
-  );
-  assert_eq!(confirmed_texts(&agreement), vec![" A", " X"]);
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A X Y Z",
-  );
-}
-
-#[test]
-fn a_widened_word_is_not_confirmed_before_an_unmarked_continuation_can_revise_it() {
-  // #94 (codex round 12, finding 1). THE WIDENING'S OWN PREMISE IS ABOUT THE
-  // NEXT RESULT, AND THE SPLIT RUNS BEFORE IT EXISTS. `budgeted_split` widens
-  // past a word the prefill cannot carry, and round 8's argument for settling it
-  // on the spot -- "whatever the next hypothesis produces over that extent was
-  // decoded from a prefix the word is not in, and from audio the clip excludes"
-  // -- is true of a MARKED continuation and of nothing else. A caller that does
-  // not use `decoding_options_for_next` is subject to neither reduction: its
-  // decoder saw that audio and can revise the word. Confirming at the advance
-  // strands the stale reading beside the revision, which is the exact defect
-  // `finalize`'s `holdback_superseded` branch exists to prevent -- reached one
-  // word earlier and through the append-only list, where nothing can take it
-  // back.
-  //
-  // The split still has to widen: with " S" left in the holdback the retarget
-  // would prefill " B" while clipping at " S"'s own start, so a marked
-  // continuation would be forced to contradict the audio it was given and would
-  // disagree every stride (round 8's arithmetic). What is deferrable is the
-  // widened-past word's DESTINATION, not the split, so it goes to
-  // `pending_words` and `ingest` settles it on the first hypothesis whose window
-  // starts at the watermark.
-  //
-  // " S" is tokenless, so `budgeted_split` widens past it; " B" ties with it at
-  // 1.0, so the watermark stays at 1.0 and " S" OVERLAPS the still-open span --
-  // which is what leaves it revisable at all (see the advance's own `end >
-  // watermark` split, and `the_split_settles_a_widened_word_the_span_can_never_
-  // reach` for the other side of that line).
-  //
-  // Mutation proof, both faces: put the widened-past words straight into
-  // `confirmed_words` at the advance (`extend_from_slice(&common[..split])`,
-  // with no `pending_words`) and the state reads back ([" A", " S"], []) and the
-  // transcript " A S Y B C" -- " S" and its own replacement " Y" side by side.
-  // The transcript face has a second falsifier of its own: append
-  // `pending_words` ahead of `hypothesis_words` on `finalize`'s superseded path
-  // instead of dropping them, and the same " A S Y B C" comes back.
-  let a = || word(" A", 0.0, 1.0);
-  let s = || special_only_word(" S", 1.0, 1.5);
-  let b = || word(" B", 1.0, 1.5);
-  // " Y" revises " S", at " S"'s own extent.
-  let y = || word(" Y", 1.0, 1.5);
-  let c = || word(" C", 1.5, 2.0);
-
-  let mut agreement = LocalAgreement::new();
-  let opening = || result_with_words(vec![a(), s(), b()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-
-  // The streaming face, read between pushes: " S" is agreed and out of the
-  // holdback, but NOT yet irrevocable.
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A"], vec![" S"]),
-    "the widened-past word waits for the provenance that decides it",
-  );
-  assert_eq!(
-    agreement
-      .last_agreed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" B"],
-    "non-vacuous: the split really did widen -- \" S\" is out of the holdback, \
-     so the prefill below carries no id the decoder's filter erases",
-  );
-  assert!(
-    agreement
-      .decoding_options_for_next(&DecodingOptions::new())
-      .prefix_tokens_slice()
-      .iter()
-      .all(|&id| id < MIN_SPECIAL_TOKEN_BEGIN),
-    "and the retarget is the widened one, unchanged by the deferral",
-  );
-  // Finalized HERE, with nothing having superseded it, the pending word is still
-  // in the transcript: deferring is not dropping. (Mutation: delete
-  // `finalize`'s Swift-shaped `append(&mut self.pending_words)` and this reads
-  // " A B".)
-  assert_eq!(
-    agreement.clone().finalize(&DecodingOptions::new()).text(),
-    " A S B",
-    "nothing superseded it, so it is still the only estimate for its span",
-  );
-
-  // The continuation the widening's premise does not cover: decoded some other
-  // way, so it saw " S"'s audio and revised it.
-  let unmarked = DecodingOptions::new();
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![y(), b(), c()]), &unmarked)
-      .is_awaiting_agreement(),
-    "the revision disagrees with the hypothesis it revises",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A Y B C",
-    "the finalized face: the revision replaces the word it revises rather than \
-     landing beside it",
-  );
-}
-
-#[test]
-fn a_marked_continuation_settles_the_widened_word_it_could_not_have_revised() {
-  // The other half of the pair above, and the reason the deferral is not a
-  // regression on round 8's fix: a hypothesis decoded under the retarget could
-  // not have revised the widened-past word (no prefill token of it, and its
-  // audio outside the clip), so the word settles the moment one arrives -- one
-  // ingest later than round 8 settled it, and irrevocably from then on.
-  //
-  // Mutation proof: delete the promotion drain from `ingest` and the SECOND
-  // assertion reads back ([" A"], [" S"]) -- the word never settles, and the
-  // stream that could not have revised it is treated as though it might.
-  let a = || word(" A", 0.0, 1.0);
-  let s = || special_only_word(" S", 1.0, 1.5);
-  let b = || word(" B", 1.0, 1.5);
-  let c = || word(" C", 1.5, 2.0);
-
-  let mut agreement = LocalAgreement::new();
-  let opening = || result_with_words(vec![a(), s(), b()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A"], vec![" S"]),
-    "non-vacuous: there is a pending word for the next stride to settle",
-  );
-
-  // `ingest_streamed` decodes under the engine's own retarget, so its window
-  // starts at the watermark.
-  agreement.ingest_streamed(result_with_words(vec![b(), c()]));
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A", " S"], Vec::<&str>::new()),
-    "a hypothesis clipped at the watermark settles it",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A S B C",
-    "and it stays in the transcript, exactly as round 8 required",
-  );
-}
-
-#[test]
 fn an_empty_holdback_leaves_nothing_pending_because_nothing_could_ever_clear_it() {
   // The second half of the advance's reachability split, and the reason the
   // promotion above can read `prefill_reproduces_holdback` without ever reading
   // it VACUOUSLY. That predicate answers TRUE for anything when the holdback is
-  // empty -- a state `budgeted_split` reaches by design (round 7, finding 2) --
-  // and its vacuity was only ever justified for the FRONTIER, where both
-  // readings name the same column
-  // (`with_nothing_held_back_both_frontiers_are_the_same_column`).
+  // empty -- a state `budgeted_split` reaches by design (round 7, finding 2).
   //
   // Rather than bolt a clause on for a state that must not arise, the state is
   // removed: a pending word waits for a hypothesis this engine ANCHORED, and
@@ -3538,11 +2412,8 @@ fn an_empty_holdback_leaves_nothing_pending_because_nothing_could_ever_clear_it(
   // (Round 12 recorded that mutation as reaching the transcript too; it does
   // not, and the vacuity is why.) Add the other two clauses that finding asks
   // for -- promote only on a NON-VACUOUS anchor (`&& !self.last_agreed_words
-  // .is_empty()`), and read `seams.unattributed` while the holdback is empty --
-  // and the transcript face reds at " Y Z": " L" and " B" deleted, which is
-  // round 7 finding 2's loss returning. Nothing else in this module reds with
-  // all three applied, so that deletion is the whole of what the
-  // recommendation buys.
+  // .is_empty()`) -- and the transcript face reds at " Y Z": " L" and " B"
+  // deleted, which is round 7 finding 2's loss returning.
   let long = || word_of_tokens(" L", 1.0, 5.0, 1);
   let big = || word_of_tokens(" B", 2.0, 3.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   let y = || word(" Y", 3.0, 5.0);
@@ -3612,9 +2483,11 @@ fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
   // So "a confirmed word overlaps a later hypothesis's word" is not a property
   // the empty-holdback arm introduces; it is the LocalAgreement-2 contract, which
   // confirms on agreement between two consecutive hypotheses and is append-only.
-  // The frontier is what decides whether an offered word is a settled one coming
-  // BACK (`settled_seams`), and it decides that by alignment; it said " Y" is not
-  // " P". The alternative the finding proposes -- hold the word until an anchor
+  // Whether an offered word is a settled one coming BACK is a question RULE W
+  // makes unaskable rather than answers: the split never puts the watermark at a
+  // tied start, so no confirmed word can pass the offered filter, and " Y" is
+  // simply new text over a span " P" also covers. The alternative the finding
+  // proposes -- hold the word until an anchor
   // certifies it -- has no terminating condition when the holdback is empty, and
   // ends in the deletion round 7 finding 2 removed. See that test's own comment.
   //
@@ -3661,175 +2534,6 @@ fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
     "the overlapping confirmed word and the later re-reading of its audio are \
      BOTH in the transcript -- the append-only contract, reached without the \
      empty-holdback arm being involved at all",
-  );
-}
-
-#[test]
-fn a_retarget_with_a_foreign_prefix_does_not_settle_a_pending_word() {
-  // The promotion's premise is the whole prefill contract, not the clip half of
-  // it. A caller can clip exactly where the engine asked and still hand the
-  // decoder a prefix of its own -- and then nothing forces the hypothesis to
-  // BEGIN with the holdback, so it is free to put a word in front of that
-  // reproduction, over the very span the pending word occupies. (Here " S" runs
-  // 1.0..1.5 and the clip is at 1.0, so its audio is inside that window: the
-  // clip alone excludes nothing.)
-  //
-  // Mutation proof, both faces: promote on the clip clause alone
-  // (`decoded_under.clip_timestamps_slice() == [self.last_agreed_seconds]`,
-  // threaded in beside `decoded_under`) and the state reads back
-  // ([" A", " S"], []) and the transcript " A S Y B C".
-  let a = || word(" A", 0.0, 1.0);
-  let s = || special_only_word(" S", 1.0, 1.5);
-  let b = || word(" B", 1.0, 1.5);
-  let y = || word(" Y", 1.0, 1.5);
-  let c = || word(" C", 1.5, 2.0);
-
-  let mut agreement = LocalAgreement::new();
-  let opening = || result_with_words(vec![a(), s(), b()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A"], vec![" S"]),
-    "non-vacuous: there is a pending word for the retarget to settle or not",
-  );
-
-  // The engine's own clip, with someone else's prefix.
-  let honest = agreement.decoding_options_for_next(&DecodingOptions::new());
-  let foreign = honest.clone().with_prefix_tokens(vec![9_001, 9_002]);
-  assert_eq!(
-    foreign.clip_timestamps_slice(),
-    [agreement.last_agreed_seconds()],
-    "non-vacuous: the clip clause alone IS satisfied",
-  );
-  assert!(
-    !agreement.prefill_reproduces_holdback(&foreign),
-    "and the contract as a whole is not",
-  );
-  assert!(
-    s().start() < agreement.last_agreed_seconds() + 0.001
-      && s().end() > agreement.last_agreed_seconds(),
-    "non-vacuous: the pending word's audio straddles the clip point, so the \
-     clip excludes none of it",
-  );
-
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![y(), b(), c()]), &foreign)
-      .is_awaiting_agreement()
-  );
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A"], vec![" S"]),
-    "the retarget settled nothing -- the word is still revisable, and the \
-     disagreement leaves `finalize` to say what became of it",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A Y B C",
-    "and there it is superseded by the hypothesis that re-covered its span",
-  );
-}
-
-#[test]
-fn a_late_clipped_disagreement_does_not_supersede_the_span_it_never_decoded() {
-  // #94 (codex round 13, finding 2). THE ENGINE ASSUMED EVERY RESULT SAW THE
-  // AUDIO IT WAS JUDGING. `finalize`'s `holdback_superseded` branch replaces the
-  // engine's own provisional record of the still-open span -- `pending_words`
-  // then `last_agreed_words` -- with the final hypothesis's own post-watermark
-  // words, on the premise that hypothesis RE-COVERED that span carrying a
-  // revision. For a marked continuation the clip guarantees it; for an unmarked
-  // one it was simply assumed, and `ingest` documents no requirement that an
-  // unmarked result's window reach the watermark at all.
-  //
-  // A window that begins AFTER the words it supersedes falsifies it outright.
-  // " S" and " B" both run 1.0..1.5 and this decode's `clip_timestamps` begin at
-  // 1.5, so it shares no instant with either: it produced no revision of them,
-  // it produced nothing over their span at all, and the branch's whole
-  // justification -- prefer the revision to the reading it replaced -- has no
-  // referent. Dropping them deletes two words the stream agreed on and nothing
-  // contradicted.
-  //
-  // The fact was already in hand: `decoded_under` carries `clip_timestamps`, and
-  // `ProvenancedResult` already pairs a result with what was known when it
-  // arrived, so the window travels with the result exactly as its prefill
-  // premise does (`ProvenancedResult::window`).
-  //
-  // Mutation proof, the finalized face: make `finalize` drop the whole record
-  // regardless (pass `0` where it passes `open_record_split`) and the first row
-  // reads back " A C" -- " S" and " B" gone. The second row is the falsifier for
-  // how the declared window is READ: `clip_timestamps` holds `(start, end)`
-  // pairs, and reading only the last point as a start (`[2.0, ..)`) refuses a
-  // window that plainly covered the span.
-  let a = || word(" A", 0.0, 1.0);
-  let s = || special_only_word(" S", 1.0, 1.5);
-  let b = || word(" B", 1.0, 1.5);
-  let c = || word(" C", 1.5, 2.0);
-
-  let settled = || {
-    let mut agreement = LocalAgreement::new();
-    let opening = || result_with_words(vec![a(), s(), b()]);
-    agreement.ingest_streamed(opening());
-    assert!(agreement.ingest_streamed(opening()).is_advanced());
-    assert_eq!(
-      (confirmed_texts(&agreement), pending_texts(&agreement)),
-      (vec![" A"], vec![" S"]),
-      "non-vacuous: there is a pending word AND a holdback for the branch to \
-       drop",
-    );
-    assert_eq!(agreement.last_agreed_seconds(), 1.0);
-    agreement
-  };
-
-  for (clip, expected, why) in [
-    // Honest options for a decoder that resumed at 1.5 -- STRICTLY past the
-    // watermark, and at or past the end of every word the branch would drop.
-    (
-      vec![1.5],
-      " A S B C",
-      "a decode that never covered the span does not get to replace the only \
-       estimate it has",
-    ),
-    // A whole `(start, end)` pair whose START precedes the record: this window
-    // DID cover 1.0..1.5, so the branch fires exactly as it always did.
-    (
-      vec![0.5, 2.0],
-      " A C",
-      "a window that covered the span still supersedes it -- the guard is a \
-       coverage test, not a blanket refusal of unmarked results",
-    ),
-  ] {
-    let mut agreement = settled();
-    let late = DecodingOptions::new().with_clip_timestamps(clip.clone());
-    assert!(
-      !agreement.prefill_reproduces_holdback(&late),
-      "non-vacuous: unmarked, so nothing is promoted on arrival and the pending \
-       word is still there to be dropped ({clip:?})",
-    );
-    assert!(
-      agreement
-        .ingest(result_with_words(vec![c()]), &late)
-        .is_awaiting_agreement(),
-      "it disagrees, so `holdback_superseded` fires ({clip:?})",
-    );
-    // The streaming face is unmoved on both rows -- the decision is
-    // `finalize`'s alone, and this pins that the ingest above neither promoted
-    // nor dropped anything.
-    assert_eq!(
-      (confirmed_texts(&agreement), pending_texts(&agreement)),
-      (vec![" A"], vec![" S"]),
-      "{clip:?}",
-    );
-    assert_eq!(
-      agreement.finalize(&DecodingOptions::new()).text(),
-      expected,
-      "the finalized face, clipped at {clip:?}: {why}",
-    );
-  }
-  assert!(
-    s().end() <= 1.5 && b().end() <= 1.5,
-    "non-vacuous: the refusing row's window shares NO instant with either word \
-     it would supersede",
   );
 }
 
@@ -3923,78 +2627,6 @@ fn the_still_open_span_begins_where_the_engines_own_record_does() {
     " P Q R D",
     "with nothing pending the holdback is still a record to protect, not an \
      absent one",
-  );
-}
-
-#[test]
-fn a_late_clipped_agreement_confirms_the_span_it_could_not_re_read() {
-  // Round 13, finding 2's OTHER consumer, and the reason the coverage fact is a
-  // property of the result rather than a clause bolted onto `finalize`. The
-  // advance replaces the same provisional record -- `pending_words.clear()` and
-  // `last_agreed_words = common[split..]` -- on the same unchecked premise, and
-  // its own comment stated it outright ("this hypothesis saw its audio"). Two
-  // consecutive late-clipped hypotheses agree on " C D" at 1.5 onwards; `common`
-  // is their words, not a re-reading of 1.0..1.5, so replacing " S" and " B"
-  // with it deletes them -- and here it deletes them from the STREAMING face
-  // too, where nothing downstream can put them back.
-  //
-  // Confirming is what is left, and it is the same claim every other confirmed
-  // word carries: two consecutive hypotheses agreed on them, and no hypothesis
-  // that could see their audio has contradicted them since. Holding them instead
-  // has no terminating condition -- the watermark has moved past them, so no
-  // future result can be offered over their span at all.
-  //
-  // Mutation proof, both faces: drop the `covers` guard from the advance's
-  // replacement and the streaming face reads back ([" A"], []) and the
-  // transcript " A C D".
-  let a = || word(" A", 0.0, 1.0);
-  let s = || special_only_word(" S", 1.0, 1.5);
-  let b = || word(" B", 1.0, 1.5);
-  let c = || word(" C", 1.5, 2.0);
-  let d = || word(" D", 2.0, 2.5);
-
-  let mut agreement = LocalAgreement::new();
-  let opening = || result_with_words(vec![a(), s(), b()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A"], vec![" S"]),
-    "non-vacuous: there is a pending word AND a holdback for the advance to \
-     replace",
-  );
-
-  let late = DecodingOptions::new().with_clip_timestamps(vec![1.5]);
-  let resumed = || result_with_words(vec![c(), d()]);
-  assert!(
-    agreement.ingest(resumed(), &late).is_awaiting_agreement(),
-    "the first one has nothing to agree with over this span",
-  );
-  assert!(
-    agreement.ingest(resumed(), &late).is_advanced(),
-    "the second corroborates it: an advance whose `common` is entirely past 1.5",
-  );
-
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A", " S", " B"], Vec::<&str>::new()),
-    "the streaming face: what the advance could not re-read, it confirms rather \
-     than drops",
-  );
-  assert_eq!(
-    agreement
-      .last_agreed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" C", " D"],
-    "and the holdback is the agreeing pair's own words, as always",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A S B C D",
-    "the finalized face: nothing the stream agreed on was lost to a window that \
-     excluded it",
   );
 }
 
@@ -4559,57 +3191,5 @@ fn the_driver_takes_its_special_range_from_the_loaded_vocabulary() {
     streamer.agreement().special_token_begin(),
     vocabulary,
     "the driver's engine reads the loaded vocabulary, not the floor",
-  );
-}
-
-#[test]
-fn an_unmarked_hypothesis_may_re_agree_a_pending_word_because_it_is_not_confirmed() {
-  // Where the pending words sit in the ALIGNMENT, pinned by the case that can
-  // tell. They are not confirmed, so they belong to `settled_seams`' revisable
-  // half beside the holdback: an offered word that re-covers one is a
-  // reproduction the engine WANTS -- a second hypothesis agreeing over that span
-  // is how the word earns its place. Filing them in the settled half instead
-  // would refuse exactly that reproduction, which is the right treatment for a
-  // word already in the caller's hands and the wrong one for a word that is not.
-  //
-  // Mutation proof: put `pending` in `watermark_filtered_with`'s settled half
-  // (concatenate it onto `confirmed` and leave `revisable` as the holdback) and
-  // both faces red -- the outcome becomes `awaiting_agreement`, the state
-  // ([" A"], [" S"]) survives for the wrong reason, and the transcript loses
-  // " S" entirely (" A B C"). Separately, drop `self.pending_words.clear()` from
-  // the advance and the state reads back ([" A"], [" S", " S"]).
-  let a = || word(" A", 0.0, 1.0);
-  let s = || special_only_word(" S", 1.0, 1.5);
-  let b = || word(" B", 1.0, 1.5);
-  let c = || word(" C", 1.5, 2.0);
-
-  let mut agreement = LocalAgreement::new();
-  let opening = || result_with_words(vec![a(), s(), b()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A"], vec![" S"]),
-    "non-vacuous: there is a pending word for the re-offer to re-agree",
-  );
-
-  // Decoded some other way, and reproducing the pending word rather than
-  // revising it.
-  let unmarked = DecodingOptions::new();
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![s(), b(), c()]), &unmarked)
-      .is_advanced(),
-    "the re-offer agrees with the hypothesis that produced the pending word",
-  );
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A"], vec![" S"]),
-    "and the re-agreement leaves it pending, not doubled and not dropped: it is \
-     still a word the prefill cannot carry",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A S B C",
   );
 }

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -404,8 +404,9 @@ fn the_split_never_cuts_at_a_tied_start() {
   // non-empty confirmed list, and the sweep DRIVES the empty holdback rather
   // than avoiding it: some trials raise the prefill cost of one word past
   // `MAX_HOLDBACK_PREFILL_TOKENS`, which is the only thing that still empties
-  // the holdback, and `empty_holdbacks` below is the non-vacuity proof that it
-  // really happened.
+  // the holdback -- on a round that strands nothing past `common`, since one
+  // that would defers -- and `empty_holdbacks` below is the non-vacuity proof
+  // that it really happened.
   //
   // The shape then still had ONE oversized word as its only route past the
   // budget, and that could not build the AGGREGATE trigger (codex round 3 on
@@ -417,8 +418,21 @@ fn the_split_never_cuts_at_a_tied_start() {
   // the postcondition below holds under the old widen-off-the-end fallback too,
   // which is why the deletion that fallback caused needed its own falsifier
   // (`an_over_budget_tied_run_defers_rather_than_stranding_its_suffix`). The
-  // aggregate trials below take it to 133, and `deferrals` is that half's own
+  // aggregate trials below took it to 133, and `deferrals` is that half's own
   // non-vacuity proof.
+  //
+  // A SECOND POSTCONDITION now rides the same sweep, and reaching the state it
+  // speaks about needed one more shape change (codex round 3 on PR #95, second
+  // finding). `nothing_unconfirmed_falls_below_the_watermark` is the claim that
+  // an advance may not push the watermark past a word of its own hypothesis it
+  // did not confirm; the state that breaks it is the FORCED arm reached with a
+  // live suffix beyond `common`, and offering every stride TWICE could not build
+  // it -- measured at 0 rounds of 1353. `repeats` below offers a stride once in
+  // three, which leaves the next stride's first ingest comparing consecutive
+  // GROWING lists, and `forced_strands` is that half's non-vacuity proof.
+  // Measured on the shape below, at 512 trials: 491 tied truths, 2736
+  // observations, 265 empty holdbacks, 231 deferrals, 12 forced-arm rounds with
+  // a live suffix.
   //
   // The sweep draws starts from a coarse grid whose repeats make consecutive
   // words tie -- the `a=[0,0.5)/b=[0,1.0)` shape both #94 regressions are built
@@ -430,9 +444,9 @@ fn the_split_never_cuts_at_a_tied_start() {
   // `omitting_a_confirmed_tied_word_does_not_drop_provisional_words` is built
   // from.
   //
-  // Mutation proof: drop the `.max(last.start().next_up())` from `ingest`'s
-  // empty-holdback watermark and this reds on a swept over-budget zero-duration
-  // word; make the boundary non-strict (`<=` for `<` in
+  // Mutation proof: drop the `.max(last.start().next_up())` from
+  // `empty_holdback_watermark` and this reds on a swept over-budget
+  // zero-duration word; make the boundary non-strict (`<=` for `<` in
   // `split_at_a_strict_boundary`) and it reds on a swept tie; let the back-off
   // cross the prefill budget floor (`0..widened` for `floor..widened`) and it
   // reds too. It does NOT red when the back-off arm is deleted outright: the
@@ -444,6 +458,13 @@ fn the_split_never_cuts_at_a_tied_start() {
   // clause below, at `0 deferred rounds`, for the same reason: the postcondition
   // survives that fallback, and what it costs is the DELETION its own falsifier
   // pins.
+  //
+  // The SECOND postcondition has its own rows. Hand
+  // `split_at_a_strict_boundary` an empty `beyond_common` at the call site --
+  // the information state it had before this repair -- and
+  // `nothing_unconfirmed_falls_below_the_watermark` reds on a swept forced-arm
+  // round; return `repeats` to a constant 2 and `forced_strands` reds at
+  // `0 rounds` instead, the state being unreachable rather than unguarded.
   const TEXTS: [&str; 4] = [" A", " B", " C", " D"];
   // Repeated 0.0 entries are the ties; the rest keep the grid coarse enough for
   // two words to share an instant often.
@@ -473,6 +494,45 @@ fn the_split_never_cuts_at_a_tied_start() {
     Some(agreement.last_agreed_words_slice().is_empty())
   }
 
+  /// RULE W'S SECOND POSTCONDITION, and the one the forced empty holdback broke
+  /// (codex round 3 on PR #95, second finding): an advance may not push the
+  /// watermark past a word of its own hypothesis that it did not CONFIRM.
+  ///
+  /// Word starts inside one hypothesis are non-decreasing, so the words that
+  /// fall below the new watermark are a PREFIX of `hypothesis_words` -- and each
+  /// one is either a word this round appended to the confirmed list or a word
+  /// the stream can never offer again. Counting the first against the second is
+  /// the whole statement. It is TOTAL for the same reason the first
+  /// postcondition is: a round that does not advance appends nothing and moves
+  /// no watermark, and every word of `hypothesis_words` cleared `start >=
+  /// last_agreed_seconds` to be there at all, so both sides are zero.
+  ///
+  /// `appended` is measured across the call rather than read off a split, so
+  /// this cannot be satisfied by the same arithmetic that produced it.
+  fn nothing_unconfirmed_falls_below_the_watermark(
+    agreement: &LocalAgreement,
+    appended: usize,
+    trial: u32,
+    stride: usize,
+  ) {
+    let below: Vec<&str> = agreement
+      .hypothesis_words
+      .iter()
+      .filter(|word| word.start() < agreement.last_agreed_seconds())
+      .map(WordTiming::word)
+      .collect();
+    assert!(
+      below.len() <= appended,
+      "trial {trial}, stride {stride}: {} words of the hypothesis are below \
+       the {} s watermark ({below:?}) but only {appended} were confirmed this \
+       round -- the rest are STRANDED: the next worded ingest filters them out \
+       of both hypotheses at once and `finalize` can no longer reach them, \
+       after this round's own `finalize` already published them",
+      below.len(),
+      agreement.last_agreed_seconds(),
+    );
+  }
+
   let mut state: u64 = 0x2545_F491_4F6C_DD1D;
   let mut next = move || {
     state ^= state << 13;
@@ -484,8 +544,9 @@ fn the_split_never_cuts_at_a_tied_start() {
   let mut empty_holdbacks = 0u32;
   let mut tied_truths = 0u32;
   let mut deferrals = 0u32;
+  let mut forced_strands = 0u32;
 
-  for trial in 0..256u32 {
+  for trial in 0..512u32 {
     let length = 4 + (next() % 5) as usize;
     // TWO ways to blow the prefill budget, and the sweep drives BOTH.
     //
@@ -542,12 +603,33 @@ fn the_split_never_cuts_at_a_tied_start() {
       } else {
         truth[..stride].to_vec()
       };
-      for _ in 0..2 {
+      // ONE offering of a stride, sometimes, instead of two. TWO is what the
+      // sweep did everywhere, and it can never put a live suffix at the FORCED
+      // arm: the second ingest of a stride compares a hypothesis against itself,
+      // so `common` is the whole filtered list with nothing beyond it, and where
+      // that list ENDS on the over-budget word the forced arm confirms it there
+      // -- one stride BEFORE the growth that would have given it a suffix.
+      // Measured on the two-everywhere shape: 0 such rounds in 256 trials.
+      //
+      // Offering a stride once leaves the next stride's FIRST ingest comparing
+      // `truth[..s]` against `truth[..s + 1]`, so `common` ends on `truth[s - 1]`
+      // with `truth[s]` beyond it -- the reproduction's own shape, reached
+      // whenever the over-budget word lands on that boundary.
+      let repeats = if next() % 3 == 0 { 1 } else { 2 };
+      for _ in 0..repeats {
+        let before = agreement.confirmed_words_slice().len();
         agreement.ingest_streamed(result_with_words(offered.clone()));
         // Read straight off the engine: a deferral returns
         // `AwaitingAgreement`, which a disagreement returns too, so the outcome
         // cannot tell them apart.
         deferrals += u32::from(agreement.split_deferred);
+        forced_strands += u32::from(forced_arm_with_a_live_suffix(&agreement));
+        nothing_unconfirmed_falls_below_the_watermark(
+          &agreement,
+          agreement.confirmed_words_slice().len() - before,
+          trial,
+          stride,
+        );
         if let Some(empty) = postcondition(&agreement, trial, stride) {
           checked += 1;
           empty_holdbacks += u32::from(empty);
@@ -561,8 +643,8 @@ fn the_split_never_cuts_at_a_tied_start() {
   // skipped, and the EMPTY-HOLDBACK state -- the one the earlier shape of this
   // test skipped, and the one #94 was re-opened from -- really was reached.
   assert!(
-    tied_truths > 64,
-    "the sweep must actually produce tied starts: {tied_truths} of 256 trials",
+    tied_truths > 128,
+    "the sweep must actually produce tied starts: {tied_truths} of 512 trials",
   );
   assert!(
     checked > 256,
@@ -578,6 +660,12 @@ fn the_split_never_cuts_at_a_tied_start() {
     deferrals > 64,
     "and the DEFERRED state must be reached, which is the state the \
      one-oversized-word shape could not build: {deferrals} deferred rounds",
+  );
+  assert!(
+    forced_strands > 4,
+    "and the FORCED arm must be reached with a live suffix beyond `common` -- \
+     the state the second postcondition above speaks about, and the one an \
+     unconditional forced advance strands: {forced_strands} rounds",
   );
 }
 #[test]
@@ -1561,6 +1649,41 @@ fn a_stutter_at_the_watermark_keeps_both_occurrences() {
 /// `last_agreed_words_slice()` as text -- the still-provisional half of the
 /// streaming face, asserted beside `confirmed_texts` wherever a word could be in
 /// one list rather than the other.
+/// Whether the round just ingested reached `split_at_a_strict_boundary`'s FORCED
+/// arm -- the budget floor at `common.len()` -- with words still beyond `common`
+/// that the advance's own watermark would put out of reach.
+///
+/// Written LONGHAND from the engine's recorded comparison state rather than by
+/// calling `budgeted_split` or `empty_holdback_watermark`, so a mutation to
+/// either cannot mutate this counter along with them:
+///
+/// - `budgeted_split(common, 0) == common.len()` is exactly "`common`'s last
+///   word alone exceeds `MAX_HOLDBACK_PREFILL_TOKENS`". The loop subtracts words
+///   from the front while the holdback is over budget, so it can only run off
+///   the end from `split == common.len() - 1`, where the holdback is that one
+///   word.
+/// - the sweep's alphabet is four distinct plain texts, so
+///   `find_longest_common_prefix`'s `normalized` comparison is text equality.
+fn forced_arm_with_a_live_suffix(agreement: &LocalAgreement) -> bool {
+  let common_len = agreement
+    .prev_words
+    .iter()
+    .zip(&agreement.hypothesis_words)
+    .take_while(|(previous, current)| previous.word() == current.word())
+    .count();
+  if common_len < agreement.agreement_count_needed() {
+    return false;
+  }
+  let last = &agreement.hypothesis_words[common_len - 1];
+  if last.tokens_slice().len() <= MAX_HOLDBACK_PREFILL_TOKENS {
+    return false;
+  }
+  let watermark = last.end().max(last.start().next_up());
+  agreement.hypothesis_words[common_len..]
+    .iter()
+    .any(|word| word.start() < watermark)
+}
+
 fn held_back_texts(agreement: &LocalAgreement) -> Vec<&str> {
   agreement
     .last_agreed_words_slice()
@@ -2169,6 +2292,12 @@ fn a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held() {
   // " H" gone. The empty PENDING half: make the advance's
   // `self.last_agreed_words.is_empty()` arm DEFER (`0` in place of
   // `widened.len()`) and both words wait for an anchor that can never arrive.
+  //
+  // This is also what bounds the SUFFIX guard the forced arm grew in codex
+  // round 3 (see `a_forced_empty_holdback_defers_rather_than_retracting_its_
+  // suffix`): make that arm defer unconditionally instead of only where it would
+  // strand something, and the `is_advanced` assertion below reds. Nothing lies
+  // beyond `common` here, so deferring waits forever -- round 7's finding again.
   let a = || word_of_tokens(" A", 1.0, 2.0, 1);
   let huge = || word_of_tokens(" H", 2.0, 3.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   assert!(
@@ -2504,6 +2633,14 @@ fn a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed() {
   // needs a non-default `agreement_count_needed` (here 1) and a zero-duration
   // word; `add_word_timestamps` never emits a 112-token word.
   //
+  // The forced arm still ADVANCES here, and this test is half of why it may:
+  // both hypotheses are `[" A", " Z"]`, so nothing lies beyond `common` for the
+  // advance to strand, and there is no anchor a deferral could ever wait for.
+  // The word this costs -- `" B"` below -- arrives one hypothesis LATER, which
+  // is outside what any split can see. Where the strand IS already visible the
+  // arm defers instead
+  // (`a_forced_empty_holdback_defers_rather_than_retracting_its_suffix`).
+  //
   // Mutation proof: drop the `.max(last.start().next_up())` from `ingest`'s
   // empty-holdback watermark and this reds with `" Z"` confirmed twice.
   let a = || word(" A", 0.0, 1.0);
@@ -2569,6 +2706,158 @@ fn a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed() {
      adjudicated bias applied to the evidence: an unbounded re-confirmation \
      REWRITES the confirmed text and breaks the portable prefix property, while \
      this leaves a truncation, which that property tolerates.",
+  );
+}
+#[test]
+fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
+  // #94, codex round 3 on PR #95, SECOND FINDING -- the forced arm of
+  // `split_at_a_strict_boundary`, which the tied-run deferral deliberately left
+  // alone. Where the budget FLOOR itself reaches `common.len()` the split runs
+  // off the end unconditionally, and it does so WITHOUT LOOKING at what the
+  // newer hypothesis produced beyond `common`: the helper was handed `common`,
+  // `requested` and the last confirmed start, and nothing else.
+  //
+  // So the advance empties the holdback, anchors the watermark at
+  // `start.next_up()` -- strictly past the run's instant -- and every word the
+  // newer hypothesis produced AT that instant beyond `common` fails the offered
+  // filter from then on. That is not a deletion of something never emitted: the
+  // round's OWN `finalize` already emitted it, through
+  // `differentSuffix(prev, hypothesis)`. What the next hypothesis costs is a
+  // RETRACTION of published transcript, and `confirmed_words`' monotonicity --
+  // the #89 property -- cannot see it, because the retracted word was never
+  // confirmed.
+  //
+  // It needs no unusual count: " H" alone exceeds `MAX_HOLDBACK_PREFILL_TOKENS`,
+  // which is the only thing that drives `budgeted_split`'s loop off the end, and
+  // that is the whole of the forced arm's condition (see
+  // `a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held`,
+  // the state this rule may NOT swallow: there the budget forces the empty
+  // holdback and nothing lies beyond `common`, so deferring would wait for an
+  // anchor that can never arrive).
+  //
+  // The repair is the same one the tied run got, conditioned on the strand
+  // actually existing: `split_at_a_strict_boundary` now takes the hypothesis's
+  // post-`common` words and defers the forced advance exactly while one of them
+  // starts before the watermark that advance would set.
+  //
+  // Mutation proof, every row run: pass an empty `beyond_common` at the call
+  // site (the pre-repair information state) and the deferred-state row reds
+  // reading `([" A", " H"], [], 1.0000001)`; with that row neutralized the
+  // RETRACTION row reds at `" A H Y"`, `" X"` gone from a transcript that had
+  // already published it. Defer the forced arm unconditionally (drop the
+  // `beyond_common` test) and
+  // `a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held`
+  // reds -- the anchor that can never arrive. Drop `|| self.split_deferred`
+  // from `finalize`'s guard and the IMMEDIATE row reds at `" X"`, the deferred
+  // round's own transcript reduced to the differing suffix.
+  let a = || word(" A", 0.0, 1.0);
+  let over = || word_of_tokens(" H", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
+  let tied = || word(" X", 1.0, 1.0);
+  let anchor = || word(" Y", 2.0, 3.0);
+  assert_eq!(
+    (
+      over().tokens_slice().len() > MAX_HOLDBACK_PREFILL_TOKENS,
+      over().start() == tied().start(),
+      over().end() == over().start(),
+      tied().end() == tied().start(),
+    ),
+    (true, true, true, true),
+    "non-vacuous: ONE word over the budget -- the forced arm's own condition, \
+     not the tied run's aggregate -- and the word beyond `common` shares its \
+     zero-duration instant",
+  );
+
+  let older = || result_with_words(vec![a(), over()]);
+  let newer = || result_with_words(vec![a(), over(), tied()]);
+  let later = || result_with_words(vec![a(), over(), tied(), anchor()]);
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, the only one the driver reaches",
+  );
+  agreement.ingest_streamed(older());
+  agreement.ingest_streamed(newer());
+  assert_eq!(
+    (
+      confirmed_texts(&agreement),
+      held_back_texts(&agreement),
+      agreement.last_agreed_seconds(),
+    ),
+    (Vec::new(), Vec::new(), 0.0),
+    "the forced empty holdback would strand \" X\", so the round DEFERS: \
+     nothing is confirmed, the watermark does not move, and \" X\" stays \
+     offerable",
+  );
+
+  // FINALIZE POINT ONE. The retraction is only visible across two of these, and
+  // this is the one that publishes the word: byte-identical to what the
+  // unconditional forced advance produced on this same round, since a deferred
+  // round finalizes `confirmed ++ hypothesis_words` and that advance finalized
+  // `confirmed ++ common ++ differentSuffix`, which is the same list.
+  assert_eq!(
+    agreement
+      .clone()
+      .finalize(&DecodingOptions::new())
+      .text()
+      .to_string(),
+    " A H X",
+    "a stream ENDING here publishes \" X\" either way -- the divergence is \
+     entirely in what a LATER ingest can still see",
+  );
+
+  // FINALIZE POINT TWO, after a hypothesis that repeats " X" and carries an
+  // anchor starting strictly later. Under the unconditional forced advance " X"
+  // is below the watermark by then, so the filter drops it from the hypothesis
+  // AND from the re-read previous result -- both sides at once -- and this reads
+  // " A H Y".
+  agreement.ingest_streamed(later());
+  assert_eq!(
+    agreement
+      .clone()
+      .finalize(&DecodingOptions::new())
+      .text()
+      .to_string(),
+    " A H X Y",
+    "THE RETRACTION: a word this engine already published stays published",
+  );
+
+  // And the deferral is relieved rather than a deadlock: the anchor reaches
+  // `common` on the second ingest and opens a legal boundary above the floor.
+  assert!(
+    agreement.ingest_streamed(later()).is_advanced(),
+    "the anchor's strictly later start opens a boundary the forced arm no \
+     longer needs",
+  );
+  let advanced = (
+    confirmed_texts(&agreement)
+      .into_iter()
+      .map(str::to_string)
+      .collect::<Vec<_>>(),
+    held_back_texts(&agreement)
+      .into_iter()
+      .map(str::to_string)
+      .collect::<Vec<_>>(),
+    agreement.last_agreed_seconds(),
+  );
+  assert_eq!(
+    (
+      advanced,
+      agreement
+        .finalize(&DecodingOptions::new())
+        .text()
+        .to_string(),
+    ),
+    (
+      (
+        vec![" A".to_string(), " H".to_string(), " X".to_string()],
+        vec![" Y".to_string()],
+        2.0,
+      ),
+      " A H X Y".to_string(),
+    ),
+    "and \" X\" is confirmed exactly once, by the ordinary interior split",
   );
 }
 #[test]

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -439,12 +439,30 @@ fn the_split_never_cuts_at_a_tied_start() {
   // rewrites the LAST offered word on every other offering, which pins `common`
   // in front of it; `contradictions` is that half's non-vacuity proof, `escapes`
   // proves the bound fires, and `tie_strands` proves the second postcondition's
-  // one exception is reached rather than merely written down. Measured on the
-  // shape below, at 512 trials: 489 tied truths, 2292 observations, 268 empty
-  // holdbacks, 176 deferrals, 37 forced-arm rounds with a live suffix, 1221
-  // contradicting rounds, 79 escapes, 12 of which stranded at the settled
-  // instant. (On the shape before this change: 491, 2736, 265, 231, 12, and no
-  // escape reachable at all.)
+  // one exception is reached rather than merely written down.
+  //
+  // A FIFTH reaches the two shapes the LENGTH bound got wrong (codex round 5 on
+  // PR #95). Both are pairs of CONSECUTIVE deferrals, which is what a bound is
+  // read from, and the sweep had neither. `growth_deferrals` counts finding 1's:
+  // a `common` that is LONGER every round, which the length predicate never
+  // escapes -- reached by the aggregate tied runs above, whose trailing tie
+  // survives the prefix growth. `shift_deferrals` counts finding 2's: EQUAL
+  // lengths whose terminal instant MOVED, which the length predicate escapes
+  // although the wait it measured was a different one -- reached by `retiming`,
+  // which drifts a whole offering's timings and leaves its texts alone.
+  // `signature_escapes` and `counted_escapes` prove that BOTH bounds fire, since
+  // neither subsumes the other, and `erasures` is the non-vacuity proof for the
+  // TRANSCRIPT-level property below.
+  //
+  // Measured on the shape below, at 512 trials: 495 tied truths, 2383
+  // observations, 277 empty holdbacks, 113 deferrals, 49 forced-arm rounds with
+  // a live suffix, 1207 contradicting rounds, 43 escapes (41 from a repeating
+  // signature, 2 from the count), 29 of which stranded at the settled instant,
+  // 17 growth deferrals, 10 shift deferrals, and 26 rounds that erased a word
+  // from the published transcript. (On the round-4 shape: 489, 2292, 268, 176,
+  // 37, 1221, 79 escapes, 12 tie strands, and neither round-5 shape reachable at
+  // all. On the shape before THAT: 491, 2736, 265, 231, 12, and no escape
+  // reachable at all.)
   //
   // The sweep draws starts from a coarse grid whose repeats make consecutive
   // words tie -- the `a=[0,0.5)/b=[0,1.0)` shape both #94 regressions are built
@@ -487,6 +505,16 @@ fn the_split_never_cuts_at_a_tied_start() {
   // swept round whose strand is BEYOND the settled instant; drop only its filter
   // (fold over every start) and the FIRST postcondition reds, the watermark
   // having landed on the confirmed word's own start.
+  //
+  // The ROUND 5 rows: restore round 4's own predicate (`DeferralWait::is_over`
+  // reading `previous.is_some_and(|before| signature.common_len <=
+  // before.common_len)`) and `shift_deferrals` reds at `0 rounds` -- that state
+  // ESCAPES under it rather than deferring, which is the finding. Drop the count
+  // from `is_over` and the counter's own cap row reds at `5 deferrals stand
+  // against a cap of 4` -- read INSIDE the loop, since a stall is only visible
+  // while it is happening. Drop the signature instead and `signature_escapes`
+  // reds at `0`. Force `retiming` to `false` and `shift_deferrals` reds at
+  // `0 rounds` again, the state being unreachable rather than unguarded.
   //
   // The exception's two clauses red nothing when mutated ALONE, because on a
   // correct engine neither state they reject is reachable -- an ordinary advance
@@ -595,6 +623,114 @@ fn the_split_never_cuts_at_a_tied_start() {
     true
   }
 
+  /// THE PUBLISHED TRANSCRIPT, with its timings — `LocalAgreement::finalize`'s
+  /// own word list rather than its merged text, which is why
+  /// `take_finalized_words` exists as a function at all.
+  fn published(agreement: &LocalAgreement) -> Vec<(String, f32)> {
+    agreement
+      .clone()
+      .take_finalized_words()
+      .into_iter()
+      .map(|word| (word.word().to_string(), word.start()))
+      .collect()
+  }
+
+  /// THE TRANSCRIPT'S OWN RETENTION, swept across every round (#94, codex round
+  /// 5 on PR #95, closing note). Both findings that round raised hid in the same
+  /// gap: `LocalAgreement::confirmed_words_slice` is append-only, so a word that
+  /// reaches the transcript through a round's PROVISIONAL tail and then
+  /// disappears is invisible to every property written over the confirmed list —
+  /// and disappearing is exactly what a strand does one round after the advance
+  /// that stranded it, when `watermark_filtered` drops it from both hypotheses
+  /// at once.
+  ///
+  /// Plain monotonicity is FALSE here and must not be asserted: revising an
+  /// unconfirmed word is the whole point of LocalAgreement-2, and a revision
+  /// removes the reading it replaces — including by RE-TIMING it, which this
+  /// module's residual 3 already names. So the claim is scoped to the words the
+  /// newest result STILL SAYS: a word the transcript published, that this very
+  /// result offers again at the same text and instant, and that the watermark
+  /// has since put out of reach. Nothing revised it; the engine simply cannot
+  /// see it any more, and no later `finalize` can reach it.
+  ///
+  /// Each such word must sit at the last confirmed word's OWN start, the one
+  /// instant where no watermark both clears the confirmed start (#94) and spares
+  /// the strand — this module's residual 1. Anything strictly below that is a
+  /// word the engine erased while it could still have held it.
+  ///
+  /// **What this does NOT catch, stated rather than implied.** The retraction in
+  /// round 5's finding 2 IS at the settled instant — an escape strands exactly
+  /// the tie — so it is identical in SHAPE to the residual-1 retraction this
+  /// permits, and no property over the transcript alone can separate them. What
+  /// separates them is whether the engine had already waited on that state,
+  /// which is a fact about the DEFERRAL rather than about the transcript, and
+  /// `DeferralSignature` is where it is decided
+  /// (`a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat`). What
+  /// this DOES buy is the bound: retraction is confined to that one instant on
+  /// every round of every shape the sweep drives, and counted so the confinement
+  /// is not vacuous.
+  ///
+  /// **It is DOMINATED, and by which assertion.** Every transcript
+  /// `LocalAgreement::finalize` publishes is a subset of
+  /// `confirmed_words ++ hypothesis_words` -- the holdback and
+  /// `find_longest_different_suffix`'s output are both slices of the latter --
+  /// so a word this can see leaving the transcript was in `hypothesis_words`
+  /// below the new watermark on the round it left, which is exactly what
+  /// `nothing_unconfirmed_falls_below_the_watermark` reads one step earlier.
+  /// This is kept because it is the SOLE DISCRIMINATOR once that assertion is
+  /// neutralized -- drop the sparing fold from `empty_holdback_watermark` and
+  /// neutralize it, and this reds on `[(" C", 2.0), (" C", 2.0)]` erased below a
+  /// 2.5 s watermark at a 1.5 s settled instant -- and because it reads
+  /// `finalize`'s OWN output rather than the engine's internal word lists, so a
+  /// defect on the publication path has somewhere to show. Conditional on
+  /// mutants, not on inputs; the same standing the exception clauses above have.
+  ///
+  /// Returns whether an erasure happened.
+  fn nothing_the_stream_still_says_is_erased(
+    before: &[(String, f32)],
+    after: &[(String, f32)],
+    offered: &[(String, f32)],
+    agreement: &LocalAgreement,
+    trial: u32,
+    stride: usize,
+  ) -> bool {
+    let watermark = agreement.last_agreed_seconds();
+    let settled = agreement
+      .confirmed_words_slice()
+      .last()
+      .map(WordTiming::start);
+    // MULTISET, not set: the sweep's alphabet is four texts over a coarse grid,
+    // so one transcript can carry the same (text, start) twice and a set-shaped
+    // comparison would call the second copy retained by the first.
+    let mut kept: Vec<&(String, f32)> = after.iter().collect();
+    let erased: Vec<&(String, f32)> = before
+      .iter()
+      .filter(|word| match kept.iter().position(|held| held == word) {
+        Some(index) => {
+          kept.swap_remove(index);
+          false
+        }
+        None => true,
+      })
+      .filter(|(_, start)| *start < watermark)
+      .filter(|word| offered.contains(word))
+      .collect();
+    assert!(
+      erased
+        .iter()
+        .all(|(_, start)| settled.is_some_and(|settled| *start == settled)),
+      "trial {trial}, stride {stride}: {erased:?} left the published transcript \
+       while this very result still offers them, and they sit below the \
+       {watermark} s watermark -- so nothing revised them, no hypothesis can \
+       carry them again and no `finalize` can reach them, after this engine had \
+       already published them. Only the settled instant {settled:?} may lose a \
+       word that way. Transcript before: {before:?}; after: {after:?}; offered: \
+       {offered:?}; confirmed: {:?}",
+      confirmed_texts(agreement),
+    );
+    !erased.is_empty()
+  }
+
   let mut state: u64 = 0x2545_F491_4F6C_DD1D;
   let mut next = move || {
     state ^= state << 13;
@@ -610,6 +746,11 @@ fn the_split_never_cuts_at_a_tied_start() {
   let mut contradictions = 0u32;
   let mut escapes = 0u32;
   let mut tie_strands = 0u32;
+  let mut growth_deferrals = 0u32;
+  let mut shift_deferrals = 0u32;
+  let mut signature_escapes = 0u32;
+  let mut counted_escapes = 0u32;
+  let mut erasures = 0u32;
 
   for trial in 0..512u32 {
     let length = 4 + (next() % 5) as usize;
@@ -662,7 +803,14 @@ fn the_split_never_cuts_at_a_tied_start() {
     let mut agreement =
       LocalAgreement::new().with_agreement_count_needed(1 + (next() % 2) as usize);
     let alternating = next() % 2 == 0;
+    // The SHIFT shape, exclusive with the rewrite above because both act on the
+    // same word: `alternating` takes the last offered word OUT of `common` by
+    // changing what it says, and this leaves it IN by changing only WHEN it is.
+    let retiming = !alternating && next() % 2 == 0;
     let mut offering = 0u32;
+    // A fresh engine publishes nothing, so the first round is compared against
+    // the empty transcript and can only ADD.
+    let mut transcript: Vec<(String, f32)> = Vec::new();
     for stride in 2..=truth.len() {
       let omit_head = stride > 2 && next() % 4 == 0;
       let offered = if omit_head {
@@ -707,11 +855,58 @@ fn the_split_never_cuts_at_a_tied_start() {
             last.probability(),
           );
         }
+        // THE SHIFT, the shape codex round 5 on PR #95 (finding 2) needed and
+        // no half above could build. `alternating` rewrites the last word's
+        // TEXT, which pins `common` in FRONT of it; this rewrites TIMINGS and
+        // leaves every text alone, so the words stay inside `common` and the
+        // NORMALIZED PREFIX two consecutive hypotheses agree on is unchanged
+        // while the instant an escape would have to anchor past MOVES. That is
+        // the exact pair of deferrals a `common.len()` record cannot tell apart.
+        //
+        // The WHOLE offering drifts, by a step that only ever grows. Two weaker
+        // shapes were tried and are wrong: shifting the last word alone breaks
+        // it out of the trailing tie and OPENS the boundary the deferral is
+        // waiting for, relieving the state instead of building it; shifting the
+        // trailing tied run alternately moves those words BACK again on the next
+        // offering, which is this module's residual 3 (drift wider than the gap
+        // in front of the watermark) and loses words for a reason that has
+        // nothing to do with the bound. Drifting everything monotonically keeps
+        // every start non-decreasing across offerings as well as within one, so
+        // the only thing that moves is the instant itself.
+        // OFF the 0.5 grid the starts are drawn from, deliberately: a drift of
+        // one grid step makes a re-timed word land exactly where a DIFFERENT
+        // word of the round before sat, and every property that identifies a
+        // word by its text and instant then confuses the two. A real re-decode's
+        // timings are not on the offered grid either.
+        let drift = if retiming {
+          0.03 * offering as f32
+        } else {
+          0.0
+        };
+        if drift > 0.0 {
+          for word in &mut offered {
+            *word = WordTiming::new(
+              word.word(),
+              word.tokens_slice().to_vec(),
+              word.start() + drift,
+              word.end() + drift,
+              word.probability(),
+            );
+          }
+        }
         offering += 1;
+        // The RAW offering, kept past the ingest that consumes it: what the
+        // stream is still saying is half of what separates a revision from an
+        // erasure.
+        let still_offered: Vec<(String, f32)> = offered
+          .iter()
+          .map(|word| (word.word().to_string(), word.start()))
+          .collect();
         let before = agreement.confirmed_words_slice().len();
-        // Captured BEFORE the call, since `ingest` overwrites both: they are
-        // the two inputs the escape decision is actually made from.
-        let deferred_before = agreement.deferred_common_len;
+        // Captured BEFORE the call, since `ingest` overwrites all three: they
+        // are the inputs the escape decision is actually made from.
+        let deferred_before = agreement.deferred;
+        let taken_before = agreement.deferrals_since_advance;
         let confirmed_last_before = agreement
           .confirmed_words_slice()
           .last()
@@ -720,7 +915,20 @@ fn the_split_never_cuts_at_a_tied_start() {
         // Read straight off the engine: a deferral returns
         // `AwaitingAgreement`, which a disagreement returns too, so the outcome
         // cannot tell them apart.
-        deferrals += u32::from(agreement.deferred_common_len.is_some());
+        deferrals += u32::from(agreement.deferred.is_some());
+        // THE TWO SHAPES ROUND 5's FINDINGS ARE, counted so a repair cannot be
+        // reported as swept without the sweep having built them. GROWTH is
+        // finding 1: consecutive deferrals whose `common` is LONGER every round,
+        // which round 4's length predicate never escapes. A SHIFT is finding 2:
+        // consecutive deferrals of EQUAL length whose terminal instant moved,
+        // which round 4's length predicate escapes although the wait it measured
+        // was a different one.
+        if let (Some(before), Some(now)) = (deferred_before, agreement.deferred) {
+          growth_deferrals += u32::from(now.common_len > before.common_len);
+          shift_deferrals += u32::from(
+            now.common_len == before.common_len && now.terminal_start != before.terminal_start,
+          );
+        }
         forced_strands += u32::from(forced_arm_with_a_live_suffix(&agreement));
         let common_len = common_prefix_len(&agreement);
         contradictions += u32::from(
@@ -729,19 +937,41 @@ fn the_split_never_cuts_at_a_tied_start() {
             && common_len < agreement.hypothesis_words.len(),
         );
         // EXACT, rather than inferred from the outcome: re-ask
-        // `split_at_a_strict_boundary` what it would have answered WITHOUT the
-        // bound, from the same inputs the engine handed it.
-        let escaped = common_len >= agreement.agreement_count_needed()
-          && deferred_before.is_some_and(|deferred| common_len <= deferred)
-          && split_at_a_strict_boundary(
-            &agreement.hypothesis_words[..common_len],
-            &agreement.hypothesis_words[common_len..],
-            common_len - agreement.agreement_count_needed(),
-            confirmed_last_before,
-            false,
-          )
-          .is_none();
+        // `split_at_a_strict_boundary` what it would have answered with NO wait
+        // behind it at all, from the same inputs the engine handed it. An escape
+        // is a round that would have deferred and did not.
+        let would_defer = common_len >= agreement.agreement_count_needed()
+          && matches!(
+            split_at_a_strict_boundary(
+              &agreement.hypothesis_words[..common_len],
+              &agreement.hypothesis_words[common_len..],
+              common_len - agreement.agreement_count_needed(),
+              confirmed_last_before,
+              DeferralWait {
+                previous: None,
+                taken: 0,
+              },
+            ),
+            SplitDecision::Defer(_)
+          );
+        let escaped = would_defer && agreement.deferred.is_none();
         escapes += u32::from(escaped);
+        // WHICH bound authorized it. The signature ends a wait that repeated;
+        // the count ends one that never does. Both are counted so neither can be
+        // reported as firing on the strength of the other.
+        if escaped {
+          if taken_before >= MAX_CONSECUTIVE_DEFERRALS {
+            counted_escapes += 1;
+          } else {
+            signature_escapes += 1;
+          }
+        }
+        assert!(
+          taken_before <= MAX_CONSECUTIVE_DEFERRALS,
+          "trial {trial}, stride {stride}: {taken_before} deferrals stand \
+           against a cap of {MAX_CONSECUTIVE_DEFERRALS} -- the counter may not \
+           pass the bound it is, since a round only defers while it is below it",
+        );
         tie_strands += u32::from(nothing_unconfirmed_falls_below_the_watermark(
           &agreement,
           agreement.confirmed_words_slice().len() - before,
@@ -749,6 +979,18 @@ fn the_split_never_cuts_at_a_tied_start() {
           trial,
           stride,
         ));
+        // Read AFTER the ingest and kept for the next round, so every round is
+        // compared against the transcript the round before it published.
+        let after = published(&agreement);
+        erasures += u32::from(nothing_the_stream_still_says_is_erased(
+          &transcript,
+          &after,
+          &still_offered,
+          &agreement,
+          trial,
+          stride,
+        ));
+        transcript = after;
         if let Some(empty) = postcondition(&agreement, trial, stride) {
           checked += 1;
           empty_holdbacks += u32::from(empty);
@@ -803,6 +1045,33 @@ fn the_split_never_cuts_at_a_tied_start() {
     "and the second postcondition's one exception must be reached rather than \
      merely written down -- an escape that strands at the settled instant, \
      which is the only strand any watermark leaves: {tie_strands} rounds",
+  );
+  assert!(
+    growth_deferrals > 0,
+    "and a deferral must be reached whose `common` GREW since the deferral \
+     before it -- codex round 5's finding 1, the shape a `common.len()` bound \
+     never escapes because the length rises every round: {growth_deferrals} \
+     rounds",
+  );
+  assert!(
+    shift_deferrals > 0,
+    "and a deferral must be reached whose `common` is the same LENGTH as the \
+     one before it while its terminal instant MOVED -- codex round 5's finding \
+     2, the pair of different waits a `common.len()` bound cannot tell apart: \
+     {shift_deferrals} rounds",
+  );
+  assert!(
+    signature_escapes > 0 && counted_escapes > 0,
+    "and BOTH bounds must actually fire, since neither subsumes the other: \
+     {signature_escapes} escapes from a repeating signature, {counted_escapes} \
+     from the {MAX_CONSECUTIVE_DEFERRALS}-round count",
+  );
+  assert!(
+    erasures > 0,
+    "and the TRANSCRIPT's own retention must be read against a round that \
+     actually erases something below the watermark, which is the gap both of \
+     round 5's findings hid in and the one `confirmed_words`' append-only \
+     guarantee cannot see: {erasures} rounds",
   );
 }
 #[test]
@@ -943,10 +1212,15 @@ fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
   // see.
   //
   // This wait is the FIRST one, and TAIL growth really does relieve it here:
-  // both rounds after the deferral grow `common`, so the bound in
-  // `split_at_a_strict_boundary`'s arm 3 never fires. What happens when growth
-  // does NOT arrive is
-  // `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`.
+  // both rounds after the deferral grow `common`, so neither bound in
+  // `split_at_a_strict_boundary`'s arm 3 fires -- the signature never repeats
+  // and two deferrals is under `MAX_CONSECUTIVE_DEFERRALS`. RELIEF COSTS TWO
+  // ROUNDS here, one for the anchor to appear in a hypothesis and one for it to
+  // be corroborated into `common`, which is where that constant's number comes
+  // from. What happens when growth does NOT arrive is
+  // `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`;
+  // what happens when it arrives and never helps is
+  // `a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`.
   //
   // Mutation proof, every row run: restore the widen-off-the-end fallback
   // (`.or(Some(common.len()))` after the back-off) and the deferral assertion
@@ -957,12 +1231,12 @@ fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
   // floor bites at all (`if floor > 0 { return None }`) and the deadlock clause
   // below reds -- along with
   // `an_over_budget_holdback_is_capped_rather_than_silently_truncated`, which is
-  // the ordinary budget path this may not swallow. Make the bound fire on EVERY
-  // round (`deferral_gained_nothing = true`) and the deferral assertion reds, the
-  // first wait taken away; record `usize::MAX` rather than `common.len()`, or
-  // never clear the record, and it reds the same way -- the advance's own Swift
-  // shape replaced by the hypothesis. Make `word` emit two tokens and the
-  // non-vacuity row reds at `(113, 226, false)`.
+  // the ordinary budget path this may not swallow. Make the escape
+  // unconditional (`DeferralWait::is_over` returning `true`) and the deferral
+  // assertion reds, the first wait taken away; never clear the record
+  // (`self.deferred = deferred.or(self.deferred)`) and it reds the same way --
+  // the advance's own Swift shape replaced by the hypothesis. Make `word` emit
+  // two tokens and the non-vacuity row reds at `(113, 226, false)`.
   //
   // The `finalize` half has its own two rows at its own assertions below.
   const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
@@ -1026,9 +1300,9 @@ fn an_over_budget_tied_run_defers_rather_than_stranding_its_suffix() {
   // ++ differentSuffix(prev, hypothesis)`, and on a deferred round the holdback
   // is an EARLIER agreement's -- here it does not exist at all -- so the sum
   // drops every word the two hypotheses agreed on. A deferred round therefore
-  // finalizes from the latest hypothesis instead (`deferred_common_len`).
+  // finalizes from the latest hypothesis instead (`deferred`).
   //
-  // Mutation proof for that clause alone: drop `|| self.deferred_common_len.is_some()` from
+  // Mutation proof for that clause alone: drop `|| self.deferred.is_some()` from
   // `finalize`'s guard and this reads `" x0 x1"` -- the whole 113-word run gone,
   // exactly the `commonPrefix.count` leading words the Swift expression cannot
   // account for once the holdback is not the round's own.
@@ -2893,12 +3167,14 @@ fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
   // post-`common` words and defers the forced advance exactly while one of them
   // starts before the watermark that advance would set.
   //
-  // This wait is the FIRST one, and it is the one worth taking: what ENDS it is
-  // the bound in `split_at_a_strict_boundary`'s arm 3, whose own falsifiers are
-  // `an_alternating_suffix_escapes_the_deferral_instead_of_stalling` and
-  // `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`.
-  // The two rounds after the deferral here GROW `common`, so the bound never
-  // fires in this test -- which is exactly what it must not do.
+  // This wait is the FIRST one, and it is the one worth taking: what ENDS it are
+  // the two bounds in `split_at_a_strict_boundary`'s arm 3, whose own falsifiers
+  // are `an_alternating_suffix_escapes_the_deferral_instead_of_stalling`,
+  // `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling`
+  // and `a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`. The
+  // two rounds after the deferral here GROW `common` and the anchor arrives, so
+  // neither bound fires -- which is exactly what they must not do, and the two
+  // rounds relief takes here are what sizes `MAX_CONSECUTIVE_DEFERRALS`.
   //
   // Mutation proof, every row run: pass an empty `beyond_common` at the call
   // site (the pre-repair information state) and the deferred-state row reds
@@ -2908,13 +3184,11 @@ fn a_forced_empty_holdback_defers_rather_than_retracting_its_suffix() {
   // `beyond_common` test, keeping the bound) and
   // `a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held`
   // reds -- the anchor that can never arrive, and the bound does not rescue it,
-  // since that shape never defers twice. Make the bound fire on EVERY round
-  // (`deferral_gained_nothing = true`) and this test's deferred-state row reds
-  // instead; record `usize::MAX` rather than `common.len()` and it reds the same
-  // way, the LENGTH being what makes the measurement a measurement, and so does
-  // never clearing the record
-  // (`self.deferred_common_len = deferred.or(self.deferred_common_len)`). Drop
-  // `|| self.deferred_common_len.is_some()` from `finalize`'s guard and the
+  // since that shape never defers twice. Make the escape unconditional
+  // (`DeferralWait::is_over` returning `true`) and this test's deferred-state row
+  // reds instead, and so does never clearing the record
+  // (`self.deferred = deferred.or(self.deferred)`). Drop
+  // `|| self.deferred.is_some()` from `finalize`'s guard and the
   // IMMEDIATE row reds at `" X"`, the deferred round's own transcript reduced to
   // the differing suffix.
   let a = || word(" A", 0.0, 1.0);
@@ -3069,11 +3343,15 @@ fn an_alternating_suffix_escapes_the_deferral_instead_of_stalling() {
   // state: `" T"` and `" U"` below DO start strictly later, and they never help,
   // because they can only join `common` once the words in front of them agree.
   //
-  // THE BOUND: a deferral over a `common` no longer than the one the previous
-  // round already deferred over is that round again. It is a measurement of the
-  // wait that has already happened, not a prediction about the next one, and it
-  // costs at most one round. Round 1 defers; round 2 finds `common` no longer
-  // and takes the empty holdback instead.
+  // THE BOUND: a deferral whose boundary-relevant SIGNATURE repeats the previous
+  // round's is that round again. It is a measurement of the wait that has
+  // already happened, not a prediction about the next one, and it costs exactly
+  // one round. Round 1 defers; round 2 finds the identical state -- same floor,
+  // same `common.len()`, same terminal instant, same watermark an escape would
+  // anchor at -- and takes the empty holdback instead. The OTHER bound,
+  // `MAX_CONSECUTIVE_DEFERRALS`, is for the wait that never repeats
+  // (`a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals`); here
+  // it would fire three rounds later and the signature gets there first.
   //
   // WHAT THAT TRADES, stated in the direction that costs something. `" X"` and
   // `" Y"` sit at `" H"`'s own instant, so no watermark strictly past `" H"`'s
@@ -3087,18 +3365,21 @@ fn an_alternating_suffix_escapes_the_deferral_instead_of_stalling() {
   // prefix` stops at it by construction, so it is uncorroborated on every round
   // it is offered, and `finalize` already published a DIFFERENT one each round.
   //
-  // Mutation proof, every row run: drop `deferral_gained_nothing` from the
-  // forced arm's test (`if empty_holdback_strands()`) and the face reds with
-  // eight `awaiting_agreement` rounds at watermark 0 -- the stall itself.
-  // Compare with `<` instead of `<=` in `deferral_gained_nothing` and it reds
-  // the same way, `common.len()` being EQUAL rather than smaller here. Record
-  // `usize::MAX` instead of `common.len()` and this goes GREEN while
+  // Mutation proof, every row run: drop `!wait.is_over(&signature)` from the
+  // forced arm's test (`if empty_holdback_strands()`) and this test alone reds,
+  // with eight `awaiting_agreement` rounds at watermark 0 -- the stall itself.
+  // Drop the SIGNATURE from `DeferralWait::is_over` (count only) and it reds the
+  // same way at three deferrals where it asserts one, which is what makes the
+  // signature bound load-bearing beside the count. Make the escape unconditional
+  // (`is_over` returning `true`) and
   // `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` and
-  // `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix` red, which
-  // is the same statement from the other side: what makes the bound a
-  // MEASUREMENT rather than a one-round cap is the length. Make the escape
-  // unconditional (`deferral_gained_nothing = true`) and those same two red --
-  // the FIRST wait is the one that is worth taking.
+  // `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix` red
+  // instead -- the FIRST wait is the one that is worth taking. Restore round 4's
+  // own predicate (`is_over` reading `previous.is_some_and(|before|
+  // signature.common_len <= before.common_len)`) and this stays GREEN, `common`
+  // being EQUAL in length here: that predicate was right about THIS shape and
+  // wrong about two others, which is why round 5 replaced it rather than
+  // widening it.
   let a = || word(" A", 0.0, 1.0);
   let over = || word_of_tokens(" H", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
   let x = || word(" X", 1.0, 1.0);
@@ -3245,14 +3526,16 @@ fn a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling() 
   // and one bound; splitting them would let a repair pass on the half it
   // happened to cover.
   //
-  // Mutation proof, every row run: delete the escape arm outright (the final
-  // `.or_else` in `split_at_a_strict_boundary`) and the STABLE face reds with six
-  // `awaiting_agreement` rounds at watermark 0. Re-introduce a
-  // `!empty_holdback_strands()` guard beside `deferral_gained_nothing` -- the
-  // shape that exempts the arm's own strand from its own bound -- and the
-  // ALTERNATING face reds the same way while the stable one stays green, which
-  // is why both halves are here. Make the escape unconditional
-  // (`.or(Some(common.len()))`) and
+  // Mutation proof, every row run: delete the escape arm outright (the
+  // `None if wait.is_over(&signature)` row of `split_at_a_strict_boundary`'s
+  // final match) and the STABLE face reds with six `awaiting_agreement` rounds
+  // at watermark 0. Re-introduce a `!empty_holdback_strands()` guard beside
+  // `wait.is_over(&signature)` there -- the shape that exempts the arm's own
+  // strand from its own bound -- and the ALTERNATING face reds the same way
+  // while the stable one stays green, which is why both halves are here. Drop
+  // the SIGNATURE from `DeferralWait::is_over` (count only) and both faces red
+  // at three deferrals where they assert one. Make the escape unconditional
+  // (`is_over` returning `true`) and
   // `an_over_budget_tied_run_defers_rather_than_stranding_its_suffix`,
   // `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` and the
   // sweep red, the first wait taken away.
@@ -3388,6 +3671,484 @@ fn a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_stalling() 
       ("awaiting_agreement".to_string(), RUN, 0, 2.0f32.next_up()),
     ],
     "an alternating suffix at the run's own instant must not freeze this arm      either -- the run is confirmed and the disputed words at its instant are      the residual, not the reason to wait",
+  );
+}
+
+#[test]
+fn a_growing_tied_prefix_escapes_after_a_bounded_number_of_deferrals() {
+  // #94, codex round 5 on PR #95, FINDING 1 -- the deferral's liveness again,
+  // and the shape round 4's bound could not see.
+  //
+  // That bound was a LENGTH: escape once `common` is no longer than the length
+  // the round before already deferred over. It measures a wait that REPEATED,
+  // and it is blind to a wait whose state MOVES. An over-budget tied run that
+  // gains one more TIED word every stride moves it every round: `common` is
+  // longer each time, the budget floor rises with it, every boundary the forward
+  // search and the back-off can reach still ties, and `common.len() <= already`
+  // is false forever. Every round defers, nothing is confirmed, the watermark
+  // never moves -- and because an AGREEING round is a KEPT round, one whole
+  // result is retained per round over a clip window that never advances. The
+  // stall is unbounded in rounds and in retention both.
+  //
+  // The driver's own cadence is one hypothesis per stride and
+  // `add_word_timestamps` produces exactly this run from an all-zero alignment
+  // matrix, so the shape needs no over-budget WORD and no alternation: 113
+  // ordinary one-token words at one instant, then 114, then 115.
+  //
+  // THE BOUND IS A COUNT, and the count is asserted here as a NUMBER rather than
+  // implied by an outcome: at most `MAX_CONSECUTIVE_DEFERRALS` rounds may defer
+  // between advances, whatever their signatures say. What it costs when it fires
+  // is this module's residual 1 and nothing else -- the escape anchors at
+  // `empty_holdback_watermark`'s lowest sparing instant, so the only word it can
+  // strand is one at the settled instant, which here is the run's own.
+  //
+  // Mutation proof, every row run: restore round 4's predicate
+  // (`is_over` reading `previous.is_some_and(|before| signature.common_len <=
+  // before.common_len)`) and the face below reds with EIGHT
+  // `awaiting_agreement` rounds at watermark 0 -- the stall itself, retaining a
+  // result on every one of them. Drop the count from `DeferralWait::is_over`
+  // (leaving the signature) and it reds the same way, the signature being fresh
+  // every round. Drop the SIGNATURE instead (leaving the count) and this stays
+  // green while `an_alternating_suffix_escapes_the_deferral_instead_of_stalling`
+  // and `a_tied_run_above_the_budget_floor_escapes_the_deferral_instead_of_
+  // stalling` red at three deferrals where they assert one -- which is why both
+  // halves are here and neither is redundant. Reset `deferrals_since_advance` on
+  // a disagreement as well as on an advance and this stays green, since nothing
+  // here disagrees; `a_deferral_alternating_with_a_disagreement_is_bounded_too`
+  // is that clause's own falsifier.
+  const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
+  let tied = |words: usize| -> Vec<WordTiming> {
+    (0..words)
+      .map(|index| word(&format!(" w{index:03}"), 2.0, 2.0))
+      .collect()
+  };
+  assert_eq!(
+    (
+      tied(RUN).len(),
+      tied(RUN)
+        .iter()
+        .map(|word| word.tokens_slice().len())
+        .sum::<usize>()
+        > MAX_HOLDBACK_PREFILL_TOKENS,
+      tied(RUN).iter().all(|word| word.start() == 2.0),
+    ),
+    (113, true, true),
+    "non-vacuous: ORDINARY one-token words, over the budget by their SUM at ONE \
+     instant -- the shape an all-zero alignment matrix produces, not a \
+     hand-built oversized word",
+  );
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, the only one the driver reaches",
+  );
+
+  // One MORE tied word each round, which is the driver's one-hypothesis-per-
+  // stride cadence over a run that keeps growing.
+  const ROUNDS: usize = 8;
+  let mut face = Vec::with_capacity(ROUNDS);
+  let mut deferred_lengths = Vec::new();
+  let mut deferrals = 0usize;
+  let mut stalled_transcript = String::new();
+  for round in 0..ROUNDS {
+    let outcome = agreement.ingest_streamed(result_with_words(tied(RUN + round)));
+    if let Some(signature) = agreement.deferred {
+      deferrals += 1;
+      deferred_lengths.push(signature.common_len);
+    }
+    if round == 2 {
+      stalled_transcript = agreement
+        .clone()
+        .finalize(&DecodingOptions::new())
+        .text()
+        .to_string();
+    }
+    face.push((
+      outcome.to_string(),
+      agreement.confirmed_words_slice().len(),
+      // The RETENTION the bound bounds: an agreeing round is a kept round, so a
+      // round that defers costs one whole retained result over a clip that has
+      // not moved.
+      agreement.results_slice().len(),
+      agreement.last_agreed_seconds(),
+    ));
+  }
+
+  // THE NUMBER, asserted directly rather than read off the outcomes: the wait is
+  // this many rounds and no more.
+  assert_eq!(
+    (deferrals, MAX_CONSECUTIVE_DEFERRALS),
+    (MAX_CONSECUTIVE_DEFERRALS, 4),
+    "the wait must be bounded by the count, and the count is what it says it is",
+  );
+  // NON-VACUOUS, and the whole of finding 1: `common` GREW on every one of those
+  // rounds, so round 4's length predicate was false on every one of them and
+  // could never have ended this wait.
+  assert_eq!(
+    deferred_lengths,
+    vec![RUN, RUN + 1, RUN + 2, RUN + 3],
+    "every deferral must be over a LONGER `common` than the one before it -- \
+     otherwise a length bound would have escaped and this test would be \
+     measuring the wrong stall",
+  );
+
+  let awaiting = |confirmed: usize, results: usize, watermark: f32| {
+    (
+      "awaiting_agreement".to_string(),
+      confirmed,
+      results,
+      watermark,
+    )
+  };
+  assert_eq!(
+    face,
+    vec![
+      // No previous hypothesis to agree with.
+      awaiting(0, 1, 0.0),
+      // THE WAIT, four rounds of it, each retaining its own result.
+      awaiting(0, 2, 0.0),
+      awaiting(0, 3, 0.0),
+      awaiting(0, 4, 0.0),
+      awaiting(0, 5, 0.0),
+      // THE ESCAPE, at the only instant that clears the run's own start. The
+      // 117 words two hypotheses had agreed on are confirmed; the 118th, at that
+      // same instant, is the residual.
+      ("advanced".to_string(), RUN + 4, 6, 2.0f32.next_up()),
+      // Every word this degenerate stream has is at one instant, so a longer run
+      // now offers nothing past the watermark. That is the input being
+      // degenerate, not the engine stalling -- and the result is DROPPED rather
+      // than retained, so even that costs no memory.
+      awaiting(RUN + 4, 6, 2.0f32.next_up()),
+      awaiting(RUN + 4, 6, 2.0f32.next_up()),
+    ],
+    "a growing tied prefix must not freeze the stream, and the wait must cost \
+     exactly `MAX_CONSECUTIVE_DEFERRALS` retained results",
+  );
+
+  // THE TRADE, both directions. A stream that ENDS inside the wait publishes
+  // every word it produced; one that CONTINUES loses the word at the settled
+  // instant and keeps moving.
+  let escaped_transcript = agreement
+    .finalize(&DecodingOptions::new())
+    .text()
+    .to_string();
+  assert_eq!(
+    (
+      stalled_transcript.split_whitespace().count(),
+      escaped_transcript.split_whitespace().count(),
+    ),
+    (RUN + 2, RUN + 4),
+    "a deferred round finalizes `confirmed ++ hypothesis_words`, so the wait \
+     costs nothing on its own rounds; the escape confirms everything two \
+     hypotheses agreed on and strands only the word at the settled instant",
+  );
+}
+
+#[test]
+fn a_deferral_alternating_with_a_disagreement_is_bounded_too() {
+  // #94, codex round 5 on PR #95 -- the clause that decides WHICH rounds reset
+  // the count, pinned on its own because nothing else in this suite reaches it.
+  //
+  // `LocalAgreement::deferred` is cleared by an advance AND by a disagreement,
+  // since either one moves the state a signature describes. If
+  // `deferrals_since_advance` were cleared on the same schedule, a stream that
+  // alternates a deferral with a disagreement would reset the count every other
+  // round, never repeat a signature, and never advance -- the unbounded wait
+  // back again through a door the signature cannot close. So only an ADVANCE
+  // resets it.
+  //
+  // Mutation proof: reset `deferrals_since_advance` on a disagreement as well
+  // (`if advanced || skip_append`) and the face below reds with ten
+  // `awaiting_agreement` rounds at watermark 0.
+  const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
+  let tied: Vec<WordTiming> = (0..RUN)
+    .map(|index| word(&format!(" w{index:03}"), 2.0, 2.0))
+    .collect();
+  // AGREES with the run and defers: every boundary at or above the floor ties.
+  let agreeing = || result_with_words(tied.clone());
+  // DISAGREES with it outright, from its very first word, so no prefix survives
+  // and the round is `skipAppend` rather than a deferral.
+  let disagreeing = || {
+    result_with_words(
+      (0..RUN)
+        .map(|index| word(&format!(" d{index:03}"), 2.0, 2.0))
+        .collect(),
+    )
+  };
+
+  // A DEFERRAL takes two consecutive AGREEING hypotheses, so the cycle is three
+  // rounds long: agree, agree (defer), disagree. The round after a disagreement
+  // agrees with nothing either -- it is compared against the disagreeing
+  // hypothesis -- which is what makes every deferral here a FRESH one with no
+  // signature behind it, and the count the only thing that can end the run.
+  let mut agreement = LocalAgreement::new();
+  const ROUNDS: usize = 3 * MAX_CONSECUTIVE_DEFERRALS + 2;
+  let mut outcomes = Vec::with_capacity(ROUNDS);
+  let mut deferrals = 0usize;
+  let mut repeats = 0usize;
+  for round in 0..ROUNDS {
+    let previous = agreement.deferred;
+    let outcome = if round % 3 == 2 {
+      agreement.ingest_streamed(disagreeing())
+    } else {
+      agreement.ingest_streamed(agreeing())
+    };
+    if let Some(now) = agreement.deferred {
+      deferrals += 1;
+      repeats += usize::from(previous == Some(now));
+    }
+    outcomes.push(outcome.to_string());
+  }
+  assert_eq!(
+    (
+      deferrals,
+      repeats,
+      outcomes.iter().filter(|o| *o == "advanced").count(),
+    ),
+    (MAX_CONSECUTIVE_DEFERRALS, 0, 1),
+    "a deferral every third round must still reach the count, with no \
+     signature ever repeating to end it sooner: {outcomes:?}",
+  );
+  assert!(
+    agreement.last_agreed_seconds() > 2.0,
+    "and the watermark must actually have moved past the run rather than \
+     staying at {}",
+    agreement.last_agreed_seconds(),
+  );
+}
+
+#[test]
+fn a_shifted_terminal_timestamp_is_a_new_wait_rather_than_a_repeat() {
+  // #94, codex round 5 on PR #95, FINDING 2 -- the other half of the same
+  // predicate, and a TRANSCRIPT-level regression rather than a liveness one.
+  //
+  // Round 4's bound was `common.len()`, and equal lengths do not establish that
+  // the wait already taken covered the state now in front of the engine.
+  // Agreement compares NORMALIZED TEXT; the escape's cost is a question about
+  // TIMINGS. Defer over `[" A", " H"@1]` with a tied strand `" X"@1`, then offer
+  // `[" A", " H"@2, " Y"@2]`: the normalized prefix is unchanged and two words
+  // long either way, while the hazardous boundary has moved from 1 s to 2 s.
+  // Escaping there is escaping from a DIFFERENT deferral: it confirms `" H"@2`,
+  // anchors past 2 s and strands `" Y"` -- a word this round's own `finalize`
+  // publishes and the NEXT ingest retracts. `confirmed_words`' append-only
+  // guarantee cannot see it, because `" Y"` was never confirmed.
+  //
+  // And the wait would have WORKED: repeating that hypothesis grows `common` to
+  // include `" Y"`, which is why the loss is a loss rather than an ordering. The
+  // assertions below are `finalize` before and after, which is the only place it
+  // shows.
+  //
+  // `DeferralSignature` is the repair: the floor, the length, the terminal
+  // instant and the watermark an escape would anchor at, compared for EQUALITY.
+  // The two rounds above differ in the last two, so the second is a new wait.
+  //
+  // REACHABILITY, both halves. The first is the finding's own sequence and needs
+  // a single 113-token word to force the empty holdback, which
+  // `add_word_timestamps` does not emit -- the same artificial word
+  // `a_forced_empty_holdback_defers_rather_than_retracting_its_suffix` needs.
+  // The SECOND half runs the same shift on the aggregate arm, where the trigger
+  // is 113 ORDINARY one-token words at one instant, which that function does
+  // produce from an all-zero alignment matrix. The timestamp SHIFT itself is
+  // ordinary either way: a re-decode over a longer window is free to move the
+  // instants it emits, and `find_longest_common_prefix` compares text alone, so
+  // the prefix is unchanged while the instant is not.
+  //
+  // Mutation proof, every row run: restore round 4's predicate
+  // (`is_over` reading `previous.is_some_and(|before| signature.common_len <=
+  // before.common_len)`) and BOTH halves red -- the first at `" A H"`, `" Y"`
+  // retracted from a transcript that had published it, the second at 113 words
+  // where it asserts 114. Drop `terminal_start` and `escape_watermark` from the
+  // signature (comparing floor and length alone) and they red the same way,
+  // which is what makes those two fields the load-bearing ones.
+  //
+  // ONE MUTATION REDS NOTHING and is recorded rather than dropped: comparing the
+  // length with `<=` beside equality on the rest -- escaping where `common`
+  // SHRANK at an otherwise identical state. That is a SUITE GAP, not dead code:
+  // `common` shrinks whenever the newest hypothesis agrees with its predecessor
+  // on less, so the state is reachable, and no shape in this file or in the
+  // sweep produces it (measured: 0 shrinking deferral pairs in 512 sweep
+  // trials). Equality is kept because its direction is the safe one -- it can
+  // only make the engine WAIT longer, and `MAX_CONSECUTIVE_DEFERRALS` caps that
+  // at four rounds -- so the gap costs a mutation score rather than a
+  // correctness claim.
+  let a = || word(" A", 0.0, 1.0);
+  let over = |at: f32| word_of_tokens(" H", at, at, MAX_HOLDBACK_PREFILL_TOKENS + 1);
+  let x = || word(" X", 1.0, 1.0);
+  let y = || word(" Y", 2.0, 2.0);
+  assert_eq!(
+    (
+      over(1.0).tokens_slice().len() > MAX_HOLDBACK_PREFILL_TOKENS,
+      over(1.0).word() == over(2.0).word(),
+      over(1.0).start() == x().start(),
+      over(2.0).start() == y().start(),
+      over(1.0).start() < over(2.0).start(),
+    ),
+    (true, true, true, true, true),
+    "non-vacuous: ONE word over the budget, the SAME word by text at two \
+     different instants, each tied by a strand at its own instant",
+  );
+
+  let older = || result_with_words(vec![a(), over(1.0)]);
+  let tied_at_one = || result_with_words(vec![a(), over(1.0), x()]);
+  let tied_at_two = || result_with_words(vec![a(), over(2.0), y()]);
+
+  let mut agreement = LocalAgreement::new();
+  assert_eq!(
+    agreement.agreement_count_needed(),
+    DEFAULT_AGREEMENT_COUNT_NEEDED,
+    "non-vacuous: the DEFAULT count, the only one the driver reaches",
+  );
+  agreement.ingest_streamed(older());
+  agreement.ingest_streamed(tied_at_one());
+  let deferred_at_one = agreement.deferred;
+  let published_at_one = agreement
+    .clone()
+    .finalize(&DecodingOptions::new())
+    .text()
+    .to_string();
+  agreement.ingest_streamed(tied_at_two());
+  let deferred_at_two = agreement.deferred;
+  let published_at_two = agreement
+    .clone()
+    .finalize(&DecodingOptions::new())
+    .text()
+    .to_string();
+
+  // NON-VACUOUS: both rounds really did DEFER, and their signatures really do
+  // agree on the length round 4 compared while differing on the timings it did
+  // not. Without this the transcript below could be produced by an engine that
+  // never reached the state.
+  assert_eq!(
+    (
+      deferred_at_one.map(|signature| signature.common_len),
+      deferred_at_two.map(|signature| signature.common_len),
+      deferred_at_one.map(|signature| signature.terminal_start),
+      deferred_at_two.map(|signature| signature.terminal_start),
+      deferred_at_one == deferred_at_two,
+    ),
+    (Some(2), Some(2), Some(1.0), Some(2.0), false),
+    "two deferrals of EQUAL `common.len()` whose hazardous instant MOVED -- the \
+     exact pair a length record cannot tell apart",
+  );
+
+  // THE REGRESSION, at `finalize` across the rounds it spans. The escape is one
+  // ingest late in showing itself: the escaping round still publishes the strand
+  // through `find_longest_different_suffix`, and only the NEXT hypothesis loses
+  // it.
+  agreement.ingest_streamed(tied_at_two());
+  let published_after = agreement
+    .clone()
+    .finalize(&DecodingOptions::new())
+    .text()
+    .to_string();
+  assert_eq!(
+    (
+      published_at_one.as_str(),
+      published_at_two.as_str(),
+      published_after.as_str(),
+    ),
+    (" A H X", " A H Y", " A H Y"),
+    "the shifted round is a NEW wait, so `\" Y\"` stays published; escaping it \
+     as a repeat confirms `\" H\"@2`, anchors past 2 s and retracts `\" Y\"` on \
+     the next ingest",
+  );
+
+  // And the wait ENDS: the repeat above really does repeat the signature, so the
+  // round after it escapes -- with `" Y"` inside `common` by then, which is
+  // exactly what waiting bought.
+  assert!(
+    agreement.ingest_streamed(tied_at_two()).is_advanced(),
+    "the repeated signature must end the wait rather than extend it",
+  );
+  let settled = (
+    confirmed_texts(&agreement)
+      .into_iter()
+      .map(str::to_string)
+      .collect::<Vec<_>>(),
+    held_back_texts(&agreement)
+      .into_iter()
+      .map(str::to_string)
+      .collect::<Vec<_>>(),
+  );
+  assert_eq!(
+    (
+      settled,
+      agreement
+        .finalize(&DecodingOptions::new())
+        .text()
+        .to_string(),
+    ),
+    (
+      (
+        vec![" A".to_string(), " H".to_string(), " Y".to_string()],
+        Vec::new(),
+      ),
+      " A H Y".to_string(),
+    ),
+    "and what the wait bought is `\" Y\"` CONFIRMED rather than stranded",
+  );
+
+  // ── SECOND HALF: the same shift on the arm this crate's own pipeline reaches.
+  const RUN: usize = MAX_HOLDBACK_PREFILL_TOKENS + 1;
+  let run_at = |at: f32| -> Vec<WordTiming> {
+    (0..RUN)
+      .map(|index| word(&format!(" w{index:03}"), at, at))
+      .collect()
+  };
+  let run_at_one = || result_with_words([run_at(1.0), vec![word(" x", 1.0, 1.0)]].concat());
+  let run_at_two = || result_with_words([run_at(2.0), vec![word(" y", 2.0, 2.0)]].concat());
+  assert_eq!(
+    (
+      run_at(1.0)
+        .iter()
+        .map(|word| word.tokens_slice().len())
+        .sum::<usize>()
+        > MAX_HOLDBACK_PREFILL_TOKENS,
+      run_at(1.0)
+        .iter()
+        .all(|word| word.tokens_slice().len() == 1),
+    ),
+    (true, true),
+    "non-vacuous: no single word here is over budget -- it is the SUM of \
+     ordinary one-token words at one instant, which is the shape \
+     `add_word_timestamps` produces from an all-zero alignment matrix",
+  );
+
+  let mut aggregate = LocalAgreement::new();
+  aggregate.ingest_streamed(result_with_words(run_at(1.0)));
+  aggregate.ingest_streamed(run_at_one());
+  let aggregate_at_one = aggregate.deferred;
+  aggregate.ingest_streamed(run_at_two());
+  let aggregate_at_two = aggregate.deferred;
+  let after_shift = aggregate
+    .clone()
+    .finalize(&DecodingOptions::new())
+    .text()
+    .to_string();
+  aggregate.ingest_streamed(run_at_two());
+  let after_repeat = aggregate
+    .clone()
+    .finalize(&DecodingOptions::new())
+    .text()
+    .to_string();
+  assert_eq!(
+    (
+      aggregate_at_one.map(|signature| signature.common_len),
+      aggregate_at_two.map(|signature| signature.common_len),
+      aggregate_at_one == aggregate_at_two,
+      after_shift.split_whitespace().count(),
+      after_repeat.split_whitespace().count(),
+    ),
+    (Some(RUN), Some(RUN), false, RUN + 1, RUN + 1),
+    "the same two deferrals of equal length at moved instants, on the arm no \
+     over-budget word is needed to reach -- and `\" y\"` survives the round \
+     that would have escaped: {after_repeat:?}",
+  );
+  assert!(
+    aggregate.ingest_streamed(run_at_two()).is_advanced(),
+    "and this wait ends on its repeat too",
   );
 }
 

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -1746,6 +1746,82 @@ fn a_confirmed_word_from_before_the_watermark_is_out_of_the_alignment() {
   );
 }
 
+#[test]
+fn a_recurring_phrase_does_not_delete_the_words_between_its_occurrences() {
+  // #94, the re-admission FRONTIER's own deletion failure mode -- the direction
+  // this section calls "worse than the duplication the ledger records", reached
+  // by the rule that closed the ledger. It fires whenever a phrase RECURS inside
+  // one decode window, which is the shape Whisper's repetition loop manufactures
+  // and which the crate's own canonical phrase contains twice.
+  //
+  // The frontier aligns `settled ++ holdback` as a WHOLE, and a globally optimal
+  // alignment is free to explain the settled word by an EARLIER occurrence and
+  // the whole holdback by a LATER one. The seam then cuts past both, and every
+  // word BETWEEN the two occurrences is refused -- never confirmed, never held,
+  // and never re-offerable, because the advance that follows moves the watermark
+  // past them.
+  //
+  //   settled  [" the"]                       confirmed, end == watermark
+  //   holdback [" cat", " sat"]               forced into the next decode
+  //   offered  [" cat"," sat"," on"," the"," cat"," sat"," down"]
+  //   scores   [2, 2, 2, 2, 3, 2, 1, 1]       best 3, smallest optimal seam 4
+  //   REFUSED  [" cat"," sat"," on"," the"]   kept [" cat"," sat"," down"]
+  //
+  // `prev_words` is `[" cat", " sat"]` and the kept head is `[" cat", " sat"]`,
+  // so the two still AGREE. The advance fires, installs the LATER occurrence as
+  // the holdback, drops the earlier one, and moves the watermark from 1.0 s to
+  // 5.0 s -- past " on" and past the second " the", which the stream produced
+  // and nothing revised.
+  //
+  //   ingest    [the@0, cat@1, sat@2] twice        -> confirmed [the], held [cat, sat]
+  //   ingest    [the@0, cat@1, sat@2, on@3, the@4, cat@5, sat@6, down@7]
+  let the = |start: f32| word(" the", start, start + 1.0);
+  let cat = |start: f32| word(" cat", start, start + 1.0);
+  let sat = |start: f32| word(" sat", start, start + 1.0);
+  let opening = || result_with_words(vec![the(0.0), cat(1.0), sat(2.0)]);
+
+  let mut agreement = LocalAgreement::new();
+  agreement.ingest_streamed(opening());
+  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert_eq!(
+    confirmed_texts(&agreement),
+    vec![" the"],
+    "confirmed [the], holding [cat, sat] at a 1.0 s watermark",
+  );
+
+  // The window has grown far enough ahead of the watermark to contain the
+  // phrase a second time -- the only thing the green golden run lacks.
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(vec![
+        the(0.0),
+        cat(1.0),
+        sat(2.0),
+        word(" on", 3.0, 4.0),
+        the(4.0),
+        cat(5.0),
+        sat(6.0),
+        word(" down", 7.0, 8.0),
+      ]))
+      .is_advanced(),
+    "the refused prefix leaves both sides agreeing, so the watermark still moves",
+  );
+
+  let text = agreement
+    .finalize(&crate::audio::whisper::options::DecodingOptions::new())
+    .text()
+    .to_string();
+  assert!(
+    text.contains(" on"),
+    "the word between the two occurrences was deleted: {text:?}"
+  );
+  assert_eq!(
+    text.matches(" the").count(),
+    2,
+    "both occurrences of the recurring word must reach the transcript: {text:?}"
+  );
+}
+
 // ---------------------------------------------------------------------
 // What the frontier rule deliberately LEAVES
 // ---------------------------------------------------------------------

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -138,7 +138,7 @@ fn agreement_confirms_the_common_prefix_minus_the_agreed_tail() {
     word(" my", 0.7, 1.0),
     word(" fellow", 1.0, 1.5),
   ]);
-  assert!(agreement.ingest_streamed(second).is_advanced());
+  assert!(agreement.ingest_streamed(second).agreed());
   assert_eq!(agreement.results_slice().len(), 2);
   // common = [And, so, my]; last agreed = suffix(2) = [so, my];
   // confirmed += prefix(1) = [And]; watermark = " so".start.
@@ -267,7 +267,7 @@ fn agreement_count_needed_is_configurable() {
   let second = result_with_words(vec![word(" And", 0.0, 0.4), word(" so", 0.4, 0.7)]);
   // A single-word common prefix ([And]) already meets a threshold of 1 —
   // it would NOT at the default threshold of 2.
-  assert!(agreement.ingest_streamed(second).is_advanced());
+  assert!(agreement.ingest_streamed(second).agreed());
   assert!(agreement.confirmed_words_slice().is_empty());
   assert_eq!(agreement.last_agreed_words_slice().len(), 1);
   assert_eq!(agreement.last_agreed_words_slice()[0].word(), " And");
@@ -871,6 +871,8 @@ fn the_split_never_cuts_at_a_tied_start() {
   let mut backward_strands = 0u32;
   let mut backward_truths = 0u32;
   let mut drifted_advances = 0u32;
+  let mut agreeing_rounds = 0u32;
+  let mut stationary_rounds = 0u32;
   let mut erasures = 0u32;
   let mut loss_free_rounds = 0u32;
   let mut avoidable_backward_strands = 0u32;
@@ -1067,6 +1069,11 @@ fn the_split_never_cuts_at_a_tied_start() {
           .map(|word| (word.word().to_string(), word.start()))
           .collect();
         let before = agreement.confirmed_words_slice().len();
+        // The same two quantities `ingest` decides `Progressed` against, read
+        // from the PUBLIC face a caller reads them from. Asserting the outcome
+        // against these over every round is what makes the honest signal a swept
+        // property rather than two hand-built examples.
+        let watermark_bits_before = agreement.last_agreed_seconds().to_bits();
         // Captured BEFORE the call, since `ingest` overwrites it: it is one of
         // the inputs the split decision is actually made from. The HIGH-WATER
         // start rather than the last confirmed word's, which is what the engine
@@ -1075,9 +1082,38 @@ fn the_split_never_cuts_at_a_tied_start() {
         // exists to drive.
         let confirmed_high_before = highest_start(agreement.confirmed_words_slice());
         let outcome = agreement.ingest_streamed(result_with_words(offered));
+        // THE HONEST SIGNAL, asserted on every round of every trial: an
+        // agreeing round says `progressed` exactly when one of the two things a
+        // caller can observe moved, and `stationary` exactly when neither did;
+        // a round that did not agree moves neither.
+        //
+        // Mutation proof, and the reason this rides the sweep rather than only
+        // the two hand-built pairs: decide progress by `split != 0` instead of
+        // by comparing state and the RE-TIMED half reds -- those rounds drift
+        // every start by 0.03 s per offering, so their zero-split advances DO
+        // move the watermark and would be misreported as stationary.
+        let moved = agreement.last_agreed_seconds().to_bits() != watermark_bits_before
+          || agreement.confirmed_words_slice().len() != before;
+        assert_eq!(
+          outcome.is_progressed(),
+          outcome.agreed() && moved,
+          "trial {trial} stride {stride}: the round reported `{outcome}` while \
+           the watermark went {watermark_bits_before:#x} -> {:#x} and the \
+           confirmed prefix {before} -> {} words. An agreeing round must report \
+           `progressed` exactly when one of those two moved.",
+          agreement.last_agreed_seconds().to_bits(),
+          agreement.confirmed_words_slice().len(),
+        );
+        assert!(
+          outcome.agreed() || !moved,
+          "trial {trial} stride {stride}: `{outcome}` did not agree, so no \
+           advance ran, yet the watermark or the confirmed prefix moved",
+        );
+        agreeing_rounds += u32::from(outcome.agreed());
+        stationary_rounds += u32::from(outcome.is_stationary());
         // The RE-TIMED half's own non-vacuity: a drifted offering must actually
         // reach the advance path, not merely be constructed and disagreed with.
-        drifted_advances += u32::from(drift > 0.0 && outcome.is_advanced());
+        drifted_advances += u32::from(drift > 0.0 && outcome.agreed());
         forced_strands += u32::from(forced_arm_with_a_live_suffix(&agreement));
         let common_len = common_prefix_len(&agreement);
         contradictions += u32::from(
@@ -1235,6 +1271,14 @@ fn the_split_never_cuts_at_a_tied_start() {
      rounds",
   );
   assert!(
+    stationary_rounds > 256,
+    "and the STATIONARY outcome -- an agreeing round that kept its result and \
+     moved neither the watermark nor the confirmed prefix -- must actually be \
+     reached in bulk, or the honest-signal assertion above only ever read the \
+     `progressed` side. Measured here: 1281 of 2965 agreeing rounds, over 4233 \
+     rounds in all. Got {stationary_rounds} of {agreeing_rounds}",
+  );
+  assert!(
     loss_free_rounds > 128,
     "and the AVOIDABILITY oracle must actually find loss-free splits, or the \
      zero it reports below is vacuous: {loss_free_rounds} rounds had one at or \
@@ -1319,7 +1363,7 @@ fn a_trailing_tied_run_never_confirms_itself_twice_at_the_default_count() {
     "non-vacuous: the DEFAULT count, the only one the driver reaches",
   );
   agreement.ingest_streamed(hypothesis());
-  assert!(agreement.ingest_streamed(hypothesis()).is_advanced());
+  assert!(agreement.ingest_streamed(hypothesis()).agreed());
   assert_eq!(
     (
       confirmed_texts(&agreement),
@@ -1456,7 +1500,7 @@ fn an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant() {
   );
   agreement.ingest_streamed(older());
   assert!(
-    agreement.ingest_streamed(newer()).is_advanced(),
+    agreement.ingest_streamed(newer()).agreed(),
     "the agreeing round ADVANCES: an agreeing round always does",
   );
   assert_eq!(
@@ -1549,7 +1593,7 @@ fn an_over_budget_tied_run_strands_its_suffix_at_the_settled_instant() {
   // AND IT IS NOT A STALL: the grown tail reaches `common` on the next ingest
   // and the stream keeps moving.
   assert!(
-    agreement.ingest_streamed(grown()).is_advanced(),
+    agreement.ingest_streamed(grown()).agreed(),
     "the grown tail reaches `common` and the round advances",
   );
   assert_eq!(
@@ -1581,8 +1625,11 @@ fn a_dropped_disagreeing_hypothesiss_draw_survives_into_finalize() {
   // R2 disagrees with R1 (no common prefix) AND drew from an unseeded sampler.
   let r2 = result_with_words(vec![word(" But", 0.0, 0.4), word(" then", 0.4, 0.7)])
     .with_task_facts(TaskFacts::observed_clean().with_drew_from_rng(true));
-  // R3 agrees with the retained R2 control hypothesis, so the round returns
-  // `Advanced` -- on a ZERO split, so it confirms nothing and the watermark holds.
+  // R3 agrees with the retained R2 control hypothesis, so the round ADVANCES --
+  // on a ZERO split, so it confirms nothing, and on timings R3 repeats verbatim
+  // from R2, so the redrawn watermark lands where it already was. The split
+  // alone would not decide that; see
+  // `an_agreeing_round_with_a_zero_split_and_drifting_timings_progresses`.
   let r3 = result_with_words(vec![
     word(" But", 0.0, 0.4),
     word(" then", 0.4, 0.7),
@@ -1597,7 +1644,7 @@ fn a_dropped_disagreeing_hypothesiss_draw_survives_into_finalize() {
     "R2 disagrees with R1 and is dropped from results",
   );
   assert!(
-    agreement.ingest_streamed(r3).is_advanced(),
+    agreement.ingest_streamed(r3).agreed(),
     "R3 agrees with the retained R2 control hypothesis",
   );
 
@@ -1682,7 +1729,7 @@ fn finalize_keeps_the_earliest_ingested_language_over_a_later_survivor() {
     "R2 disagrees with R1 and is dropped from results",
   );
   assert!(
-    agreement.ingest_streamed(r3).is_advanced(),
+    agreement.ingest_streamed(r3).agreed(),
     "R3 agrees with the retained R2 control hypothesis",
   );
   assert_eq!(
@@ -1738,7 +1785,7 @@ fn finalize_reports_an_unknown_worker_schedule() {
     "R2 disagrees with R1 and is dropped from results",
   );
   assert!(
-    agreement.ingest_streamed(r3).is_advanced(),
+    agreement.ingest_streamed(r3).agreed(),
     "R3 agrees with the retained R2 control hypothesis",
   );
   // The surviving results R1 (worker 0) and R3 (worker 2) carry a knowable [0, 2],
@@ -1786,7 +1833,7 @@ fn a_disagreeing_final_hypothesis_replaces_the_holdback_instead_of_duplicating_i
         word(" bravo", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
       ]))
-      .is_advanced(),
+      .agreed(),
     "identical rerun agrees on all three: confirms alpha, holds bravo+charlie",
   );
   assert_eq!(
@@ -1906,7 +1953,7 @@ fn a_final_hypothesis_with_nothing_past_the_watermark_keeps_the_holdback() {
         word(" bravo", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
       ]))
-      .is_advanced()
+      .agreed()
   );
   assert!((agreement.last_agreed_seconds() - 0.4).abs() < 1e-6);
 
@@ -1955,7 +2002,7 @@ fn an_agreement_after_a_disagreement_restores_the_swift_shape() {
         word(" bravo", 0.4, 0.7),
         word(" charlie", 0.7, 1.0),
       ]))
-      .is_advanced()
+      .agreed()
   );
   // Revises the held-back " bravo": disagrees, dropped, holdback superseded.
   assert!(
@@ -1977,7 +2024,7 @@ fn an_agreement_after_a_disagreement_restores_the_swift_shape() {
         word(" delta", 1.0, 1.3),
         word(" echo", 1.3, 1.6),
       ]))
-      .is_advanced()
+      .agreed()
   );
   assert_eq!(
     agreement
@@ -2016,7 +2063,7 @@ fn a_revision_that_repeats_a_held_back_word_is_not_duplicated() {
   };
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(settled());
-  assert!(agreement.ingest_streamed(settled()).is_advanced());
+  assert!(agreement.ingest_streamed(settled()).agreed());
   // Rule W (#94): the split may not cut at a tied start, so it widens past the
   // tie -- one word moves from `last_agreed_words_slice()` into
   // `confirmed_words_slice()` and the watermark moves to the first word past
@@ -2090,10 +2137,10 @@ fn a_corroborated_revision_that_repeats_a_held_back_word_reaches_the_transcript(
   };
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(settled());
-  assert!(agreement.ingest_streamed(settled()).is_advanced());
+  assert!(agreement.ingest_streamed(settled()).agreed());
   agreement.ingest_streamed(revision());
   assert!(
-    agreement.ingest_streamed(revision()).is_advanced(),
+    agreement.ingest_streamed(revision()).agreed(),
     "the revision corroborates itself",
   );
 
@@ -2235,7 +2282,7 @@ fn a_stutter_at_the_watermark_keeps_both_occurrences() {
   // Mutation proof: make the offered filter STRICT (`start > watermark` in
   // `watermark_filtered`) and the advance never happens -- both stuttered A's
   // sit exactly at the 0.0 s watermark, the hypothesis comes back as the single
-  // word " B", and `is_advanced()` is false. The non-strict endpoint is what
+  // word " B", and `agreed()` is false. The non-strict endpoint is what
   // lets a hypothesis re-offer the instant the watermark sits on, which is the
   // whole of what Rule W then has to keep safe.
   let hypothesis = || {
@@ -2247,7 +2294,7 @@ fn a_stutter_at_the_watermark_keeps_both_occurrences() {
   };
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(hypothesis());
-  assert!(agreement.ingest_streamed(hypothesis()).is_advanced());
+  assert!(agreement.ingest_streamed(hypothesis()).agreed());
   assert_eq!(
     agreement
       .finalize(&crate::audio::whisper::options::DecodingOptions::new())
@@ -2365,7 +2412,7 @@ fn a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream() {
   let stutter = || result_with_words(vec![a(), a(), b()]);
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(stutter());
-  assert!(agreement.ingest_streamed(stutter()).is_advanced());
+  assert!(agreement.ingest_streamed(stutter()).agreed());
   // Rule W (#94): the split may not cut at a tied start, so it widens past the
   // tie -- one word moves from `last_agreed_words_slice()` into
   // `confirmed_words_slice()` and the watermark moves to the first word past
@@ -2382,7 +2429,7 @@ fn a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream() {
   // that pin cannot see this.
   let onward = || result_with_words(vec![a(), b(), c(), d()]);
   agreement.ingest_streamed(onward());
-  assert!(agreement.ingest_streamed(onward()).is_advanced());
+  assert!(agreement.ingest_streamed(onward()).agreed());
   assert_eq!(
     confirmed_texts(&agreement),
     vec![" A", " A", " B"],
@@ -2433,7 +2480,7 @@ fn rule_w_deletes_a_tied_insertion_that_reproduces_nothing_confirmed() {
   assert!(
     agreement
       .ingest_streamed(result_with_words(vec![a(), b(), c()]))
-      .is_advanced()
+      .agreed()
   );
   assert_eq!(
     confirmed_texts(&agreement),
@@ -2454,7 +2501,7 @@ fn rule_w_deletes_a_tied_insertion_that_reproduces_nothing_confirmed() {
 
   let inserted = || result_with_words(vec![word(" X", 0.0, 0.3), b(), c(), word(" D", 2.0, 2.5)]);
   agreement.ingest_streamed(inserted());
-  assert!(agreement.ingest_streamed(inserted()).is_advanced());
+  assert!(agreement.ingest_streamed(inserted()).agreed());
   assert_eq!(
     confirmed_texts(&agreement),
     vec![" A", " B"],
@@ -2519,7 +2566,7 @@ fn a_recurring_phrase_does_not_delete_the_words_between_its_occurrences() {
 
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert!(agreement.ingest_streamed(opening()).agreed());
   assert_eq!(
     confirmed_texts(&agreement),
     vec![" the"],
@@ -2540,7 +2587,7 @@ fn a_recurring_phrase_does_not_delete_the_words_between_its_occurrences() {
         sat(6.0),
         word(" down", 7.0, 8.0),
       ]))
-      .is_advanced(),
+      .agreed(),
     "the refused prefix leaves both sides agreeing, so the watermark still moves",
   );
 
@@ -2602,7 +2649,7 @@ fn rule_w_deletes_an_unaccounted_repeat_of_a_settled_word() {
   assert!(
     agreement
       .ingest_streamed(result_with_words(vec![a(), b(), c()]))
-      .is_advanced()
+      .agreed()
   );
   assert_eq!(
     (confirmed_texts(&agreement), agreement.last_agreed_seconds()),
@@ -2683,7 +2730,7 @@ fn a_re_utterance_separated_from_the_watermark_keeps_its_word() {
   assert!(
     agreement
       .ingest_streamed(result_with_words(vec![a0(), b0(), c0(), d0()]))
-      .is_advanced()
+      .agreed()
   );
   assert_eq!(
     confirmed_texts(&agreement),
@@ -2700,7 +2747,7 @@ fn a_re_utterance_separated_from_the_watermark_keeps_its_word() {
     ])
   };
   agreement.ingest_streamed(re_uttered());
-  assert!(agreement.ingest_streamed(re_uttered()).is_advanced());
+  assert!(agreement.ingest_streamed(re_uttered()).agreed());
   assert_eq!(
     confirmed_texts(&agreement),
     vec![" A", " B", " B", " C"],
@@ -2757,11 +2804,7 @@ fn the_next_strides_prefill_is_the_holdback_verbatim() {
     word(" my", 0.8, 1.2),
   ];
   agreement.ingest_streamed(result_with_words(words.clone()));
-  assert!(
-    agreement
-      .ingest_streamed(result_with_words(words))
-      .is_advanced()
-  );
+  assert!(agreement.ingest_streamed(result_with_words(words)).agreed());
 
   // The base has the prompt turned OFF, which is what makes the flag assertion
   // below non-vacuous: on the default base it would hold with no code at all.
@@ -2833,7 +2876,7 @@ fn an_over_budget_holdback_is_capped_rather_than_silently_truncated() {
 
   let first = || result_with_words(words[..7].to_vec());
   agreement.ingest_streamed(first());
-  assert!(agreement.ingest_streamed(first()).is_advanced());
+  assert!(agreement.ingest_streamed(first()).agreed());
 
   let requested: usize = agreement
     .last_agreed_words_slice()
@@ -2869,7 +2912,7 @@ fn an_over_budget_holdback_is_capped_rather_than_silently_truncated() {
   // truncated one does not.
   let onward = || result_with_words(words[4..].to_vec());
   agreement.ingest_streamed(onward());
-  assert!(agreement.ingest_streamed(onward()).is_advanced());
+  assert!(agreement.ingest_streamed(onward()).agreed());
   assert_eq!(
     confirmed_texts(&agreement),
     vec![" w0", " w1", " w2", " w3", " w4", " w5"],
@@ -2916,7 +2959,7 @@ fn a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held() {
   // advance (see
   // `a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant`, the
   // round where refusing WOULD have saved a word): make that arm return `0`
-  // instead of `common.len()` and the `is_advanced` assertion below reds.
+  // instead of `common.len()` and the `agreed` assertion below reds.
   // Nothing lies beyond `common` here, so there is no anchor a wait could ever
   // be waiting for -- round 7's finding again.
   let a = || word_of_tokens(" A", 1.0, 2.0, 1);
@@ -2929,7 +2972,7 @@ fn a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held() {
   let mut agreement = LocalAgreement::new();
   let pair = || result_with_words(vec![a(), huge()]);
   agreement.ingest_streamed(pair());
-  assert!(agreement.ingest_streamed(pair()).is_advanced());
+  assert!(agreement.ingest_streamed(pair()).agreed());
 
   // The streaming face, read between pushes: both agreed words are settled,
   // because the second one is a word the engine can never hand a decoder whole.
@@ -3109,11 +3152,7 @@ fn the_first_strides_options_keep_the_callers_prefill_flag() {
     word(" my", 0.8, 1.2),
   ];
   agreement.ingest_streamed(result_with_words(words.clone()));
-  assert!(
-    agreement
-      .ingest_streamed(result_with_words(words))
-      .is_advanced()
-  );
+  assert!(agreement.ingest_streamed(result_with_words(words)).agreed());
   assert!(
     agreement
       .decoding_options_for_next(&base)
@@ -3180,11 +3219,7 @@ fn the_prefill_reaches_decode_text_as_the_whole_holdback() {
     word(" my", 0.8, 1.2),
   ];
   agreement.ingest_streamed(result_with_words(words.clone()));
-  assert!(
-    agreement
-      .ingest_streamed(result_with_words(words))
-      .is_advanced()
-  );
+  assert!(agreement.ingest_streamed(result_with_words(words)).agreed());
 
   let holdback_tokens: Vec<u32> = agreement
     .last_agreed_words_slice()
@@ -3208,7 +3243,7 @@ fn the_prefill_reaches_decode_text_as_the_whole_holdback() {
   let mut wide = LocalAgreement::new().with_agreement_count_needed(5);
   let first = || result_with_words(budget[..7].to_vec());
   wide.ingest_streamed(first());
-  assert!(wide.ingest_streamed(first()).is_advanced());
+  assert!(wide.ingest_streamed(first()).agreed());
   let wide_holdback: Vec<u32> = wide
     .last_agreed_words_slice()
     .iter()
@@ -3274,7 +3309,7 @@ fn a_zero_duration_word_at_an_empty_holdback_is_not_re_confirmed() {
   let mut agreement = LocalAgreement::new().with_agreement_count_needed(1);
   let opening = || result_with_words(vec![a(), zero()]);
   agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert!(agreement.ingest_streamed(opening()).agreed());
   assert_eq!(
     (
       confirmed_texts(&agreement),
@@ -3423,7 +3458,7 @@ fn a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant() {
   );
   agreement.ingest_streamed(older());
   assert!(
-    agreement.ingest_streamed(newer()).is_advanced(),
+    agreement.ingest_streamed(newer()).agreed(),
     "the agreeing round ADVANCES: an agreeing round always does",
   );
   assert_eq!(
@@ -3481,7 +3516,7 @@ fn a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant() {
   // AND IT IS NOT A STALL: the anchor reaches `common` on the next ingest and
   // an ordinary interior split takes over.
   assert!(
-    agreement.ingest_streamed(later()).is_advanced(),
+    agreement.ingest_streamed(later()).agreed(),
     "the anchor's strictly later start opens an ordinary interior boundary",
   );
   assert_eq!(
@@ -3647,13 +3682,27 @@ fn an_alternating_suffix_advances_instead_of_stalling() {
       watermark,
     )
   };
-  let advanced = |confirmed: &[&str], held: &[&str], watermark: f32| {
+  let labelled = |label: &str, confirmed: &[&str], held: &[&str], watermark: f32| {
     (
-      "advanced".to_string(),
+      label.to_string(),
       confirmed.iter().map(|w| (*w).to_string()).collect(),
       held.iter().map(|w| (*w).to_string()).collect(),
       watermark,
     )
+  };
+  let progressed = |confirmed: &[&str], held: &[&str], watermark: f32| {
+    labelled("progressed", confirmed, held, watermark)
+  };
+  // The FIXED POINT this shape settles into, and the label is now the point of
+  // the row. The input is periodic, so once the interior split is taken nothing
+  // settles again and the watermark stops moving. Under the single `Advanced`
+  // these rows read as five more advances; they are five rounds in which the
+  // caller's confirmed prefix and watermark did not change, and the outcome
+  // says so now. Not a defect -- an alternation that never corroborates its own
+  // suffix has nothing left to give -- but a caller with a stall watchdog is
+  // entitled to see it, which is the whole of why `Stationary` is a value.
+  let stationary = |confirmed: &[&str], held: &[&str], watermark: f32| {
+    labelled("stationary", confirmed, held, watermark)
   };
   assert_eq!(
     face,
@@ -3663,17 +3712,19 @@ fn an_alternating_suffix_advances_instead_of_stalling() {
       // THE FALLBACK. `common` is `[" A", " H"]` and the budget floor reaches
       // its end, so the empty holdback is taken at the only instant that clears
       // `" H"`'s own start.
-      advanced(&[" A", " H"], &[], PAST_ONE_SECOND),
+      progressed(&[" A", " H"], &[], PAST_ONE_SECOND),
       // And the stream is a stream: the tail the alternation was blocking
       // reaches `common` and is held back under an ordinary interior split.
-      advanced(&[" A", " H"], &[" T", " U"], 2.0),
-      advanced(&[" A", " H"], &[" T", " U"], 2.0),
-      advanced(&[" A", " H"], &[" T", " U"], 2.0),
-      advanced(&[" A", " H"], &[" T", " U"], 2.0),
-      advanced(&[" A", " H"], &[" T", " U"], 2.0),
-      advanced(&[" A", " H"], &[" T", " U"], 2.0),
+      progressed(&[" A", " H"], &[" T", " U"], 2.0),
+      stationary(&[" A", " H"], &[" T", " U"], 2.0),
+      stationary(&[" A", " H"], &[" T", " U"], 2.0),
+      stationary(&[" A", " H"], &[" T", " U"], 2.0),
+      stationary(&[" A", " H"], &[" T", " U"], 2.0),
+      stationary(&[" A", " H"], &[" T", " U"], 2.0),
     ],
-    "the alternation must not freeze the stream",
+    "the alternation must not freeze the stream BEFORE it escapes the forced \
+     arm, and must report honestly once it has: two rounds of real progress, \
+     then a fixed point the outcome names",
   );
 
   // THE TRADE, both directions, so neither can be reported as free. A stream
@@ -3789,8 +3840,10 @@ fn a_tied_run_above_the_budget_floor_advances_instead_of_stalling() {
     face,
     vec![
       ("awaiting_agreement".to_string(), 0, 0, 0.0, RUN),
-      // THE FALLBACK, at the only instant that clears the run's own.
-      ("advanced".to_string(), RUN, 0, PAST_TWO_SECONDS, RUN),
+      // THE FALLBACK, at the only instant that clears the run's own -- and the
+      // only round of this shape that moves anything, which is why it is the
+      // only `progressed` one.
+      ("progressed".to_string(), RUN, 0, PAST_TWO_SECONDS, RUN),
       // The run is behind the watermark now, so a hypothesis that keeps
       // repeating it offers nothing -- which is the input being degenerate, not
       // the engine stalling: every word it has is at one instant.
@@ -3872,7 +3925,7 @@ fn a_tied_run_above_the_budget_floor_advances_instead_of_stalling() {
     alternating_face,
     vec![
       ("awaiting_agreement".to_string(), 0, 0, 0.0),
-      ("advanced".to_string(), RUN, 0, PAST_TWO_SECONDS),
+      ("progressed".to_string(), RUN, 0, PAST_TWO_SECONDS),
       ("awaiting_agreement".to_string(), RUN, 0, PAST_TWO_SECONDS),
       ("awaiting_agreement".to_string(), RUN, 0, PAST_TWO_SECONDS),
       ("awaiting_agreement".to_string(), RUN, 0, PAST_TWO_SECONDS),
@@ -3958,15 +4011,24 @@ fn a_word_starting_strictly_later_lowers_the_watermark_instead_of_being_stranded
       // the advance clears the settled start without reaching past a word the
       // hypothesis has already produced.
       (
-        "advanced".to_string(),
+        "progressed".to_string(),
         vec![" A".to_string(), " H".to_string()],
         Vec::new(),
         2.0,
       ),
       // And `" X"` was never filtered away, so it is held back like any other
       // agreed word one round later.
+      //
+      // `stationary`, not `progressed`, and deliberately: this round grew the
+      // HOLDBACK from nothing to two words, and the holdback is not a progress
+      // channel. It is provisional by construction -- every advance replaces it
+      // wholesale, with this hypothesis's timings -- so a stream re-agreeing on
+      // the same two words forever churns it every round. Counting that as
+      // progress is exactly how a stall stays invisible. What moved here is what
+      // MIGHT still be revised; nothing settled, and the clip boundary the next
+      // stride decodes from is where it was.
       (
-        "advanced".to_string(),
+        "stationary".to_string(),
         vec![" A".to_string(), " H".to_string()],
         vec![" X".to_string(), " T".to_string()],
         2.0,
@@ -4021,7 +4083,7 @@ fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
   let mut agreement = LocalAgreement::new();
   let opening = || result_with_words(vec![p(), q(), r()]);
   agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
+  assert!(agreement.ingest_streamed(opening()).agreed());
   assert_eq!(agreement.last_agreed_seconds(), 1.0);
   assert_eq!(
     confirmed_texts(&agreement),
@@ -4467,7 +4529,7 @@ fn a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word() {
     "non-vacuous: the DEFAULT count, which is the driver's own",
   );
   agreement.ingest_streamed(offered());
-  assert!(agreement.ingest_streamed(offered()).is_advanced());
+  assert!(agreement.ingest_streamed(offered()).agreed());
   assert_eq!(
     (
       confirmed_texts(&agreement),
@@ -4511,7 +4573,7 @@ fn a_backward_start_from_the_segment_pipeline_does_not_strand_a_later_word() {
     "`\" D\"` is still offerable, so a later hypothesis can still revise or \
      corroborate it",
   );
-  assert!(agreement.ingest_streamed(offered()).is_advanced());
+  assert!(agreement.ingest_streamed(offered()).agreed());
   assert!(
     agreement
       .finalize(&crate::audio::whisper::options::DecodingOptions::new())
@@ -4566,7 +4628,7 @@ fn a_backwards_start_two_words_back_still_cannot_be_re_admitted() {
   };
   let mut agreement = LocalAgreement::new();
   agreement.ingest_streamed(offered());
-  assert!(agreement.ingest_streamed(offered()).is_advanced());
+  assert!(agreement.ingest_streamed(offered()).agreed());
   assert_eq!(
     (
       confirmed_texts(&agreement),
@@ -4707,7 +4769,7 @@ fn a_backward_start_past_the_requested_split_backs_off_instead_of_stranding_it()
     "non-vacuous: the DEFAULT count, which is the driver's own",
   );
   agreement.ingest_streamed(offered());
-  assert!(agreement.ingest_streamed(offered()).is_advanced());
+  assert!(agreement.ingest_streamed(offered()).agreed());
 
   // THE FINDING, read on the PUBLISHED TRANSCRIPT across rounds rather than on
   // the confirmed list -- which is append-only and cannot see a retraction.
@@ -4832,10 +4894,12 @@ fn a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forev
   let mut agreement = LocalAgreement::new();
   let mut first_confirmation = None;
   let mut confirmed_after: Vec<usize> = Vec::new();
+  let mut stationary_rounds = 0usize;
   for round in 1..=expected_confirmation_round + 6 {
     let offered = offering(round);
     let published_words = offered.len();
-    agreement.ingest_streamed(result_with_words(offered));
+    let outcome = agreement.ingest_streamed(result_with_words(offered));
+    stationary_rounds += usize::from(outcome.is_stationary());
     let confirmed = agreement.confirmed_words_slice().len();
     if confirmed > 0 && first_confirmation.is_none() {
       first_confirmation = Some(round);
@@ -4872,6 +4936,26 @@ fn a_permanently_backwards_tail_confirms_at_the_budget_rather_than_holding_forev
     confirmed_after.last() > confirmed_after.get(expected_confirmation_round - 1),
     "and it KEEPS confirming afterwards rather than returning to zero for good: \
      {confirmed_after:?}",
+  );
+
+  // AND THE CALLER CAN SEE THE WAIT. This is the shape the honest signal exists
+  // for: the bound above is a BOUND, not a promise of movement, and for most of
+  // it the engine agrees round after round while confirming nothing and holding
+  // the watermark still. 110 of these 120 rounds are that state. While both
+  // agreeing cases shared one `Advanced`, a caller reading the outcome saw 110
+  // consecutive reports of progress across a stream that made none, and a stall
+  // watchdog keyed on it could never fire -- which is the whole reason the
+  // outcome now distinguishes them.
+  //
+  // Asserted as a floor rather than an equality because it is evidence about a
+  // shape, not a contract on a count: what must not happen is this shape
+  // reporting progress on rounds that made none.
+  assert!(
+    stationary_rounds >= 100,
+    "the wait must be VISIBLE to a caller: {stationary_rounds} of {} rounds \
+     agreed, kept their result and moved neither the watermark nor the \
+     confirmed prefix (measured: 110 of 120)",
+    confirmed_after.len(),
   );
 }
 
@@ -4970,7 +5054,7 @@ fn a_backward_start_beyond_common_backs_the_split_off_too() {
   assert!(
     agreement
       .ingest_streamed(result_with_words(with_beyond.clone()))
-      .is_advanced()
+      .agreed()
   );
   assert_eq!(
     (
@@ -5008,42 +5092,26 @@ fn a_backward_start_beyond_common_backs_the_split_off_too() {
 }
 
 #[test]
-fn characterization_an_agreeing_round_returns_advanced_without_moving_the_watermark() {
-  // CHARACTERIZATION of what `AgreementOutcome::Advanced` reports TODAY, not a
-  // property that holds. The CORRECT answer is in the failure messages below.
+fn an_agreeing_round_that_moves_nothing_reports_stationary() {
+  // Was `characterization_an_agreeing_round_returns_advanced_without_moving_the_
+  // watermark`, which PINNED the dishonest signal and named the correct answer
+  // in its own failure message. This asserts that answer instead: a round that
+  // agreed, kept its result and moved NOTHING says so.
   //
-  // `Advanced`'s doc said "the confirmation watermark advanced and the result
-  // was kept", and `AwaitingAgreement`'s said "two hypotheses that AGREE always
-  // advance the watermark ... what this value reports is whether the watermark
-  // moved". Both were false, and neither is a rounding artifact.
+  // WHY IT MATTERS, measured rather than argued. On the pathological input
+  // `the_split_never_cuts_at_a_tied_start` builds, 399 of 400 rounds are this
+  // one. While both agreeing cases shared a single `Advanced`, a caller with a
+  // stall watchdog keyed on the outcome saw 399 consecutive reports of progress
+  // and could not tell the stall from a working stream.
   //
-  // MEASURED, on the real tiny model: strides 7 and 9 of the shipping
-  // `jfk_simulated_stream_confirms_the_transcript` fixture return `Advanced`
-  // with `last_agreed_seconds` BIT-identical to the stride before (`0x3fb5c28f`
-  // and `0x3fb851ec`) and the confirmed prefix unchanged at `"and so my"`, while
-  // every stride that really moves changes the bits by ~0.02 s. Instrumenting
-  // the same 512-trial shape `the_split_never_cuts_at_a_tied_start` sweeps finds
-  // 1281 such rounds out of 4233 at this commit and 1128 out of 4233 on `main`,
-  // with the rounded-only count at ZERO on both. The behaviour predates this
-  // branch: the JFK trace is element-wise identical across `main`, `7b353b4`
-  // and `eb1e412`.
-  //
-  // WHY, and it is not the budget. An advance confirms `common[..split]` and
-  // holds `common[split..]`. Where the split is ZERO -- here the earliest
-  // boundary the budget floor allows, `budgeted_split(common, 0) == 0`, and a
-  // legal one -- the round confirms nothing, so `sparing_watermark` re-anchors on
-  // the first held-back word, which is the word the watermark already sat on.
-  // The EXHAUSTED-BUDGET arm is the opposite case and does move the watermark:
-  // it runs the split off the end of `common` and confirms all of it
-  // (`a_forced_empty_holdback_retracts_its_suffix_at_the_settled_instant`).
-  //
-  // Split > 0 cannot reach this state, which is why the pin is at split 0: every
-  // word of `common` clears the watermark by `watermark_filtered`, so confirming
-  // one raises `highest_start(confirmed_words)` to at least the watermark, and
-  // Rule W's first postcondition then puts the new watermark strictly past it.
+  // The MINIMAL PAIR is
+  // `an_agreeing_round_with_a_zero_split_and_drifting_timings_progresses`: the
+  // same three rounds with `" so"`'s start moved from 0.4 to 0.42 and nothing
+  // else changed. Its split is zero too, and it reports `progressed` -- so the
+  // two zero-split cases are told apart by tests, not only by prose.
   //
   // Mutation proof: make the third ingest disagree (change `" my"`'s text in
-  // `revised`) and the `is_advanced` row reds -- so the round asserted here is
+  // `revised`) and the `agreed()` row reds -- so the round asserted here is
   // genuinely an AGREEING one and not a disagreement in disguise.
   let and = || word(" and", 0.0, 0.4);
   let so = || word(" so", 0.4, 0.7);
@@ -5065,7 +5133,7 @@ fn characterization_an_agreeing_round_returns_advanced_without_moving_the_waterm
         my(),
         word(" fellow", 1.0, 1.5),
       ]))
-      .is_advanced()
+      .is_progressed()
   );
   assert_eq!(
     (
@@ -5079,30 +5147,24 @@ fn characterization_an_agreeing_round_returns_advanced_without_moving_the_waterm
   );
 
   // The steady state: this round re-agrees on exactly `agreement_count_needed`
-  // words and holds both, so its split is zero and it confirms nothing new.
+  // words and holds both, so its split is zero and it confirms nothing new --
+  // and this hypothesis repeats the previous one's timings for both held words,
+  // so the redrawn watermark lands on the instant it already held.
   let settled = agreement.last_agreed_seconds();
   let revised = result_with_words(vec![so(), my(), word(" americans", 1.0, 1.6)]);
   let outcome = agreement.ingest_streamed(revised);
 
   assert!(
-    outcome.is_advanced(),
-    "non-vacuous: this round AGREED and its result was kept -- it is the \
-     `Advanced` path, not a disagreement",
+    outcome.agreed(),
+    "non-vacuous: this round AGREED and its result was kept -- it is an \
+     advancing round, not a disagreement",
   );
   assert_eq!(
     agreement.last_agreed_seconds().to_bits(),
     settled.to_bits(),
-    "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94): \
-     this pins that a round returning `{outcome}` moves the watermark NOWHERE \
-     -- left is the {} it holds now, right the {settled} it already held, \
-     compared as BITS so no rounding can be blamed either way. The CORRECT \
-     answer is that a caller can read `advanced` as \"something progressed\" \
-     and act on it: drive a \
-     progress indicator, decide a stream has stalled, or stop re-offering audio \
-     that will never be confirmed. Today it only says the round AGREED and its \
-     result was KEPT. Making the signal honest is tracked separately, because \
-     it changes what the JFK regression trace records and that trace must stay \
-     byte-identical on this branch.",
+    "the watermark really did not move -- left is the {} it holds now, right \
+     the {settled} it already held, compared as BITS so no rounding can be \
+     blamed either way",
     agreement.last_agreed_seconds(),
   );
   assert_eq!(
@@ -5110,7 +5172,106 @@ fn characterization_an_agreeing_round_returns_advanced_without_moving_the_waterm
     (vec![" and"], vec![" so", " my"]),
     "and nothing else progressed either: the confirmed prefix is unchanged and \
      the whole agreed prefix is still the holdback, which is what a zero split \
-     leaves behind. A caller polling `confirmed_words_slice()` on an `advanced` \
-     sees the same words it saw last round.",
+     leaves behind",
+  );
+  assert!(
+    outcome.is_stationary(),
+    "so the round must REPORT that, and it reports `{outcome}`. A caller may \
+     read `progressed` as \"something moved\" and act on it -- drive a progress \
+     indicator, decide a stream has stalled, stop re-offering audio that will \
+     never be confirmed -- and this round moved nothing.",
+  );
+}
+
+#[test]
+fn an_agreeing_round_with_a_zero_split_and_drifting_timings_progresses() {
+  // THE OTHER ZERO-SPLIT CASE, and the one two commits of this branch said could
+  // not exist. `79fe099` and `47023a7` stated that a zero split leaves the
+  // watermark BIT-identical; a zero split guarantees only that no word is
+  // appended to `confirmed_words`. The watermark is REDRAWN from this
+  // hypothesis's own timings on every advance -- `find_longest_common_prefix`
+  // agrees on normalized TEXT and hands back a slice of the NEW hypothesis -- so
+  // it moves whenever those timings drift, split or no split.
+  //
+  // This is the MINIMAL PAIR to
+  // `an_agreeing_round_that_moves_nothing_reports_stationary`: identical rounds
+  // except that the third hypothesis re-times `" so"` from 0.4 to 0.42, the way
+  // a re-decode over a longer buffer does. Same texts, same agreement, same zero
+  // split -- and the watermark moves, so the outcome must say `progressed`.
+  //
+  // An ORDINARY test rather than a characterization: it does not record
+  // behaviour we tolerate but do not endorse, it pins the honest-signal contract
+  // itself. A round that moves the watermark and reports no progress would be a
+  // defect to fix, not a note to keep.
+  //
+  // MUTATION PROOF, and it is the whole reason the test exists: implement
+  // `ingest`'s progress decision as `split != 0` -- the reading the false claim
+  // invites -- and this reds with `stationary`, while
+  // `an_agreeing_round_that_moves_nothing_reports_stationary` stays green. The
+  // shipping `jfk_simulated_stream_confirms_the_transcript` fixture runs the
+  // same shape on the real tiny model: `confirmed` sits at 3 from stride 3
+  // through stride 9 -- so every advance from stride 4 on splits at zero --
+  // while the watermark walks 1.36 -> 1.38 -> 1.40 -> 1.42, and 1.42 -> 1.44 at
+  // stride 8.
+  let and = || word(" and", 0.0, 0.4);
+  let so = || word(" so", 0.4, 0.7);
+  let my = || word(" my", 0.7, 1.0);
+
+  let mut agreement = LocalAgreement::new();
+  agreement.ingest_streamed(result_with_words(vec![and(), so(), my()]));
+  assert!(
+    agreement
+      .ingest_streamed(result_with_words(vec![
+        and(),
+        so(),
+        my(),
+        word(" fellow", 1.0, 1.5),
+      ]))
+      .is_progressed(),
+    "the SETUP round confirms `\" and\"` and moves the watermark to 0.4",
+  );
+  assert_eq!(
+    (
+      confirmed_texts(&agreement),
+      held_back_texts(&agreement),
+      agreement.last_agreed_seconds().to_bits(),
+    ),
+    (vec![" and"], vec![" so", " my"], 0.4f32.to_bits()),
+  );
+
+  // THE DRIFT, and the only difference from the stationary pair: `" so"` comes
+  // back 0.02 s later. It still clears the 0.4 watermark, so it is still
+  // offered; its text is unchanged, so `common` is still `[" so", " my"]` and
+  // the split is still zero.
+  let settled = agreement.last_agreed_seconds();
+  let outcome = agreement.ingest_streamed(result_with_words(vec![
+    word(" so", 0.42, 0.7),
+    my(),
+    word(" americans", 1.0, 1.6),
+  ]));
+
+  assert_eq!(
+    (confirmed_texts(&agreement), held_back_texts(&agreement)),
+    (vec![" and"], vec![" so", " my"]),
+    "the split really is ZERO: nothing new was confirmed and the whole agreed \
+     prefix is still the holdback",
+  );
+  assert_ne!(
+    agreement.last_agreed_seconds().to_bits(),
+    settled.to_bits(),
+    "and the watermark really did MOVE across that zero split -- {} against \
+     the {settled} it held before, compared as BITS",
+    agreement.last_agreed_seconds(),
+  );
+  assert_eq!(
+    agreement.last_agreed_seconds().to_bits(),
+    0.42f32.to_bits(),
+    "onto the re-timed held word's own start, which is where the anchor is \
+     drawn from",
+  );
+  assert!(
+    outcome.is_progressed(),
+    "so a zero split is NOT the stationary condition, and the outcome must \
+     report the move: `{outcome}`",
   );
 }

--- a/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
+++ b/crates/coremlit/src/audio/whisper/stream/agreement/tests.rs
@@ -23,8 +23,8 @@ fn word_of_tokens(text: &str, start: f32, end: f32, token_count: usize) -> WordT
 /// [`MIN_SPECIAL_TOKEN_BEGIN`], so the filter drops the lot and the word
 /// contributes NOTHING to the initial prompt. `add_word_timestamps` never emits
 /// one — it strips exactly those ids and skips an alignment entry that has
-/// nothing left — so this is a hand-built shape, which is precisely the call
-/// shape [`LocalAgreement::ingest`]'s `decoded_under` parameter exists for.
+/// nothing left — so this is a hand-built shape, reachable only through
+/// [`LocalAgreement::ingest`]'s public, hand-built [`TranscriptionResult`].
 fn special_only_word(text: &str, start: f32, end: f32) -> WordTiming {
   WordTiming::new(text, vec![MIN_SPECIAL_TOKEN_BEGIN], start, end, 0.9)
 }
@@ -74,23 +74,18 @@ fn initial_prompt_for(
 // defaults for these either") — same brief-vs-shipped-API fix as
 // `tests/pipeline.rs`'s `tiny_options`/`tests/parity_jfk.rs`. Both call sites
 // below pass the real values directly instead.
-/// Ingest the way [`LocalAgreementTranscriber::push_samples`] does: under the
-/// options the engine itself issued for its current state, so the prefill
-/// premise `LocalAgreement::prefill_reproduces_holdback` checks is ESTABLISHED
-/// rather than assumed.
-///
-/// Every test below that is modelling the streaming loop goes through this. The
-/// bare [`LocalAgreement::ingest`] is the UNMARKED path — a result decoded some
-/// other way — and the tests that mean that call it directly, with the options
-/// they mean.
+/// Ingest the way [`LocalAgreementTranscriber::push_samples`] does. The driver
+/// retargets its options through
+/// [`LocalAgreement::decoding_options_for_next`] between strides; the engine
+/// itself takes only the result, so this is a one-line alias kept for the
+/// streaming-shaped tests to read as what they model.
 trait IngestStreamed {
   fn ingest_streamed(&mut self, result: TranscriptionResult) -> AgreementOutcome;
 }
 
 impl IngestStreamed for LocalAgreement {
   fn ingest_streamed(&mut self, result: TranscriptionResult) -> AgreementOutcome {
-    let options = self.decoding_options_for_next(&DecodingOptions::new());
-    self.ingest(result, &options)
+    self.ingest(result)
   }
 }
 
@@ -1212,18 +1207,6 @@ fn confirmed_texts(agreement: &LocalAgreement) -> Vec<&str> {
     .collect()
 }
 
-/// `pending_words_slice()` as text — the agreed-but-not-yet-irrevocable head of
-/// the holdback. Always read in the SAME assertion as `confirmed_texts`, so the
-/// boundary between the two is pinned rather than implied: a mutation that moves
-/// a word across it fails the pair even though the concatenation is unchanged.
-fn pending_texts(agreement: &LocalAgreement) -> Vec<&str> {
-  agreement
-    .pending_words_slice()
-    .iter()
-    .map(WordTiming::word)
-    .collect()
-}
-
 #[test]
 fn a_distinct_repetition_of_a_confirmed_word_survives_the_continuing_stream() {
   // #94 (codex round 3, finding 2) -- the ledger's OTHER face, a DELETION rather
@@ -1619,10 +1602,11 @@ fn a_re_utterance_separated_from_the_watermark_keeps_its_word() {
 #[test]
 fn the_next_strides_prefill_is_the_holdback_verbatim() {
   // THE PREMISE, pinned as the fact it is: the engine WRITES the holdback into
-  // the next hypothesis rather than asking for it. That is what makes a marked
-  // continuation unable to put anything in front of the holdback, which is what
-  // `prefill_reproduces_holdback` and the pending promotion rest on. This
-  // asserts the two halves of that contract that live in this module:
+  // the next hypothesis rather than asking for it. That is what makes the next
+  // hypothesis a RE-AGREEMENT over the span the holdback covers rather than an
+  // independent reading of it, and it is what `budgeted_split`'s whole budget
+  // argument is about. This asserts the two halves of that contract that live in
+  // this module:
   //
   //   * `prefix_tokens` is the holdback's own tokens, in order, concatenated --
   //     not a count, not a summary. `decode::prefill_tokens` appends them to the
@@ -1751,12 +1735,9 @@ fn an_over_budget_holdback_is_capped_rather_than_silently_truncated() {
     "five words were asked for; three is what 112 tokens can carry",
   );
   assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" w0", " w1", " w2", " w3"], Vec::<&str>::new()),
-    "the two words that could not be held are CONFIRMED, not dropped -- and \
-     confirmed OUTRIGHT, not left pending: both end at or before the watermark, \
-     so no word the engine will ever be offered again can overlap them (codex \
-     round 12, finding 1)",
+    confirmed_texts(&agreement),
+    vec![" w0", " w1", " w2", " w3"],
+    "the two words that could not be held are CONFIRMED, not dropped",
   );
   // The face that matters to the decoder: what the next stride will prefill.
   assert_eq!(
@@ -1775,11 +1756,8 @@ fn an_over_budget_holdback_is_capped_rather_than_silently_truncated() {
   agreement.ingest_streamed(onward());
   assert!(agreement.ingest_streamed(onward()).is_advanced());
   assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (
-      vec![" w0", " w1", " w2", " w3", " w4", " w5"],
-      Vec::<&str>::new()
-    ),
+    confirmed_texts(&agreement),
+    vec![" w0", " w1", " w2", " w3", " w4", " w5"],
     "confirmation kept moving, and nothing was retracted",
   );
 
@@ -1832,12 +1810,9 @@ fn a_holdback_word_the_prefill_cannot_carry_is_confirmed_rather_than_held() {
 
   // The streaming face, read between pushes: both agreed words are settled,
   // because the second one is a word the engine can never hand a decoder whole.
-  // Settled OUTRIGHT rather than left pending -- the watermark is " H"'s own
-  // end, so the still-open span starts where " H" stops and can never overlap
-  // it (codex round 12, finding 1).
   assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A", " H"], Vec::<&str>::new()),
+    confirmed_texts(&agreement),
+    vec![" A", " H"],
     "a word the prefill cannot carry is CONFIRMED, never held",
   );
   assert!(
@@ -1890,13 +1865,10 @@ fn a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held() {
   // `prefill_tokens` reduces `prefix_tokens` twice on its way to the decoder: it
   // keeps only the last `MAX_HOLDBACK_PREFILL_TOKENS` ids, AND it drops every id
   // at or above the vocabulary's `special_token_begin`. `budgeted_split` bounded
-  // only the first, and `prefill_reproduces_holdback` proves the caller's prefix
-  // EQUALS the holdback -- which is exactly as true for a holdback whose tokens
-  // the second filter erases. So a hand-built stream can settle a word, hold a
-  // word made of ids the decoder never receives, pass the retarget
-  // `decoding_options_for_next` just issued, and have `ProvenancedResult` record
-  // `prefilled = true` for a hypothesis the engine did NOT write the holdback
-  // into.
+  // only the first. So a hand-built stream can settle a word, hold a word made
+  // of ids the decoder never receives, and have `decoding_options_for_next`
+  // issue a retarget that promises the decoder a holdback it will never be
+  // given.
   //
   // REACHABILITY, since round 3 classified this half unreachable. That
   // classification's evidence is correct -- `update_segments_with_word_timings`
@@ -1911,13 +1883,8 @@ fn a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held() {
   // NEITHER SEAM IS THE REPAIR, which is why the fix is in the split. Read the
   // arithmetic of this very stream three ways:
   //
-  //   - held and read MARKED (the defect): " S" is never confirmed, the
-  //     re-offer supersedes the holdback that carried it, and the transcript
-  //     loses it -- " A A Y C".
-  //   - held and read UNATTRIBUTED (refuse the marked reading): the offered head
-  //     is cut as well, so the stream loses " S" AND the " A" that replaced it --
-  //     " A Y C". Refusing is not the conservative choice here; the state is the
-  //     defect, not the reading of it.
+  //   - HELD (the defect): " S" is never confirmed, the re-offer supersedes the
+  //     holdback that carried it, and the transcript loses it -- " A A Y C".
   //   - CONFIRMED instead of held (this fix): " A S A Y C", every word two
   //     hypotheses agreed on, and the later revision still applied.
   //
@@ -1957,11 +1924,9 @@ fn a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held() {
   // The streaming face, read between pushes: the word the prefill cannot carry
   // is SETTLED, and the holdback is the one word that survives the filter whole.
   assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A", " S"], Vec::<&str>::new()),
-    "a word the decoder can never be given is CONFIRMED, never held -- and \
-     outright, since \" S\" ends exactly where the watermark starts and no \
-     offered word can overlap it (codex round 12, finding 1)",
+    confirmed_texts(&agreement),
+    vec![" A", " S"],
+    "a word the decoder can never be given is CONFIRMED, never held",
   );
   assert_eq!(
     agreement
@@ -1979,9 +1944,8 @@ fn a_holdback_word_the_prefill_would_filter_is_confirmed_rather_than_held() {
   );
 
   // The face the decoder sees: every id the engine issues survives BOTH of
-  // `prefill_tokens`'s reductions, so the equality
-  // `prefill_reproduces_holdback` checks really does establish that the
-  // hypothesis was written to begin with the whole holdback.
+  // `prefill_tokens`'s reductions, so the retarget really does hand the decoder
+  // the whole holdback.
   let next = agreement.decoding_options_for_next(&DecodingOptions::new());
   assert!(
     next
@@ -2313,8 +2277,8 @@ fn the_first_strides_prompt_is_the_bare_start_of_transcript() {
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn the_prefill_reaches_decode_text_as_the_whole_holdback() {
-  // The contract `LocalAgreement::prefill_reproduces_holdback` rests on, pinned
-  // at the layer that decides it. `DecodingOptions::prefix_tokens` is
+  // The contract `budgeted_split`'s budget argument rests on, pinned at the
+  // layer that decides it. `DecodingOptions::prefix_tokens` is
   // only what the engine RECORDED; `prefill_tokens` keeps just the last
   // `MAX_TOKEN_CONTEXT / 2` of them and drops every id at or above
   // `special_token_begin` before `decode_text` sees a single token. What the
@@ -2383,122 +2347,109 @@ fn the_prefill_reaches_decode_text_as_the_whole_holdback() {
 }
 
 #[test]
-fn an_empty_holdback_leaves_nothing_pending_because_nothing_could_ever_clear_it() {
-  // The second half of the advance's reachability split, and the reason the
-  // promotion above can read `prefill_reproduces_holdback` without ever reading
-  // it VACUOUSLY. That predicate answers TRUE for anything when the holdback is
-  // empty -- a state `budgeted_split` reaches by design (round 7, finding 2).
+fn an_empty_holdback_leaves_a_zero_duration_word_at_the_watermark() {
+  // RULE W's ONE RESIDUAL, characterized rather than closed. The postcondition
+  // -- `confirmed.last().start() < last_agreed_seconds` strictly -- is a claim
+  // about a NON-EMPTY holdback, because the watermark is then the first held
+  // word's start and the rule widens past any tie with it. When
+  // `budgeted_split` empties the holdback the watermark falls back to
+  // `common.last().end()` instead, and Rule W has no `common[split]` to anchor
+  // against: if that last word has `start == end` the watermark EQUALS its
+  // start, the word passes `watermark_filtered`'s own `start >= watermark`, and
+  // a re-decode that offers it back -- with no holdback, so no prefill to
+  // displace it -- confirms it a SECOND time.
   //
-  // Rather than bolt a clause on for a state that must not arise, the state is
-  // removed: a pending word waits for a hypothesis this engine ANCHORED, and
-  // with nothing held back no future result can ever be one. Waiting would be an
-  // indefinite hold, and `finalize`'s superseded path would end it by deleting a
-  // word the stream produced -- exactly the loss round 7 finding 2 removed. So
-  // the whole widened-past run is settled at the advance, and
-  // `pending_words` non-empty implies `last_agreed_words` non-empty for good.
+  // Reaching it needs three things at once, and the driver supplies none of
+  // them: a non-default `agreement_count_needed` (here 1), a word whose OWN
+  // tokens exceed `MAX_HOLDBACK_PREFILL_TOKENS` so the split runs to
+  // `common.len()`, and a ZERO-DURATION word in that position.
+  // `LocalAgreementTranscriber` never leaves `DEFAULT_AGREEMENT_COUNT_NEEDED`,
+  // and `add_word_timestamps` never emits a 112-token word.
   //
-  // The shape: " L" runs 1.0..5.0 and " B" 2.0..3.0, so the budget forces the
-  // split to the end (an empty holdback, watermark at 3.0) and " L" OVERLAPS the
-  // still-open span -- the one case the overlap test alone would defer. Word ends
-  // inside a hypothesis are not monotone, which is also why the advance takes a
-  // `position` prefix.
-  //
-  // Mutation proof, one face each, and the second one is codex round 13 finding
-  // 1's recommendation run end to end. Dropping the
-  // `self.last_agreed_words.is_empty()` arm from the advance's second split reds
-  // the STATE face at ([], [" L", " B"]) -- and stops there: the transcript
-  // survives, because `prefill_reproduces_holdback` answers the unanchored
-  // continuation below TRUE vacuously and the promotion puts both words back.
-  // (Round 12 recorded that mutation as reaching the transcript too; it does
-  // not, and the vacuity is why.) Add the other two clauses that finding asks
-  // for -- promote only on a NON-VACUOUS anchor (`&& !self.last_agreed_words
-  // .is_empty()`) -- and the transcript face reds at " Y Z": " L" and " B"
-  // deleted, which is round 7 finding 2's loss returning.
-  let long = || word_of_tokens(" L", 1.0, 5.0, 1);
-  let big = || word_of_tokens(" B", 2.0, 3.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
-  let y = || word(" Y", 3.0, 5.0);
-  let z = || word(" Z", 5.0, 6.0);
+  // Recorded, not repaired: the alternatives are anchoring the empty-holdback
+  // watermark at `end + epsilon` (a threshold with the same cliff one instant
+  // further on, and one that makes the watermark a value no word's `start` ever
+  // equals) or refusing the advance (the blocking policy this issue's ledger
+  // already refuted for deadlock).
+  let a = || word(" A", 0.0, 1.0);
+  let zero = || word_of_tokens(" Z", 1.0, 1.0, MAX_HOLDBACK_PREFILL_TOKENS + 1);
+  let b = || word(" B", 1.0, 2.0);
 
-  let mut agreement = LocalAgreement::new();
-  let opening = || result_with_words(vec![long(), big()]);
+  let mut agreement = LocalAgreement::new().with_agreement_count_needed(1);
+  let opening = || result_with_words(vec![a(), zero()]);
   agreement.ingest_streamed(opening());
   assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert!(
-    agreement.last_agreed_words_slice().is_empty(),
-    "non-vacuous: the budget left NOTHING held back, so there is no anchor a \
-     later result could be checked against",
-  );
-  assert_eq!(agreement.last_agreed_seconds(), 3.0);
-  assert!(
-    long().end() > agreement.last_agreed_seconds(),
-    "non-vacuous: \" L\" DOES overlap the still-open span, so the overlap test \
-     alone would have deferred it",
+  assert_eq!(
+    (
+      confirmed_texts(&agreement),
+      agreement.last_agreed_words_slice().len(),
+      agreement.last_agreed_seconds()
+    ),
+    (vec![" A", " Z"], 0, 1.0),
+    "non-vacuous: the budget emptied the holdback, so the watermark is \
+     \" Z\"'s END -- which for a zero-duration word is also its START",
   );
   assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" L", " B"], Vec::<&str>::new()),
-    "with no anchor to wait for, the widened-past run is settled at the advance",
+    agreement
+      .confirmed_words_slice()
+      .last()
+      .map(WordTiming::start),
+    Some(agreement.last_agreed_seconds()),
+    "the postcondition is VACUOUS here: with no held-back word the last \
+     confirmed word's start EQUALS the watermark instead of preceding it",
   );
 
-  // And it stays settled through a continuation the engine did not write.
-  let unmarked = DecodingOptions::new();
-  assert!(
-    agreement.prefill_reproduces_holdback(&unmarked),
-    "non-vacuous: these options satisfy the prefill premise VACUOUSLY -- the \
-     answer that would have been read had anything been left pending",
-  );
+  // The re-decode offers " Z" back at the head of its word list. Nothing
+  // displaces it: the holdback is empty, so `decoding_options_for_next` attaches
+  // an empty prefix and the decoder was never fed a reproduction to begin with.
+  //
+  // One ingest is enough: the previous hypothesis already contributed " Z" at
+  // this watermark, so the pair agrees on it immediately.
   assert!(
     agreement
-      .ingest(result_with_words(vec![y(), z()]), &unmarked)
-      .is_awaiting_agreement()
+      .ingest_streamed(result_with_words(vec![zero(), b()]))
+      .is_advanced()
   );
   assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " L B Y Z",
-    "the finalized face: nothing the stream agreed on was dropped by the wait \
-     it never took",
+    confirmed_texts(&agreement),
+    vec![" A", " Z", " Z"],
+    "CHARACTERIZATION (https://github.com/findit-studio/coremlit/issues/94, \
+     residual 1): the CORRECT answer is [\" A\", \" Z\"] -- \" Z\" is one word \
+     the stream produced once and it reaches the confirmed list twice. Rule W \
+     cannot help: it widens the split past a tie with `common[split]`, and here \
+     the split ran to `common.len()` so there is no `common[split]` to widen \
+     past. If this state is ever closed, assert [\" A\", \" Z\"] and delete this \
+     message.",
   );
 }
 
 #[test]
 fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
-  // #94 (codex round 13, finding 1), REFUTED HERE RATHER THAN FIXED, and this is
-  // the row that says why. The finding reads the empty-holdback arm of the
-  // advance's second split as a NEW hazard: `overlapping` is forced to
-  // `widened.len()`, so a widened-past word whose `end` is past the watermark is
-  // confirmed even though a later unanchored decode could re-read its audio, and
-  // `an_empty_holdback_leaves_nothing_pending_because_nothing_could_ever_clear_
-  // it` is offered as the counterexample (" L" 1.0..5.0 confirmed, then " Y"
-  // 3.0..5.0 landing beside it).
+  // #94 (codex round 13, finding 1), REFUTED RATHER THAN FIXED, and this is the
+  // row that says why. The finding reads "a word is confirmed even though a
+  // later decode could re-read its audio" as a hazard some particular arm of the
+  // advance introduces. It is not: `common[..split]` -- the MAINLINE
+  // confirmation, the one Swift has and this port has never touched -- appends
+  // with no overlap test of any kind.
   //
-  // That reading of the state IS what that test asserts. What makes it not a
-  // defect is this row: `common[..requested]` -- the MAINLINE confirmation, the
-  // one Swift has and this port has never touched -- appends with no overlap
-  // test of any kind, and lands in exactly the same place. Word ends inside a
-  // hypothesis are not monotone, so an agreed word can extend past the first
-  // held-back word's start; here " P" runs 0.0..5.0 while the watermark lands at
-  // " Q"'s 1.0, and the unmarked " Y" that follows re-reads 1.0..5.0. Both are
-  // in the transcript, overlapping.
+  // Word ends inside a hypothesis are not monotone, so an agreed word can extend
+  // past the first held-back word's start. Here " P" runs 0.0..5.0 while the
+  // watermark lands at " Q"'s 1.0, and the " Y" that follows re-reads 1.0..5.0.
+  // Both are in the transcript, overlapping.
   //
-  // So "a confirmed word overlaps a later hypothesis's word" is not a property
-  // the empty-holdback arm introduces; it is the LocalAgreement-2 contract, which
-  // confirms on agreement between two consecutive hypotheses and is append-only.
-  // Whether an offered word is a settled one coming BACK is a question RULE W
-  // makes unaskable rather than answers: the split never puts the watermark at a
+  // So "a confirmed word overlaps a later hypothesis's word" is the
+  // LocalAgreement-2 contract itself, which confirms on agreement between two
+  // consecutive hypotheses and is append-only. Whether an offered word is a
+  // settled one coming BACK is a different question, and RULE W makes it
+  // unaskable rather than answering it: the split never puts the watermark at a
   // tied start, so no confirmed word can pass the offered filter, and " Y" is
-  // simply new text over a span " P" also covers. The alternative the finding
-  // proposes -- hold the word until an anchor
-  // certifies it -- has no terminating condition when the holdback is empty, and
-  // ends in the deletion round 7 finding 2 removed. See that test's own comment.
+  // simply new text over a span " P" also covers. P/Q/R have distinct starts, so
+  // Rule W does not fire here at all.
   //
-  // Mutation proof: this row's whole point is that no mutation of the
-  // empty-holdback arm can red it -- the arm is not on this path. The mutation
-  // that DOES red it is the finding's own recommendation carried to its logical
-  // end: take the same `position(|word| word.end() > self.last_agreed_seconds)`
-  // prefix of `common[..requested]` that the widened run takes, and the state
-  // below reads back ([], []) -- " P" never reaches `confirmed_words_slice()` at
-  // all. Eighteen other rows in this module red with it, which is the measure of
-  // how much of the port that recommendation actually moves.
+  // Mutation proof: apply the finding's recommendation to the mainline --
+  // confirm only the `position(|word| word.end() > self.last_agreed_seconds)`
+  // prefix of `common[..split]` -- and the state below reads back [] : " P"
+  // never reaches `confirmed_words_slice()` at all.
   let p = || word(" P", 0.0, 5.0);
   let q = || word(" Q", 1.0, 2.0);
   let r = || word(" R", 2.0, 3.0);
@@ -2511,10 +2462,9 @@ fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
   assert!(agreement.ingest_streamed(opening()).is_advanced());
   assert_eq!(agreement.last_agreed_seconds(), 1.0);
   assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" P"], Vec::<&str>::new()),
-    "non-vacuous: \" P\" came from `common[..requested]`, not from the widened \
-     run -- nothing was ever pending here",
+    confirmed_texts(&agreement),
+    vec![" P"],
+    "non-vacuous: \" P\" is confirmed by the mainline `common[..split]`",
   );
   assert!(
     p().end() > agreement.last_agreed_seconds(),
@@ -2522,562 +2472,16 @@ fn an_overlapping_agreed_word_is_confirmed_on_the_mainline_path_too() {
      still-open span, with no overlap test anywhere on it",
   );
 
-  let unmarked = DecodingOptions::new();
   assert!(
     agreement
-      .ingest(result_with_words(vec![y(), z()]), &unmarked)
+      .ingest_streamed(result_with_words(vec![y(), z()]))
       .is_awaiting_agreement()
   );
   assert_eq!(
     agreement.finalize(&DecodingOptions::new()).text(),
     " P Y Z",
     "the overlapping confirmed word and the later re-reading of its audio are \
-     BOTH in the transcript -- the append-only contract, reached without the \
-     empty-holdback arm being involved at all",
-  );
-}
-
-#[test]
-fn the_still_open_span_begins_where_the_engines_own_record_does() {
-  // Round 13, finding 2's span, from both ends. `open_record_split` scans the
-  // record the engine would DROP, and that record is `pending_words ++
-  // last_agreed_words` -- so it begins at the pending head whenever anything is
-  // pending, and at the holdback otherwise. Reading only one of the two is a
-  // live hole in each direction, and neither is visible in the shapes above,
-  // where the pending word and the holdback tie at the same start.
-  //
-  // The FIRST case is also round 14 finding 2's boundary seen from the pending
-  // side: the window opens at 2.0, which is inside " S1" (1.5..3.0) and at the
-  // head of " B" (2.0..3.0), so the record splits between them -- the pending
-  // head is preserved because no clip re-read it whole, and the holdback is
-  // superseded because one did. A verdict applied to the whole record cannot
-  // express that in either direction.
-  //
-  // Mutation proof, one per case, each mutating `open_record` AND
-  // `open_record_len` together -- moving only one of them leaves the split
-  // arithmetic inconsistent and the mutation self-cancelling, which is how the
-  // first attempt at this pair passed. Make the record the HOLDBACK alone and
-  // the FIRST case reads back " A S0 C": " S1" is no longer in the record, so
-  // nothing protects it and it goes with " B". Make it PENDING alone and the
-  // SECOND case reads back " P D": nothing is pending, so the record is empty,
-  // every word of it is vacuously re-read, and the holdback goes.
-
-  // A pending word that starts STRICTLY before the holdback -- the shape
-  // `the_split_settles_a_widened_word_the_span_can_never_reach` builds, where
-  // the split widens past two words and only the straddling one stays pending.
-  let a = || word(" A", 0.0, 1.0);
-  let s0 = || special_only_word(" S0", 1.0, 2.0);
-  let s1 = || special_only_word(" S1", 1.5, 3.0);
-  let b = || word(" B", 2.0, 3.0);
-  let c = || word(" C", 3.0, 4.0);
-
-  let mut agreement = LocalAgreement::new().with_agreement_count_needed(3);
-  let opening = || result_with_words(vec![a(), s0(), s1(), b()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A", " S0"], vec![" S1"]),
-    "non-vacuous: the record's head is PENDING, and it starts at 1.5 while the \
-     holdback starts at 2.0",
-  );
-  assert_eq!(agreement.last_agreed_seconds(), 2.0);
-
-  // Exactly at the watermark, which is exactly where the holdback begins -- so
-  // measuring the holdback alone would call this covering. It is not: " S1"
-  // runs from 1.5.
-  let at_the_holdback = DecodingOptions::new().with_clip_timestamps(vec![2.0]);
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![c()]), &at_the_holdback)
-      .is_awaiting_agreement()
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A S0 S1 C",
-    "the pending head is part of the record and no clip re-read it whole, so it \
-     survives a window that superseded the holdback behind it",
-  );
-
-  // The other end: nothing pending at all, so the holdback IS the record.
-  let p = || word(" P", 0.0, 1.0);
-  let q = || word(" Q", 1.0, 2.0);
-  let r = || word(" R", 2.0, 3.0);
-  let d = || word(" D", 3.5, 4.5);
-
-  let mut agreement = LocalAgreement::new();
-  let opening = || result_with_words(vec![p(), q(), r()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" P"], Vec::<&str>::new()),
-    "non-vacuous: NOTHING is pending, so the holdback is the whole record",
-  );
-  assert_eq!(agreement.last_agreed_seconds(), 1.0);
-
-  let past_the_holdback = DecodingOptions::new().with_clip_timestamps(vec![3.5]);
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![d()]), &past_the_holdback)
-      .is_awaiting_agreement()
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " P Q R D",
-    "with nothing pending the holdback is still a record to protect, not an \
-     absent one",
-  );
-}
-
-#[test]
-fn a_gap_between_clip_ranges_does_not_supersede_the_span_no_range_reached() {
-  // #94 (codex round 14, finding 1). COVERAGE IS A SET OF INTERVALS, NOT A
-  // SINGLE HALF-LINE. Round 13 recorded the window a result arrived under as its
-  // FIRST `clip_timestamps` entry and read it as `[decoded_from, ..)`.
-  // `clip_timestamps` is not a start: its own doc says "Explicit `(start, end)`-pair
-  // timestamps ... to split the audio into segments before transcription", and
-  // `WhisperKit::transcribe` hands it straight to `chunker::prepare_seek_clips`,
-  // which pairs the points and decodes each pair as its own clip.
-  //
-  // `[0.0, 0.5, 3.0]` therefore decodes `[0.0, 0.5)` and `[3.0, end)` and NOTHING
-  // between them. The still-open record here is " S1" (1.5..3.0) then " B"
-  // (2.0..3.0), which sits entirely inside that gap -- yet the half-line reading
-  // starts the window at 0.0 and calls the record covered, so a word from the
-  // SECOND range supersedes a span the decoder demonstrably never saw. Two words
-  // the stream agreed on, deleted for a revision that does not exist.
-  // Mutation proof, one per row. Read the first clip point as a half-line
-  // (`clip_timestamps.first()`, then `[start, ..)`, which is what round 13 did)
-  // and ROW 1 reads back " A S0 C" -- " S1" and " B" gone. Make the trailing
-  // comparison STRICT (`word.end() < end`) and ROW 2 reads back
-  // " A S0 S1 B Y": a clip ending exactly where the record does stops covering
-  // it. Test only the word's START against the clip end
-  // (`start <= word.start() && word.start() <= end`) and ROW 3 reads back
-  // " A S0 Y" -- half a word inside the clip counted as re-read. Full OVERLAP
-  // (`start <= word.end() && word.start() <= end`) reds row 1 first, " A S0 C",
-  // because the `[3.0, ..)` clip then touches both record words at the instant
-  // 3.0, and reds five other tests besides.
-  //
-  // The three rows below also pin the two ENDS of a clip against each other. A
-  // range is half-open and a word is covered by CONTAINMENT in ONE of them, so
-  // the trailing comparison is non-strict at a clip that ends exactly where the
-  // record does (row 2) and refuses a clip that ends one word short of it (row
-  // 3) -- overlap would have accepted both, and a strict end would have refused
-  // both. Rows 2 and 3 differ in NOTHING but that clip end.
-  let a = || word(" A", 0.0, 1.0);
-  let s0 = || special_only_word(" S0", 1.0, 2.0);
-  let s1 = || special_only_word(" S1", 1.5, 3.0);
-  let b = || word(" B", 2.0, 3.0);
-  let c = || word(" C", 3.0, 4.0);
-  let y = || word(" Y", 2.0, 2.5);
-
-  let settled = || {
-    let mut agreement = LocalAgreement::new().with_agreement_count_needed(3);
-    let opening = || result_with_words(vec![a(), s0(), s1(), b()]);
-    agreement.ingest_streamed(opening());
-    assert!(agreement.ingest_streamed(opening()).is_advanced());
-    assert_eq!(
-      (confirmed_texts(&agreement), pending_texts(&agreement)),
-      (vec![" A", " S0"], vec![" S1"]),
-      "non-vacuous: the record spans both buckets -- a pending head and a \
-       holdback",
-    );
-    assert_eq!(agreement.last_agreed_seconds(), 2.0);
-    agreement
-  };
-
-  assert_eq!(
-    crate::audio::whisper::audio::chunker::prepare_seek_clips(&[0.0, 0.5, 3.0], 16_000 * 10)
-      .unwrap(),
-    vec![(0, 8_000), (48_000, 160_000)],
-    "non-vacuous: the crate's own range derivation reads these three points as \
-     two disjoint clips, and 1.5..3.0 is in neither",
-  );
-  assert!(
-    s1().start() >= 0.5 && b().end() <= 3.0,
-    "non-vacuous: the whole record lies strictly inside the gap",
-  );
-
-  for (clip, hypothesis, expected, why) in [
-    // The gap. Every word of the record is between the two clips, and the only
-    // word offered comes out of the SECOND one.
-    (
-      vec![0.0, 0.5, 3.0],
-      vec![c()],
-      " A S0 S1 B C",
-      "a word decoded in the range AFTER the gap supersedes nothing inside it",
-    ),
-    // One clip containing the whole record, ending EXACTLY where it ends. The
-    // branch fires as it always did -- this is a coverage test, not a blanket
-    // refusal of a `(start, end)` pair.
-    (
-      vec![0.0, 3.0],
-      vec![y()],
-      " A S0 Y",
-      "a clip that ends exactly where the record does still decoded it whole",
-    ),
-    // The same clip half a second shorter, so it stops between the record's two
-    // words' starts and their shared end. Neither word was decoded WHOLE, so
-    // neither is superseded.
-    (
-      vec![0.0, 2.5],
-      vec![y()],
-      " A S0 S1 B Y",
-      "a clip that only reaches PART of each held word re-read neither of them",
-    ),
-  ] {
-    let mut agreement = settled();
-    let clipped = DecodingOptions::new().with_clip_timestamps(clip.clone());
-    assert!(
-      !agreement.prefill_reproduces_holdback(&clipped),
-      "non-vacuous: unmarked, so nothing is promoted on arrival ({clip:?})",
-    );
-    assert!(
-      agreement
-        .ingest(result_with_words(hypothesis), &clipped)
-        .is_awaiting_agreement(),
-      "it disagrees, so `holdback_superseded` fires ({clip:?})",
-    );
-    assert_eq!(
-      (confirmed_texts(&agreement), pending_texts(&agreement)),
-      (vec![" A", " S0"], vec![" S1"]),
-      "the streaming face is unmoved -- the decision is `finalize`'s alone \
-       ({clip:?})",
-    );
-    assert_eq!(
-      agreement.finalize(&DecodingOptions::new()).text(),
-      expected,
-      "the finalized face, clipped at {clip:?}: {why}",
-    );
-  }
-  assert!(
-    y().start() >= 2.0 && y().end() <= 2.5,
-    "non-vacuous: the offered word is inside BOTH of the last two rows' clips, \
-     so the rows differ only in what the clip reached of the RECORD",
-  );
-}
-
-#[test]
-fn an_agreement_from_past_a_clip_gap_confirms_the_span_no_range_reached() {
-  // #94 (codex round 14, finding 1), the advance's face. Same gapped schedule,
-  // same record, and the same deletion reached without `finalize` at all: two
-  // consecutive hypotheses whose every word comes from the `[3.0, end)` range
-  // agree, and the advance installs `common` over `pending_words` and
-  // `last_agreed_words`. `common` is not a re-reading of 1.5..3.0 -- no decode
-  // in this schedule ever looked there -- so the record is deleted from the
-  // STREAMING face, where nothing downstream can put it back.
-  //
-  // Mutation proof: read the first clip point as a half-line and the streaming
-  // face reads back ([" A", " S0"], []) with the transcript " A S0 C E F". The
-  // two halves of the confirmed prefix have their own falsifiers -- drop the
-  // holdback half of `confirm_the_unread_prefix_and_drop_the_rest` and it reads
-  // ([" A", " S0", " S1"], []); drop the pending half and it reads
-  // ([" A", " S0", " B"], []), which also pins their ORDER.
-  let a = || word(" A", 0.0, 1.0);
-  let s0 = || special_only_word(" S0", 1.0, 2.0);
-  let s1 = || special_only_word(" S1", 1.5, 3.0);
-  let b = || word(" B", 2.0, 3.0);
-  let c = || word(" C", 3.0, 4.0);
-  let e = || word(" E", 4.0, 5.0);
-  let f = || word(" F", 5.0, 6.0);
-
-  let mut agreement = LocalAgreement::new().with_agreement_count_needed(3);
-  let opening = || result_with_words(vec![a(), s0(), s1(), b()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A", " S0"], vec![" S1"]),
-    "non-vacuous: there is a pending word AND a holdback for the advance to \
-     replace",
-  );
-
-  let gapped = DecodingOptions::new().with_clip_timestamps(vec![0.0, 0.5, 3.0]);
-  let resumed = || result_with_words(vec![c(), e(), f()]);
-  assert!(
-    agreement.ingest(resumed(), &gapped).is_awaiting_agreement(),
-    "the first one has nothing to agree with over this span",
-  );
-  assert!(
-    agreement.ingest(resumed(), &gapped).is_advanced(),
-    "the second corroborates it: an advance whose `common` is entirely past the \
-     gap",
-  );
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A", " S0", " S1", " B"], Vec::<&str>::new()),
-    "the streaming face: what no clip in the schedule could re-read, the advance \
-     confirms rather than drops",
-  );
-  assert_eq!(
-    agreement
-      .last_agreed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" C", " E", " F"],
-    "and the holdback is the agreeing pair's own words, as always",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A S0 S1 B C E F",
-    "the finalized face: nothing the stream agreed on was lost to a schedule \
-     that skipped it",
-  );
-}
-
-#[test]
-fn a_window_that_opens_inside_the_record_replaces_only_the_part_it_re_read() {
-  // #94 (codex round 14, finding 2). ONE VERDICT FOR A WHOLE RECORD IS WRONG IN
-  // BOTH DIRECTIONS. Round 13 asked whether the window reached the record's
-  // FIRST word and applied that answer to every word in it. Here " Q" (1.0..2.0)
-  // and " R" (2.0..3.0) are held and the continuation clips at exactly 2.0: " Q"
-  // is outside its window and " R" is wholly inside it. The head-only reading
-  // answers "not covered" and CONFIRMS both -- so " R" becomes irrevocable on the
-  // streaming face at the very moment a hypothesis that did re-read it says it is
-  // " X" instead, and the transcript carries the stale " R" beside its own
-  // revision.
-  //
-  // That is the exact mirror of round 13's finding: there a late-clipped result
-  // was allowed to supersede a record it never saw; here the same conservatism
-  // confirms the portion it DID see and revise. The record splits at the
-  // coverage boundary instead: the uncovered prefix is preserved (or, on the
-  // advance, confirmed) and only the covered suffix is replaced.
-  //
-  // Mutation proof, four ways and both faces. Make the leading comparison STRICT
-  // (`start < word.start()`) and the finalized row reads back " P Q R X D" --
-  // the round-13 answer, and the reason that comparison cannot be tightened.
-  // Make `finalize` drop the whole record (pass `0` where it passes
-  // `open_record_split`) and it reads " P X D"; make the ADVANCE do the same and
-  // the streaming face reads ([" P"], []). Read the first clip point as a
-  // half-line, or test only the word's START, or scan FORWARD for the first
-  // covered word (`position`) instead of back over the covered suffix, and the
-  // last row reads back " P Y" -- " Q" and " R" both replaced, the second of
-  // them from behind a word no clip reached.
-  let p = || word(" P", 0.0, 1.0);
-  let q = || word(" Q", 1.0, 2.0);
-  let r = || word(" R", 2.0, 3.0);
-  let x = || word(" X", 2.0, 3.0);
-  let d = || word(" D", 3.0, 4.0);
-
-  let settled = || {
-    let mut agreement = LocalAgreement::new();
-    let opening = || result_with_words(vec![p(), q(), r()]);
-    agreement.ingest_streamed(opening());
-    assert!(agreement.ingest_streamed(opening()).is_advanced());
-    assert_eq!(
-      (confirmed_texts(&agreement), pending_texts(&agreement)),
-      (vec![" P"], Vec::<&str>::new()),
-      "non-vacuous: TWO words are held, and the window below opens between them",
-    );
-    assert_eq!(agreement.last_agreed_seconds(), 1.0);
-    agreement
-  };
-
-  // Exactly the second held word's start, which is strictly past the record's
-  // own head. `" R"` is wholly inside `[2.0, ..)`; `" Q"` is wholly outside it.
-  let inside = || DecodingOptions::new().with_clip_timestamps(vec![2.0]);
-  assert!(
-    q().start() < 2.0 && r().start() >= 2.0,
-    "non-vacuous: the window opens strictly inside the record",
-  );
-
-  // The finalized face: one disagreeing hypothesis.
-  let mut agreement = settled();
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![x(), d()]), &inside())
-      .is_awaiting_agreement(),
-    "it disagrees, so `holdback_superseded` fires",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " P Q X D",
-    "the revised half is replaced by its revision and the unreachable half is \
-     kept -- not both readings of 2.0..3.0 side by side",
-  );
-
-  // The streaming face: two agreeing hypotheses, so the advance decides.
-  let mut agreement = settled();
-  let resumed = || result_with_words(vec![x(), d()]);
-  assert!(
-    agreement
-      .ingest(resumed(), &inside())
-      .is_awaiting_agreement()
-  );
-  assert!(agreement.ingest(resumed(), &inside()).is_advanced());
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" P", " Q"], Vec::<&str>::new()),
-    "the streaming face: only the half the pair could not re-read is made \
-     irrevocable -- confirming \" R\" here would strand it against its own \
-     revision",
-  );
-  assert_eq!(
-    agreement
-      .last_agreed_words_slice()
-      .iter()
-      .map(WordTiming::word)
-      .collect::<Vec<_>>(),
-    vec![" X", " D"],
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " P Q X D",
-    "and the transcript agrees with the streaming face word for word",
-  );
-
-  // THE OTHER DIRECTION, and why the split is the start of the longest COVERED
-  // SUFFIX rather than the first covered word. A clip that CLOSES inside the
-  // record re-read " Q" and not " R", so the covered word is the one in FRONT.
-  // Replacing from it would take " R" with it -- a deletion, from behind a word
-  // the window never reached -- so the boundary moves past both and the whole
-  // record is preserved. The cost is the erring-wide one this rule is drawn to
-  // pay: " Q" reaches the transcript beside its own revision " Y". A repetition,
-  // not a deletion, and the same direction the advance's `position` split takes
-  // for the same reason.
-  let closing_inside = DecodingOptions::new().with_clip_timestamps(vec![0.0, 2.0]);
-  let y = || word(" Y", 1.0, 2.0);
-  assert!(
-    q().end() <= 2.0 && r().end() > 2.0,
-    "non-vacuous: the clip contains the FIRST held word whole and the second \
-     only in part",
-  );
-  let mut agreement = settled();
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![y()]), &closing_inside)
-      .is_awaiting_agreement(),
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " P Q R Y",
-    "a covered word in front of an uncovered one is kept, so the uncovered one \
-     is never replaced out from behind it",
-  );
-}
-
-#[test]
-fn a_final_pair_that_agreed_past_an_unreachable_record_keeps_what_they_agreed_on() {
-  // #94 (codex round 14). The record and the TAIL are two questions, and only
-  // the record's half belongs to coverage. Round 13's `finalize` guard made
-  // "this hypothesis re-read the record" decide both at once; round 14's split
-  // answers the record's half by itself -- a record nothing re-read gets
-  // `open_record_split == len` and is kept whole either way -- leaving the guard
-  // deciding only whether the tail is `hypothesis_words` or Swift's
-  // `findLongestDifferentSuffix(prevWords, hypothesisWords)`.
-  //
-  // Nothing in the suite could tell the two apart, and every shape that CAN
-  // makes the subtraction wrong. Here two consecutive late-clipped hypotheses
-  // both produce " M" at 3.0..4.0 -- a one-word common prefix, short of the
-  // threshold of 2, so it disagrees and " M" is never confirmed. Swift subtracts
-  // it on the premise that `lastAgreedWords` supplies it; `lastAgreedWords` is
-  // " Q R" at 1.0..3.0, which has nothing to do with " M", so subtracting drops
-  // a word BOTH hypotheses produced and nothing puts it back. That is
-  // `a_disagreeing_final_pair_keeps_the_words_both_hypotheses_agreed_on`'s
-  // defect reached with a NON-empty holdback.
-  //
-  // Mutation proof: restore the conjunct (`&& (record_len == 0 ||
-  // open_record_split < record_len)`, with `record_len` re-derived from
-  // `open_record_len()`) and this reads back " P Q R Z" -- " M" gone.
-  let p = || word(" P", 0.0, 1.0);
-  let q = || word(" Q", 1.0, 2.0);
-  let r = || word(" R", 2.0, 3.0);
-  let m = || word(" M", 3.0, 4.0);
-  let n = || word(" N", 4.0, 5.0);
-  let z = || word(" Z", 4.0, 5.0);
-
-  let mut agreement = LocalAgreement::new();
-  let opening = || result_with_words(vec![p(), q(), r()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" P"], Vec::<&str>::new()),
-    "non-vacuous: the holdback is NON-empty, which is what separates this from \
-     the empty-holdback face of the same defect",
-  );
-
-  // Strictly past every word of the record, so nothing in it is re-read and the
-  // record survives whichever tail is taken.
-  let late = DecodingOptions::new().with_clip_timestamps(vec![3.0]);
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![m(), n()]), &late)
-      .is_awaiting_agreement()
-  );
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![m(), z()]), &late)
-      .is_awaiting_agreement(),
-    "a ONE-word common prefix is short of the threshold, so this disagrees too",
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " P Q R M Z",
-    "the unreachable record is kept whole AND the word both hypotheses produced \
-     survives -- the subtraction has no holdback to justify it here",
-  );
-}
-
-#[test]
-fn the_split_settles_a_widened_word_the_span_can_never_reach() {
-  // The line the advance's second split draws, asserted from both sides in one
-  // stream. `budgeted_split` widens past BOTH " S" words here; the still-open
-  // span begins at " B"'s start, and only the word whose extent crosses that
-  // point is still in play. The other one is settled outright -- every word the
-  // engine will ever be offered again starts at or after the watermark, so
-  // nothing can overlap it, and no provenance can change that.
-  //
-  // Deferring it anyway would be strictly worse than the round-8 behaviour it
-  // replaces: `finalize`'s superseded branch would drop a word the stream
-  // produced and nothing revised.
-  //
-  // Mutation proof: relax the advance's `word.end() > self.last_agreed_seconds`
-  // to `>=` and the first assertion reads back ([" A"], [" S0", " S1"]); test
-  // `word.start() >= self.last_agreed_seconds` instead -- the plausible mistake,
-  // since `offered` is filtered on `start` -- and it reads
-  // ([" A", " S0", " S1"], []), which the second half then falsifies too: the
-  // unmarked revision lands beside " S1" rather than replacing it,
-  // " A S0 S1 Y B C".
-  //
-  // `agreement_count_needed` is 3 so that BOTH " S" words fall inside
-  // `common[requested..split]`: at the default 2 the first of them would be
-  // confirmed by `common[..requested]` regardless, and the boundary under test
-  // would decide nothing.
-  let a = || word(" A", 0.0, 1.0);
-  // Ends exactly where the still-open span begins: unreachable from inside it.
-  let s0 = || special_only_word(" S0", 1.0, 2.0);
-  // STRADDLES that point -- starts before it, ends after it -- so an offered
-  // word can overlap it and it is still in play.
-  let s1 = || special_only_word(" S1", 1.5, 3.0);
-  let b = || word(" B", 2.0, 3.0);
-  let y = || word(" Y", 2.0, 3.0);
-  let c = || word(" C", 3.0, 4.0);
-
-  let mut agreement = LocalAgreement::new().with_agreement_count_needed(3);
-  let opening = || result_with_words(vec![a(), s0(), s1(), b()]);
-  agreement.ingest_streamed(opening());
-  assert!(agreement.ingest_streamed(opening()).is_advanced());
-  assert_eq!(agreement.last_agreed_seconds(), 2.0);
-  assert_eq!(
-    (confirmed_texts(&agreement), pending_texts(&agreement)),
-    (vec![" A", " S0"], vec![" S1"]),
-    "the widened-past words split again, on whether the still-open span can \
-     reach them",
-  );
-
-  let unmarked = DecodingOptions::new();
-  assert!(
-    agreement
-      .ingest(result_with_words(vec![y(), b(), c()]), &unmarked)
-      .is_awaiting_agreement()
-  );
-  assert_eq!(
-    agreement.finalize(&DecodingOptions::new()).text(),
-    " A S0 Y B C",
-    "the unreachable word survives the revision; the reachable one is replaced \
-     by it",
+     BOTH in the transcript -- the append-only contract",
   );
 }
 
@@ -3088,9 +2492,9 @@ fn the_holdback_filter_reads_the_configured_special_range_not_the_floor() {
   // families, but `WhisperTokenizer::from_folder` loads any parseable
   // `tokenizer.json` and probes `<|endoftext|>` for that artifact's OWN
   // threshold, rejecting nothing below the floor. For such an artifact the
-  // engine calls an id carriable that `prefill_tokens` erases, the equality
-  // `prefill_reproduces_holdback` checks is satisfied by a prefix the decoder is
-  // given only part of, and round 8's defect is back with no caller lying.
+  // engine calls an id carriable that `prefill_tokens` erases, so the retarget
+  // promises a prefix the decoder is given only part of, and round 8's defect is
+  // back with no caller lying.
   //
   // Threading the real value closes it where the value is known and costs
   // nothing where it is not: the default is exactly the floor, so no existing

--- a/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
+++ b/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
@@ -40,45 +40,6 @@ const DEFAULT_NO_SPEECH_TOKEN: u32 = 50_362;
 const DEFAULT_NO_TIMESTAMPS_TOKEN: u32 = 50_363;
 const DEFAULT_TIME_TOKEN_BEGIN: u32 = 50_364;
 
-/// The LOWEST `special_token_begin` any Whisper vocabulary reports — the
-/// conservative test for "a decoder might treat this id as special" available
-/// to code that holds no tokenizer.
-///
-/// [`SpecialTokens::special_token_begin`] is probed per vocabulary
-/// (`<|endoftext|>`'s id), so it is a property of the loaded artifact rather
-/// than a constant: multilingual Whisper puts it at
-/// `DEFAULT_SPECIAL_TOKEN_BEGIN` (`50257`, the value every tokenizer under
-/// `Models/tokenizers/` probes to), and English-only Whisper — the `51864`-vocab
-/// variants [`crate::audio::whisper::model::detect_variant`] recognizes as
-/// `tiny.en`/`base.en`/`small.en`/`medium.en` — reuses GPT-2's table, where
-/// `<|endoftext|>` is `50256` and every special id shifts down by one. This is
-/// the minimum of the two, so `id < MIN_SPECIAL_TOKEN_BEGIN` implies `id <
-/// special_token_begin` for EITHER family.
-///
-/// It is deliberately a floor rather than "the" threshold. Over-estimating a
-/// vocabulary's special range only makes a caller treat one ORDINARY
-/// multilingual id — `50256`, which that vocabulary maps to the empty string —
-/// as though a filter might drop it; under-estimating it lets a genuinely
-/// filtered id through. [`crate::audio::whisper::stream::agreement`]'s holdback
-/// is the caller this exists for: it must decide, with no tokenizer in hand,
-/// whether [`crate::audio::whisper::decode::prefill_tokens`] will carry a word's
-/// tokens into the initial prompt whole.
-///
-/// **It is a DEFAULT, not an invariant, and nothing here enforces it.**
-/// [`WhisperTokenizer::from_folder`] loads any parseable `tokenizer.json` and
-/// takes [`SpecialTokens::special_token_begin`] from whatever `<|endoftext|>`
-/// that artifact happens to map to — including something lower, which would make
-/// this an OVER-estimate of nothing and an UNDER-estimate of that vocabulary's
-/// special range. The loader deliberately does not reject such an artifact: this
-/// bound is one module's premise, the rest of the crate decodes such a
-/// vocabulary correctly, and refusing the load would take the whole pipeline down
-/// over a streaming-only concern. The engine takes the real value instead — see
-/// [`crate::audio::whisper::stream::agreement::LocalAgreement::special_token_begin`],
-/// which defaults to this and which
-/// [`crate::audio::whisper::stream::agreement::LocalAgreementTranscriber::new`]
-/// sets from the loaded vocabulary.
-pub const MIN_SPECIAL_TOKEN_BEGIN: u32 = 50_256;
-
 /// Whisper's fixed special-token ids, resolved from the loaded tokenizer's
 /// vocabulary with Swift's hardcoded defaults as fallback for any probe
 /// that misses (Swift `SpecialTokens`, `Models.swift:1111-1149`; probed in

--- a/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
+++ b/crates/coremlit/src/audio/whisper/tokenizer/mod.rs
@@ -40,6 +40,45 @@ const DEFAULT_NO_SPEECH_TOKEN: u32 = 50_362;
 const DEFAULT_NO_TIMESTAMPS_TOKEN: u32 = 50_363;
 const DEFAULT_TIME_TOKEN_BEGIN: u32 = 50_364;
 
+/// The LOWEST `special_token_begin` any Whisper vocabulary reports — the
+/// conservative test for "a decoder might treat this id as special" available
+/// to code that holds no tokenizer.
+///
+/// [`SpecialTokens::special_token_begin`] is probed per vocabulary
+/// (`<|endoftext|>`'s id), so it is a property of the loaded artifact rather
+/// than a constant: multilingual Whisper puts it at
+/// `DEFAULT_SPECIAL_TOKEN_BEGIN` (`50257`, the value every tokenizer under
+/// `Models/tokenizers/` probes to), and English-only Whisper — the `51864`-vocab
+/// variants [`crate::audio::whisper::model::detect_variant`] recognizes as
+/// `tiny.en`/`base.en`/`small.en`/`medium.en` — reuses GPT-2's table, where
+/// `<|endoftext|>` is `50256` and every special id shifts down by one. This is
+/// the minimum of the two, so `id < MIN_SPECIAL_TOKEN_BEGIN` implies `id <
+/// special_token_begin` for EITHER family.
+///
+/// It is deliberately a floor rather than "the" threshold. Over-estimating a
+/// vocabulary's special range only makes a caller treat one ORDINARY
+/// multilingual id — `50256`, which that vocabulary maps to the empty string —
+/// as though a filter might drop it; under-estimating it lets a genuinely
+/// filtered id through. [`crate::audio::whisper::stream::agreement`]'s holdback
+/// is the caller this exists for: it must decide, with no tokenizer in hand,
+/// whether [`crate::audio::whisper::decode::prefill_tokens`] will carry a word's
+/// tokens into the initial prompt whole.
+///
+/// **It is a DEFAULT, not an invariant, and nothing here enforces it.**
+/// [`WhisperTokenizer::from_folder`] loads any parseable `tokenizer.json` and
+/// takes [`SpecialTokens::special_token_begin`] from whatever `<|endoftext|>`
+/// that artifact happens to map to — including something lower, which would make
+/// this an OVER-estimate of nothing and an UNDER-estimate of that vocabulary's
+/// special range. The loader deliberately does not reject such an artifact: this
+/// bound is one module's premise, the rest of the crate decodes such a
+/// vocabulary correctly, and refusing the load would take the whole pipeline down
+/// over a streaming-only concern. The engine takes the real value instead — see
+/// [`crate::audio::whisper::stream::agreement::LocalAgreement::special_token_begin`],
+/// which defaults to this and which
+/// [`crate::audio::whisper::stream::agreement::LocalAgreementTranscriber::new`]
+/// sets from the loaded vocabulary.
+pub const MIN_SPECIAL_TOKEN_BEGIN: u32 = 50_256;
+
 /// Whisper's fixed special-token ids, resolved from the loaded tokenizer's
 /// vocabulary with Swift's hardcoded defaults as fallback for any probe
 /// that misses (Swift `SpecialTokens`, `Models.swift:1111-1149`; probed in

--- a/crates/coremlit/tests/whisper/streaming.rs
+++ b/crates/coremlit/tests/whisper/streaming.rs
@@ -1,11 +1,11 @@
 //! Simulated-stream LocalAgreement-2 on jfk.wav / tiny (ports the
 //! whisperkit-cli `transcribeStreamSimulated` loop, TranscribeCLI.swift:322-424).
 //!
-//! # Two portable properties, and one host-scoped measurement
+//! # Three portable properties, and two host-scoped measurements
 //!
 //! The PORTABLE properties are asserted on every host, because each compares
 //! this run against ITSELF on the same machine — host fp16 drift moves both
-//! sides of the comparison together, so neither can red for hardware reasons:
+//! sides of the comparison together, so none can red for hardware reasons:
 //!
 //! - **Truncation, never rewriting.** [`finalize`](
 //!   coremlit::audio::whisper::stream::agreement::LocalAgreementTranscriber::finalize)'s
@@ -17,20 +17,35 @@
 //! - **Monotone confirmation.** Across the pushes, `confirmed_words_slice()`
 //!   only grows, `last_agreed_seconds()` never decreases, and no already-
 //!   confirmed word is revised.
+//! - **Honest outcome labels.** Every [`AgreementOutcome`] a push reported is
+//!   the one an INDEPENDENT reconstruction of that push says it had to be. The
+//!   reconstruction ([`Route`]) reads engine state — which hypotheses
+//!   `results_slice()` retained, whether the retained one carried word timings,
+//!   and the common-prefix length recomputed from the results themselves — and
+//!   never the label under test. WHICH strides agree is host-scoped; that a
+//!   label matches its own push's route is not.
 //!
-//! Both are non-vacuous by construction: the prefix check refuses a confirmed
-//! text too short to have completed one agreement round (every string starts
-//! with the empty string, so an unconstrained prefix check on an empty
-//! confirmation asserts nothing), and the monotonicity check refuses a run in
-//! which nothing was ever confirmed. The falsifiers for each are the hermetic
-//! tests at the bottom of this file; they are NOT `#[ignore]`d, so the
-//! predicates are gated on every host, model or no model.
+//! All three are non-vacuous by construction: the prefix check refuses a
+//! confirmed text too short to have completed one agreement round (every string
+//! starts with the empty string, so an unconstrained prefix check on an empty
+//! confirmation asserts nothing), the monotonicity check refuses a run in which
+//! nothing was ever confirmed, and the label check refuses a run in which no
+//! stride ever progressed. The falsifiers for each are the hermetic tests at the
+//! bottom of this file; they are NOT `#[ignore]`d, so the predicates are gated
+//! on every host, model or no model.
 //!
-//! The MEASURED observation is whether the confirmed stream ever reaches the
-//! clip's canonical phrase, [`CANONICAL_PHRASE`]. That is a description of one
-//! machine, not a property of the port, so it rides `tests/support/measured_band.rs`'s
-//! three-way host gate: asserted on [`CHARACTERIZED_ON`], computed and PRINTED
-//! everywhere else.
+//! The MEASURED observations are TWO, both descriptions of one machine rather
+//! than properties of the port, so both ride `tests/support/measured_band.rs`'s
+//! three-way host gate — asserted on [`CHARACTERIZED_ON`], computed and PRINTED
+//! everywhere else:
+//!
+//! - whether the confirmed stream ever reaches the clip's canonical phrase,
+//!   [`CANONICAL_PHRASE`];
+//! - the per-stride outcome sequence, [`RECORDED_OUTCOMES`] — the belt to the
+//!   label check's braces. The label check proves each label matches its own
+//!   push's route on every host; this pins WHICH routes this clip takes here,
+//!   and so catches a stride whose behaviour changed while its label stayed
+//!   self-consistent.
 //!
 //! # Why the phrase describes a host rather than the port
 //!
@@ -95,8 +110,10 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use coremlit::audio::whisper::{
   options::{DecodingOptions, Options},
   result::WordTiming,
-  stream::agreement::{AgreementOutcome, LocalAgreement, STRIDE_SAMPLES},
-  text::normalized,
+  stream::agreement::{
+    AgreementOutcome, DEFAULT_AGREEMENT_COUNT_NEEDED, LocalAgreement, STRIDE_SAMPLES,
+  },
+  text::{find_longest_common_prefix, normalized},
   transcribe::WhisperKit,
 };
 
@@ -137,14 +154,73 @@ const CHARACTERIZED_ON: Option<common::CharacterizedHost> = Some(common::Charact
   arch: "arm64",
 });
 
-/// The exact command that re-measures the phrase on THIS machine, quoted into
-/// every band-gate banner so a log names its own fix.
+/// The per-stride [`AgreementOutcome`] sequence the shipping JFK stream reports
+/// on [`CHARACTERIZED_ON`].
+///
+/// MEASURED, exactly like [`CANONICAL_PHRASE`] and for the same reason: which
+/// strides agree, and which of the agreeing ones move anything, is decided by
+/// the host-scoped timestamp-mass gate this module's docs describe. It
+/// therefore rides the same three-way band gate — asserted on the recorded host
+/// class, computed and PRINTED everywhere else — and not a portable `assert!`.
+///
+/// # Why record a sequence at all, next to a portable relation
+///
+/// [`check_outcomes_match_independent_evidence`] is the portable braces and
+/// this is the belt. The relation proves each label matches the route its push
+/// took; this pins WHICH routes this clip takes on this machine. They fail on
+/// different things: the relation catches a label that contradicts the engine
+/// on any host, and this catches a stride whose behaviour changed while its
+/// label stayed self-consistent — the stationary strides 7 and 9 becoming
+/// agreeing-and-moving ones, say, or stride 1 finding word timings it did not
+/// have.
+///
+/// The `[outcome ...]` trace this is compared against is also digested outside
+/// the test, and the two must agree by construction:
+///
+/// ```text
+/// cargo test -p coremlit --features whisper --test whisper_streaming -- --ignored --nocapture \
+///   | grep -E '^\[outcome' | shasum -a 256
+/// 9ce93ed6b510bba3c685061c03110cae2108cf0a6e813528fc47ee41c3e51911
+/// ```
+///
+/// To re-record: run that command, read the `[outcome ...]` lines, and replace
+/// this list — but only from a host that matches [`CHARACTERIZED_ON`]. A
+/// sequence measured anywhere else must not be armed here, for the reason the
+/// [`common::BandVerdict::Foreign`] path exists.
+const RECORDED_OUTCOMES: &[AgreementOutcome] = &[
+  AgreementOutcome::NoWordTimings,
+  AgreementOutcome::AwaitingAgreement,
+  AgreementOutcome::Progressed,
+  AgreementOutcome::Progressed,
+  AgreementOutcome::Progressed,
+  AgreementOutcome::Progressed,
+  AgreementOutcome::Stationary,
+  AgreementOutcome::Progressed,
+  AgreementOutcome::Stationary,
+  AgreementOutcome::Progressed,
+  AgreementOutcome::Progressed,
+];
+
+/// [`RECORDED_OUTCOMES`] as the `[outcome ...]` trace spells it, for a band
+/// line and a failure message.
+fn joined_labels(outcomes: &[AgreementOutcome]) -> String {
+  outcomes
+    .iter()
+    .map(ToString::to_string)
+    .collect::<Vec<_>>()
+    .join(",")
+}
+
+/// The exact command that re-measures BOTH host-scoped measurements — the
+/// phrase and [`RECORDED_OUTCOMES`] — on THIS machine, quoted into every
+/// band-gate banner so a log names its own fix.
 fn recharacterize_command() -> String {
   "cargo test -p coremlit --features whisper --test whisper_streaming -- --ignored --nocapture\n                \
-   then read the printed `[band]` line: if the phrase was present, set\n                \
+   then read the printed `[band]` lines: if the phrase was present, set\n                \
    CHARACTERIZED_ON in crates/coremlit/tests/whisper/streaming.rs to the `this host`\n                \
-   line above; if it was ABSENT, leave the recorded host alone — a host that does not\n                \
-   produce the phrase must not arm it."
+   line above and replace RECORDED_OUTCOMES with the `[outcome ...]` labels the same\n                \
+   run printed; if the phrase was ABSENT, leave BOTH alone — a host that does not\n                \
+   produce the phrase must not arm either of them."
     .to_string()
 }
 
@@ -159,8 +235,8 @@ fn recharacterize_command() -> String {
 /// `[stride ...]` trace exists to prove that the watermark work changes no
 /// transcript, and mixing the outcome label into it made an honest-signal change
 /// disturb a guard that is not about signals. See
-/// [`check_outcomes_match_observed_progress`] for what the labels are asserted
-/// against instead.
+/// [`check_outcomes_match_independent_evidence`] for what the labels are
+/// asserted against instead.
 #[derive(Debug, Clone)]
 struct Confirmation {
   /// 1-based stride index; also the buffered seconds, at a 1 s stride.
@@ -177,16 +253,25 @@ struct Confirmation {
   /// 1 s pushes this is one element — but it is a list because `push_samples`
   /// returns one.
   outcomes: Vec<AgreementOutcome>,
+  /// What this push looked like from OUTSIDE [`Self::outcomes`] — the oracle's
+  /// input. See [`OutcomeEvidence`].
+  evidence: OutcomeEvidence,
 }
 
 impl Confirmation {
-  fn observe(stride: usize, agreement: &LocalAgreement, outcomes: Vec<AgreementOutcome>) -> Self {
+  fn observe(
+    stride: usize,
+    agreement: &LocalAgreement,
+    outcomes: Vec<AgreementOutcome>,
+    evidence: OutcomeEvidence,
+  ) -> Self {
     Self {
       stride,
       last_agreed_seconds: agreement.last_agreed_seconds(),
       confirmed: normalized_words(agreement.confirmed_words_slice()),
       held_back: normalized_words(agreement.last_agreed_words_slice()),
       outcomes,
+      evidence,
     }
   }
 
@@ -205,6 +290,208 @@ impl Confirmation {
 /// Word timings as the normalized word strings the agreement compares.
 fn normalized_words(words: &[WordTiming]) -> Vec<String> {
   words.iter().map(|word| normalized(word.word())).collect()
+}
+
+/// `words` filtered the way [`LocalAgreement::ingest`] filters BOTH sides of
+/// its agreement comparison — `start >= watermark`. The engine's own
+/// `watermark_filtered` is crate-internal; this is that filter rebuilt from the
+/// public parts, so [`OutcomeEvidence::common_prefix`] compares the same two
+/// lists the engine compared.
+fn at_or_past(words: &[WordTiming], watermark: f32) -> Vec<WordTiming> {
+  words
+    .iter()
+    .filter(|word| word.start() >= watermark)
+    .cloned()
+    .collect()
+}
+
+// ---------------------------------------------------------------------
+// The agreement oracle: what a push DID, decided without reading what it SAID
+// ---------------------------------------------------------------------
+
+/// One push's route through [`LocalAgreement::ingest`], reconstructed from
+/// engine state rather than from the [`AgreementOutcome`] under test.
+///
+/// # Why the label cannot be its own witness
+///
+/// The relation this replaced asked the outcome whether the round had agreed
+/// (`outcome.agreed()`) and then checked progress against that answer. On a
+/// round where nothing moved, THREE labels satisfy such a relation —
+/// `stationary` through `is_progressed() == moved`, and `awaiting_agreement`
+/// and `no_word_timings` through the not-agreed branch — so a regression that
+/// swapped a stalled stride's `stationary` for `awaiting_agreement`, or the
+/// reverse, passed. The transcript trace cannot catch it either: it is blind to
+/// labels by construction (that is the point of the two-trace split above).
+///
+/// These four routes are genuinely different events, and each leaves a
+/// signature outside the returned enum:
+///
+/// | route | previous hypothesis | word timings | result | oracle reads |
+/// | --- | --- | --- | --- | --- |
+/// | [`Self::Agreed`] | yes | yes | KEPT | `results_slice` grew, the kept result has words, and the recomputed common prefix reached `agreement_count_needed` |
+/// | [`Self::FirstHypothesis`] | no | yes | KEPT | `results_slice` grew and the kept result has words, but no worded result preceded it |
+/// | [`Self::Disagreed`] | yes | yes | DROPPED | `results_slice` did NOT grow |
+/// | [`Self::NoWordTimings`] | — | no | KEPT | `results_slice` grew and the kept result carries no word timings |
+///
+/// Retention is the load-bearing one, and it is a channel the label cannot
+/// reach: `ingest` drops a hypothesis on exactly one route, and
+/// [`LocalAgreement::results_slice`] is the list [`LocalAgreement::finalize`]
+/// merges. `common_prefix` is a SECOND, independent leg over the same question
+/// — see [`OutcomeEvidence::common_prefix`] for the defect it catches that
+/// retention alone does not.
+///
+/// No production accessor was added for any of this: `results_slice`,
+/// `TranscriptionResult::segments_slice`/`all_words`,
+/// `TranscriptionSegment::words_slice`, `last_agreed_seconds`,
+/// `agreement_count_needed` and
+/// [`find_longest_common_prefix`] were already public.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Route {
+  /// A previous hypothesis existed, this result carried word timings, their
+  /// common prefix reached `agreement_count_needed`, and the result was KEPT.
+  /// The only route that runs an advance, and so the only one that may move
+  /// anything.
+  Agreed,
+  /// The first WORDED result — however many wordless ones preceded it. There is
+  /// no previous hypothesis to compare against, so no agreement logic runs and
+  /// the result is KEPT.
+  ///
+  /// It is the first WORDED one rather than the first one at all because
+  /// `ingest`'s no-timings route returns BEFORE the assignment that installs a
+  /// previous hypothesis, so a wordless result never becomes one. The shipping
+  /// JFK run is exactly this shape: stride 1 is wordless, and stride 2 takes
+  /// this route.
+  FirstHypothesis,
+  /// A previous hypothesis existed and the common prefix fell short, so the
+  /// result was DROPPED. The one route on which `results_slice` does not grow.
+  Disagreed,
+  /// The result carried no word timings to agree over. Kept, and the engine
+  /// returned before it could look at a previous hypothesis at all.
+  NoWordTimings,
+}
+
+impl Route {
+  /// The label a push on this route MUST report. `moved` is consulted only on
+  /// [`Self::Agreed`], the one route that runs an advance.
+  const fn expected_label(self, moved: bool) -> AgreementOutcome {
+    match self {
+      Self::Agreed if moved => AgreementOutcome::Progressed,
+      Self::Agreed => AgreementOutcome::Stationary,
+      Self::FirstHypothesis | Self::Disagreed => AgreementOutcome::AwaitingAgreement,
+      Self::NoWordTimings => AgreementOutcome::NoWordTimings,
+    }
+  }
+
+  /// Whether this route ran the advance — the only one that may move the
+  /// watermark or the confirmed prefix.
+  const fn advanced(self) -> bool {
+    matches!(self, Self::Agreed)
+  }
+
+  /// The evidence that put a push on this route, for a failure message.
+  const fn evidenced_by(self) -> &'static str {
+    match self {
+      Self::Agreed => {
+        "the result was KEPT, it carried word timings, and a worded hypothesis \
+         preceded it"
+      }
+      Self::FirstHypothesis => {
+        "the result was KEPT and carried word timings, and no worded hypothesis \
+         preceded it"
+      }
+      Self::Disagreed => "the result was DROPPED, which `ingest` does on no other route",
+      Self::NoWordTimings => "the result was KEPT and carried no word timings",
+    }
+  }
+}
+
+/// What one push looked like from OUTSIDE the value under test.
+///
+/// [`check_outcomes_match_independent_evidence`] decides which [`Route`] a push
+/// took from these three facts alone, works out the label that route demands,
+/// and only then looks at what the push actually reported. Nothing here reads
+/// that report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutcomeEvidence {
+  /// [`LocalAgreement::results_slice`]'s length AFTER this push. It grows by
+  /// one for a KEPT result and not at all for a dropped one, and `ingest` drops
+  /// on exactly one route — a hypothesis whose common prefix with the previous
+  /// one fell short. So this length alone separates [`Route::Disagreed`] from
+  /// the three kept routes.
+  kept_results: usize,
+  /// Whether the result this push newly KEPT carried word timings, recomputed
+  /// with `ingest`'s own gate: ANY segment with a non-empty `words_slice`.
+  ///
+  /// `None` when the push kept nothing. A dropped result is not in
+  /// `results_slice` to look at — and it does not need to be, since it is
+  /// necessarily worded: the no-timings route returns before any comparison
+  /// that could drop one.
+  kept_has_words: Option<bool>,
+  /// The common-prefix length `ingest`'s agreement gate reads, recomputed here
+  /// from the two RESULTS with [`find_longest_common_prefix`] over
+  /// [`at_or_past`]-filtered words — the engine's own comparison, rebuilt from
+  /// public parts.
+  ///
+  /// This is the second leg, and it catches a defect retention alone cannot: a
+  /// broken agreement gate that KEEPS a hypothesis whose prefix fell short. The
+  /// retention leg would call that round [`Route::Agreed`] and rubber-stamp
+  /// whatever progress label it reported; this leg reds.
+  ///
+  /// `None` where the engine's previous hypothesis is out of the test's reach.
+  /// Two ways in: no worded result has been ingested yet, or the previous
+  /// ingested result was DROPPED and so never reached `results_slice`. Both are
+  /// legitimate runs, so the coverage this leg achieves is REPORTED per stride
+  /// in the `[evidence ...]` trace rather than floored — a run whose every
+  /// agreeing round follows a dropped hypothesis would have no reachable
+  /// predecessor anywhere, and refusing it would red a correct stream.
+  common_prefix: Option<usize>,
+}
+
+impl OutcomeEvidence {
+  /// A push that KEPT a result carrying word timings.
+  const fn kept_worded(kept_results: usize, common_prefix: Option<usize>) -> Self {
+    Self {
+      kept_results,
+      kept_has_words: Some(true),
+      common_prefix,
+    }
+  }
+
+  /// A push that KEPT a result with no word timings.
+  const fn kept_wordless(kept_results: usize) -> Self {
+    Self {
+      kept_results,
+      kept_has_words: Some(false),
+      common_prefix: None,
+    }
+  }
+
+  /// A push whose result was DROPPED — `kept_results` is therefore the length
+  /// it already had.
+  const fn dropped(kept_results: usize) -> Self {
+    Self {
+      kept_results,
+      kept_has_words: None,
+      common_prefix: None,
+    }
+  }
+
+  /// The `[evidence ...]` trace's payload.
+  fn trace(&self) -> String {
+    format!(
+      "kept {:>2}  words {}  common {}",
+      self.kept_results,
+      match self.kept_has_words {
+        Some(true) => "yes    ",
+        Some(false) => "none   ",
+        None => "DROPPED",
+      },
+      match self.common_prefix {
+        Some(length) => length.to_string(),
+        None => "-".to_string(),
+      },
+    )
+  }
 }
 
 /// PORTABLE: `confirmed` is a word-for-word prefix of `batch`, and long enough
@@ -304,38 +591,63 @@ fn check_confirmed_is_prefix_of_batch(
   Err(report)
 }
 
-/// PORTABLE: every reported [`AgreementOutcome`] agrees with what the engine's
-/// own state did across that push.
+/// PORTABLE: every reported [`AgreementOutcome`] is the one an INDEPENDENT
+/// reconstruction of that push says it had to be.
 ///
 /// The outcome sequence is real behaviour and must stay asserted, but the
 /// LABELS are not portable — which strides agree, and which of the agreeing ones
 /// move anything, is decided by the same host-scoped timestamp-mass gate this
-/// file's docs describe. What IS portable is the relation between the label and
-/// the state, because it compares this run against itself: an agreeing round
-/// reports `progressed` exactly when [`LocalAgreement::last_agreed_seconds`] or
-/// the confirmed prefix moved, and `stationary` exactly when neither did. A
-/// round that did not agree runs no advance, so it must move neither.
+/// file's docs describe. What IS portable is that each label matches the route
+/// its push actually took, because that compares this run against itself.
 ///
-/// The watermark is compared by BITS. Rounding it to the two decimals the trace
-/// prints would report a 0.02 s step as a stall, which is precisely the reading
-/// the outcome now exists to replace.
+/// The route comes from [`Route`], which reads engine state and never the
+/// outcome under test: which hypotheses [`LocalAgreement::results_slice`]
+/// retained, whether the retained one carried word timings, and the
+/// common-prefix length recomputed from the results themselves. That
+/// independence is the whole guard — see [`Route`] for the three-label
+/// ambiguity a self-referential relation leaves open on a round that moved
+/// nothing.
+///
+/// Progress within the agreeing route is still measured the same way `ingest`
+/// measures it: [`LocalAgreement::last_agreed_seconds`] by BITS and the
+/// confirmed prefix by length. Rounding the watermark to the two decimals the
+/// trace prints would report a 0.02 s step as a stall, which is precisely the
+/// reading the outcome exists to replace.
+///
+/// `agreement_count_needed` is the run's own
+/// [`LocalAgreement::agreement_count_needed`], the threshold the recomputed
+/// common prefix is read against.
 ///
 /// # Errors
-/// The first stride whose label contradicts its own state transition, naming
-/// both; or a run in which no stride ever reported progress, which would leave
-/// the relation asserted only on its trivial side.
-fn check_outcomes_match_observed_progress(steps: &[Confirmation]) -> Result<(), String> {
+/// Evidence that cannot describe one ingest; a round the oracle says ran no
+/// advance that moved something anyway; the first stride whose label is not the
+/// one its route demands, naming both; or a run in which no stride ever
+/// progressed, which would leave the agreeing route asserted only on its
+/// stationary side.
+fn check_outcomes_match_independent_evidence(
+  steps: &[Confirmation],
+  agreement_count_needed: usize,
+) -> Result<(), String> {
   let mut progressed = 0usize;
+  // `LocalAgreement`'s private `prev_result`, reconstructed as a boolean: the
+  // no-timings route returns BEFORE the assignment that installs one, so a
+  // wordless result never becomes a hypothesis however many of them arrive.
+  // Both other kept routes and the dropped one do install theirs.
+  let mut worded_before = false;
   for (index, after) in steps.iter().enumerate() {
-    // The first push has no predecessor; the engine starts at watermark 0.0 with
-    // nothing confirmed, which is what a synthetic zeroth snapshot would say.
-    let (was_watermark, was_confirmed) =
-      index.checked_sub(1).map_or((0.0f32, 0usize), |previous| {
-        (
-          steps[previous].last_agreed_seconds,
-          steps[previous].confirmed.len(),
-        )
-      });
+    // The first push has no predecessor; the engine starts at watermark 0.0
+    // with nothing confirmed and no results kept, which is what a synthetic
+    // zeroth snapshot would say.
+    let (was_watermark, was_confirmed, was_kept) =
+      index
+        .checked_sub(1)
+        .map_or((0.0f32, 0usize, 0usize), |previous| {
+          (
+            steps[previous].last_agreed_seconds,
+            steps[previous].confirmed.len(),
+            steps[previous].evidence.kept_results,
+          )
+        });
     let moved = after.last_agreed_seconds.to_bits() != was_watermark.to_bits()
       || after.confirmed.len() != was_confirmed;
     // One push, one ingest at this stride and cadence — so the push's labels
@@ -352,36 +664,156 @@ fn check_outcomes_match_observed_progress(steps: &[Confirmation]) -> Result<(), 
         after.outcome_labels(),
       ));
     };
-    progressed += usize::from(outcome.is_progressed());
-    let honest = if outcome.agreed() {
-      outcome.is_progressed() == moved
-    } else {
-      !moved
+
+    // ── The evidence must describe ONE ingest, or it is not evidence for one.
+    let evidence = &after.evidence;
+    let kept = match evidence.kept_results.checked_sub(was_kept) {
+      Some(0) => false,
+      Some(1) => true,
+      _ => {
+        return Err(format!(
+          "stride {}: the kept-result count went {was_kept} -> {}, which one \
+           ingest cannot do — it keeps exactly one result or none, and the list \
+           is append-only.\n\
+           Either the cadence changed (see the one-outcome check above) or the \
+           evidence was not read from the same engine the outcome came from.",
+          after.stride, evidence.kept_results,
+        ));
+      }
     };
-    if !honest {
+    if kept != evidence.kept_has_words.is_some() {
       return Err(format!(
-        "stride {} reported `{outcome}` while the watermark went {was_watermark} s \
-         -> {} s ({:#x} -> {:#x}) and the confirmed prefix {was_confirmed} -> {} \
-         words.\n\
-         An agreeing round must say `progressed` exactly when one of those two \
-         moved and `stationary` exactly when neither did; a round that did not \
-         agree ran no advance and must move neither.\n\
+        "stride {}: the kept-result count says the result was {}, and the \
+         word-timing evidence says it was {}.\n\
+         `kept_has_words` is read FROM the newly kept result, so it is present \
+         exactly when one was kept. Fix the observation, not this check.",
+        after.stride,
+        if kept { "KEPT" } else { "DROPPED" },
+        if evidence.kept_has_words.is_some() {
+          "KEPT"
+        } else {
+          "DROPPED"
+        },
+      ));
+    }
+
+    // ── The route, from that evidence and nothing the push reported.
+    let this_worded = evidence.kept_has_words != Some(false);
+    let route = if !kept {
+      if !worded_before {
+        return Err(format!(
+          "stride {}: the result was DROPPED, but no worded hypothesis had been \
+           ingested yet.\n\
+           `ingest` drops on ONE route — a common prefix too short — and that \
+           comparison only runs against a previous hypothesis. With none there \
+           is nothing to disagree with and the result is kept. This evidence \
+           describes a state the engine cannot be in.",
+          after.stride,
+        ));
+      }
+      Route::Disagreed
+    } else if evidence.kept_has_words == Some(false) {
+      Route::NoWordTimings
+    } else if worded_before {
+      Route::Agreed
+    } else {
+      Route::FirstHypothesis
+    };
+    worded_before |= this_worded;
+
+    // ── Second leg: the common prefix, where the previous hypothesis is still
+    // reachable. It answers the SAME question as retention through a different
+    // channel, so a disagreement between them is an engine defect either way.
+    if let Some(common) = evidence.common_prefix {
+      let agreed_by_prefix = common >= agreement_count_needed;
+      if agreed_by_prefix != route.advanced() {
+        return Err(format!(
+          "stride {}: the two independent readings of whether this round AGREED \
+           contradict each other.\n  \
+           retention  : {} — so the round {}\n  \
+           common prefix: {common} word(s) vs the {agreement_count_needed} this \
+           run requires — so the round {}\n\
+           `ingest` keeps a hypothesis exactly when that prefix reaches the \
+           threshold, so these cannot differ. Suspect the agreement gate itself: \
+           a gate that keeps a result whose prefix fell short reads as an \
+           agreement to the retention leg and would rubber-stamp whatever \
+           progress label followed.",
+          after.stride,
+          route.evidenced_by(),
+          if route.advanced() {
+            "agreed"
+          } else {
+            "did not agree"
+          },
+          if agreed_by_prefix {
+            "agreed"
+          } else {
+            "did not agree"
+          },
+        ));
+      }
+    }
+
+    // ── A round that ran no advance may not have moved anything, whatever it
+    // reported. This is about the ENGINE, not about the label.
+    if !route.advanced() && moved {
+      return Err(format!(
+        "stride {} did not agree — {} — so it ran no advance, yet the watermark \
+         went {was_watermark} s -> {} s ({:#x} -> {:#x}) and the confirmed \
+         prefix {was_confirmed} -> {} words.\n\
+         Only the agreeing route touches either channel.\n\
          This compares the run against ITSELF on this machine, so host fp16 \
          drift moves both sides together and cannot cause it.",
         after.stride,
+        route.evidenced_by(),
         after.last_agreed_seconds,
         was_watermark.to_bits(),
         after.last_agreed_seconds.to_bits(),
         after.confirmed.len(),
       ));
     }
+
+    // ── The label, against the route's demand rather than against itself.
+    let expected = route.expected_label(moved);
+    if *outcome != expected {
+      return Err(format!(
+        "stride {} reported `{outcome}`, but the evidence says it had to report \
+         `{expected}`.\n  \
+         route     : {route:?} — {}\n  \
+         watermark : {was_watermark} s -> {} s ({:#x} -> {:#x})\n  \
+         confirmed : {was_confirmed} -> {} words\n  \
+         kept      : {was_kept} -> {} result(s)\n  \
+         common    : {}\n\
+         The route is read from the engine's own state and NEVER from the \
+         outcome, so this cannot be satisfied by relabelling: on a round that \
+         moved nothing, `stationary`, `awaiting_agreement` and \
+         `no_word_timings` are three different claims and exactly one of them \
+         is true.\n\
+         This compares the run against ITSELF on this machine, so host fp16 \
+         drift moves both sides together and cannot cause it.",
+        after.stride,
+        route.evidenced_by(),
+        after.last_agreed_seconds,
+        was_watermark.to_bits(),
+        after.last_agreed_seconds.to_bits(),
+        after.confirmed.len(),
+        evidence.kept_results,
+        evidence.common_prefix.map_or_else(
+          || "unreachable — the previous hypothesis was dropped, or none had \
+              been ingested yet"
+            .to_string(),
+          |common| format!("{common} word(s) vs the {agreement_count_needed} this run requires"),
+        ),
+      ));
+    }
+    progressed += usize::from(outcome.is_progressed());
   }
 
   if progressed == 0 {
     return Err(format!(
-      "no stride reported `progressed` across all {} stride(s), so the relation \
-       above was only ever read on its did-not-move side and asserts nothing \
-       about the moving one.\n\
+      "no stride reported `progressed` across all {} stride(s), so the agreeing \
+       route above was only ever read on its stationary side and asserts \
+       nothing about the moving one.\n\
        A run that never progressed is a stall to diagnose, not evidence.",
       steps.len(),
     ));
@@ -510,9 +942,59 @@ fn jfk_simulated_stream_confirms_the_transcript() {
   // carries the labels, which this work DOES move, and digests separately.
   // While the two shared one line, an honest-signal fix disturbed a guard that
   // is not about signals.
+  // THE ORACLE'S ONE PIECE OF STATE. `LocalAgreement::ingest` compares the new
+  // hypothesis against a PRIVATE `prev_result`, and this tracks the half of it
+  // the test can still see, by the engine's own three rules: a worded result
+  // becomes the previous hypothesis; a WORDLESS one does not (that route returns
+  // before the assignment); and a DROPPED one does become it but never reaches
+  // `results_slice`, so the test loses sight of it and says so with `None`
+  // rather than guessing. See `OutcomeEvidence::common_prefix`.
+  let mut previous_hypothesis: Option<Vec<WordTiming>> = None;
+  let mut kept_before = 0usize;
+  let mut watermark_before = 0.0f32;
   for (index, chunk) in audio.chunks(STRIDE_SAMPLES).enumerate() {
     let outcomes = streamer.push_samples(chunk).unwrap();
-    let step = Confirmation::observe(index + 1, streamer.agreement(), outcomes);
+    let agreement = streamer.agreement();
+
+    // ── The evidence, read from engine state and never from `outcomes`.
+    let kept_results = agreement.results_slice().len();
+    let newly_kept = (kept_results > kept_before).then(|| {
+      agreement
+        .results_slice()
+        .last()
+        .expect("a kept result is in the list")
+    });
+    // `ingest`'s own gate (`:371`), recomputed: ANY segment with a word timing.
+    let kept_has_words = newly_kept.map(|result| {
+      result
+        .segments_slice()
+        .iter()
+        .any(|segment| !segment.words_slice().is_empty())
+    });
+    let kept_words = newly_kept
+      .filter(|_| kept_has_words == Some(true))
+      .map(coremlit::audio::whisper::result::TranscriptionResult::all_words);
+    // The engine's own comparison, over the watermark that was current when
+    // this ingest ran — the one this push started from, not the one it ended
+    // with.
+    let common_prefix =
+      previous_hypothesis
+        .as_ref()
+        .zip(kept_words.as_ref())
+        .map(|(previous, hypothesis)| {
+          find_longest_common_prefix(
+            &at_or_past(previous, watermark_before),
+            &at_or_past(hypothesis, watermark_before),
+          )
+          .len()
+        });
+    let evidence = OutcomeEvidence {
+      kept_results,
+      kept_has_words,
+      common_prefix,
+    };
+
+    let step = Confirmation::observe(index + 1, agreement, outcomes, evidence);
     println!(
       "[stride {:>2}] watermark {:>6.2} s  confirmed {:>2}  held {:>2}  {:?}",
       step.stride,
@@ -522,6 +1004,18 @@ fn jfk_simulated_stream_confirms_the_transcript() {
       step.confirmed.join(" "),
     );
     println!("[outcome {:>2}] {}", step.stride, step.outcome_labels());
+    // A THIRD trace line, on its own prefix so neither digest above moves: what
+    // the oracle read, so a failure can be diagnosed from a log alone.
+    println!("[evidence {:>2}] {}", step.stride, step.evidence.trace());
+
+    // Maintain the tracker by the three rules above, then the two baselines.
+    match kept_has_words {
+      Some(false) => {}
+      Some(true) => previous_hypothesis = kept_words,
+      None => previous_hypothesis = None,
+    }
+    kept_before = kept_results;
+    watermark_before = step.last_agreed_seconds;
     steps.push(step);
   }
   // Read before `finalize` consumes the driver: the floor the prefix check needs
@@ -538,14 +1032,62 @@ fn jfk_simulated_stream_confirms_the_transcript() {
   if let Err(why) = check_confirmed_is_prefix_of_batch(&confirmed, &batch, agreement_count_needed) {
     panic!("streaming confirmation is not a prefix of the batch transcript: {why}");
   }
-  // The outcome labels, asserted against the state they claim to describe rather
-  // than against a recorded sequence — the labels themselves are host-scoped,
-  // the relation is not.
-  if let Err(why) = check_outcomes_match_observed_progress(&steps) {
+  // The outcome labels, asserted against an INDEPENDENT reconstruction of what
+  // each push did — the labels themselves are host-scoped, the relation between
+  // a label and its push's route is not.
+  if let Err(why) = check_outcomes_match_independent_evidence(&steps, agreement_count_needed) {
     panic!("a reported agreement outcome did not match what the engine did: {why}");
   }
 
   // ── Measured, asserted only on the host class that produced it.
+  //
+  // The recorded label sequence is the belt to the relation's braces: the
+  // relation proves every label matches its own push's route on every host, and
+  // this pins WHICH routes this clip takes on the host that was characterized.
+  // On that host it catches the one thing a self-consistent relabelling could
+  // still hide — a stationary stride becoming a moving one, or stride 1 finding
+  // word timings it did not have.
+  let observed: Vec<AgreementOutcome> = steps
+    .iter()
+    .flat_map(|step| step.outcomes.iter().copied())
+    .collect();
+  gate.check_holds(
+    "per-stride agreement outcome sequence",
+    observed == RECORDED_OUTCOMES,
+    &format!(
+      "the {} recorded label(s) {}",
+      RECORDED_OUTCOMES.len(),
+      joined_labels(RECORDED_OUTCOMES),
+    ),
+    &format!(
+      "the per-stride outcome sequence is not the one recorded on this host \
+       class.\n  recorded : {} label(s) {}\n  observed : {} label(s) {}\n{}\n\
+       The portable relation above already passed, so every label still matches \
+       its own push's route —\nwhat moved is WHICH route a stride takes. That is \
+       either a real behaviour change to\nunderstand or a host drift to \
+       re-record; it is not a sequence to widen.",
+      RECORDED_OUTCOMES.len(),
+      joined_labels(RECORDED_OUTCOMES),
+      observed.len(),
+      joined_labels(&observed),
+      RECORDED_OUTCOMES
+        .iter()
+        .zip(&observed)
+        .position(|(recorded, seen)| recorded != seen)
+        .map_or_else(
+          || "  the shared prefix matched, so the two differ only in LENGTH — \
+              the clip produced a different number of strides"
+            .to_string(),
+          |index| format!(
+            "  first divergence at stride {}: recorded `{}`, observed `{}`",
+            index + 1,
+            RECORDED_OUTCOMES[index],
+            observed[index],
+          ),
+        ),
+    ),
+  );
+
   gate.check_holds(
     "confirmed stream reaches the clip's canonical phrase",
     confirmed.contains(CANONICAL_PHRASE),
@@ -568,8 +1110,8 @@ fn jfk_simulated_stream_confirms_the_transcript() {
 
 /// Snapshots from normalized word lists, for the hermetic cases below.
 ///
-/// No outcome: the monotonicity cases are about the state sequence alone.
-/// [`step_reporting`] is the one the outcome cases use.
+/// No outcome and no evidence: the monotonicity cases are about the state
+/// sequence alone. [`step_reporting`] is the one the outcome cases use.
 fn step(stride: usize, watermark: f32, confirmed: &[&str], held_back: &[&str]) -> Confirmation {
   Confirmation {
     stride,
@@ -577,55 +1119,107 @@ fn step(stride: usize, watermark: f32, confirmed: &[&str], held_back: &[&str]) -
     confirmed: confirmed.iter().map(|w| (*w).to_string()).collect(),
     held_back: held_back.iter().map(|w| (*w).to_string()).collect(),
     outcomes: Vec::new(),
+    evidence: OutcomeEvidence::dropped(0),
   }
 }
 
-/// The same snapshot carrying the label this push reported.
+/// The same snapshot carrying the label this push reported AND the independent
+/// evidence the oracle reads. The two are supplied separately on purpose: every
+/// falsifier below moves exactly one of them and leaves the other alone, which
+/// is what makes each case a real minimal pair.
 fn step_reporting(
   stride: usize,
   outcome: AgreementOutcome,
   watermark: f32,
   confirmed: &[&str],
+  evidence: OutcomeEvidence,
 ) -> Confirmation {
   Confirmation {
     outcomes: vec![outcome],
+    evidence,
     ..step(stride, watermark, confirmed, &[])
   }
 }
 
-/// The JFK run's own shape, as the labels a correct engine reports for it: two
-/// silent strides, then rounds that move the watermark and one that does not.
+/// The JFK run's own shape, as the labels a correct engine reports for it AND
+/// the evidence that same engine leaves behind: a wordless stride, the first
+/// worded hypothesis, then rounds that move the watermark and one that does
+/// not.
+///
+/// The evidence is the shipping run's, not an invention — stride 1 keeps a
+/// wordless result, stride 2 keeps the first worded one (it cannot agree: the
+/// no-timings route never installed a hypothesis for it to agree with), and
+/// every stride after that keeps a worded result whose recomputed common prefix
+/// clears the default width of 2.
 fn honest_run() -> Vec<Confirmation> {
   vec![
-    step_reporting(1, AgreementOutcome::NoWordTimings, 0.0, &[]),
-    step_reporting(2, AgreementOutcome::AwaitingAgreement, 0.0, &[]),
-    step_reporting(3, AgreementOutcome::Progressed, 1.36, &["and", "so", "my"]),
-    step_reporting(4, AgreementOutcome::Progressed, 1.38, &["and", "so", "my"]),
-    step_reporting(5, AgreementOutcome::Stationary, 1.38, &["and", "so", "my"]),
+    step_reporting(
+      1,
+      AgreementOutcome::NoWordTimings,
+      0.0,
+      &[],
+      OutcomeEvidence::kept_wordless(1),
+    ),
+    step_reporting(
+      2,
+      AgreementOutcome::AwaitingAgreement,
+      0.0,
+      &[],
+      OutcomeEvidence::kept_worded(2, None),
+    ),
+    step_reporting(
+      3,
+      AgreementOutcome::Progressed,
+      1.36,
+      &["and", "so", "my"],
+      OutcomeEvidence::kept_worded(3, Some(5)),
+    ),
+    step_reporting(
+      4,
+      AgreementOutcome::Progressed,
+      1.38,
+      &["and", "so", "my"],
+      OutcomeEvidence::kept_worded(4, Some(5)),
+    ),
+    step_reporting(
+      5,
+      AgreementOutcome::Stationary,
+      1.38,
+      &["and", "so", "my"],
+      OutcomeEvidence::kept_worded(5, Some(2)),
+    ),
   ]
 }
+
+/// The width [`honest_run`]'s evidence is read at. Bound to the shipping
+/// [`DEFAULT_AGREEMENT_COUNT_NEEDED`] rather than written as `2`, so a change to
+/// the default moves these cases with it instead of leaving them asserting
+/// against a literal the engine no longer uses.
+const HERMETIC_AGREEMENT_WIDTH: usize = DEFAULT_AGREEMENT_COUNT_NEEDED;
 
 /// The honest shape passes, and it is the JFK stall's own: a `stationary` round
 /// with the watermark bit-identical to the round before it.
 #[test]
 fn an_outcome_sequence_that_matches_the_state_is_accepted() {
   assert_eq!(
-    check_outcomes_match_observed_progress(&honest_run()),
+    check_outcomes_match_independent_evidence(&honest_run(), HERMETIC_AGREEMENT_WIDTH),
     Ok(())
   );
 }
 
-/// THE FALSIFIER the honest-signal fix exists for: a round that moved NOTHING
-/// and claimed progress. This is what every stalled stride reported before the
-/// two agreeing cases were told apart.
+/// THE FALSIFIER the honest-signal fix exists for: a round that moved neither
+/// SETTLED channel — not the watermark, not the confirmed prefix — and claimed
+/// progress. This is what every stalled stride reported before the two agreeing
+/// cases were told apart.
 #[test]
 fn a_progressed_label_on_a_stalled_stride_reds() {
   let mut steps = honest_run();
   steps[4].outcomes = vec![AgreementOutcome::Progressed];
-  let why = check_outcomes_match_observed_progress(&steps)
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
     .expect_err("a stalled stride claiming progress must red");
   assert!(why.contains("stride 5"), "{why}");
-  assert!(why.contains("`progressed`"), "{why}");
+  assert!(why.contains("reported `progressed`"), "{why}");
+  assert!(why.contains("had to report `stationary`"), "{why}");
   assert!(why.contains("1.38"), "{why}");
 }
 
@@ -636,21 +1230,187 @@ fn a_progressed_label_on_a_stalled_stride_reds() {
 fn a_stationary_label_on_a_moving_stride_reds() {
   let mut steps = honest_run();
   steps[3].outcomes = vec![AgreementOutcome::Stationary];
-  let why = check_outcomes_match_observed_progress(&steps)
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
     .expect_err("a moving stride claiming to be stationary must red");
   assert!(why.contains("stride 4"), "{why}");
-  assert!(why.contains("`stationary`"), "{why}");
+  assert!(why.contains("reported `stationary`"), "{why}");
+  assert!(why.contains("had to report `progressed`"), "{why}");
+}
+
+// ── The three swaps a self-referential relation could not see ────────────────
+//
+// All three land on rounds where NOTHING moved, which is exactly where the
+// relation this replaced went blind: it asked the outcome whether the round had
+// agreed and then checked progress against that answer, so `stationary`
+// (`is_progressed() == moved`, false == false), `awaiting_agreement` (`!moved`)
+// and `no_word_timings` (`!moved`) all satisfied it. The oracle reads the route
+// from `results_slice` and the kept result's own timings instead, so exactly one
+// of the three is true on any given round.
+
+/// SWAP 1: a stationary stride relabelled `awaiting_agreement`. The stride kept
+/// a worded result behind a worded predecessor, so it AGREED; a round that
+/// agreed cannot report the label of one that did not.
+#[test]
+fn a_stationary_stride_relabelled_awaiting_agreement_reds() {
+  let mut steps = honest_run();
+  // Non-vacuous: the round this replaces is the stall, and nothing moved across
+  // it — the exact shape the old relation accepted under either label.
+  assert_eq!(
+    steps[4].last_agreed_seconds.to_bits(),
+    steps[3].last_agreed_seconds.to_bits(),
+  );
+  assert_eq!(steps[4].confirmed.len(), steps[3].confirmed.len());
+
+  steps[4].outcomes = vec![AgreementOutcome::AwaitingAgreement];
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("an agreeing stall relabelled `awaiting_agreement` must red");
+  assert!(why.contains("stride 5"), "{why}");
+  assert!(why.contains("reported `awaiting_agreement`"), "{why}");
+  assert!(why.contains("had to report `stationary`"), "{why}");
+  assert!(why.contains("the result was KEPT"), "{why}");
+}
+
+/// SWAP 2: the same stationary stride relabelled `no_word_timings`. Its kept
+/// result carried word timings, so the no-timings route is not one it could
+/// have taken.
+#[test]
+fn a_stationary_stride_relabelled_no_word_timings_reds() {
+  let mut steps = honest_run();
+  steps[4].outcomes = vec![AgreementOutcome::NoWordTimings];
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("an agreeing stall relabelled `no_word_timings` must red");
+  assert!(why.contains("stride 5"), "{why}");
+  assert!(why.contains("reported `no_word_timings`"), "{why}");
+  assert!(why.contains("had to report `stationary`"), "{why}");
+  assert!(why.contains("carried word timings"), "{why}");
+}
+
+/// SWAP 3, the reverse: a genuinely non-agreeing round relabelled `stationary`.
+/// Stride 2 is the first WORDED hypothesis — the no-timings stride before it
+/// never installed one to agree with — so no agreement logic ran at all, and it
+/// moved nothing, which is what let the old relation take `stationary` for it.
+#[test]
+fn a_non_agreeing_stride_relabelled_stationary_reds() {
+  let mut steps = honest_run();
+  assert_eq!(steps[1].last_agreed_seconds.to_bits(), 0.0f32.to_bits());
+  assert!(steps[1].confirmed.is_empty());
+
+  steps[1].outcomes = vec![AgreementOutcome::Stationary];
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("a first-hypothesis round relabelled `stationary` must red");
+  assert!(why.contains("stride 2"), "{why}");
+  assert!(why.contains("reported `stationary`"), "{why}");
+  assert!(why.contains("had to report `awaiting_agreement`"), "{why}");
+  assert!(why.contains("FirstHypothesis"), "{why}");
+
+  // And the OTHER non-agreeing route reads the same way: a DROPPED result is a
+  // disagreement whatever label it carries.
+  let mut steps = honest_run();
+  steps[2].evidence = OutcomeEvidence::dropped(2);
+  steps[2].last_agreed_seconds = steps[1].last_agreed_seconds;
+  steps[2].confirmed = Vec::new();
+  steps[2].outcomes = vec![AgreementOutcome::Stationary];
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("a dropped round relabelled `stationary` must red");
+  assert!(why.contains("stride 3"), "{why}");
+  assert!(why.contains("had to report `awaiting_agreement`"), "{why}");
+  assert!(why.contains("the result was DROPPED"), "{why}");
+}
+
+/// A wordless stride relabelled as one of the agreeing ones reds too — the
+/// fourth corner of the same square.
+#[test]
+fn a_wordless_stride_relabelled_stationary_reds() {
+  let mut steps = honest_run();
+  steps[0].outcomes = vec![AgreementOutcome::Stationary];
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("a wordless stride relabelled `stationary` must red");
+  assert!(why.contains("stride 1"), "{why}");
+  assert!(why.contains("had to report `no_word_timings`"), "{why}");
+  assert!(why.contains("carried no word timings"), "{why}");
 }
 
 /// A round that did not agree ran no advance, so it may not have moved either.
+/// This is a statement about the ENGINE rather than about the label, so the
+/// evidence is what moves here: the round is made a DISAGREEMENT while its
+/// watermark still steps.
 #[test]
-fn a_non_agreeing_label_on_a_moving_stride_reds() {
+fn a_non_agreeing_round_that_moved_reds() {
   let mut steps = honest_run();
+  // Stride 4 keeps its 1.36 -> 1.38 step and its `awaiting_agreement` label,
+  // but its result was dropped — so no advance ran and nothing may have moved.
+  steps[3].evidence = OutcomeEvidence::dropped(3);
   steps[3].outcomes = vec![AgreementOutcome::AwaitingAgreement];
-  let why = check_outcomes_match_observed_progress(&steps)
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
     .expect_err("a non-agreeing stride that moved the watermark must red");
   assert!(why.contains("stride 4"), "{why}");
   assert!(why.contains("did not agree"), "{why}");
+  assert!(why.contains("ran no advance"), "{why}");
+}
+
+/// The SECOND leg. A gate that KEEPS a hypothesis whose common prefix fell
+/// short reads as an agreement to the retention leg, which would then
+/// rubber-stamp whatever progress label followed. The recomputed prefix refuses
+/// it.
+#[test]
+fn a_kept_round_whose_prefix_fell_short_reds() {
+  let mut steps = honest_run();
+  steps[4].evidence = OutcomeEvidence::kept_worded(5, Some(HERMETIC_AGREEMENT_WIDTH - 1));
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("a kept round whose prefix fell short must red");
+  assert!(why.contains("stride 5"), "{why}");
+  assert!(why.contains("contradict each other"), "{why}");
+  assert!(why.contains("common prefix"), "{why}");
+
+  // Non-vacuous: the SAME step at the full width is accepted, so the case turns
+  // on the prefix length and on nothing else.
+  steps[4].evidence = OutcomeEvidence::kept_worded(5, Some(HERMETIC_AGREEMENT_WIDTH));
+  assert_eq!(
+    check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH),
+    Ok(())
+  );
+}
+
+/// Evidence that cannot have come from one ingest is refused rather than
+/// interpreted. Both directions: a kept-count that jumped, and a kept-count
+/// that disagrees with whether a result was there to look at.
+#[test]
+fn evidence_that_cannot_describe_one_ingest_reds() {
+  let mut steps = honest_run();
+  steps[2].evidence = OutcomeEvidence::kept_worded(4, Some(5));
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("a kept-count that jumped by two must red");
+  assert!(why.contains("stride 3"), "{why}");
+  assert!(why.contains("one ingest cannot do"), "{why}");
+
+  let mut steps = honest_run();
+  steps[2].evidence = OutcomeEvidence {
+    kept_results: 2,
+    kept_has_words: Some(true),
+    common_prefix: Some(5),
+  };
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("a dropped result that was somehow inspected must red");
+  assert!(why.contains("stride 3"), "{why}");
+  assert!(why.contains("DROPPED"), "{why}");
+  assert!(why.contains("Fix the observation"), "{why}");
+}
+
+/// Nothing can be dropped before there is a hypothesis to disagree with, so
+/// evidence claiming it describes a state the engine cannot reach.
+#[test]
+fn a_drop_before_the_first_hypothesis_reds() {
+  let steps = [step_reporting(
+    1,
+    AgreementOutcome::AwaitingAgreement,
+    0.0,
+    &[],
+    OutcomeEvidence::dropped(0),
+  )];
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("a drop with no previous hypothesis must red");
+  assert!(why.contains("stride 1"), "{why}");
+  assert!(why.contains("cannot be in"), "{why}");
 }
 
 /// Rounding is what the bit comparison is there to refuse: 1.38 and a watermark
@@ -665,20 +1425,33 @@ fn a_sub_printed_precision_step_is_still_a_move() {
     format!("{:.2}", steps[3].last_agreed_seconds),
     "non-vacuous: the two print the same at the trace's own precision",
   );
-  let why = check_outcomes_match_observed_progress(&steps)
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
     .expect_err("a one-ULP step is a move, and calling it stationary must red");
   assert!(why.contains("stride 5"), "{why}");
 }
 
-/// A run in which nothing ever progressed satisfies the relation on its trivial
-/// side only, so the predicate must refuse it rather than report a green.
+/// A run in which nothing ever progressed reads the agreeing route on its
+/// stationary side only, so the predicate must refuse it rather than report a
+/// green.
 #[test]
 fn a_run_that_never_progresses_is_not_outcome_evidence() {
   let steps = [
-    step_reporting(1, AgreementOutcome::AwaitingAgreement, 0.0, &[]),
-    step_reporting(2, AgreementOutcome::Stationary, 0.0, &[]),
+    step_reporting(
+      1,
+      AgreementOutcome::AwaitingAgreement,
+      0.0,
+      &[],
+      OutcomeEvidence::kept_worded(1, None),
+    ),
+    step_reporting(
+      2,
+      AgreementOutcome::Stationary,
+      0.0,
+      &[],
+      OutcomeEvidence::kept_worded(2, Some(HERMETIC_AGREEMENT_WIDTH)),
+    ),
   ];
-  let why = check_outcomes_match_observed_progress(&steps)
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
     .expect_err("a run with no progress at all must red");
   assert!(why.contains("no stride reported `progressed`"), "{why}");
 }
@@ -690,10 +1463,41 @@ fn a_run_that_never_progresses_is_not_outcome_evidence() {
 fn a_push_with_more_than_one_ingest_reds_rather_than_guessing() {
   let mut steps = honest_run();
   steps[2].outcomes = vec![AgreementOutcome::Progressed, AgreementOutcome::Stationary];
-  let why =
-    check_outcomes_match_observed_progress(&steps).expect_err("a multi-ingest push must red");
+  let why = check_outcomes_match_independent_evidence(&steps, HERMETIC_AGREEMENT_WIDTH)
+    .expect_err("a multi-ingest push must red");
   assert!(why.contains("reported 2 outcome(s)"), "{why}");
   assert!(why.contains("progressed,stationary"), "{why}");
+}
+
+/// The RECORDED sequence is the belt, so it must be able to red: a stride whose
+/// route changed while its label stayed self-consistent passes the portable
+/// relation and is caught only here.
+#[test]
+fn the_recorded_outcome_sequence_notices_a_changed_route() {
+  // The shipping shape, and a copy in which stride 7's stall became a moving
+  // round. Both are internally honest — the relation would pass either.
+  let mut moved_stride_7 = RECORDED_OUTCOMES.to_vec();
+  assert_eq!(moved_stride_7[6], AgreementOutcome::Stationary);
+  moved_stride_7[6] = AgreementOutcome::Progressed;
+
+  assert_eq!(RECORDED_OUTCOMES.to_vec(), RECORDED_OUTCOMES);
+  assert_ne!(moved_stride_7, RECORDED_OUTCOMES);
+  assert_eq!(
+    moved_stride_7
+      .iter()
+      .zip(RECORDED_OUTCOMES)
+      .position(|(seen, recorded)| seen != recorded),
+    Some(6),
+    "and the divergence the failure message names is stride 7",
+  );
+
+  // The recorded list is the trace's own payload, so a log and this constant
+  // cannot drift apart silently.
+  assert_eq!(
+    joined_labels(RECORDED_OUTCOMES),
+    "no_word_timings,awaiting_agreement,progressed,progressed,progressed,\
+     progressed,stationary,progressed,stationary,progressed,progressed",
+  );
 }
 
 const BATCH: &str = "and so my fellow americans ask not what your country can do for you";
@@ -939,11 +1743,11 @@ fn an_unrecorded_phrase_gate_reports_and_cannot_red() {
   assert!(line.contains("no characterization host recorded"), "{line}");
 }
 
-/// The phrase is the ONLY thing behind the host gate: the portable properties
-/// are asserted bare, so no verdict can silence them. Checked against this
-/// file's real source, the way siglip's `band_provenance` checks its own.
+/// Only MEASUREMENTS ride the host gate: the portable properties are asserted
+/// bare, so no verdict can silence them. Checked against this file's real
+/// source, the way siglip's `band_provenance` checks its own.
 #[test]
-fn only_the_phrase_is_host_scoped() {
+fn only_measurements_are_host_scoped() {
   let source = std::fs::read_to_string(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/tests/whisper/streaming.rs"
@@ -960,25 +1764,42 @@ fn only_the_phrase_is_host_scoped() {
     .expect("the falsifier section still follows it")
     .0;
 
-  // Exactly one measurement rides the gate, and it is the phrase. A second
-  // `gate.check_` would mean a portable property had been moved behind a
-  // verdict that can switch it off.
+  // Exactly TWO measurements ride the gate, and both are named here: the
+  // canonical phrase and the recorded outcome sequence. A third `gate.check_`
+  // would mean a portable property had been moved behind a verdict that can
+  // switch it off — which is the failure this scan exists to catch, and the
+  // reason it counts rather than merely looking for the two it knows about.
   let gated: Vec<&str> = body
     .lines()
     .filter(|line| line.contains("gate.check_"))
     .collect();
   assert_eq!(
     gated.len(),
-    1,
-    "exactly one measurement may ride the host gate, and it must be the phrase: {gated:?}"
+    2,
+    "exactly two measurements may ride the host gate — the canonical phrase and \
+     the recorded outcome sequence: {gated:?}"
   );
-  assert!(gated[0].contains("check_holds"), "{:?}", gated[0]);
+  for line in &gated {
+    assert!(line.contains("check_holds"), "{line:?}");
+  }
+  // Named, so that swapping one of them for a portable property under the same
+  // call shape does not slip past the count above.
+  for measurement in [
+    "\"per-stride agreement outcome sequence\",",
+    "\"confirmed stream reaches the clip's canonical phrase\",",
+  ] {
+    assert!(
+      body.contains(measurement),
+      "the host-gated measurement `{measurement}` is gone; the count above \
+       cannot tell a replacement from the original"
+    );
+  }
 
   // Both portable properties are called bare, so no verdict can silence them.
   for portable in [
     "check_monotone_confirmation(&steps)",
     "check_confirmed_is_prefix_of_batch(&confirmed, &batch, agreement_count_needed)",
-    "check_outcomes_match_observed_progress(&steps)",
+    "check_outcomes_match_independent_evidence(&steps, agreement_count_needed)",
   ] {
     assert!(
       body.contains(portable),

--- a/crates/coremlit/tests/whisper/streaming.rs
+++ b/crates/coremlit/tests/whisper/streaming.rs
@@ -60,7 +60,9 @@
 //! exactly `agreement_count_needed` words, confirms nothing, and re-establishes
 //! the prefix that caused the stall. The `[stride ...]` lines this test prints
 //! show it directly: a run of strides pinned at a 1.4 s watermark with three
-//! confirmed words, then one stride that escapes.
+//! confirmed words, then one stride that escapes. The `[outcome ...]` lines
+//! beside them name the same thing in one word — the pinned strides that move
+//! nothing report `stationary`.
 //!
 //! That is a BOOLEAN control-flow gate riding a sub-nat logit margin, not a
 //! cascade of argmax flips, and it is sensitive to PLACEMENT on a single
@@ -93,7 +95,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use coremlit::audio::whisper::{
   options::{DecodingOptions, Options},
   result::WordTiming,
-  stream::agreement::{LocalAgreement, STRIDE_SAMPLES},
+  stream::agreement::{AgreementOutcome, LocalAgreement, STRIDE_SAMPLES},
   text::normalized,
   transcribe::WhisperKit,
 };
@@ -151,6 +153,14 @@ fn recharacterize_command() -> String {
 // ---------------------------------------------------------------------
 
 /// One completed push's view of the confirmation state.
+///
+/// The TRANSCRIPT fields and the OUTCOME field are deliberately separate
+/// concerns, and the test prints them on separate lines for the same reason: the
+/// `[stride ...]` trace exists to prove that the watermark work changes no
+/// transcript, and mixing the outcome label into it made an honest-signal change
+/// disturb a guard that is not about signals. See
+/// [`check_outcomes_match_observed_progress`] for what the labels are asserted
+/// against instead.
 #[derive(Debug, Clone)]
 struct Confirmation {
   /// 1-based stride index; also the buffered seconds, at a 1 s stride.
@@ -162,16 +172,33 @@ struct Confirmation {
   /// [`LocalAgreement::last_agreed_words_slice`], normalized — agreed but held
   /// back, still revisable by a later hypothesis.
   held_back: Vec<String>,
+  /// Every [`AgreementOutcome`] this push reported, in order. A push runs one
+  /// ingest per complete stride that newly accumulated, so at a 1 s stride and
+  /// 1 s pushes this is one element — but it is a list because `push_samples`
+  /// returns one.
+  outcomes: Vec<AgreementOutcome>,
 }
 
 impl Confirmation {
-  fn observe(stride: usize, agreement: &LocalAgreement) -> Self {
+  fn observe(stride: usize, agreement: &LocalAgreement, outcomes: Vec<AgreementOutcome>) -> Self {
     Self {
       stride,
       last_agreed_seconds: agreement.last_agreed_seconds(),
       confirmed: normalized_words(agreement.confirmed_words_slice()),
       held_back: normalized_words(agreement.last_agreed_words_slice()),
+      outcomes,
     }
+  }
+
+  /// The outcome labels this push reported, comma-joined — the `[outcome ...]`
+  /// trace's payload.
+  fn outcome_labels(&self) -> String {
+    self
+      .outcomes
+      .iter()
+      .map(ToString::to_string)
+      .collect::<Vec<_>>()
+      .join(",")
   }
 }
 
@@ -275,6 +302,91 @@ fn check_confirmed_is_prefix_of_batch(
      cannot cause it. Do not add a\ntolerance: there is no number here to relax.",
   );
   Err(report)
+}
+
+/// PORTABLE: every reported [`AgreementOutcome`] agrees with what the engine's
+/// own state did across that push.
+///
+/// The outcome sequence is real behaviour and must stay asserted, but the
+/// LABELS are not portable — which strides agree, and which of the agreeing ones
+/// move anything, is decided by the same host-scoped timestamp-mass gate this
+/// file's docs describe. What IS portable is the relation between the label and
+/// the state, because it compares this run against itself: an agreeing round
+/// reports `progressed` exactly when [`LocalAgreement::last_agreed_seconds`] or
+/// the confirmed prefix moved, and `stationary` exactly when neither did. A
+/// round that did not agree runs no advance, so it must move neither.
+///
+/// The watermark is compared by BITS. Rounding it to the two decimals the trace
+/// prints would report a 0.02 s step as a stall, which is precisely the reading
+/// the outcome now exists to replace.
+///
+/// # Errors
+/// The first stride whose label contradicts its own state transition, naming
+/// both; or a run in which no stride ever reported progress, which would leave
+/// the relation asserted only on its trivial side.
+fn check_outcomes_match_observed_progress(steps: &[Confirmation]) -> Result<(), String> {
+  let mut progressed = 0usize;
+  for (index, after) in steps.iter().enumerate() {
+    // The first push has no predecessor; the engine starts at watermark 0.0 with
+    // nothing confirmed, which is what a synthetic zeroth snapshot would say.
+    let (was_watermark, was_confirmed) =
+      index.checked_sub(1).map_or((0.0f32, 0usize), |previous| {
+        (
+          steps[previous].last_agreed_seconds,
+          steps[previous].confirmed.len(),
+        )
+      });
+    let moved = after.last_agreed_seconds.to_bits() != was_watermark.to_bits()
+      || after.confirmed.len() != was_confirmed;
+    // One push, one ingest at this stride and cadence — so the push's labels
+    // describe exactly the transition measured above. A push that ran several
+    // ingests would need per-ingest snapshots to say anything this sharp.
+    let [outcome] = after.outcomes.as_slice() else {
+      return Err(format!(
+        "stride {} reported {} outcome(s), and this check reads the state ONCE \
+         per push: {:?}.\nAt a 1 s stride and 1 s pushes exactly one ingest \
+         runs per push. If the cadence changed, snapshot the engine per ingest \
+         rather than weakening this.",
+        after.stride,
+        after.outcomes.len(),
+        after.outcome_labels(),
+      ));
+    };
+    progressed += usize::from(outcome.is_progressed());
+    let honest = if outcome.agreed() {
+      outcome.is_progressed() == moved
+    } else {
+      !moved
+    };
+    if !honest {
+      return Err(format!(
+        "stride {} reported `{outcome}` while the watermark went {was_watermark} s \
+         -> {} s ({:#x} -> {:#x}) and the confirmed prefix {was_confirmed} -> {} \
+         words.\n\
+         An agreeing round must say `progressed` exactly when one of those two \
+         moved and `stationary` exactly when neither did; a round that did not \
+         agree ran no advance and must move neither.\n\
+         This compares the run against ITSELF on this machine, so host fp16 \
+         drift moves both sides together and cannot cause it.",
+        after.stride,
+        after.last_agreed_seconds,
+        was_watermark.to_bits(),
+        after.last_agreed_seconds.to_bits(),
+        after.confirmed.len(),
+      ));
+    }
+  }
+
+  if progressed == 0 {
+    return Err(format!(
+      "no stride reported `progressed` across all {} stride(s), so the relation \
+       above was only ever read on its did-not-move side and asserts nothing \
+       about the moving one.\n\
+       A run that never progressed is a stall to diagnose, not evidence.",
+      steps.len(),
+    ));
+  }
+  Ok(())
 }
 
 /// PORTABLE: confirmation only ever moves forward across the pushes.
@@ -391,22 +503,25 @@ fn jfk_simulated_stream_confirms_the_transcript() {
   let mut streamer = kit.local_agreement_transcriber(DecodingOptions::new());
   // 1 s pushes — 11 strides, each re-transcribing the grown prefix.
   let mut steps = Vec::new();
+  // TWO TRACES, on separate lines and deliberately so. `[batch]`/`[stride
+  // ...]`/`[confirmed]` carry the TRANSCRIPT and the confirmation state, and
+  // their extract (`grep -E '^\[(batch|stride|confirmed)'`) is the digest this
+  // watermark work is measured against: it must not move. `[outcome ...]`
+  // carries the labels, which this work DOES move, and digests separately.
+  // While the two shared one line, an honest-signal fix disturbed a guard that
+  // is not about signals.
   for (index, chunk) in audio.chunks(STRIDE_SAMPLES).enumerate() {
     let outcomes = streamer.push_samples(chunk).unwrap();
-    let step = Confirmation::observe(index + 1, streamer.agreement());
+    let step = Confirmation::observe(index + 1, streamer.agreement(), outcomes);
     println!(
-      "[stride {:>2}] {:<18} watermark {:>6.2} s  confirmed {:>2}  held {:>2}  {:?}",
+      "[stride {:>2}] watermark {:>6.2} s  confirmed {:>2}  held {:>2}  {:?}",
       step.stride,
-      outcomes
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join(","),
       step.last_agreed_seconds,
       step.confirmed.len(),
       step.held_back.len(),
       step.confirmed.join(" "),
     );
+    println!("[outcome {:>2}] {}", step.stride, step.outcome_labels());
     steps.push(step);
   }
   // Read before `finalize` consumes the driver: the floor the prefix check needs
@@ -422,6 +537,12 @@ fn jfk_simulated_stream_confirms_the_transcript() {
   }
   if let Err(why) = check_confirmed_is_prefix_of_batch(&confirmed, &batch, agreement_count_needed) {
     panic!("streaming confirmation is not a prefix of the batch transcript: {why}");
+  }
+  // The outcome labels, asserted against the state they claim to describe rather
+  // than against a recorded sequence — the labels themselves are host-scoped,
+  // the relation is not.
+  if let Err(why) = check_outcomes_match_observed_progress(&steps) {
+    panic!("a reported agreement outcome did not match what the engine did: {why}");
   }
 
   // ── Measured, asserted only on the host class that produced it.
@@ -446,13 +567,133 @@ fn jfk_simulated_stream_confirms_the_transcript() {
 // ---------------------------------------------------------------------
 
 /// Snapshots from normalized word lists, for the hermetic cases below.
+///
+/// No outcome: the monotonicity cases are about the state sequence alone.
+/// [`step_reporting`] is the one the outcome cases use.
 fn step(stride: usize, watermark: f32, confirmed: &[&str], held_back: &[&str]) -> Confirmation {
   Confirmation {
     stride,
     last_agreed_seconds: watermark,
     confirmed: confirmed.iter().map(|w| (*w).to_string()).collect(),
     held_back: held_back.iter().map(|w| (*w).to_string()).collect(),
+    outcomes: Vec::new(),
   }
+}
+
+/// The same snapshot carrying the label this push reported.
+fn step_reporting(
+  stride: usize,
+  outcome: AgreementOutcome,
+  watermark: f32,
+  confirmed: &[&str],
+) -> Confirmation {
+  Confirmation {
+    outcomes: vec![outcome],
+    ..step(stride, watermark, confirmed, &[])
+  }
+}
+
+/// The JFK run's own shape, as the labels a correct engine reports for it: two
+/// silent strides, then rounds that move the watermark and one that does not.
+fn honest_run() -> Vec<Confirmation> {
+  vec![
+    step_reporting(1, AgreementOutcome::NoWordTimings, 0.0, &[]),
+    step_reporting(2, AgreementOutcome::AwaitingAgreement, 0.0, &[]),
+    step_reporting(3, AgreementOutcome::Progressed, 1.36, &["and", "so", "my"]),
+    step_reporting(4, AgreementOutcome::Progressed, 1.38, &["and", "so", "my"]),
+    step_reporting(5, AgreementOutcome::Stationary, 1.38, &["and", "so", "my"]),
+  ]
+}
+
+/// The honest shape passes, and it is the JFK stall's own: a `stationary` round
+/// with the watermark bit-identical to the round before it.
+#[test]
+fn an_outcome_sequence_that_matches_the_state_is_accepted() {
+  assert_eq!(
+    check_outcomes_match_observed_progress(&honest_run()),
+    Ok(())
+  );
+}
+
+/// THE FALSIFIER the honest-signal fix exists for: a round that moved NOTHING
+/// and claimed progress. This is what every stalled stride reported before the
+/// two agreeing cases were told apart.
+#[test]
+fn a_progressed_label_on_a_stalled_stride_reds() {
+  let mut steps = honest_run();
+  steps[4].outcomes = vec![AgreementOutcome::Progressed];
+  let why = check_outcomes_match_observed_progress(&steps)
+    .expect_err("a stalled stride claiming progress must red");
+  assert!(why.contains("stride 5"), "{why}");
+  assert!(why.contains("`progressed`"), "{why}");
+  assert!(why.contains("1.38"), "{why}");
+}
+
+/// And the other direction: a round that DID move and claimed to be stationary.
+/// A `split != 0` progress test produces exactly this on a zero-split round
+/// whose timings drifted.
+#[test]
+fn a_stationary_label_on_a_moving_stride_reds() {
+  let mut steps = honest_run();
+  steps[3].outcomes = vec![AgreementOutcome::Stationary];
+  let why = check_outcomes_match_observed_progress(&steps)
+    .expect_err("a moving stride claiming to be stationary must red");
+  assert!(why.contains("stride 4"), "{why}");
+  assert!(why.contains("`stationary`"), "{why}");
+}
+
+/// A round that did not agree ran no advance, so it may not have moved either.
+#[test]
+fn a_non_agreeing_label_on_a_moving_stride_reds() {
+  let mut steps = honest_run();
+  steps[3].outcomes = vec![AgreementOutcome::AwaitingAgreement];
+  let why = check_outcomes_match_observed_progress(&steps)
+    .expect_err("a non-agreeing stride that moved the watermark must red");
+  assert!(why.contains("stride 4"), "{why}");
+  assert!(why.contains("did not agree"), "{why}");
+}
+
+/// Rounding is what the bit comparison is there to refuse: 1.38 and a watermark
+/// one ULP away print identically at two decimals, and a `stationary` claim over
+/// that step is still false.
+#[test]
+fn a_sub_printed_precision_step_is_still_a_move() {
+  let mut steps = honest_run();
+  steps[4].last_agreed_seconds = f32::from_bits(steps[3].last_agreed_seconds.to_bits() + 1);
+  assert_eq!(
+    format!("{:.2}", steps[4].last_agreed_seconds),
+    format!("{:.2}", steps[3].last_agreed_seconds),
+    "non-vacuous: the two print the same at the trace's own precision",
+  );
+  let why = check_outcomes_match_observed_progress(&steps)
+    .expect_err("a one-ULP step is a move, and calling it stationary must red");
+  assert!(why.contains("stride 5"), "{why}");
+}
+
+/// A run in which nothing ever progressed satisfies the relation on its trivial
+/// side only, so the predicate must refuse it rather than report a green.
+#[test]
+fn a_run_that_never_progresses_is_not_outcome_evidence() {
+  let steps = [
+    step_reporting(1, AgreementOutcome::AwaitingAgreement, 0.0, &[]),
+    step_reporting(2, AgreementOutcome::Stationary, 0.0, &[]),
+  ];
+  let why = check_outcomes_match_observed_progress(&steps)
+    .expect_err("a run with no progress at all must red");
+  assert!(why.contains("no stride reported `progressed`"), "{why}");
+}
+
+/// The check reads the engine's state once per PUSH, so it is only sound while a
+/// push runs exactly one ingest. A push that ran several must red rather than
+/// silently compare one transition against several labels.
+#[test]
+fn a_push_with_more_than_one_ingest_reds_rather_than_guessing() {
+  let mut steps = honest_run();
+  steps[2].outcomes = vec![AgreementOutcome::Progressed, AgreementOutcome::Stationary];
+  let why =
+    check_outcomes_match_observed_progress(&steps).expect_err("a multi-ingest push must red");
+  assert!(why.contains("reported 2 outcome(s)"), "{why}");
+  assert!(why.contains("progressed,stationary"), "{why}");
 }
 
 const BATCH: &str = "and so my fellow americans ask not what your country can do for you";
@@ -737,6 +978,7 @@ fn only_the_phrase_is_host_scoped() {
   for portable in [
     "check_monotone_confirmation(&steps)",
     "check_confirmed_is_prefix_of_batch(&confirmed, &batch, agreement_count_needed)",
+    "check_outcomes_match_observed_progress(&steps)",
   ] {
     assert!(
       body.contains(portable),

--- a/crates/coremlit/tests/whisper/streaming.rs
+++ b/crates/coremlit/tests/whisper/streaming.rs
@@ -238,23 +238,27 @@ fn check_confirmed_is_prefix_of_batch(
     )),
     // Every shared position matched, so the confirmation ran PAST the batch
     // transcript — the signature of a word confirmed twice. Two mechanisms
-    // produce it. `LocalAgreement::finalize` folding in BOTH the held-back words
-    // and the last pair's differing suffix is now guarded (`holdback_superseded`)
-    // and has hermetic falsifiers in `stream/agreement/tests.rs`. The
-    // re-admission strip in `LocalAgreement::watermark_filtered` is NOT fixed —
-    // it only catches a reproduction at the front of the offered list, and the
-    // sequences that slide past it are the `_today` characterization tests in
-    // that same file (issue #94). Check the second before the decode, and the
-    // first before both.
+    // produce it, and both are guarded with hermetic falsifiers in
+    // `stream/agreement/tests.rs`: `LocalAgreement::finalize` folding in BOTH
+    // the held-back words and the last pair's differing suffix
+    // (`holdback_superseded`), and `LocalAgreement::watermark_filtered`'s
+    // re-admission frontier (issue #94's ledger, now the named property tests
+    // in that file). The frontier keeps ONE documented residual —
+    // `an_unaccounted_repeat_of_a_settled_word_is_kept_as_the_streams_own`: an
+    // offered list carrying more copies of a settled word than the engine's own
+    // record accounts for is read as the stream repeating it. Check that
+    // residual first, then the decode.
     None => report.push_str(&format!(
       "  every shared position matched, but the confirmation is {} word(s) LONGER \
        than the batch transcript — i.e. it emitted words the batch decode never \
        produced. Suspect a word confirmed TWICE before suspecting the decode: \
-       `LocalAgreement::watermark_filtered`'s re-admission strip has KNOWN OPEN \
-       gaps (issue #94, the `_today` characterization tests in \
-       `stream/agreement/tests.rs`), \
-       and `LocalAgreement::finalize` folds in both the held-back words and the \
-       last pair's differing suffix behind the `holdback_superseded` guard.\n",
+       `LocalAgreement::watermark_filtered`'s re-admission frontier keeps one \
+       documented residual (issue #94 — a repeat its record cannot account for \
+       is kept as the stream's own; see \
+       `an_unaccounted_repeat_of_a_settled_word_is_kept_as_the_streams_own` in \
+       `stream/agreement/tests.rs`), and `LocalAgreement::finalize` folds in \
+       both the held-back words and the last pair's differing suffix behind the \
+       `holdback_superseded` guard.\n",
       confirmed_words.len().saturating_sub(batch_words.len()),
     )),
   }

--- a/crates/coremlit/tests/whisper/streaming.rs
+++ b/crates/coremlit/tests/whisper/streaming.rs
@@ -241,22 +241,26 @@ fn check_confirmed_is_prefix_of_batch(
     // produce it, and both are guarded with hermetic falsifiers in
     // `stream/agreement/tests.rs`: `LocalAgreement::finalize` folding in BOTH
     // the held-back words and the last pair's differing suffix
-    // (`holdback_superseded`), and `LocalAgreement::watermark_filtered`'s
-    // re-admission frontier (issue #94's ledger, now the named property tests
-    // in that file). The frontier keeps ONE documented residual —
-    // `an_unaccounted_repeat_of_a_settled_word_is_kept_as_the_streams_own`: an
-    // offered list carrying more copies of a settled word than the engine's own
-    // record accounts for is read as the stream repeating it. Check that
-    // residual first, then the decode.
+    // (`holdback_superseded`), and a word confirmed twice across strides. The
+    // second is closed at its source by RULE W (issue #94) — the advance never
+    // puts the watermark at a word whose start ties the last confirmed one, so
+    // `confirmed.last().start() < last_agreed_seconds` strictly and no
+    // confirmed word can pass `watermark_filtered`'s `start >= watermark`
+    // again. `the_split_never_cuts_at_a_tied_start` sweeps that postcondition.
+    // The rule leaves ONE way back in, recorded there: with an EMPTY holdback
+    // the watermark anchors at the last confirmed word's END, so a
+    // zero-duration word there still ties it. Check that residual first, then
+    // the decode.
     None => report.push_str(&format!(
       "  every shared position matched, but the confirmation is {} word(s) LONGER \
        than the batch transcript — i.e. it emitted words the batch decode never \
        produced. Suspect a word confirmed TWICE before suspecting the decode: \
-       `LocalAgreement::watermark_filtered`'s re-admission frontier keeps one \
-       documented residual (issue #94 — a repeat its record cannot account for \
-       is kept as the stream's own; see \
-       `an_unaccounted_repeat_of_a_settled_word_is_kept_as_the_streams_own` in \
-       `stream/agreement/tests.rs`), and `LocalAgreement::finalize` folds in \
+       Rule W (issue #94) makes a re-admission unrepresentable while the \
+       holdback is non-empty, but leaves one documented residual — an EMPTY \
+       holdback anchors the watermark at the last confirmed word's END, so a \
+       zero-duration word there ties it; see \
+       `the_split_never_cuts_at_a_tied_start` in \
+       `stream/agreement/tests.rs` — and `LocalAgreement::finalize` folds in \
        both the held-back words and the last pair's differing suffix behind the \
        `holdback_superseded` guard.\n",
       confirmed_words.len().saturating_sub(batch_words.len()),

--- a/crates/coremlit/tests/whisper/streaming.rs
+++ b/crates/coremlit/tests/whisper/streaming.rs
@@ -45,8 +45,10 @@
 //! The two paths are not the same decode with different numbers. Every stride
 //! after the first re-enters the decoder with `prefix_tokens` and
 //! `clip_timestamps` that the batch path never sets
-//! ([`LocalAgreement::decoding_options_for_next`](
-//! coremlit::audio::whisper::stream::agreement::LocalAgreement::decoding_options_for_next)),
+//! (`LocalAgreement::decoding_options_for_next`, crate-internal since the M1
+//! seal — [`LocalAgreementTranscriber`](
+//! coremlit::audio::whisper::stream::agreement::LocalAgreementTranscriber) is
+//! what drives it),
 //! and that changes which code runs, not just what it computes on. Once a
 //! stride decodes `"And so my fellow Americans!"` — an exclamation mark the
 //! batch decode never produces; `jfk_tiny_golden.json`'s own text has none —
@@ -746,5 +748,115 @@ fn only_the_phrase_is_host_scoped() {
   assert!(
     source.contains("const CANONICAL_PHRASE: &str = \"ask not what your country can do for you\";"),
     "the phrase must not be weakened, widened or deleted — it is host-scoped, not relaxed"
+  );
+}
+
+// ── The seal: the engine exposes no public mutator ───────────────────────────
+
+/// Every name on [`LocalAgreement`] that MOVES its state. Each is `pub(crate)`,
+/// so the only way to drive the engine from outside this crate is through
+/// [`LocalAgreementTranscriber`](coremlit::audio::whisper::stream::agreement::LocalAgreementTranscriber),
+/// which orders the calls correctly by construction.
+///
+const SEALED_MUTATORS: &[&str] = &[
+  "fn new(",
+  "fn ingest(",
+  "fn finalize(",
+  "fn decoding_options_for_next(",
+  "fn with_agreement_count_needed(",
+  "fn set_agreement_count_needed(",
+];
+
+/// **THE SEAL'S FALSIFIER** (issue #94, M1). `LocalAgreement` stays `pub` and
+/// fully readable — `confirmed_words_slice`, `last_agreed_words_slice`,
+/// `last_agreed_seconds`, `results_slice`, `agreement_count_needed` are all
+/// public — but nothing that MOVES its state is, because the correctness this
+/// module argues for is a property of hypotheses the driver produced: the
+/// holdback reproduction that makes an advance a re-agreement, the prefill
+/// budget, and Rule W's postcondition all assume it.
+///
+/// A caller that wants its own DECODER still has one: `InferenceBackend` is
+/// public and unsealed, and `WhisperKit::local_agreement_transcriber` sits on
+/// `impl<B> WhisperKit<B>` with no bound, so a custom backend inherits this
+/// whole stack. What the seal removes is "bring your own TRANSCRIPT", the one
+/// shape that inherits none of it.
+///
+/// Grep rather than a compile-fail fixture, in the convention of
+/// `tests/vad/reexport.rs::src_authors_no_detection_logic`: publishing any of
+/// these again is a one-word edit, and a one-word edit should red a test.
+#[test]
+fn the_engine_exposes_no_public_mutator() {
+  let source = std::fs::read_to_string(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/src/audio/whisper/stream/agreement/mod.rs"
+  ))
+  .expect("the engine's source is readable");
+
+  // Scoped to the ENGINE's own inherent impl block. `LocalAgreementTranscriber`
+  // shares three of these names (`new`, `finalize`,
+  // `with_agreement_count_needed`) and is legitimately public — it IS the public
+  // surface the seal leaves.
+  let engine = source
+    .split_once("\nimpl LocalAgreement {\n")
+    .expect("the engine's inherent impl block is still here")
+    .1
+    .split_once("\n}\n")
+    .expect("that impl block still closes at column 0")
+    .0;
+
+  // Non-vacuous: the block really does declare each of these, `pub(crate)`.
+  // Without this a rename would silently empty the scan.
+  for name in SEALED_MUTATORS {
+    assert!(
+      engine.contains(name),
+      "`{name}` is gone from `impl LocalAgreement` — if it was renamed, rename \
+       it in SEALED_MUTATORS too; this gate is worthless if it scans for nothing",
+    );
+  }
+
+  let mut violations = Vec::new();
+  for (lineno, line) in engine.lines().enumerate() {
+    // Code only: a doc comment that NAMES a sealed item (this module's own docs
+    // do, repeatedly) is not a re-publication.
+    let code = line.split("//").next().unwrap_or("");
+    for name in SEALED_MUTATORS {
+      // `pub ` immediately in front, which `pub(crate) fn` does not contain.
+      if code.contains(&format!("pub {name}")) || code.contains(&format!("pub const {name}")) {
+        violations.push(format!(
+          "impl LocalAgreement, line {}: `{name}` — {}",
+          lineno + 1,
+          line.trim(),
+        ));
+      }
+    }
+  }
+
+  // A public trait impl IS a public constructor: `LocalAgreement::default()`
+  // would hand out a fresh engine with no `new` in sight, and `Default` is
+  // reachable through every generic bound that asks for it. Scanned over the
+  // WHOLE file, since a trait impl lives outside the inherent block.
+  for (lineno, line) in source.lines().enumerate() {
+    if line
+      .split("//")
+      .next()
+      .unwrap_or("")
+      .contains("impl Default for LocalAgreement")
+    {
+      violations.push(format!(
+        "mod.rs:{}: `impl Default for LocalAgreement` is a PUBLIC CONSTRUCTOR — {}",
+        lineno + 1,
+        line.trim(),
+      ));
+    }
+  }
+
+  assert!(
+    violations.is_empty(),
+    "the LocalAgreement engine must expose NO public mutator (issue #94, M1): \
+     the correctness of `ingest` is a property of hypotheses \
+     `LocalAgreementTranscriber` produced, and a caller handing in its own \
+     inherits none of it. Found {} re-publication(s):\n{}",
+    violations.len(),
+    violations.join("\n"),
   );
 }


### PR DESCRIPTION
Closes #94.