### PR TITLE
ci(coremlit): close #61's acceptance criteria — the skip is explicit, the lib shard runs, and the ci/coverage coupling is checked

### DIFF
--- a/.github/actions/stage-models/plan_parity.sh
+++ b/.github/actions/stage-models/plan_parity.sh
@@ -21,7 +21,9 @@
 #
 # SELF-DELETING. Once ci.yml calls the composite action instead of staging models
 # inline, there is no `hf download` in it to extract, and this script reports the
-# migration complete and asks to be removed along with itself.
+# migration complete and asks to be removed along with itself. THE JOB THAT RUNS
+# IT STAYS: it also runs gate_plan_parity.sh, which compares what the two
+# workflows RUN rather than what they download and is not tied to this migration.
 
 set -euo pipefail
 
@@ -100,7 +102,8 @@ PY
 if [ "$extracted" -eq 3 ]; then
   echo "ci.yml issues no \`hf download\` of its own: it has been migrated onto"
   echo ".github/actions/stage-models, so there is no second parser left to drift."
-  echo "DELETE this script and the coverage.yml job that runs it."
+  echo "DELETE this script and the coverage.yml STEP that runs it — not the job,"
+  echo "which also runs gate_plan_parity.sh over the two files' gate plans."
   exit 0
 fi
 if [ "$extracted" -ne 0 ]; then

--- a/.github/scripts/gate_plan_parity.sh
+++ b/.github/scripts/gate_plan_parity.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+#
+# Prove that ci.yml's `model-tests` shards and coverage.yml's `coverage-models`
+# legs RUN THE SAME MODEL GATES — by executing both gate runners and diffing the
+# cargo invocations they would issue, not by reading their matrices side by side.
+#
+# WHY THIS EXISTS. coverage.yml already says the coupling out loud: "the gate
+# plans are the same plans — because a coverage leg that measured a DIFFERENT
+# set of gates than the job that enforces them would report on code the
+# repository does not actually gate." That was asserted in a comment and checked
+# by nothing. `plan_parity.sh` next door covers the DOWNLOAD plan; the two files
+# were free to disagree about which gates run over what they downloaded, and
+# they did: the `speaker` leg went a whole release without the `@lib` group its
+# ci.yml twin carries (#61).
+#
+# HOW, and it is plan_parity.sh's method one level up. Each workflow's gate
+# runner is extracted from the file, a stub `cargo` is put first on PATH, and
+# the REAL script is executed once per kit with that kit's own `GATES` value.
+# The stub canonicalises each invocation and appends it to a log; the logs are
+# then diffed per kit. There is no third re-implementation of the
+# `features|selectors|filter` grammar to keep in step — the things under test
+# are the two runners' own code — so a refactor that changes their syntax while
+# preserving the plan stays green, and one that changes the plan cannot.
+#
+# THE THREE ALLOWED DIFFERENCES, encoded rather than tolerated. The stub knows
+# exactly this much about how the two sides may differ, and ANY other token is a
+# hard failure that names itself rather than being normalised away:
+#
+#   1. the subcommand: ci.yml runs `cargo test`, coverage.yml `cargo llvm-cov`;
+#   2. `--no-report`, which coverage.yml passes so the per-group runs accumulate
+#      into one profile instead of each writing a report;
+#   3. `cargo llvm-cov clean` / `cargo llvm-cov report`, coverage-only commands
+#      that bracket the gates rather than being gates. They are counted and
+#      reported, so they cannot hide a gate by being mistaken for one.
+#
+# Everything else — features, `--lib`/`--test <name>`/whole-package selection,
+# `--no-fail-fast`, and every argument after `--` including `--ignored`, the
+# plan's filter, and the `--list` half of the anti-vacuum count — must match
+# exactly, in order.
+
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$repo_root"
+
+ci=".github/workflows/ci.yml"
+cov=".github/workflows/coverage.yml"
+
+for f in "$ci" "$cov"; do
+  if [ ! -f "$f" ]; then
+    echo "::error::gate_plan_parity.sh: $f is missing" >&2
+    exit 2
+  fi
+done
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Extract each workflow's gate runner and the matrix it is driven by.
+#
+#    The runner is found by what it IS — the step whose `env:` binds `GATES`,
+#    i.e. the one driven by the matrix plan — rather than by step name or job
+#    id, and its matrix is read from the job that CONTAINS it. Renaming either
+#    survives; losing either is a diagnosed failure, not a vacuous pass.
+#
+#    `GATES` rather than the `--list --ignored` text alone, because ci.yml has a
+#    SECOND ignored-only counter: the modelless `check` job's VAD block, whose
+#    targets are hardcoded because the committed model needs no matrix. It runs
+#    gates but is not a gate PLAN, and coverage.yml has no counterpart to it.
+# ---------------------------------------------------------------------------
+extract() {
+  python3 - "$1" "$2" <<'PY'
+import re, sys, yaml
+
+path, outdir = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as fh:
+    doc = yaml.safe_load(fh)
+
+runs_gates = re.compile(r"--\s+--list\s+--ignored", re.MULTILINE)
+
+found = []
+for job_id, job in (doc.get("jobs") or {}).items():
+    for step in job.get("steps") or []:
+        run = step.get("run")
+        env = step.get("env") or {}
+        if isinstance(run, str) and runs_gates.search(run) and "GATES" in env:
+            found.append((job_id, job, run))
+
+if len(found) != 1:
+    sys.stderr.write(
+        f"::error::{path} has {len(found)} plan-driven gate runners (a step that "
+        "binds `GATES` and takes an ignored-only `--list` count); this check knows "
+        "how to execute exactly one. None means the workflow has lost its gate "
+        "runner, and its anti-vacuum guard with it; several have to say which is "
+        "the plan.\n"
+    )
+    sys.exit(4)
+
+job_id, job, script = found[0]
+
+# `${{ }}` is spliced in by the Actions runner before bash sees the script, so a
+# script that depends on it cannot be executed faithfully here and any "the
+# plans match" verdict would be a lie. Both runners pass their matrix values
+# through `env:` for exactly this reason.
+if "${{" in script:
+    sys.stderr.write(
+        f"::error::{path}'s gate runner contains a `${{{{ }}}}` expression, which this "
+        "check cannot expand — so it could not run the real script. Move the value "
+        "into the step's `env:` block.\n"
+    )
+    sys.exit(4)
+
+rows = (((job.get("strategy") or {}).get("matrix") or {}).get("include")) or []
+plans = {}
+for row in rows:
+    kit, gates = row.get("kit"), row.get("gates")
+    if not kit or not gates:
+        sys.stderr.write(
+            f"::error::{path}'s {job_id!r} matrix has a row with no `kit` or no "
+            f"`gates` ({row.get('kit')!r}); every row must carry a gate plan or this "
+            "check cannot compare it.\n"
+        )
+        sys.exit(4)
+    plans[kit] = gates
+if not plans:
+    sys.stderr.write(f"::error::{path}'s {job_id!r} job has no gate-plan matrix rows\n")
+    sys.exit(4)
+
+with open(f"{outdir}/runner.sh", "w", encoding="utf-8") as fh:
+    fh.write(script)
+with open(f"{outdir}/kits", "w", encoding="utf-8") as fh:
+    fh.write("\n".join(sorted(plans)) + "\n")
+for kit, gates in plans.items():
+    with open(f"{outdir}/gates.{kit}", "w", encoding="utf-8") as fh:
+        fh.write(gates)
+print(f"{path}: job {job_id!r}, {len(plans)} kit(s)")
+PY
+}
+
+mkdir -p "$work/ci" "$work/cov"
+extract "$ci" "$work/ci"
+extract "$cov" "$work/cov"
+
+# ---------------------------------------------------------------------------
+# 2. The kit sets must match before the plans can be compared at all: a kit with
+#    a shard and no coverage leg is code CI gates and the number never sees, and
+#    the reverse is a leg reporting on gates nothing enforces.
+# ---------------------------------------------------------------------------
+if ! diff -u "$work/ci/kits" "$work/cov/kits" > "$work/kits.diff"; then
+  echo "::error::ci.yml's model-gate shards and coverage.yml's legs cover different kits. A kit gated with no leg is code the number never sees; a leg with no shard reports on gates nothing enforces. (-) is ci.yml, (+) is coverage.yml:" >&2
+  sed 's/^/    /' "$work/kits.diff" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The stub `cargo`. It canonicalises one invocation into one log line, so the
+#    two runners' argv become directly diffable despite the wrapper.
+#
+#    It must also keep the REAL script running: both runners pipe the `--list`
+#    invocation into `grep -c ': test$'` and abort the whole plan when that
+#    count is zero (the anti-vacuum guard). So the stub prints one line in that
+#    shape — enough to satisfy the guard, and the count itself is not what this
+#    check compares.
+# ---------------------------------------------------------------------------
+mkdir -p "$work/bin"
+cat > "$work/bin/cargo" <<'PY'
+#!/usr/bin/env python3
+import os, sys
+
+argv = sys.argv[1:]
+log = os.environ["GATE_PARITY_LOG"]
+
+
+def emit(line):
+    with open(log, "a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+def bail(reason):
+    # An unknown token must NOT be normalised away: that is how a parity check
+    # gets loosened until it passes. Record it and let the differ fail naming it.
+    emit(f"UNKNOWN {reason}: {' '.join(argv)}")
+    sys.exit(0)
+
+
+if not argv:
+    bail("no subcommand")
+
+sub, rest = argv[0], argv[1:]
+
+# ALLOWED DIFFERENCE 1: the subcommand.
+if sub == "test":
+    pass
+elif sub == "llvm-cov":
+    # ALLOWED DIFFERENCE 3: coverage-only commands that bracket the gates.
+    if rest and rest[0] in ("clean", "report"):
+        emit(f"NONGATE llvm-cov {rest[0]}")
+        sys.exit(0)
+    # ALLOWED DIFFERENCE 2: --no-report, so per-group runs accumulate.
+    if rest and rest[0] == "--no-report":
+        rest = rest[1:]
+else:
+    bail(f"unknown cargo subcommand {sub!r}")
+
+# Everything from here must be identical between the two runners.
+features = None
+target = "package"
+no_fail_fast = 0
+tail = None
+i = 0
+while i < len(rest):
+    tok = rest[i]
+    if tok == "--":
+        tail = rest[i + 1 :]
+        break
+    if tok == "-p":
+        if i + 1 >= len(rest) or rest[i + 1] != "coremlit":
+            bail("gates must run against -p coremlit")
+        i += 2
+        continue
+    if tok == "--features":
+        if i + 1 >= len(rest):
+            bail("--features with no value")
+        features = rest[i + 1]
+        i += 2
+        continue
+    if tok == "--lib":
+        target = "lib"
+        i += 1
+        continue
+    if tok == "--test":
+        if i + 1 >= len(rest):
+            bail("--test with no value")
+        target = f"test:{rest[i + 1]}"
+        i += 2
+        continue
+    if tok == "--no-fail-fast":
+        no_fail_fast = 1
+        i += 1
+        continue
+    bail(f"unrecognised argument {tok!r}")
+
+if tail is None:
+    bail("no `--` separator, so this is not a gate invocation")
+if features is None:
+    bail("no --features, so the gate's feature set is unknowable")
+
+mode = "list" if "--list" in tail else "run"
+emit(
+    f"GATE mode={mode} features={features!r} target={target} "
+    f"no-fail-fast={no_fail_fast} tail={' '.join(tail)!r}"
+)
+
+# Keep the real runner alive past its anti-vacuum guard.
+if mode == "list":
+    print("stub::gate: test")
+PY
+chmod +x "$work/bin/cargo"
+
+# ---------------------------------------------------------------------------
+# 4. Execute each runner, per kit, and diff.
+# ---------------------------------------------------------------------------
+run_side() {
+  side="$1" kit="$2"
+  log="$work/$side.$kit.plan"
+  : > "$log"
+  # `PROBE` is ci.yml's absent-artifact guard, not part of the gate plan; `.`
+  # always exists, so the real loop runs and passes. coverage.yml's runner does
+  # not read it. Anything else the scripts need must come through `env:`, which
+  # is the same constraint the `${{ }}` refusal above enforces.
+  (
+    cd "$work"
+    PATH="$work/bin:$PATH" \
+    GATE_PARITY_LOG="$log" \
+    KIT="$kit" \
+    PROBE="." \
+    GATES="$(cat "$work/$side/gates.$kit")" \
+      bash "$work/$side/runner.sh"
+  ) > "$work/$side.$kit.out" 2> "$work/$side.$kit.err"
+}
+
+# A divergent kit reports ITS verdict and the loop keeps going. Under a global
+# early-exit the first mismatch would hide every kit after it — the same masking
+# ci.yml's own gate runner is written to avoid, and the reason this job reports
+# all six plans rather than the first broken one.
+status=0
+while read -r kit; do
+  [ -n "$kit" ] || continue
+  bad=0
+  for side in ci cov; do
+    if ! run_side "$side" "$kit"; then
+      echo "::error::the $side gate runner failed for kit '$kit', so its plan could not be resolved:" >&2
+      sed 's/^/    /' "$work/$side.$kit.err" >&2
+      bad=1
+    fi
+  done
+  if [ "$bad" -ne 0 ]; then
+    status=1
+    continue
+  fi
+
+  if grep -q '^UNKNOWN ' "$work/ci.$kit.plan" "$work/cov.$kit.plan"; then
+    echo "::error::kit '$kit': a gate invocation used an argument this check does not know how to compare. It is refused rather than ignored, because normalising an unknown token away is how a parity check stops checking. Teach .github/scripts/gate_plan_parity.sh the argument, or stop passing it:" >&2
+    grep -h '^UNKNOWN ' "$work/ci.$kit.plan" "$work/cov.$kit.plan" | sed 's/^/    /' >&2
+    status=1
+    continue
+  fi
+
+  grep '^GATE ' "$work/ci.$kit.plan" > "$work/ci.$kit.gates" || true
+  grep '^GATE ' "$work/cov.$kit.plan" > "$work/cov.$kit.gates" || true
+  gates=$(grep -c . "$work/ci.$kit.gates" || true)
+  if [ "$gates" -eq 0 ]; then
+    echo "::error::kit '$kit': ci.yml's gate runner issued no gate invocation at all, so this comparison would pass over nothing" >&2
+    status=1
+    continue
+  fi
+
+  if diff -u "$work/ci.$kit.gates" "$work/cov.$kit.gates" > "$work/gates.$kit.diff"; then
+    nongate=$(grep -c '^NONGATE ' "$work/cov.$kit.plan" || true)
+    echo "== $kit: $gates gate invocation(s) identical, $nongate coverage-only command(s) =="
+  else
+    echo "::error::kit '$kit': ci.yml's model-tests shard and coverage.yml's coverage leg do not run the same model gates. coverage.yml's own comment says these are the same plans; a leg that measures a different set reports on code the repository does not actually gate. (-) is ci.yml, (+) is coverage.yml:" >&2
+    sed 's/^/    /' "$work/gates.$kit.diff" >&2
+    status=1
+  fi
+done < "$work/ci/kits"
+
+if [ "$status" -ne 0 ]; then
+  exit 1
+fi
+echo "every kit's gate plan resolves identically in $ci and $cov"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,12 @@ jobs:
       # refuse a mismatched host outright. It stays a local/dev gate against a
       # same-host oracle.
       #
+      # There is no in-lib half to add here either, and that is measured rather
+      # than assumed: `--features vad --lib -- --list --ignored` lists ZERO —
+      # every VAD model gate is a `tests/vad/*` target — so a `--lib` run would
+      # be exactly the vacuum the counts below refuse. (See the in-lib coverage
+      # ledger over `model-tests`'s matrix for the kits that do have one.)
+      #
       # Anti-vacuum, the same idiom `model-tests`'s gate runner applies to every
       # shard: an ignored-only run over a target whose gates were deleted,
       # renamed, un-ignored, or that failed to BUILD runs 0 tests and exits 0,
@@ -196,6 +202,34 @@ jobs:
   #                  sweep step.
   #   gates          the gate plan, one `features|selectors|filter` group per
   #                  line — see the gate step.
+  #
+  # WHERE THE LIBRARY'S OWN MODEL GATES RUN. 230 of this repository's model
+  # gates are not in `tests/` at all: they are `#[ignore]`d unit tests inside
+  # the pipeline modules, more than every `tests/` binary holds put together
+  # (#61). They reach CI through a row's gate plan like any other target — as
+  # `@lib`, or inside an `@all` — and through nothing else, so the plans below
+  # ARE the in-lib coverage. Counted per kit with
+  # `cargo test -p coremlit --features <kit> --lib -- --list --ignored`:
+  #
+  #   whisper  118  covered by this row's two `@all` groups. `@all` is the
+  #                 whole package, which BUILDS AND RUNS the lib target too, so
+  #                 the row needs no `@lib` of its own; adding one would run
+  #                 the same 118 gates a second time. (Measured: that row's
+  #                 `whisper|@all` lists 150, of which 118 are the lib's.)
+  #   granite   51  covered by `@lib`.
+  #   speaker   38  covered by `@lib`, less the eleven that read a tree no
+  #                 runner fetches — see that row.
+  #   ced        0  these kits' model gates all live in `tests/`, so a `@lib`
+  #   clap       0  group would list ZERO ignored tests and (correctly) trip
+  #   siglip     0  the gate runner's anti-vacuum guard, exactly as
+  #                 `clap_tokenizer_identity` would. The same is true of the
+  #                 `vad` gates in the modelless `check` job.
+  #   align     19  (20 with `tracing`) NO ROW REACHES THEM, and none can from
+  #                 here: `align` has no MODELS_LOCK table — alignkit is one of
+  #                 `UNSTAGED_DEFECT_VENDORS` (tests/whisper/models_lock.rs),
+  #                 360 MB and unstaged — so there is no shard to hang a `@lib`
+  #                 on. They stay local/dev gates alongside the five
+  #                 `tests/align/*` targets, which are equally ungated.
   model-tests:
     name: model-tests (${{ matrix.kit }})
     runs-on: macos-15
@@ -288,6 +322,38 @@ jobs:
           # Face, so undeclared-means-all-rights-reserved applies and this
           # repository does not fetch those graphs in CI at all. NOTICE records
           # that; adding them here would quietly reverse a licensing decision.
+          #
+          # The SECOND gate group is the library's own suite, and it is free:
+          # `--features speaker --lib` lists 38 `#[ignore]`d model gates that
+          # read exactly the two graphs this shard already stages, so the group
+          # costs one more `cargo test` over an already-built binary (26 s
+          # measured) and not one byte of download. Without it the shard pulls
+          # 108 MB for three `tests/` targets and leaves the larger half of the
+          # kit's gates unrun (#61).
+          #
+          # `--skip=argmax` IS THE LICENSING DECISION ABOVE, one level down.
+          # ELEVEN of those 38 load ARGMAX_TEST_MODELS — the ten in
+          # `audio::speaker::source::argmax::tests`, plus
+          # `source::tests::any_source_load_dispatches_fluid_audio_and_argmax`,
+          # which loads BOTH sources — and no runner has that tree. Measured
+          # with it removed: an unfiltered `@lib` fails eleven, a skip that did
+          # not reach the dispatcher gate fails one, and this filter leaves 27
+          # passing. The gate that needs the tree says `argmax` in its NAME,
+          # which is what lets one substring cover all eleven.
+          #
+          # `ci_speaker_lib_gates_skip_exactly_the_unstaged_argmax_tree` pins
+          # both directions. A new argmax gate the filter misses only goes red
+          # after a 108 MB download; a filter that WIDENED onto a
+          # speakerkit-only gate would drop it with no signal at all, because
+          # the anti-vacuum `--list` count is taken through this same filter and
+          # would simply fall with the run instead of reaching zero.
+          #
+          # The three `extract_serde_bypassed_*` gates are not reachable from
+          # here and are not counted above: they are `#[cfg(feature = "serde")]`,
+          # so covering them means a `speaker,serde` group, and they FAIL today
+          # — `Options`' deserializer validates `step_samples`/`onset` itself,
+          # so the serde bypass their premise describes no longer exists.
+          # Gating a red test is not coverage; that is a test-side repair.
           - kit: speaker
             cache: Models/speakerkit
             probe: Models/speakerkit/pyannote_segmentation.mlmodelc Models/speakerkit/wespeaker_v2.mlmodelc
@@ -299,6 +365,7 @@ jobs:
             fp16-vendors: vadkit,speakerkit
             gates: |
               speaker|speaker_model_io speaker_parity_seg speaker_parity_embed
+              speaker|@lib|--skip=argmax
           # 400 MB. The whole granite bundle directory, `CHECKSUMS.sha256` and
           # the 24 MB `tokenizer.json` sidecar included — the crate stopped
           # embedding that tokenizer (`include_bytes!` of that size overruns the
@@ -702,8 +769,13 @@ jobs:
       # ONE gate runner for all six shards, driven by the matrix row's `gates`
       # plan: one `features|selectors|filter` group per line, where a selector
       # is a test-target name, `@lib` for the in-lib gates, or `@all` for the
-      # whole suite under those features. An empty `features` field is the
-      # crate's bare default.
+      # whole suite under those features. `@all` SUBSUMES `@lib`, because a
+      # bare `cargo test` builds and runs the lib target alongside every
+      # integration one — which is why the `whisper` row carries no `@lib`. An
+      # empty `features` field is the crate's bare default, and `filter` is
+      # handed to libtest as ONE word, so an EXCLUSION has to be spelled
+      # `--skip=<substring>` rather than `--skip <substring>` (the `speaker`
+      # row is the one that needs it).
       #
       # Every model gate in this repository is `#[ignore]`d — the convention —
       # so CI has to ask for them by name, and that opens two ways to pass while

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
       # feature-gated audio module AND the oracle features under one
       # `-D warnings` pass across all targets (lib/tests/benches/examples). ort
       # is `load-dynamic`, so this builds without onnxruntime present.
+      #
+      # This is also THE row that compiles the `harness = false` benches, which
+      # neither `cargo test` nor `clippy --tests` reaches (#61) — and it has to
+      # be the all-features one: every bench declares `required-features`
+      # (whisper, whisper, align, clap), so a default-feature `--all-targets`
+      # build compiles zero of them and would satisfy that acceptance criterion
+      # only on paper.
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo doc --no-deps --all-features
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -273,9 +273,19 @@ jobs:
           # step, which hashes both graphs; this leg deliberately does not
           # re-verify that (see the note on checksums below) — it consumes the
           # same cache entry ci.yml's speaker shard verified on the same commit.
+          #
+          # `@lib` is load-bearing here for the same reason it is on the granite
+          # leg: 38 of this kit's model gates are `#[ignore]`d unit tests inside
+          # `src/audio/speaker/**`, not `tests/` targets, and their lines are
+          # unreachable without this group. `--skip=argmax` drops the eleven
+          # that read `Models/argmax-speakerkit`, which no runner fetches for a
+          # LICENSING reason — ci.yml's speaker row carries the full argument,
+          # and `ci_speaker_lib_gates_skip_exactly_the_unstaged_argmax_tree`
+          # pins the skip set against the source in both directions.
           - kit: speaker
             gates: |
               speaker|speaker_model_io speaker_parity_seg speaker_parity_embed
+              speaker|@lib|--skip=argmax
           # `@lib` is load-bearing here: the granite tokenizer is a 24 MB sidecar
           # the artifact ships rather than something `include_bytes!`d, so the
           # in-lib tokenizer/chunking gates are model gates like the rest and
@@ -459,12 +469,28 @@ jobs:
   # shared action's, per kit. There is no third re-implementation to keep in
   # step — the thing under test is ci.yml's real code.
   #
-  # Its own success message tells you when to delete it: once ci.yml issues no
-  # `hf download` of its own, there is no second parser left and the script says
-  # so. `ubuntu-latest` because nothing here is macOS-specific and nothing is
-  # downloaded.
+  # Its own success message tells you when to delete THAT SCRIPT AND ITS STEP:
+  # once ci.yml issues no `hf download` of its own, there is no second parser
+  # left and the script says so. The job outlives it — the gate-plan check below
+  # is not tied to the staging migration.
+  #
+  # THE SECOND CHECK is the same idea applied to what runs AFTER the download.
+  # This file's `coverage-models` comment states the coupling plainly ("the gate
+  # plans are the same plans"), and until #61 nothing enforced it: the `speaker`
+  # leg spent a release without the `@lib` group its ci.yml twin carries, and no
+  # job could have noticed, because `plan_parity.sh` diffs only the DOWNLOAD
+  # plan. `gate_plan_parity.sh` executes BOTH workflows' real gate runners with
+  # `cargo` stubbed out and diffs the canonicalised invocations per kit, so a
+  # refactor that changes their syntax while preserving the plan stays green and
+  # a one-token change to either plan cannot.
+  #
+  # Both checks live in one job on purpose: "do the two workflows still agree"
+  # is one question, and this is the one place to look for its answer.
+  # `ubuntu-latest` because nothing here is macOS-specific and nothing is
+  # downloaded — the gate check never builds or runs a test, it only resolves
+  # what the two runners would invoke.
   lock-parser-parity:
-    name: MODELS_LOCK parser parity
+    name: ci.yml / coverage.yml plan parity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -472,6 +498,8 @@ jobs:
         run: python3 -c 'import yaml' || pip install --quiet pyyaml
       - name: Diff ci.yml's download plan against the shared action's
         run: .github/actions/stage-models/plan_parity.sh
+      - name: Diff ci.yml's gate plans against this workflow's
+        run: .github/scripts/gate_plan_parity.sh
 
   # Merge every leg's report into one readable answer to "which code do the tests
   # actually reach".

--- a/README.md
+++ b/README.md
@@ -134,7 +134,28 @@ hf download openai/whisper-tiny tokenizer.json tokenizer_config.json config.json
   --local-dir Models/tokenizers/whisper-tiny
 ```
 
-Each pipeline resolves its models root from its own env var (`WHISPERKIT_TEST_MODELS`, `ALIGNKIT_TEST_MODELS`, `SPEAKERKIT_TEST_MODELS`/`ARGMAX_TEST_MODELS`, `VADKIT_TEST_MODELS`), defaulting to `<repo>/Models/...`, which is gitignored — with one exception. The VAD model is small enough (1.1 MiB) to be **committed**, at `Models/vadkit/silero-vad-unified-256ms-v6.2.1.mlmodelc/`, so `cargo test -p coremlit --features vad -- --ignored` works on a fresh clone with nothing downloaded, and CI runs those gates the same way. It is redistributed under MIT; see `NOTICE` sections 1-2 and the `LICENSE` inside that directory. It is *not* part of the published crate — a crates.io consumer fetches every model itself. See each module's `tests/<kit>/model_io.rs` for the pinned repo id, revision, and per-file SHA-256, and the module docs for fetch commands. The model-gated suites load multi-hundred-MB CoreML models per test and libtest runs tests in one binary concurrently by default; on memory-constrained hosts (< 16 GB) append `--test-threads=1` after `--ignored` to run them serially.
+Each pipeline resolves its models root from its own env var (`WHISPERKIT_TEST_MODELS`, `ALIGNKIT_TEST_MODELS`, `SPEAKERKIT_TEST_MODELS`/`ARGMAX_TEST_MODELS`, `VADKIT_TEST_MODELS`, `CLAPKIT_TEST_MODELS`, `EMBEDKIT_TEST_MODELS`, `SIGLIP_TEST_MODELS`, `CED_TEST_MODELS`), defaulting to `<repo>/Models/...`, which is gitignored — with one exception. The VAD model is small enough (1.1 MiB) to be **committed**, at `Models/vadkit/silero-vad-unified-256ms-v6.2.1.mlmodelc/`, so `cargo test -p coremlit --features vad -- --ignored` works on a fresh clone with nothing downloaded, and CI runs those gates the same way. It is redistributed under MIT; see `NOTICE` sections 1-2 and the `LICENSE` inside that directory. It is *not* part of the published crate — a crates.io consumer fetches every model itself. See each module's `tests/<kit>/model_io.rs` for the pinned repo id, revision, and per-file SHA-256, and the module docs for fetch commands. The model-gated suites load multi-hundred-MB CoreML models per test and libtest runs tests in one binary concurrently by default; on memory-constrained hosts (< 16 GB) append `--test-threads=1` after `--ignored` to run them serially.
+
+### Running the model-gated suites
+
+Every model gate here is `#[ignore]`d, so a plain `cargo test` runs none of them — and now says how many it skipped instead of leaving that to a wall of `ignored`. Each test binary (and the library's own unit-test binary) prints one line naming its gate count and the state of the models roots those gates read:
+
+```text
+model-gates | ced_model_io: 8 of 13 tests are #[ignore]d model gates and did not run here; CED_TEST_MODELS=<repo>/Models/ced MISSING -> stage the models (README, "Getting models") before running them
+```
+
+With the models staged, **one command runs the whole gated suite**:
+
+```sh
+cargo test -p coremlit --features whisper,align,speaker,vad,clap,granite,siglip,ced,serde,tracing,nl-recognizer --no-fail-fast -- --ignored
+```
+
+That feature list is CI's "all non-oracle" combo, pinned by the `feature_map` golden test ([`FEATURE_MAP.md`](crates/coremlit/FEATURE_MAP.md)); the `--test-threads=1` advice above applies to it. `--no-fail-fast` is not optional — without it the first red binary aborts the run and hides every gate after it, the same masking CI's own gate runner avoids. It covers every model gate that needs no third-party oracle — all the `tests/` binaries plus the in-crate gates in `src/`, which are the larger half. Four things it deliberately does not cover, each needing its own command:
+
+- **The hermetic tests.** `-- --ignored` is ignored-*only*: it skips every non-gated test exactly as a plain run skips every gate. The two runs are disjoint, so a full local check is both — the same command again without `-- --ignored`.
+- **The third-party parity oracles**, which need artifacts and an ONNX Runtime that `Models/` does not hold: `align-oracle` here (asry's ONNX wav2vec2 export, `ALIGNKIT_ASRY_MODELS`; enabling it also builds whisper.cpp), and `speaker-oracle` / `clap-oracle` / `vad-bundled` in [`crates/coremlit-parity`](crates/coremlit-parity). Run them **one oracle per invocation** — `cargo test -p coremlit-parity --features speaker-oracle -- --ignored` — never two at once, and never `-p coremlit-parity --all-features`: two `ort` consumers unified into one build can wedge in `dlopen` when the runtime dylib is absent.
+- **The benches.** They are `harness = false`, so no `cargo test` invocation compiles them; `cargo clippy --all-targets --all-features` is the CI row that proves they still build, and the table below is what runs them.
+- **Gates that `Models/` alone does not satisfy.** The command *selects* these, so when their inputs are absent they FAIL rather than skip: `speaker_parity_diarize_wiring` needs the sibling `diarization` checkout (`DIA_PARITY_FIXTURES`), `siglip_preprocess`'s `full_tensor_parity_against_staged_npy` needs a local torch `.npy` dump no artifact repo publishes, and the Swift-golden gates (`whisper_parity_jfk` / `parity_es`, `vad_parity_swift`) refuse a host whose class differs from the one that generated their goldens, rather than reporting host drift as a port defect ([#36](https://github.com/findit-studio/coremlit/issues/36)). A kit whose bundle you have not fetched fails the same way — the `model-gates` line above says which root is MISSING before you get there, but it probes the root, not every file inside it.
 
 ## Examples & benches
 

--- a/crates/coremlit/src/audio/speaker/source/tests.rs
+++ b/crates/coremlit/src/audio/speaker/source/tests.rs
@@ -64,7 +64,7 @@ fn source_serde_round_trips() {
 // `AnySource` counterpart — the only way one source could silently route to
 // another — fails to COMPILE. The two properties a test CAN add are the
 // no-fallback error path (below) and real dispatch
-// (`any_source_load_dispatches_by_source`, model-gated).
+// (`any_source_load_dispatches_fluid_audio_and_argmax`, model-gated).
 
 /// Loading `Source::Argmax` from a directory that holds only the FluidAudio
 /// artifacts must FAIL, not silently fall back to `FluidAudioSource` — the
@@ -592,9 +592,16 @@ fn config_round_trips_paths_and_compute_names() {
 
 /// [`AnySource::load`] builds the source [`Options::source`] names — and
 /// dispatches `extract` to it.
+///
+/// The name carries `argmax` because CI reads it. This is the only in-lib
+/// speaker gate outside `source::argmax::tests` that needs
+/// `ARGMAX_TEST_MODELS`, a tree no runner is allowed to fetch, and the
+/// `speaker` shard excludes the whole set of eleven with one `--skip=argmax`
+/// (.github/workflows/ci.yml, pinned in both directions by
+/// `ci_speaker_lib_gates_skip_exactly_the_unstaged_argmax_tree`).
 #[test]
 #[ignore = "requires local argmax + speakerkit models (both env vars)"]
-fn any_source_load_dispatches_by_source() {
+fn any_source_load_dispatches_fluid_audio_and_argmax() {
   let samples = load_ted_head();
 
   let fluid = AnySource::load(models_dir(), Options::new().with_source(Source::FluidAudio))

--- a/crates/coremlit/src/lib.rs
+++ b/crates/coremlit/src/lib.rs
@@ -51,3 +51,8 @@ pub use units::{ComputeUnits, ParseComputeUnitsError};
 
 pub mod audio;
 pub mod embeddings;
+
+// The in-lib model gates outnumber every `tests/` binary's put together, and a
+// modelless run reports them as `ignored` and nothing else. See the module.
+#[cfg(test)]
+mod tests;

--- a/crates/coremlit/src/tests.rs
+++ b/crates/coremlit/src/tests.rs
@@ -2,8 +2,12 @@
 //!
 //! Most of this crate's model gates are NOT integration tests: they are
 //! `#[ignore]`d unit tests inside the pipeline modules — more of them than
-//! every `tests/` binary holds put together — and CI reaches a subset of them
-//! through the granite shard's `@lib` selector. They are skipped by the same
+//! every `tests/` binary holds put together — and CI reaches them through
+//! three `model-tests` shards: whisper's two `@all` groups, which build and run
+//! the lib target alongside every integration one, and the granite and speaker
+//! shards' `@lib` ones. The `align` gates reach no shard at all, because
+//! alignkit has no MODELS_LOCK table; ci.yml's matrix carries the per-kit
+//! ledger, counts included. They are skipped by the same
 //! silence, so they get the same report; see
 //! `crates/coremlit/tests/support/model_gate_report.rs` for the mechanism.
 //!

--- a/crates/coremlit/src/tests.rs
+++ b/crates/coremlit/src/tests.rs
@@ -1,0 +1,81 @@
+//! The in-lib half of the model-gate report (#61).
+//!
+//! Most of this crate's model gates are NOT integration tests: they are
+//! `#[ignore]`d unit tests inside the pipeline modules — more of them than
+//! every `tests/` binary holds put together — and CI reaches a subset of them
+//! through the granite shard's `@lib` selector. They are skipped by the same
+//! silence, so they get the same report; see
+//! `crates/coremlit/tests/support/model_gate_report.rs` for the mechanism.
+//!
+//! That module lives under `tests/` because every other caller is a test
+//! binary, and this one `#[path]`-hops to it rather than keeping a second copy
+//! — the `tests/support/coremlit_dir.rs` convention, one level further. The hop
+//! is `#[cfg(test)]`, so a published crate never compiles it.
+
+use std::path::PathBuf;
+
+#[path = "../tests/support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// `<workspace>/Models/<sub>` unless `var` overrides it — the fallback every
+/// in-lib `models_dir()` in this crate resolves. `sub` is empty for whisper,
+/// whose gates read the `Models/` root itself.
+fn root(var: &str, sub: &str) -> PathBuf {
+  std::env::var_os(var).map_or_else(
+    || {
+      let models = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("Models");
+      if sub.is_empty() {
+        models
+      } else {
+        models.join(sub)
+      }
+    },
+    PathBuf::from,
+  )
+}
+
+/// Reports how many of the library's own unit tests are `#[ignore]`d model
+/// gates that did not run, and whether the models roots they read are on disk.
+///
+/// The roots are named per feature because the gates are: a bare
+/// `default = []` build compiles no pipeline, so it has no model gates and
+/// claims no roots. `cfg!` rather than `#[cfg]` on the elements, so the vector
+/// is used mutably on every combination — including that empty one.
+///
+/// Today's in-lib gates span exactly these four kits (whisper, align, speaker,
+/// granite); the `clap`/`siglip`/`ced`/`vad` gates are all in `tests/`, where
+/// their own `common/mod.rs` names their root. A new in-lib gate under one of
+/// those would still be COUNTED — the count is libtest's, not this list's — it
+/// would simply have no root named beside it until a line is added here.
+#[test]
+fn model_gate_report() {
+  let mut roots: Vec<(&str, PathBuf)> = Vec::new();
+  if cfg!(feature = "whisper") {
+    roots.push(("WHISPERKIT_TEST_MODELS", root("WHISPERKIT_TEST_MODELS", "")));
+  }
+  if cfg!(feature = "align") {
+    roots.push((
+      "ALIGNKIT_TEST_MODELS",
+      root("ALIGNKIT_TEST_MODELS", "alignkit"),
+    ));
+  }
+  if cfg!(feature = "speaker") {
+    roots.push((
+      "SPEAKERKIT_TEST_MODELS",
+      root("SPEAKERKIT_TEST_MODELS", "speakerkit"),
+    ));
+    roots.push((
+      "ARGMAX_TEST_MODELS",
+      root("ARGMAX_TEST_MODELS", "argmax-speakerkit"),
+    ));
+  }
+  if cfg!(feature = "granite") {
+    roots.push((
+      "EMBEDKIT_TEST_MODELS",
+      root("EMBEDKIT_TEST_MODELS", "embedkit-granite"),
+    ));
+  }
+  model_gate_report::report(&roots);
+}

--- a/crates/coremlit/tests/align/common/mod.rs
+++ b/crates/coremlit/tests/align/common/mod.rs
@@ -287,3 +287,22 @@ pub fn sha256_hex(path: &Path) -> String {
     .map(|b| format!("{b:02x}"))
     .collect()
 }
+
+// ── Model-gate visibility (#61) ─────────────────────────────────────────────
+//
+// NOT `#[ignore]`d, deliberately. This is the ordinary-run half of the gate
+// accounting: an ignored-ONLY run (`-- --ignored`, what every CI gate uses)
+// never selects it, and it never appears in an ignored-only `--list`, so the
+// anti-vacuum counts those gates take are unchanged. What it adds is the case
+// no gate covers — a plain, modelless run — where the skipped gates otherwise
+// say nothing but `ignored`. Mechanism, and what it does and does not refuse,
+// in the shared module.
+#[path = "../../support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// Reports how many of this binary's tests are `#[ignore]`d alignkit model gates
+/// that did not run, and whether the models root they read is on disk.
+#[test]
+fn model_gate_report() {
+  model_gate_report::report(&[("ALIGNKIT_TEST_MODELS", models_dir())]);
+}

--- a/crates/coremlit/tests/ced/common/mod.rs
+++ b/crates/coremlit/tests/ced/common/mod.rs
@@ -308,3 +308,22 @@ pub fn assert_exact_sha_manifest(dir: &Path, cases: &[(&str, &str)]) {
     );
   }
 }
+
+// ── Model-gate visibility (#61) ─────────────────────────────────────────────
+//
+// NOT `#[ignore]`d, deliberately. This is the ordinary-run half of the gate
+// accounting: an ignored-ONLY run (`-- --ignored`, what every CI gate uses)
+// never selects it, and it never appears in an ignored-only `--list`, so the
+// anti-vacuum counts those gates take are unchanged. What it adds is the case
+// no gate covers — a plain, modelless run — where the skipped gates otherwise
+// say nothing but `ignored`. Mechanism, and what it does and does not refuse,
+// in the shared module.
+#[path = "../../support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// Reports how many of this binary's tests are `#[ignore]`d CED model gates
+/// that did not run, and whether the models root they read is on disk.
+#[test]
+fn model_gate_report() {
+  model_gate_report::report(&[("CED_TEST_MODELS", models_dir())]);
+}

--- a/crates/coremlit/tests/clap/common/mod.rs
+++ b/crates/coremlit/tests/clap/common/mod.rs
@@ -237,3 +237,22 @@ pub fn deterministic_window(len: usize) -> Vec<f32> {
     })
     .collect()
 }
+
+// ── Model-gate visibility (#61) ─────────────────────────────────────────────
+//
+// NOT `#[ignore]`d, deliberately. This is the ordinary-run half of the gate
+// accounting: an ignored-ONLY run (`-- --ignored`, what every CI gate uses)
+// never selects it, and it never appears in an ignored-only `--list`, so the
+// anti-vacuum counts those gates take are unchanged. What it adds is the case
+// no gate covers — a plain, modelless run — where the skipped gates otherwise
+// say nothing but `ignored`. Mechanism, and what it does and does not refuse,
+// in the shared module.
+#[path = "../../support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// Reports how many of this binary's tests are `#[ignore]`d clapkit model gates
+/// that did not run, and whether the models root they read is on disk.
+#[test]
+fn model_gate_report() {
+  model_gate_report::report(&[("CLAPKIT_TEST_MODELS", models_dir())]);
+}

--- a/crates/coremlit/tests/common/mod.rs
+++ b/crates/coremlit/tests/common/mod.rs
@@ -16,3 +16,22 @@ pub fn tiny_dir() -> PathBuf {
     .join("whisperkit-coreml")
     .join("openai_whisper-tiny")
 }
+
+// ── Model-gate visibility (#61) ─────────────────────────────────────────────
+//
+// NOT `#[ignore]`d, deliberately. This is the ordinary-run half of the gate
+// accounting: an ignored-ONLY run (`-- --ignored`, what every CI gate uses)
+// never selects it, and it never appears in an ignored-only `--list`, so the
+// anti-vacuum counts those gates take are unchanged. What it adds is the case
+// no gate covers — a plain, modelless run — where the skipped gates otherwise
+// say nothing but `ignored`. Mechanism, and what it does and does not refuse,
+// in the shared module.
+#[path = "../support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// Reports how many of this binary's tests are `#[ignore]`d whisperkit model gates
+/// that did not run, and whether the models root they read is on disk.
+#[test]
+fn model_gate_report() {
+  model_gate_report::report(&[("WHISPERKIT_TEST_MODELS", models_dir())]);
+}

--- a/crates/coremlit/tests/granite/common/mod.rs
+++ b/crates/coremlit/tests/granite/common/mod.rs
@@ -247,3 +247,22 @@ pub fn collect_files_rel(root: &Path, dir: &Path, out: &mut std::collections::BT
     }
   }
 }
+
+// ── Model-gate visibility (#61) ─────────────────────────────────────────────
+//
+// NOT `#[ignore]`d, deliberately. This is the ordinary-run half of the gate
+// accounting: an ignored-ONLY run (`-- --ignored`, what every CI gate uses)
+// never selects it, and it never appears in an ignored-only `--list`, so the
+// anti-vacuum counts those gates take are unchanged. What it adds is the case
+// no gate covers — a plain, modelless run — where the skipped gates otherwise
+// say nothing but `ignored`. Mechanism, and what it does and does not refuse,
+// in the shared module.
+#[path = "../../support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// Reports how many of this binary's tests are `#[ignore]`d granite model gates
+/// that did not run, and whether the models root they read is on disk.
+#[test]
+fn model_gate_report() {
+  model_gate_report::report(&[("EMBEDKIT_TEST_MODELS", models_dir())]);
+}

--- a/crates/coremlit/tests/siglip/common/mod.rs
+++ b/crates/coremlit/tests/siglip/common/mod.rs
@@ -344,3 +344,22 @@ pub fn recharacterize_command(test_target: &str, source_rel: &str) -> String {
      CHARACTERIZED_ON to the `this host` line above."
   )
 }
+
+// ── Model-gate visibility (#61) ─────────────────────────────────────────────
+//
+// NOT `#[ignore]`d, deliberately. This is the ordinary-run half of the gate
+// accounting: an ignored-ONLY run (`-- --ignored`, what every CI gate uses)
+// never selects it, and it never appears in an ignored-only `--list`, so the
+// anti-vacuum counts those gates take are unchanged. What it adds is the case
+// no gate covers — a plain, modelless run — where the skipped gates otherwise
+// say nothing but `ignored`. Mechanism, and what it does and does not refuse,
+// in the shared module.
+#[path = "../../support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// Reports how many of this binary's tests are `#[ignore]`d siglip model gates
+/// that did not run, and whether the models root they read is on disk.
+#[test]
+fn model_gate_report() {
+  model_gate_report::report(&[("SIGLIP_TEST_MODELS", models_dir())]);
+}

--- a/crates/coremlit/tests/speaker/common/mod.rs
+++ b/crates/coremlit/tests/speaker/common/mod.rs
@@ -748,3 +748,25 @@ mod host_class;
 // ones with no golden to host-gate reference none of these four.
 #[allow(unused_imports)]
 pub use host_class::{HostClass, HostVerdict, check_host_class, legacy_failure_note};
+
+// ── Model-gate visibility (#61) ─────────────────────────────────────────────
+//
+// NOT `#[ignore]`d, deliberately. This is the ordinary-run half of the gate
+// accounting: an ignored-ONLY run (`-- --ignored`, what every CI gate uses)
+// never selects it, and it never appears in an ignored-only `--list`, so the
+// anti-vacuum counts those gates take are unchanged. What it adds is the case
+// no gate covers — a plain, modelless run — where the skipped gates otherwise
+// say nothing but `ignored`. Mechanism, and what it does and does not refuse,
+// in the shared module.
+#[path = "../../support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// Reports how many of this binary's tests are `#[ignore]`d speakerkit model gates
+/// that did not run, and whether the models root they read is on disk.
+#[test]
+fn model_gate_report() {
+  model_gate_report::report(&[
+    ("SPEAKERKIT_TEST_MODELS", models_dir()),
+    ("ARGMAX_TEST_MODELS", argmax_models_dir()),
+  ]);
+}

--- a/crates/coremlit/tests/support/model_gate_report.rs
+++ b/crates/coremlit/tests/support/model_gate_report.rs
@@ -1,0 +1,158 @@
+//! Makes a modelless run's SKIPPED model gates say so, per test binary (#61).
+//!
+//! Every model gate in this repository is `#[ignore]`d — the convention — so a
+//! run without `Models/` reports them as `ignored` and nothing else. That reads
+//! identically whether the gates were deliberately skipped or whether the whole
+//! suite evaporated, which is the third gap in #61: the absence is silent.
+//!
+//! [`report`] is a plain (NOT `#[ignore]`d) test body that each kit's shared
+//! `common/mod.rs` calls, so every binary that already writes `mod common;`
+//! gets it — including `coremlit-parity`'s oracle binaries, which
+//! `#[path]`-include the very same files. It prints one line naming how many of
+//! the binary's tests are model gates that did not run, and whether the models
+//! root they need is on disk.
+//!
+//! # The count is libtest's, not a guess
+//!
+//! The binary re-executes ITSELF with `--list --ignored` — libtest's
+//! ignored-ONLY listing, the same `RunIgnored::Only` filter and the same
+//! `NAME: test` line shape CI's anti-vacuum guards count. So the number is what
+//! libtest would actually select, not a scan of `#[ignore]` attributes that a
+//! `cfg` could make a lie. `--list` executes no test, so the child cannot
+//! recurse. Deliberately NOT a `cargo` invocation: `cargo` cannot nest inside a
+//! `cargo test` run without deadlocking on the target-dir lock, which is why
+//! the two gate-inventory checks next door are shell scripts rather than tests.
+//!
+//! # Written to the real fd 2, on purpose
+//!
+//! libtest CAPTURES `println!`/`eprintln!` from a test that PASSES and discards
+//! it, so a passing test that "reports" something reports it to nobody unless
+//! the reader remembers `--nocapture` — the same silence this is meant to end.
+//! The capture is installed on the Rust-level stdout/stderr handles (and is
+//! inherited by spawned threads), so the report writes to the inherited stderr
+//! descriptor instead, in one `write` so lines from sibling tests cannot
+//! interleave.
+//!
+//! # What it refuses, and what it does not
+//!
+//! Delete, un-`#[ignore]`, or `cfg` away a kit's gates and its binaries print
+//! `0 of N`, in every ordinary run, next to that binary's own result line —
+//! the "visibly report zero" half of the same property CI's `--list --ignored`
+//! counts enforce by failing. It does NOT refuse a RENAMED gate: a rename
+//! leaves the count alone. CI catches that where it matters, because a rename
+//! breaks the gate plan's own selector (and, for CED, its `tiny::` filter).
+//!
+//! The one thing this DOES fail on is its own mechanism: a binary whose
+//! unfiltered `--list` is empty could not have run this test, so an empty
+//! listing means the self-exec is broken and every count it prints is a lie.
+//!
+//! The root probe is the DIRECTORY's existence, not an inventory of what is in
+//! it: a half-staged tree — siglip's 33 MB tokenizer sidecar without its 748 MB
+//! towers, say — reports `present`, and its gates then fail loudly on the
+//! missing file. Naming the root is what turns "ignored" into "ignored, and
+//! this is where the models would have been"; proving a tree COMPLETE is the
+//! per-kit `model_io` gates' job, and CI's checksum step's.
+
+use std::{
+  io::Write,
+  path::{Component, Path, PathBuf},
+  process::Command,
+};
+
+/// Folds `a/../b` down to `b` so a root reads as a path rather than as the
+/// expression that produced it. Purely lexical — the roots that most need
+/// printing are the ones that do not exist, which `canonicalize` refuses.
+fn tidy(path: &Path) -> PathBuf {
+  let mut out = PathBuf::new();
+  for component in path.components() {
+    match component {
+      Component::ParentDir
+        if matches!(out.components().next_back(), Some(Component::Normal(_))) =>
+      {
+        out.pop();
+      }
+      other => out.push(other),
+    }
+  }
+  out
+}
+
+/// Prints this binary's model-gate count and the state of the models roots
+/// those gates need.
+///
+/// `roots` pairs each env var that overrides a root with the path this
+/// binary's own resolver produced for it — pass `common::models_dir()` and
+/// friends, never a second copy of the fallback, so the report cannot drift
+/// from the gates it describes.
+///
+/// Panics only if the self-listing described in the module docs comes back
+/// empty or fails to run.
+pub fn report(roots: &[(&str, PathBuf)]) {
+  let name = env!("CARGO_CRATE_NAME");
+  let exe = std::env::current_exe()
+    .unwrap_or_else(|e| panic!("model-gate report: cannot locate this test binary: {e}"));
+
+  let list = |args: &[&str]| -> usize {
+    let out = Command::new(&exe)
+      .args(args)
+      .output()
+      .unwrap_or_else(|e| panic!("model-gate report: `{name} {}` failed: {e}", args.join(" ")));
+    assert!(
+      out.status.success(),
+      "model-gate report: `{name} {}` exited {}",
+      args.join(" "),
+      out.status
+    );
+    String::from_utf8_lossy(&out.stdout)
+      .lines()
+      .filter(|line| line.ends_with(": test"))
+      .count()
+  };
+
+  let total = list(&["--list"]);
+  let gated = list(&["--list", "--ignored"]);
+  assert!(
+    total != 0,
+    "model-gate report: `{name} --list` listed no tests, yet this test is running in it — \
+     the self-listing is broken, so any count reported from it would be fiction"
+  );
+
+  let mut line =
+    format!("model-gates | {name}: {gated} of {total} tests are #[ignore]d model gates");
+  line.push_str(if gated == 0 {
+    " (none — this binary gates on no models)"
+  } else {
+    " and did not run here"
+  });
+  let mut missing = false;
+  for (var, root) in roots {
+    let present = root.exists();
+    missing |= !present;
+    line.push_str(&format!(
+      "; {var}={} {}",
+      tidy(root).display(),
+      if present { "present" } else { "MISSING" }
+    ));
+  }
+  if gated > 0 {
+    line.push_str(if missing {
+      " -> stage the models (README, \"Getting models\") before running them"
+    } else {
+      " -> run them with `-- --ignored`"
+    });
+  }
+  line.push('\n');
+
+  // The inherited stderr descriptor, which libtest's capture does not touch.
+  // `ManuallyDrop` because dropping a `File` closes its fd, and fd 2 belongs to
+  // the process, not to this test. Best-effort: a report that cannot be written
+  // must not turn a healthy suite red.
+  //
+  // SAFETY: fd 2 is open for the whole life of the process (libtest redirects
+  // the Rust-level handles, never the descriptor), it is only ever written to
+  // here, and `ManuallyDrop` keeps the `File` from closing it.
+  let mut fd2 = std::mem::ManuallyDrop::new(unsafe {
+    <std::fs::File as std::os::fd::FromRawFd>::from_raw_fd(2)
+  });
+  let _ = fd2.write_all(line.as_bytes());
+}

--- a/crates/coremlit/tests/vad/common/mod.rs
+++ b/crates/coremlit/tests/vad/common/mod.rs
@@ -206,3 +206,22 @@ mod host_class;
 // ones with no golden to host-gate reference none of these four.
 #[allow(unused_imports)]
 pub use host_class::{HostClass, HostVerdict, check_host_class, legacy_failure_note};
+
+// ── Model-gate visibility (#61) ─────────────────────────────────────────────
+//
+// NOT `#[ignore]`d, deliberately. This is the ordinary-run half of the gate
+// accounting: an ignored-ONLY run (`-- --ignored`, what every CI gate uses)
+// never selects it, and it never appears in an ignored-only `--list`, so the
+// anti-vacuum counts those gates take are unchanged. What it adds is the case
+// no gate covers — a plain, modelless run — where the skipped gates otherwise
+// say nothing but `ignored`. Mechanism, and what it does and does not refuse,
+// in the shared module.
+#[path = "../../support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// Reports how many of this binary's tests are `#[ignore]`d vadkit model gates
+/// that did not run, and whether the models root they read is on disk.
+#[test]
+fn model_gate_report() {
+  model_gate_report::report(&[("VADKIT_TEST_MODELS", models_dir())]);
+}

--- a/crates/coremlit/tests/whisper/common/mod.rs
+++ b/crates/coremlit/tests/whisper/common/mod.rs
@@ -380,3 +380,22 @@ fn top_two(logits: &[f32]) -> ((u32, f32), (u32, f32)) {
   }
   (best, second)
 }
+
+// ── Model-gate visibility (#61) ─────────────────────────────────────────────
+//
+// NOT `#[ignore]`d, deliberately. This is the ordinary-run half of the gate
+// accounting: an ignored-ONLY run (`-- --ignored`, what every CI gate uses)
+// never selects it, and it never appears in an ignored-only `--list`, so the
+// anti-vacuum counts those gates take are unchanged. What it adds is the case
+// no gate covers — a plain, modelless run — where the skipped gates otherwise
+// say nothing but `ignored`. Mechanism, and what it does and does not refuse,
+// in the shared module.
+#[path = "../../support/model_gate_report.rs"]
+mod model_gate_report;
+
+/// Reports how many of this binary's tests are `#[ignore]`d whisperkit model gates
+/// that did not run, and whether the models root they read is on disk.
+#[test]
+fn model_gate_report() {
+  model_gate_report::report(&[("WHISPERKIT_TEST_MODELS", models_dir())]);
+}

--- a/crates/coremlit/tests/whisper/models_lock.rs
+++ b/crates/coremlit/tests/whisper/models_lock.rs
@@ -21,7 +21,7 @@
 use std::{
   collections::{BTreeMap, BTreeSet},
   fs,
-  path::PathBuf,
+  path::{Path, PathBuf},
 };
 
 struct LockTable {
@@ -648,6 +648,200 @@ fn ci_runs_the_ced_gates_for_exactly_the_size_the_lock_stages() {
      count and the run, so a deleted or renamed `{size}` module could still count the other \
      sizes' gates and then run none"
   );
+}
+
+/// Every `#[ignore]`d test under `dir`, as `(full libtest path, ignore reason)`.
+///
+/// Text-based like every other reader in this file, and for the same reason:
+/// the alternative is asking libtest for the list, which means building the
+/// `speaker` feature and — for the gates this is used to check — having the
+/// models the check exists to run without.
+///
+/// The shape it needs is the one `src/` uses throughout: `#[ignore = "..."]` on
+/// ONE line (asserted, so a reason that grows a line continuation fails here
+/// rather than silently dropping a gate), the `fn <name>` somewhere below it in
+/// the same attribute block, and the module path taken from the file's own path
+/// under `src/` — the sibling-`tests.rs` layout.
+fn ignored_gates(src_root: &Path, dir: &Path) -> Vec<(String, String)> {
+  let mut gates: Vec<(String, String)> = Vec::new();
+  let mut stack = vec![dir.to_path_buf()];
+  while let Some(current) = stack.pop() {
+    let entries = fs::read_dir(&current)
+      .unwrap_or_else(|e| panic!("{} reads: {e}", current.display()))
+      .map(|e| e.expect("a directory entry reads").path());
+    for path in entries {
+      if path.is_dir() {
+        stack.push(path);
+        continue;
+      }
+      if path.extension().is_none_or(|ext| ext != "rs") {
+        continue;
+      }
+      let module = path
+        .strip_prefix(src_root)
+        .expect("scanned under src/")
+        .with_extension("")
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .filter(|c| c != "mod")
+        .collect::<Vec<_>>()
+        .join("::");
+      let contents = fs::read_to_string(&path).expect("a source file reads");
+      let lines: Vec<&str> = contents.lines().collect();
+      for (i, line) in lines.iter().enumerate() {
+        let Some(rest) = line.trim_start().strip_prefix("#[ignore") else {
+          continue;
+        };
+        assert!(
+          rest.trim_end().ends_with(']'),
+          "{}:{}: this reader needs the whole `#[ignore ...]` attribute on one line",
+          path.display(),
+          i + 1
+        );
+        let reason = match rest.split_once('"').and_then(|(_, r)| r.rsplit_once('"')) {
+          Some((reason, _)) => reason.to_string(),
+          None => String::new(),
+        };
+        let name = lines[i + 1..]
+          .iter()
+          .find_map(|l| l.trim_start().strip_prefix("fn "))
+          .and_then(|l| l.split(['(', '<']).next())
+          .unwrap_or_else(|| {
+            panic!(
+              "{}:{}: an `#[ignore]` attribute with no `fn` after it",
+              path.display(),
+              i + 1
+            )
+          });
+        gates.push((format!("{module}::{name}"), reason));
+      }
+    }
+  }
+  gates.sort();
+  gates
+}
+
+/// The `speaker` shard runs the library's own model gates, and the one thing it
+/// must NOT run is a gate that reads a tree no runner is allowed to fetch.
+///
+/// 230 of this repository's model gates are `#[ignore]`d unit tests inside the
+/// pipeline modules rather than `tests/` binaries (#61), and
+/// `--features speaker --lib` lists 38 of them. ELEVEN read
+/// `ARGMAX_TEST_MODELS` — the `argmax-speakerkit` tree
+/// [`UNSTAGED_DEFECT_VENDORS`] records as deliberately unfetched, for a
+/// LICENSING reason rather than a cost one — so the shard's gate plan skips
+/// exactly those and runs the other 27.
+///
+/// Both drift directions are pinned, and they fail in opposite ways. A new
+/// argmax-tree gate the filter does not name turns the shard red on a missing
+/// bundle: loud, but only after a 108 MB download. A filter that grows to match
+/// a SPEAKERKIT-only gate drops it from CI with no signal at all — the gate
+/// runner's anti-vacuum `--list` count is taken through the same filter as the
+/// run, so both numbers fall together and neither reaches zero.
+#[test]
+fn ci_speaker_lib_gates_skip_exactly_the_unstaged_argmax_tree() {
+  let Some((_, workflow_path)) = repo_files() else {
+    return;
+  };
+  let ci_contents = fs::read_to_string(workflow_path).expect(".github/workflows/ci.yml reads");
+  let row = matrix_rows(&ci_contents)
+    .into_iter()
+    .find(|r| row_field(r, "kit") == "speaker")
+    .expect("ci.yml has no `speaker` shard");
+
+  // The `@lib` group must exist at all. Without it the shard downloads 108 MB,
+  // runs three `tests/` targets, and leaves the larger half of the kit's gates
+  // unrun — the gap this pin was added with.
+  let lib_group = require_field(&row, "gates")
+    .lines()
+    .find(|group| {
+      group
+        .split('|')
+        .nth(1)
+        .is_some_and(|selectors| selectors.split_whitespace().any(|s| s == "@lib"))
+    })
+    .map(str::to_string)
+    .expect(
+      "ci.yml's speaker shard has no `@lib` gate group. The library's own speaker model gates \
+       read exactly the two graphs this shard already stages, so dropping the group means the \
+       shard downloads for them and then runs none of them.",
+    );
+  let filter = lib_group.splitn(3, '|').nth(2).unwrap_or_default();
+
+  // The gate runner hands `filter` to libtest as ONE word, so an exclusion is
+  // spelled `--skip=<substring>`. Any other token here (a positional include
+  // filter, a bare `--skip`) would change which gates run WITHOUT changing the
+  // skip set this check models, so it is refused rather than ignored.
+  let skips: Vec<&str> = filter
+    .split_whitespace()
+    .map(|token| {
+      token.strip_prefix("--skip=").unwrap_or_else(|| {
+        panic!(
+          "ci.yml's speaker `@lib` group has the filter {filter:?}; this pin models libtest's \
+           `--skip=<substring>` exclusions only, and a token of another shape would change which \
+           gates run without changing what is checked here"
+        )
+      })
+    })
+    .collect();
+  assert!(
+    !skips.is_empty(),
+    "ci.yml's speaker `@lib` group has no filter, so it would run the eleven gates that load \
+     Models/argmax-speakerkit — a tree no runner fetches (see UNSTAGED_DEFECT_VENDORS)"
+  );
+
+  let src_root = workspace_root().join("crates/coremlit/src");
+  let gates = ignored_gates(&src_root, &src_root.join("audio/speaker"));
+  assert!(
+    gates.len() > 30,
+    "only {} `#[ignore]`d gates found under src/audio/speaker; this reader has stopped matching \
+     the source layout, and every assertion below would pass vacuously",
+    gates.len()
+  );
+
+  // `argmax` in the ignore REASON is what marks a gate as needing the unstaged
+  // tree; both wordings say it ("requires local argmax speakerkit models
+  // (ARGMAX_TEST_MODELS)" and the two-root "requires local argmax + speakerkit
+  // models (both env vars)"). The reason is the right marker rather than the
+  // module path, because `source::tests` holds one gate of each kind.
+  let mut needs_argmax = 0usize;
+  for (name, reason) in &gates {
+    let skipped = skips.iter().any(|s| name.contains(s));
+    if reason.contains("argmax") {
+      needs_argmax += 1;
+      assert!(
+        skipped,
+        "the in-lib gate {name:?} says it needs the argmax tree ({reason:?}), but the speaker \
+         shard's `@lib` filter {filter:?} does not skip it. CI deliberately does not fetch that \
+         tree (UNSTAGED_DEFECT_VENDORS), so the shard would fail on a missing bundle. Name the \
+         gate so an existing `--skip=` substring matches it, or add one."
+      );
+    } else {
+      assert!(
+        !skipped,
+        "the speaker shard's `@lib` filter {filter:?} skips {name:?}, which needs only the \
+         speakerkit tree this shard stages ({reason:?}). A skip that widens onto a runnable gate \
+         drops it from CI silently: the anti-vacuum `--list` count is taken through this same \
+         filter, so it falls with the run instead of reaching zero."
+      );
+    }
+  }
+  // Non-vacuity for the branch above: gates were found, but if none of them
+  // declared an argmax dependency the completeness half checked nothing at all.
+  assert!(
+    needs_argmax > 0,
+    "no in-lib speaker gate names argmax in its `#[ignore]` reason, so the filter this shard \
+     carries is excluding gates for a dependency nothing declares any more"
+  );
+  for skip in &skips {
+    assert!(
+      gates
+        .iter()
+        .any(|(name, reason)| name.contains(skip) && reason.contains("argmax")),
+      "the speaker shard's `@lib` filter skips {skip:?}, which matches no in-lib gate that needs \
+       the argmax tree — a stale exclusion can only be hiding a gate CI could run"
+    );
+  }
 }
 
 /// The two `speaker` tables are the one place in MODELS_LOCK where table order


### PR DESCRIPTION
Closes #61.