### PR TITLE
feat(coremlit/clap): publish SAMPLE_RATE_HZ so a downstream crate can pin the rate exactly (#98 item 2)

### DIFF
--- a/crates/coremlit/benches/clap/encode.rs
+++ b/crates/coremlit/benches/clap/encode.rs
@@ -72,7 +72,7 @@ use coremlit::{
   ComputeUnits,
   embeddings::clap::{
     AudioEncoder, AudioEncoderOptions, Embedding, TextEncoder, TextEncoderOptions,
-    audio::TARGET_SAMPLES,
+    audio::{SAMPLE_RATE_HZ, TARGET_SAMPLES},
   },
 };
 
@@ -387,10 +387,9 @@ fn models_dir() -> PathBuf {
 /// giving both towers a stable, non-trivial input. Mirrors
 /// `tests/clap/common::deterministic_window` (unreachable from a bench crate).
 fn deterministic_window(len: usize) -> Vec<f32> {
-  const SR: f32 = 48_000.0;
   (0..len)
     .map(|i| {
-      let t = i as f32 / SR;
+      let t = i as f32 / SAMPLE_RATE_HZ as f32;
       let two_pi = std::f32::consts::TAU;
       0.5 * (two_pi * 220.0 * t).sin()
         + 0.3 * (two_pi * 440.0 * t).sin()

--- a/crates/coremlit/src/embeddings/clap/audio/mel/mod.rs
+++ b/crates/coremlit/src/embeddings/clap/audio/mel/mod.rs
@@ -50,12 +50,18 @@ pub const T_FRAMES: usize = 1001;
 /// Re-exported from [`crate::embeddings::clap::audio`].
 pub const N_MELS: usize = 64;
 
-/// Fixed audio window: 10 s at 48 kHz. Re-exported from [`crate::embeddings::clap::audio`].
+/// CLAP's fixed audio sample rate, in Hz. Re-exported from
+/// [`crate::embeddings::clap::audio`]. [`TARGET_SAMPLES`] `== 10 ×
+/// SAMPLE_RATE_HZ`; pin this constant directly rather than re-deriving the
+/// rate from `TARGET_SAMPLES / 10`.
+pub const SAMPLE_RATE_HZ: u32 = 48_000;
+
+/// Fixed audio window: 10 s at [`SAMPLE_RATE_HZ`]. Re-exported from
+/// [`crate::embeddings::clap::audio`].
 pub const TARGET_SAMPLES: usize = 480_000;
 
 const N_FFT: usize = 1024;
 const HOP: usize = 480;
-const SR: u32 = 48_000;
 const FMIN: f64 = 50.0;
 const FMAX: f64 = 14_000.0;
 const POWER_TO_DB_AMIN: f64 = 1e-10;
@@ -160,7 +166,7 @@ impl MelExtractor {
 
   pub(crate) fn new() -> Self {
     let window = Self::periodic_hann(N_FFT);
-    let filterbank = Self::build_mel_filterbank(SR, N_FFT, N_MELS, FMIN, FMAX);
+    let filterbank = Self::build_mel_filterbank(SAMPLE_RATE_HZ, N_FFT, N_MELS, FMIN, FMAX);
     let mut planner = FftPlanner::<f64>::new();
     let fft = planner.plan_fft_forward(N_FFT);
     Self {

--- a/crates/coremlit/src/embeddings/clap/audio/mel/mod.rs
+++ b/crates/coremlit/src/embeddings/clap/audio/mel/mod.rs
@@ -54,6 +54,16 @@ pub const N_MELS: usize = 64;
 /// [`crate::embeddings::clap::audio`]. [`TARGET_SAMPLES`] `== 10 ×
 /// SAMPLE_RATE_HZ`; pin this constant directly rather than re-deriving the
 /// rate from `TARGET_SAMPLES / 10`.
+///
+/// This doctest is the guard: it compiles against the crate's public API
+/// (not the internal `mel` module), so it fails to compile — not just to
+/// pass — if `SAMPLE_RATE_HZ` ever stops being reachable at this path.
+///
+/// ```
+/// use coremlit::embeddings::clap::audio::{SAMPLE_RATE_HZ, TARGET_SAMPLES};
+///
+/// assert_eq!(TARGET_SAMPLES, 10 * SAMPLE_RATE_HZ as usize);
+/// ```
 pub const SAMPLE_RATE_HZ: u32 = 48_000;
 
 /// Fixed audio window: 10 s at [`SAMPLE_RATE_HZ`]. Re-exported from

--- a/crates/coremlit/src/embeddings/clap/audio/mel/tests.rs
+++ b/crates/coremlit/src/embeddings/clap/audio/mel/tests.rs
@@ -87,6 +87,16 @@ fn nan_prop_min(xs: impl IntoIterator<Item = f32>) -> f32 {
     .expect("nan_prop_min over an empty iterator")
 }
 
+/// Pins the cross-crate derivation downstream code relies on
+/// (`TARGET_SAMPLES == 10 × SAMPLE_RATE_HZ` — e.g. mediagraph currently
+/// derives its own `SAMPLE_RATE_HZ` as `TARGET_SAMPLES / 10` rather than
+/// reading a public rate constant). Guards against the two constants ever
+/// drifting apart independently.
+#[test]
+fn target_samples_is_ten_seconds_at_sample_rate() {
+  assert_eq!(TARGET_SAMPLES, 10 * SAMPLE_RATE_HZ as usize);
+}
+
 /// Periodic Hann at n=1024: peak (1.0) exactly at index n/2, last sample small
 /// but POSITIVE (distinguishing periodic from symmetric, which would be 0).
 #[test]

--- a/crates/coremlit/src/embeddings/clap/audio/mod.rs
+++ b/crates/coremlit/src/embeddings/clap/audio/mod.rs
@@ -14,7 +14,7 @@ use crate::embeddings::clap::{
   window::{WindowEmbedding, WindowPlan},
 };
 
-pub use self::mel::{N_MELS, T_FRAMES, TARGET_SAMPLES};
+pub use self::mel::{N_MELS, SAMPLE_RATE_HZ, T_FRAMES, TARGET_SAMPLES};
 
 /// Declared feature names on `clap_audio.mlmodelc` (pinned by
 /// `tests/clap/model_io.rs`).
@@ -186,14 +186,15 @@ impl AudioEncoder {
 
   /// Embeds one audio window into a unit-norm [`Embedding`].
   ///
-  /// `samples` is 48 kHz mono and must be `1..=`[`TARGET_SAMPLES`] long. A
-  /// shorter clip is `repeatpad`ed up to the fixed 480 000-sample window (exactly
-  /// as HF's `ClapFeatureExtractor` does); a **longer** clip is rejected with
-  /// [`Error::AudioTooLong`] rather than silently head-truncated. This is the
-  /// per-window primitive — feed a longer clip to [`Self::embed_windows`] (the
-  /// long-audio pipeline), which hops it into 480 000-sample windows first. (HF is
-  /// configured for `rand_trunc`, so head-truncating here would be neither
-  /// deterministic nor HF-faithful; clapkit will not truncate behind your back.)
+  /// `samples` is 48 kHz ([`SAMPLE_RATE_HZ`]) mono and must be
+  /// `1..=`[`TARGET_SAMPLES`] long. A shorter clip is `repeatpad`ed up to the
+  /// fixed 480 000-sample window (exactly as HF's `ClapFeatureExtractor` does);
+  /// a **longer** clip is rejected with [`Error::AudioTooLong`] rather than
+  /// silently head-truncated. This is the per-window primitive — feed a longer
+  /// clip to [`Self::embed_windows`] (the long-audio pipeline), which hops it
+  /// into 480 000-sample windows first. (HF is configured for `rand_trunc`, so
+  /// head-truncating here would be neither deterministic nor HF-faithful;
+  /// clapkit will not truncate behind your back.)
   ///
   /// # Errors
   /// [`Error::EmptyAudio`] if `samples` is empty.
@@ -319,11 +320,10 @@ impl AudioEncoder {
   /// As [`Self::embed_window`]; a failure here surfaces a broken model at prewarm
   /// time rather than on the first request.
   pub fn prewarm(&self) -> Result<()> {
-    const SR: f32 = 48_000.0;
     // 1 s of a fixed 440 Hz tone: a valid, non-silent window (avoids the
     // zero-magnitude path) that `embed_window` `repeatpad`s to the full window.
-    let signal: Vec<f32> = (0..48_000)
-      .map(|i| 0.5 * (std::f32::consts::TAU * 440.0 * (i as f32 / SR)).sin())
+    let signal: Vec<f32> = (0..SAMPLE_RATE_HZ)
+      .map(|i| 0.5 * (std::f32::consts::TAU * 440.0 * (i as f32 / SAMPLE_RATE_HZ as f32)).sin())
       .collect();
     self.embed_window(&signal)?;
     Ok(())

--- a/crates/coremlit/src/embeddings/clap/mod.rs
+++ b/crates/coremlit/src/embeddings/clap/mod.rs
@@ -13,9 +13,10 @@
 //!
 //! # Sample rate: 48 kHz (a documented deviation)
 //!
-//! CLAP is a **48 kHz** model. clapkit's audio API therefore takes 48 kHz mono
-//! `&[f32]` — a deliberate, documented deviation from the workspace's 16 kHz
-//! convention. Resampling to 48 kHz is the caller's responsibility (sans-I/O).
+//! CLAP is a **48 kHz** model ([`audio::SAMPLE_RATE_HZ`]). clapkit's audio API
+//! therefore takes 48 kHz mono `&[f32]` — a deliberate, documented deviation
+//! from the workspace's 16 kHz convention. Resampling to 48 kHz is the
+//! caller's responsibility (sans-I/O).
 //!
 //! # Model artifacts
 //!


### PR DESCRIPTION
Item 2 of #98. Item 1 (the vector `Smoother`) is windit's side — findit-studio/windit#12 — and lands here as a one-line re-export once that releases.

## What was there

The authoritative sample rate was `const SR: u32 = 48_000` at `clap/audio/mel/mod.rs:58`, **module-private, sitting immediately beside `pub const TARGET_SAMPLES`**. A downstream crate could only pin the rate by deriving it — `TARGET_SAMPLES / 10`.

(The `const SR: f32` at `audio/mod.rs:322` is a different thing: a function-local for synthesising a warm-up tone, not the contract.)

## What changed

`pub const SAMPLE_RATE_HZ: u32 = 48_000`, re-exported on the same `pub use self::mel::{…}` line as `TARGET_SAMPLES` and nowhere else — so it lands at `embeddings::clap::audio::SAMPLE_RATE_HZ`, matching where `TARGET_SAMPLES` actually is. (It is **not** in `clap/mod.rs`'s own `pub use` list; the issue's "beside `TARGET_SAMPLES`" only makes sense under the real path.)

**`u32`, not `usize`.** It is the type the only real call site — `build_mel_filterbank(sr: u32, …)` — needs with zero cast, it matches the audio ecosystem (`cpal`, `hound`, `symphonia` all use `u32`), and keeping "rate" and "length" as distinct types is a small type-safety win. The two casts this pushes elsewhere are in cold paths.

## The relationship is asserted, and the reachability is too

`TARGET_SAMPLES == 10 * SAMPLE_RATE_HZ as usize` is pinned in `mel/tests.rs`. Proved a real falsifier before being trusted: mutating the constant to `44_100` gives `left: 480000, right: 441000`.

But that test lives in an **internal** module, which can see private items — so it pins the arithmetic and says nothing about the thing this change exists for. Verified: removing `SAMPLE_RATE_HZ` from the `pub use` leaves it **green**.

So a doctest on the constant pins the **public path**, compiling as an external consumer does:

```rust
/// use coremlit::embeddings::clap::audio::{SAMPLE_RATE_HZ, TARGET_SAMPLES};
/// assert_eq!(TARGET_SAMPLES, 10 * SAMPLE_RATE_HZ as usize);
```

Falsified with the mutation that isolates exactly that property — downgrading the re-export to `pub(crate)`, so the item stays crate-visible and the internal test stays green: `error[E0603]: constant SAMPLE_RATE_HZ is private`, one doctest failed, exit 101. Deleting it from the `pub use` outright would also break `prewarm`'s internal reference, a different failure class.

Both tests are kept: one pins the arithmetic, the other the path.

## Docs now link the value

`clap/mod.rs`'s "Sample rate: 48 kHz" section, `embed_window`'s per-call contract, and `TARGET_SAMPLES`' own doc all link `SAMPLE_RATE_HZ`, so the prose and the pinnable value cannot drift. That is the actual point of the change — `audio/mod.rs:189` already *said* "48 kHz mono" and a caller had nothing to pin.

## Bare-literal audit (non-test code)

| site | verdict |
|---|---|
| `mel/mod.rs:58` | the authoritative one — became the constant |
| `audio/mod.rs` `prewarm()`, two literals | fixed, read the constant |
| `benches/clap/encode.rs` `deterministic_window` | fixed — its doc claims 220/440/1760 Hz, and `t = i / SAMPLE_RATE_HZ` is what makes that true rather than aliased |
| `window/mod.rs` `WINDOW_SAMPLES = TARGET_SAMPLES` | not a literal, already derived |
| `mel/mod.rs:45` doc `1 + 480000/480` | that is `TARGET_SAMPLES`/`HOP`, a different number |
| `assets/tokenizer.json` `"Ire": 48000` | unrelated BPE token id |

## Verification

`fmt=0 clippy_all_targets=0 lib=0 (1218 passed) doc=0 clap=0 doctest=0 (8 passed)`.
