### PR TITLE
feat(coremlit): a per-artifact model licence register, checked in three directions (#115)

### DIFF
--- a/coremlit/FEATURE_MAP.md
+++ b/coremlit/FEATURE_MAP.md
@@ -110,9 +110,11 @@ no weight bytes (see `NOTICE`, "CI DOWNLOADS; IT DOES NOT REDISTRIBUTE").
 
 Any such artifact rides a feature named with the **`commercial-` prefix**, which
 is never in `default`. The prefix reads backwards — `commercial-face` looks like
-"cleared for commercial use" — so **the first sentence of the feature's comment
-in `Cargo.toml` must say that a commercial licence is required**. That is not
-decoration; it is what stops the name being read as an endorsement.
+"cleared for commercial use" — so **the feature's comment in `Cargo.toml` must
+BEGIN with the warning that a commercial licence is required**. Begins with, not
+contains: "This feature no longer requires a commercial license" and "Cleared
+for commercial use! This feature requires a commercial license" both contain the
+phrase and both say the opposite of it.
 
 None of these features exists yet. The mechanism does:
 `coremlit/tests/model_licences.rs` holds the licence table — keyed by
@@ -120,17 +122,30 @@ None of these features exists yet. The mechanism does:
 tag can contradict the terms of bytes it merely re-hosts — and refuses all
 three of
 
-- a `MODELS_LOCK` artifact with no licence row (and a row naming no staged
-  repository);
-- a research-only row reachable from `default`, or gated by a plain kit
-  feature instead of a `commercial-` one;
-- a `commercial-` feature gating artifacts whose rows are all clear — a gate
-  left standing after the restriction it protected went away.
+- a file `MODELS_LOCK` stages with no licence row, and a row naming a file no
+  table stages. At FILE granularity: a table with an explicit `files` list is
+  an exact bijection against the rows, and a globbed table's rows must be
+  selected by the glob and must cover their whole `.mlmodelc` through a
+  per-file SHA-256 manifest;
+- a research-only row whose loader's `#[cfg(feature = ...)]` is reachable from
+  **any** non-commercial feature closure — not just `default`'s, because
+  `speaker = ["commercial-face"]` ships it just as surely — or that is not
+  `commercial-` prefixed;
+- a `commercial-` feature gating artifacts whose rows are all clear (a gate
+  left standing after the restriction it protected went away), or that **no
+  `#[cfg(feature = ...)]` in `src/` names at all** — a feature that gates no
+  code is a name, not a gate.
 
-Adding a `commercial-` feature therefore means three edits, not one: the
+Every one of those reads a repository fact rather than the row: the gate comes
+from the `#[cfg]` on the module that loads the artifact, the closures from this
+manifest, and the selectors from `MODELS_LOCK`. The row's own `gate` field is a
+claim, cross-checked against the tree by
+`every_rows_gate_matches_the_cfg_that_guards_its_loader`.
+
+Adding a `commercial-` feature therefore means four edits, not one: the
 `Cargo.toml` feature (with its first-sentence warning), its row in
-`expected_features()` and the table above, and its artifact rows in the licence
-table.
+`expected_features()` and the table above, **a `#[cfg(feature = ...)]` in `src/`
+that actually gates the loader**, and its artifact rows in the licence table.
 
 ## Curated CI feature-combination list
 

--- a/coremlit/FEATURE_MAP.md
+++ b/coremlit/FEATURE_MAP.md
@@ -100,6 +100,38 @@ Compositions (pinned by the golden test): `nl-recognizer` → `whisper`;
 `vad-bundled` → `coremlit/vad`. (`granite`, `siglip`, `ced`, and `lid` each
 compose with nothing — a single leaf feature.)
 
+## Model-licence gating (the `commercial-` prefix)
+
+coremlit is MIT OR Apache-2.0, but products built on it need not be. A model
+artifact whose **weights** or whose **training corpus** forbids commercial use
+is therefore disqualifying for the shipping path — while still being perfectly
+legal for CI to fetch and test against, because this repository redistributes
+no weight bytes (see `NOTICE`, "CI DOWNLOADS; IT DOES NOT REDISTRIBUTE").
+
+Any such artifact rides a feature named with the **`commercial-` prefix**, which
+is never in `default`. The prefix reads backwards — `commercial-face` looks like
+"cleared for commercial use" — so **the first sentence of the feature's comment
+in `Cargo.toml` must say that a commercial licence is required**. That is not
+decoration; it is what stops the name being read as an endorsement.
+
+None of these features exists yet. The mechanism does:
+`coremlit/tests/model_licences.rs` holds the licence table — keyed by
+**artifact file + SHA-256, never by repository**, because a repository's own
+tag can contradict the terms of bytes it merely re-hosts — and refuses all
+three of
+
+- a `MODELS_LOCK` artifact with no licence row (and a row naming no staged
+  repository);
+- a research-only row reachable from `default`, or gated by a plain kit
+  feature instead of a `commercial-` one;
+- a `commercial-` feature gating artifacts whose rows are all clear — a gate
+  left standing after the restriction it protected went away.
+
+Adding a `commercial-` feature therefore means three edits, not one: the
+`Cargo.toml` feature (with its first-sentence warning), its row in
+`expected_features()` and the table above, and its artifact rows in the licence
+table.
+
 ## Curated CI feature-combination list
 
 The former per-crate `cargo hack --each-feature` powerset is replaced by this

--- a/coremlit/tests/model_licences.rs
+++ b/coremlit/tests/model_licences.rs
@@ -23,20 +23,31 @@
 //! failure: two rows over the same SHA-256 that disagree about what the bytes
 //! permit.
 //!
+//! **And the CHECKS have to be keyed the same way.** A table keyed by artifact
+//! whose coverage check compares repository NAMES is the same defect one level
+//! up: one row over a repository made every other file that repository stages
+//! invisible, and the check passed while `openai/whisper-tiny` staged three
+//! files and this table carried one. Every predicate below therefore
+//! reconciles against a REPOSITORY FACT — the lock's own selectors, the
+//! `#[cfg(feature = ...)]` in the source tree, the manifest's feature graph,
+//! the per-file SHA-256 pins — and never against a field of the row it is
+//! checking. The row's own `gate`, `pin` and `loader` are claims, and each one
+//! has a check whose job is to disbelieve it.
+//!
 //! # The three directions
 //!
 //! Modelled on `CHECKSUMLESS_KITS` in `tests/whisper/models_lock.rs`, which
 //! this repository already uses precisely so an exemption cannot outlive its
 //! cause. Red on all three of:
 //!
-//!   1. a `MODELS_LOCK` artifact with no licence row — and the reverse, a row
-//!      naming a repository no table stages
-//!      ([`every_staged_repo_has_a_licence_row_and_every_row_names_a_staged_repo`]);
-//!   2. a research-only row reachable from `default`, or gated by a feature
-//!      that is not `commercial-` prefixed
+//!   1. a file `MODELS_LOCK` stages with no licence row — and the reverse, a
+//!      row naming a file no table stages
+//!      ([`every_staged_file_has_a_licence_row_and_every_row_names_a_staged_file`]);
+//!   2. a research-only row whose loader's `#[cfg]` feature is reachable from
+//!      ANY non-commercial feature closure, or is not `commercial-` prefixed
 //!      ([`no_research_only_artifact_is_reachable_without_a_commercial_gate`]);
-//!   3. a `commercial-`prefixed feature gating an artifact whose row is
-//!      actually clear
+//!   3. a `commercial-`prefixed feature that gates only clear artifacts, or
+//!      that no `#[cfg(feature = ...)]` in the tree names at all
 //!      ([`every_commercial_feature_gates_a_research_only_artifact`]).
 //!
 //! The third is the one people forget, and it is what keeps the table honest
@@ -53,23 +64,122 @@
 //! a tripwire, so every predicate below is ALSO driven by hermetic falsifiers
 //! over doctored input (`falsifiers::*`), which run everywhere, need no models
 //! and no repository files, and fail if the predicate ever stops detecting the
-//! thing it exists to detect. Direction 1, the SHA-256 pin cross-check and the
-//! same-bytes-same-terms rule DO bind live data today.
+//! thing it exists to detect.
+//!
+//! What "cannot fire" does NOT mean is "reads nothing". Directions 2 and 3
+//! bind live data today even though nothing can trip them: the gate every row
+//! runs on is read out of the tree's `#[cfg(feature = ...)]` by
+//! [`loader_gates`], the closures out of the manifest by [`feature_closures`],
+//! and the set of features any `#[cfg]` in `src/` actually names by
+//! [`cfg_features_in_source`]. Break the loader gating and
+//! [`every_rows_gate_matches_the_cfg_that_guards_its_loader`] goes red now, on
+//! today's clean table. Direction 1, the SHA-256 pin cross-check, the
+//! pin-ownership rule and the same-bytes-same-terms rule bind live data too.
 //!
 //! # What this file can and cannot see
 //!
-//! `MODELS_LOCK` names repositories, selectors and revisions — not files. The
-//! file list only exists after a download, and these checks are hermetic. So
-//! direction 1 binds at TABLE granularity ("every table is covered by at least
-//! one row"), while the ROWS are per-file, which is what makes the AuraFace
-//! failure mode expressible at all. The seeding rule for rows is: one row per
-//! staged file this repository independently pins by SHA-256, plus the
-//! `revision = "main"` whisper artifacts that nothing can pin. Files inside a
-//! staged bundle that carry no independent pin (`Segmentation.mlmodelc`,
-//! `PLDA.mlmodelc` and the other FluidInference bundles) are not rows, and a
-//! research-only artifact could in principle hide in one; that is a real,
-//! named gap, and closing it needs a per-file manifest those bundles do not
-//! have.
+//! `MODELS_LOCK` selects in two shapes, and direction 1 treats them
+//! differently because they carry different amounts of truth:
+//!
+//!   - `files = "a b c"` NAMES every file the table stages, so the check is an
+//!     exact bijection — every listed file needs a row, every row must be one
+//!     of the listed files. This is the shape that was passing vacuously.
+//!   - `include = "<glob>"` names a PATTERN; the file list exists only after a
+//!     download, and these checks are hermetic. A row on such a table is
+//!     reconciled against the pattern (rows must be selected by it) and
+//!     against the repository's own per-file SHA-256 manifests, which is what
+//!     makes a row keyed on `weights/weight.bin` cover the whole `.mlmodelc`
+//!     instead of the one file it keys on.
+//!
+//! The residue is real and named rather than implied. A `.mlmodelc` this
+//! repository pins no manifest for cannot be keyed on bytes — the six
+//! FluidInference bundles nothing else publishes are in that position — so
+//! each is a BUNDLE row carrying [`Key::Unmanifested`] and the reason. They
+//! are rows, with terms, gated, and covered by directions 2 and 3; what they
+//! lack is a byte identity, and
+//! [`unpinned_rows_exist_only_where_the_lock_pins_a_moving_revision`] ties
+//! that exemption to its cause in both directions. Files a glob stages that
+//! are not model artifacts at all (`CHECKSUMS.sha256`, the `.mlpackage`
+//! sources whose `weights/weight.bin` the upstream's own checksum file lists
+//! as byte-identical to the compiled bundle's) carry no rows and are the one
+//! gap this file still cannot close hermetically.
+//!
+//! What stops "every bundle a glob stages has a row" from resting on nobody
+//! having forgotten one is a SECOND enumeration, written for an unrelated
+//! reason: `tests/fp16_guards.rs` pins guard sites per bundle, and
+//! [`every_fp16_pinned_bundle_under_a_staged_vendor_has_a_licence_row`] refuses
+//! any path in that roster which sits under a staged vendor directory and has
+//! no row here. It is partial — a bundle with no guard sites appears in neither
+//! enumeration — and it is a repository fact rather than a restatement of this
+//! table, which is the only kind of check worth having.
+//!
+//! # EVIDENCE
+//!
+//! Every verdict below that rests on an upstream statement rather than on
+//! `NOTICE` cites it here, pinned. A licence read once and not pinned is a
+//! licence somebody has to read again.
+//!
+//!   - **openai/whisper-tiny** — HF repo, revision
+//!     `169d4a4341b33bc18d8881c4b69c2e104e1cc0af`, declares `apache-2.0`. NOT
+//!     MIT: the `openai/whisper` CODE repository is MIT, which is what
+//!     `NOTICE` section 3 records for this chain.
+//!   - **argmaxinc/whisperkit-coreml** — HF repo, revision
+//!     `0f63a7800b00dd0226abd051b906c246e1907482`, declares `mit`.
+//!   - **ibm-granite/granite-embedding-97m-multilingual-r2** — HF repo,
+//!     revision `835ad14087e140460703cf0fae09f97d469d65c2`, declares
+//!     `apache-2.0`; its model card's Data Collection section states "All
+//!     training data is sourced under permissive, commercial-friendly
+//!     licenses, making Granite Embedding R2 suitable for unrestricted
+//!     enterprise deployment", over four named source classes and a stated
+//!     data-clearance process.
+//!   - **wenet-e2e/wespeaker** — `docs/pretrained.md`, section "Model
+//!     License", at commit `c28dfb71f557a7eee05be164edce2577bf8708f8`: "The
+//!     pretrained model in WeNet follows the license of it's corresponding
+//!     dataset. For example, the pretrained model on VoxCeleb follows
+//!     `Creative Commons Attribution 4.0 International License.`". There is no
+//!     `docs/model_license.md` in that repository. The rule is stated once and
+//!     worked through for VoxCeleb ONLY: the same page ships a same-named
+//!     `cnceleb_resnet34_LM`, and CN-Celeb's terms are stated nowhere.
+//!   - **VoxCeleb** — `https://mm.kaist.ac.kr/datasets/voxceleb/` (the URL
+//!     WeSpeaker cites), retrieved 2026-09-01: "The VoxCeleb dataset is
+//!     available to download for research purposes under a Creative Commons
+//!     Attribution 4.0 International License. The copyright remains with the
+//!     original owners of the video." The canonical Oxford VGG page
+//!     (`https://www.robots.ox.ac.uk/~vgg/data/voxceleb/`) states no licence
+//!     at all as of the same date, which is why the research-purposes wording
+//!     is carried as a restriction rather than smoothed away.
+//!   - **VoxLingua107** — `https://cs.taltech.ee/staff/tanel.alumae/data/voxlingua107/`,
+//!     retrieved 2026-09-01, section "License and copyright": "The
+//!     VoxLingua107 dataset is distributed under the Creative Commons
+//!     Attribution 4.0 International License. The copyright remains with the
+//!     original owners of the video." Corroborated by the Wayback snapshot
+//!     `web.archive.org/web/20250624193952/https://bark.phon.ioc.ee/voxlingua107/`;
+//!     the `bark.phon.ioc.ee` host that `NOTICE` and the literature cite is
+//!     unreachable (connection reset) as of 2026-09-01.
+//!   - **speechbrain/lang-id-voxlingua107-ecapa** — HF repo, revision
+//!     `0253049ae131d6a4be1c4f0d8b0ff483a0f8c8e9`, declares `apache-2.0`.
+//!   - **aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-CoreML** — HF repo,
+//!     revision `2aa4d715a79e410d5f9aa32bd7a4fc9225bf9eb0` (the revision
+//!     `MODELS_LOCK` pins), declares `apache-2.0`.
+//!   - **AudioSet** — `https://research.google.com/audioset/download.html`,
+//!     retrieved 2026-09-01: "The dataset is made available by Google Inc.
+//!     under a Creative Commons Attribution 4.0 International (CC BY 4.0)
+//!     license, while the ontology is available under a Creative Commons
+//!     Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) license." Note
+//!     the direction: DATASET CC-BY-4.0, ONTOLOGY CC-BY-SA-4.0. Neither
+//!     licenses the audio, which is YouTube media Google never redistributed.
+//!   - **LAION-AI/CLAP** — `README.md` at commit
+//!     `f14f288e5c9d2c7b7177b63512d0ba84f3ebf322`: "Due to copyright reasons,
+//!     we cannot release the dataset we train this model on", and "Because
+//!     most of the dataset has copyright restriction, unfortunatly we cannot
+//!     directly share other preprocessed datasets."
+//!   - **pyannote/segmentation-3.0** — HF repo, revision
+//!     `e66f3d3b9eb0873085418a7b813d3b369bf160bb`, declares `mit` via the HF
+//!     API; the card body is GATED (accessing the files requires accepting
+//!     conditions), so its training-data list — AISHELL, AliMeeting, AMI,
+//!     AVA-AVD, DIHARD, Ego4D, MSDWild, REPERE, VoxConverse, no terms stated
+//!     for any — is recorded from the public model page on 2026-09-01 rather
+//!     than pinned to that revision.
 //!
 //! Hermetic: pure file reads, no network, no models, no feature needs
 //! enabling. The `MODELS_LOCK`-reading checks SKIP outside the repository
@@ -91,37 +201,173 @@ use std::{
 // The table
 // ---------------------------------------------------------------------------
 
+/// One licence layer's terms, in the form two rows over identical bytes can
+/// actually be compared on.
+///
+/// Prose alone cannot be compared, and a four-way verdict class cannot either:
+/// MIT and Apache-2.0 are both `Permissive` while imposing different notice
+/// obligations, and two `ResearchOnly` artifacts can forbid materially
+/// different things. So the canonical identifier and the obligations are
+/// FIELDS — [`contradictory_terms`] reads them — and the prose is the reading
+/// laid on top of them rather than the thing being compared.
+#[derive(Debug, Clone, Copy)]
+struct Statement {
+  /// The canonical licence identifier: the SPDX id where one governs, or `""`
+  /// where the layer is [`Terms::Unresolved`] and no identifier has been
+  /// established. Compared VERBATIM across rows, so it is written in SPDX
+  /// spelling (`Apache-2.0`, `CC-BY-4.0`) and nothing else.
+  licence: &'static str,
+  /// What the identifier alone does not carry: the obligations and
+  /// prohibitions that travel with these bytes. Compared as a SET across rows,
+  /// so two rows over one SHA-256 that record different restrictions are a
+  /// contradiction even when they agree on the identifier.
+  restrictions: &'static [&'static str],
+  /// The reading this repository has, and where it comes from.
+  detail: &'static str,
+}
+
+/// The obligation a permissive licence imposes on a binary that ships the
+/// bytes, and the only one: reproduce the notice.
+const RETAIN_NOTICE: &[&str] = &["retain-copyright-and-licence-notice"];
+
+/// CC-BY-4.0's condition. Commercial use is permitted, but crediting the
+/// author is a CONDITION of the grant, so shipping without the credit is
+/// infringement rather than impoliteness.
+const CREDIT_AUTHOR: &[&str] = &[
+  "retain-copyright-and-licence-notice",
+  "credit-the-author-in-the-product",
+];
+
+/// CC-BY-4.0 as VoxCeleb's own distributor states it — the grant, plus the two
+/// things the identifier does not carry. The download page says the dataset is
+/// "available to download for research purposes under a Creative Commons
+/// Attribution 4.0 International License", and that "the copyright remains with
+/// the original owners of the video". CC-BY-4.0 permits commercial use; the
+/// research-purposes wording and the retained third-party copyright are the
+/// tension a shipping decision has to be taken with its eyes open, so they are
+/// recorded as restrictions rather than smoothed into the identifier.
+const CREDIT_AUTHOR_VOXCELEB: &[&str] = &[
+  "retain-copyright-and-licence-notice",
+  "credit-the-author-in-the-product",
+  "upstream-states-for-research-purposes-on-the-download-page",
+  "third-party-copyright-retained-in-the-source-videos",
+];
+
+/// CC-BY-4.0 over a scraped-video corpus: the grant, the retained third-party
+/// copyright, and the take-down policy the distributor operates — under which
+/// the corpus a model was trained on is not guaranteed to stay the corpus that
+/// is distributed.
+const CREDIT_AUTHOR_SCRAPED: &[&str] = &[
+  "retain-copyright-and-licence-notice",
+  "credit-the-author-in-the-product",
+  "third-party-copyright-retained-in-the-source-videos",
+  "upstream-operates-a-notice-and-take-down-policy",
+];
+
+/// The identifier for a layer governed by a MIXTURE that the upstream asserts
+/// is uniformly permissive without itemising it.
+///
+/// Not an SPDX id, because no single licence governs — and deliberately not
+/// rounded to one, because the row would then claim more than the upstream
+/// said. Compared verbatim like any other identifier, so a second row over the
+/// same bytes claiming a real SPDX id is a contradiction, which is correct: a
+/// vendor assertion and a licence grant are not the same evidence.
+const PERMISSIVE_MIXTURE: &str = "permissive-mixture (vendor-asserted, not itemised)";
+
+/// [`PERMISSIVE_MIXTURE`]'s obligations: the ordinary notice, plus the fact
+/// that the permission rests on the vendor's word rather than on a licence
+/// anybody can read.
+const RETAIN_NOTICE_VENDOR_ASSERTED: &[&str] = &[
+  "retain-copyright-and-licence-notice",
+  "permission-rests-on-a-vendor-assertion-rather-than-a-per-source-licence-list",
+];
+
+/// The only legal payload for [`Terms::Unresolved`]: nothing is established,
+/// so no obligation may be recorded — recording one would be an answer, and
+/// the point of the variant is that there is not one yet.
+const NOTHING_ESTABLISHED: &[&str] = &[];
+
 /// What one licence layer permits, and the reading this repository has on it.
 ///
-/// The payload is prose on purpose: a bare SPDX identifier answers "which
-/// licence" and never "and does that let us ship it", which is the only
-/// question this file is asking. Every variant is a NEWTYPE of exactly one
-/// payload — the workspace house rule
-/// (`no_enum_in_the_workspace_has_a_struct_shaped_or_multi_field_variant`).
+/// The verdict is the CLASS; [`Statement`] carries the identifier and the
+/// obligations, because the class alone is too coarse to compare two rows on.
+/// Every variant is a NEWTYPE of exactly one payload — the workspace house
+/// rule (`no_enum_in_the_workspace_has_a_struct_shaped_or_multi_field_variant`).
 #[derive(Debug, Clone, Copy)]
 enum Terms {
   /// Commercial use permitted with no condition beyond retaining notices —
-  /// MIT, Apache-2.0, BSD. Payload: the licence and where it is declared.
-  Permissive(&'static str),
+  /// MIT, Apache-2.0, BSD.
+  Permissive(Statement),
   /// Commercial use permitted, but attribution is a CONDITION of it, so
   /// shipping without the notice is infringement rather than impoliteness.
-  /// Payload: the licence, and what has to be reproduced.
-  Attribution(&'static str),
-  /// **Disqualifying.** Forbids commercial use. Payload: the exact
-  /// restriction and where it is stated.
-  ResearchOnly(&'static str),
-  /// Not established. Payload: the open QUESTION and where to go to answer it.
+  Attribution(Statement),
+  /// **Disqualifying.** Forbids commercial use.
+  ResearchOnly(Statement),
+  /// Not established. The prose names the open QUESTION and where to go to
+  /// answer it.
   ///
   /// Deliberately distinct from [`Terms::Permissive`]: rounding an unknown to
   /// "clear" is how a table stops being evidence. Unresolved is not
   /// disqualifying either — it is a row that no shipping claim may rest on
   /// until somebody resolves it.
-  Unresolved(&'static str),
+  Unresolved(Statement),
 }
 
 impl Terms {
-  /// The verdict, without the prose — what two rows over identical bytes must
-  /// agree on.
+  /// A permissive layer: SPDX id, obligations, and the reading.
+  const fn permissive(
+    licence: &'static str,
+    restrictions: &'static [&'static str],
+    detail: &'static str,
+  ) -> Self {
+    Self::Permissive(Statement {
+      licence,
+      restrictions,
+      detail,
+    })
+  }
+
+  /// A layer whose commercial grant is conditional on attribution.
+  const fn attribution(
+    licence: &'static str,
+    restrictions: &'static [&'static str],
+    detail: &'static str,
+  ) -> Self {
+    Self::Attribution(Statement {
+      licence,
+      restrictions,
+      detail,
+    })
+  }
+
+  /// A layer that forbids the shipping path.
+  const fn research_only(
+    licence: &'static str,
+    restrictions: &'static [&'static str],
+    detail: &'static str,
+  ) -> Self {
+    Self::ResearchOnly(Statement {
+      licence,
+      restrictions,
+      detail,
+    })
+  }
+
+  /// A layer nobody has established. No identifier, no obligations — see
+  /// [`NOTHING_ESTABLISHED`].
+  const fn unresolved(detail: &'static str) -> Self {
+    Self::Unresolved(Statement {
+      licence: "",
+      restrictions: NOTHING_ESTABLISHED,
+      detail,
+    })
+  }
+
+  /// The verdict class.
+  ///
+  /// NOT what two rows over identical bytes are compared on — see
+  /// [`Terms::effective`], and the finding that four coarse strings let
+  /// "MIT" and "Apache-2.0" over one SHA-256 read as agreement.
   const fn verdict(self) -> &'static str {
     match self {
       Self::Permissive(_) => "permissive",
@@ -136,11 +382,36 @@ impl Terms {
     matches!(self, Self::ResearchOnly(_))
   }
 
+  /// The structured payload.
+  const fn statement(self) -> Statement {
+    match self {
+      Self::Permissive(s) | Self::Attribution(s) | Self::ResearchOnly(s) | Self::Unresolved(s) => s,
+    }
+  }
+
   /// The prose payload.
   const fn detail(self) -> &'static str {
-    match self {
-      Self::Permissive(d) | Self::Attribution(d) | Self::ResearchOnly(d) | Self::Unresolved(d) => d,
-    }
+    self.statement().detail
+  }
+
+  /// The canonical licence identifier.
+  const fn licence(self) -> &'static str {
+    self.statement().licence
+  }
+
+  /// The obligations, as a set.
+  fn restrictions(self) -> BTreeSet<&'static str> {
+    self.statement().restrictions.iter().copied().collect()
+  }
+
+  /// **What two rows over identical bytes must agree on**: the class, the
+  /// canonical identifier, and the obligation set.
+  ///
+  /// Comparing the class alone is what let identical bytes pass while one row
+  /// called them MIT and the other Apache-2.0, and what let two research-only
+  /// rows with different redistribution restrictions read as agreement.
+  fn effective(self) -> (&'static str, &'static str, BTreeSet<&'static str>) {
+    (self.verdict(), self.licence(), self.restrictions())
   }
 }
 
@@ -157,6 +428,17 @@ enum Key {
   /// day the LOUD FOLLOW-UP in `MODELS_LOCK` lands and those tables pin a
   /// commit, this exemption goes red and has to be replaced by a hash.
   Unpinned(&'static str),
+  /// The lock pins an immutable commit, so the bytes ARE determined — but this
+  /// repository holds no per-file SHA-256 manifest for them, so the row has no
+  /// hash to key on. Payload: why, and what would close it.
+  ///
+  /// A different exemption from [`Key::Unpinned`] and it must stay different:
+  /// unpinned means "nobody can name these bytes", unmanifested means "these
+  /// bytes are named by the lock and this repository never wrote the hash
+  /// down". Legal ONLY on a table whose selector is a GLOB — an explicit
+  /// `files` list names every file it stages, so a row on one can always be
+  /// reconciled without a manifest.
+  Unmanifested(&'static str),
 }
 
 /// One staged file, and what its bytes permit.
@@ -166,18 +448,32 @@ struct Artifact {
   /// The bytes' identity — see [`Key`].
   key: Key,
   /// `<crate-relative source>::<identifier>` where this repository ALREADY
-  /// pins those bytes, or `""` for a [`Key::Unpinned`] row.
+  /// pins those bytes, or `""` for a row that has no hash to pin.
   ///
   /// The licence attaches to bytes, so a hash copied here and never checked
   /// again is a hash that goes stale the first time an artifact is
   /// re-converted. This field is what stops that: the identifier names a
   /// `const` or a `fn` in the tree, and the SHA-256 in that pin has to be the
-  /// one in this row.
+  /// one in this row. [`every_pin_locator_belongs_to_the_kit_and_bundle_it_is_read_for`]
+  /// is what stops the locator from being ANY pin that happens to hold a
+  /// `weights/weight.bin` key.
   pin: &'static str,
   /// The `MODELS_LOCK` table that stages the file.
   staged_by: &'static str,
+  /// `<crate-relative source>::<module>` — the module declaration whose
+  /// `#[cfg(feature = ...)]` decides whether the shipping path can load this
+  /// artifact at all.
+  ///
+  /// This is the field [`Artifact::gate`] is CHECKED AGAINST. The gate a row
+  /// claims is worth nothing on its own: the question direction 2 asks is
+  /// "which cargo features make this artifact loadable", and only the tree
+  /// answers it. [`loader_gates`] reads the answer, and
+  /// [`every_rows_gate_matches_the_cfg_that_guards_its_loader`] refuses a row
+  /// whose claim and whose tree disagree.
+  loader: &'static str,
   /// The cargo feature a caller must enable before the shipping path can load
-  /// it. Research-only artifacts must be gated by a `commercial-` feature; see
+  /// it — the row's CLAIM, reconciled against [`Artifact::loader`]. Research-only
+  /// artifacts must be gated by a `commercial-` feature; see
   /// [`COMMERCIAL_PREFIX`].
   gate: &'static str,
   /// Terms on the weight bytes themselves.
@@ -186,11 +482,13 @@ struct Artifact {
   ///
   /// A different question from [`Artifact::weights`], and the one nearly every
   /// model fails: Apache-2.0 weights trained on a corpus licensed for research
-  /// only are still research only. `NOTICE` records the weights layer for every
-  /// component and the corpus layer for none, which is why so many rows below
-  /// are [`Terms::Unresolved`] here.
+  /// only are still research only. The two layers have two different sources,
+  /// and a layer stays [`Terms::Unresolved`] only while its own source is
+  /// silent — `NOTICE` documenting one layer says nothing about the other.
   corpus: Terms,
-  /// Where the two verdicts above come from.
+  /// Where the two verdicts above come from — `NOTICE` for a layer this
+  /// repository already recorded, and a PINNED upstream revision for a layer
+  /// resolved from the upstream's own statement.
   source: &'static str,
 }
 
@@ -217,12 +515,24 @@ impl Artifact {
     }
   }
 
-  /// The row's SHA-256, or `None` when it is [`Key::Unpinned`].
+  /// The row's SHA-256, or `None` when it has no hash to key on.
   const fn sha256(&self) -> Option<&'static str> {
     match self.key {
       Key::Sha256(hex) => Some(hex),
-      Key::Unpinned(_) => None,
+      Key::Unpinned(_) | Key::Unmanifested(_) => None,
     }
+  }
+
+  /// The `.mlmodelc` bundle this row's file sits in, path included, or `None`
+  /// when the artifact is a loose file.
+  fn bundle(&self) -> Option<&'static str> {
+    if self.file.ends_with(".mlmodelc") {
+      return Some(self.file);
+    }
+    self
+      .file
+      .split_once(".mlmodelc/")
+      .map(|(head, _)| &self.file[..head.len() + ".mlmodelc".len()])
   }
 }
 
@@ -237,9 +547,31 @@ impl Artifact {
 /// before the misreading has time to settle.
 const COMMERCIAL_PREFIX: &str = "commercial-";
 
-/// The phrase every `commercial-` feature's documentation must open with,
+/// The openings a `commercial-` feature's first documented sentence may take,
 /// normalised (see [`normalise_spelling`]).
-const COMMERCIAL_DOC_PHRASE: &str = "requires a commercial license";
+///
+/// **Begins-with, not contains.** A substring test passes
+/// "This feature no longer requires a commercial license", which is the exact
+/// reading the rule exists to prevent, and it passes
+/// "Cleared for commercial use! This feature requires a commercial license"
+/// because a `. `-only sentence splitter never sees the first sentence end.
+/// The warning has to BE the opening, not appear somewhere inside it.
+const COMMERCIAL_DOC_OPENINGS: &[&str] = &[
+  "requires a commercial license",
+  "this feature requires a commercial license",
+  "enabling this feature requires a commercial license",
+  "using this feature requires a commercial license",
+];
+
+/// Words that invert or suspend whatever sentence they appear in.
+///
+/// Checked across the WHOLE first sentence, matched as words rather than
+/// substrings ("cannot" must not be found inside "notice"). A first sentence
+/// that opens with the warning and then takes it back has not warned anybody.
+const NEGATIONS: &[&str] = &[
+  "no", "not", "never", "neither", "nor", "none", "without", "unless", "cannot", "cant", "dont",
+  "doesnt", "isnt", "wont", "except",
+];
 
 /// Every artifact `MODELS_LOCK` stages that this repository pins by SHA-256,
 /// plus the whisper artifacts nothing can pin, and what each one permits.
@@ -256,43 +588,95 @@ const COMMERCIAL_DOC_PHRASE: &str = "requires a commercial license";
 const ARTIFACTS: &[Artifact] = &[
   // --- whisper -------------------------------------------------------------
   Artifact {
-    file: "whisperkit-coreml/openai_whisper-tiny/AudioEncoder.mlmodelc/weights/weight.bin",
+    file: "whisperkit-coreml/openai_whisper-tiny/MelSpectrogram.mlmodelc",
     key: Key::Unpinned(
       "`argmaxinc/whisperkit-coreml` is still on `revision = \"main\"` (MODELS_LOCK's LOUD \
        FOLLOW-UP), so no immutable byte identity exists to key on; the same reason puts the \
-       `whisper` kit in CHECKSUMLESS_KITS.",
+       `whisper` kit in CHECKSUMLESS_KITS. The row names the BUNDLE rather than a file inside it \
+       because with no byte identity there is no precision to be had from naming one.",
     ),
     pin: "",
     staged_by: "argmaxinc/whisperkit-coreml",
+    loader: "src/audio/mod.rs::whisper",
     gate: "whisper",
-    weights: Terms::Permissive(
-      "MIT. WhisperKit's CoreML conversion (argmaxinc/WhisperKit, MIT) of OpenAI Whisper (MIT).",
+    weights: Terms::permissive(
+      "MIT",
+      RETAIN_NOTICE,
+      "argmaxinc/whisperkit-coreml declares MIT on the artifact repository itself, and it is \
+       WhisperKit's CoreML conversion (argmaxinc/WhisperKit, MIT) of OpenAI Whisper. Note the \
+       chain is NOT MIT end to end: the openai/whisper CODE repository is MIT, but the \
+       openai/whisper-tiny MODEL repository these weights convert declares apache-2.0. Both are \
+       permissive; the tokenizer rows below record the model repository's own terms rather than \
+       reading MIT across. Revisions pinned in the module doc's EVIDENCE section.",
     ),
-    corpus: Terms::Unresolved(
-      "OpenAI has published no terms for the ~680 000 hours of web audio Whisper was trained on, \
-       and it does not name the sources. NOTICE section 3 records the weights only. Resolve \
-       against openai/whisper's model card and paper before any shipping claim rests on the \
-       corpus layer.",
+    corpus: Terms::unresolved(
+      "The mel front-end of the same conversion. Its filterbank is derived from the checkpoint's \
+       own preprocessing constants, so it inherits the encoder row's open corpus question; \
+       whether a filterbank carries anything of the corpus at all is a second question nobody \
+       here has answered, and it does not close the first.",
     ),
-    source: "NOTICE section 3",
+    source: "NOTICE section 3; openai/whisper-tiny and argmaxinc/whisperkit-coreml (EVIDENCE, \
+             module doc)",
   },
   Artifact {
-    file: "whisperkit-coreml/openai_whisper-tiny/TextDecoder.mlmodelc/weights/weight.bin",
+    file: "whisperkit-coreml/openai_whisper-tiny/AudioEncoder.mlmodelc",
     key: Key::Unpinned(
       "`argmaxinc/whisperkit-coreml` is still on `revision = \"main\"` (MODELS_LOCK's LOUD \
        FOLLOW-UP), so no immutable byte identity exists to key on; the same reason puts the \
-       `whisper` kit in CHECKSUMLESS_KITS.",
+       `whisper` kit in CHECKSUMLESS_KITS. The row names the BUNDLE rather than a file inside it \
+       because with no byte identity there is no precision to be had from naming one.",
     ),
     pin: "",
     staged_by: "argmaxinc/whisperkit-coreml",
+    loader: "src/audio/mod.rs::whisper",
     gate: "whisper",
-    weights: Terms::Permissive(
-      "MIT. WhisperKit's CoreML conversion (argmaxinc/WhisperKit, MIT) of OpenAI Whisper (MIT).",
+    weights: Terms::permissive(
+      "MIT",
+      RETAIN_NOTICE,
+      "argmaxinc/whisperkit-coreml declares MIT on the artifact repository itself, and it is \
+       WhisperKit's CoreML conversion (argmaxinc/WhisperKit, MIT) of OpenAI Whisper. Note the \
+       chain is NOT MIT end to end: the openai/whisper CODE repository is MIT, but the \
+       openai/whisper-tiny MODEL repository these weights convert declares apache-2.0. Both are \
+       permissive; the tokenizer rows below record the model repository's own terms rather than \
+       reading MIT across. Revisions pinned in the module doc's EVIDENCE section.",
     ),
-    corpus: Terms::Unresolved(
+    corpus: Terms::unresolved(
+      "OpenAI has published no terms for the ~680 000 hours of web audio Whisper was trained on, \
+       and it does not name the sources. Its model card's Training Data section says only that \
+       the models are trained on audio \"collected from the internet\". NOTICE section 3 records \
+       the weights only, and the model card revision pinned in the EVIDENCE section states \
+       nothing further.",
+    ),
+    source: "NOTICE section 3; openai/whisper-tiny and argmaxinc/whisperkit-coreml (EVIDENCE, \
+             module doc)",
+  },
+  Artifact {
+    file: "whisperkit-coreml/openai_whisper-tiny/TextDecoder.mlmodelc",
+    key: Key::Unpinned(
+      "`argmaxinc/whisperkit-coreml` is still on `revision = \"main\"` (MODELS_LOCK's LOUD \
+       FOLLOW-UP), so no immutable byte identity exists to key on; the same reason puts the \
+       `whisper` kit in CHECKSUMLESS_KITS. The row names the BUNDLE rather than a file inside it \
+       because with no byte identity there is no precision to be had from naming one.",
+    ),
+    pin: "",
+    staged_by: "argmaxinc/whisperkit-coreml",
+    loader: "src/audio/mod.rs::whisper",
+    gate: "whisper",
+    weights: Terms::permissive(
+      "MIT",
+      RETAIN_NOTICE,
+      "argmaxinc/whisperkit-coreml declares MIT on the artifact repository itself, and it is \
+       WhisperKit's CoreML conversion (argmaxinc/WhisperKit, MIT) of OpenAI Whisper. Note the \
+       chain is NOT MIT end to end: the openai/whisper CODE repository is MIT, but the \
+       openai/whisper-tiny MODEL repository these weights convert declares apache-2.0. Both are \
+       permissive; the tokenizer rows below record the model repository's own terms rather than \
+       reading MIT across. Revisions pinned in the module doc's EVIDENCE section.",
+    ),
+    corpus: Terms::unresolved(
       "Same undisclosed ~680 000-hour web-audio corpus as the encoder; see that row.",
     ),
-    source: "NOTICE section 3",
+    source: "NOTICE section 3; openai/whisper-tiny and argmaxinc/whisperkit-coreml (EVIDENCE, \
+             module doc)",
   },
   Artifact {
     file: "tokenizers/whisper-tiny/tokenizer.json",
@@ -302,12 +686,67 @@ const ARTIFACTS: &[Artifact] = &[
     ),
     pin: "",
     staged_by: "openai/whisper-tiny",
+    loader: "src/audio/mod.rs::whisper",
     gate: "whisper",
-    weights: Terms::Permissive("MIT — OpenAI's own tokenizer artifact for whisper-tiny."),
-    corpus: Terms::Unresolved(
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "OpenAI's own tokenizer artifact for whisper-tiny. The openai/whisper-tiny repository declares \
+       apache-2.0 — NOT the MIT of the openai/whisper code repository, which is what NOTICE \
+       section 3 records for this chain. Both are permissive, so nothing about the shipping path \
+       changes; the identifier does, and it is the identifier two rows over one SHA-256 are \
+       compared on. Revision pinned in the module doc's EVIDENCE section.",
+    ),
+    corpus: Terms::unresolved(
       "The BPE vocabulary was fit on the same undisclosed corpus as the weights, so the corpus \
        layer is open for the same reason. A vocabulary carries no weights, which narrows the \
        exposure but does not close the question.",
+    ),
+    source: "NOTICE section 3",
+  },
+  Artifact {
+    file: "tokenizers/whisper-tiny/tokenizer_config.json",
+    key: Key::Unpinned(
+      "`openai/whisper-tiny` is still on `revision = \"main\"` (MODELS_LOCK's LOUD FOLLOW-UP), so \
+       no immutable byte identity exists to key on.",
+    ),
+    pin: "",
+    staged_by: "openai/whisper-tiny",
+    loader: "src/audio/mod.rs::whisper",
+    gate: "whisper",
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "The tokenizer's configuration sidecar, staged by the same `files` list and under the same \
+       declared apache-2.0 as the vocabulary it configures; see that row for why this chain is \
+       not MIT.",
+    ),
+    corpus: Terms::unresolved(
+      "Configuration derived from the same undisclosed corpus as the vocabulary; open for the \
+       same reason and with the same narrowed exposure. See the `tokenizer.json` row.",
+    ),
+    source: "NOTICE section 3",
+  },
+  Artifact {
+    file: "tokenizers/whisper-tiny/config.json",
+    key: Key::Unpinned(
+      "`openai/whisper-tiny` is still on `revision = \"main\"` (MODELS_LOCK's LOUD FOLLOW-UP), so \
+       no immutable byte identity exists to key on.",
+    ),
+    pin: "",
+    staged_by: "openai/whisper-tiny",
+    loader: "src/audio/mod.rs::whisper",
+    gate: "whisper",
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "The whisper-tiny model configuration, staged by the same `files` list and under the same \
+       declared apache-2.0; see the `tokenizer.json` row for why this chain is not MIT. It \
+       carries architecture hyperparameters, no weight values.",
+    ),
+    corpus: Terms::unresolved(
+      "Architecture configuration states nothing about the corpus, and the corpus layer is open \
+       for the whole whisper-tiny checkpoint. See the `tokenizer.json` row.",
     ),
     source: "NOTICE section 3",
   },
@@ -317,15 +756,25 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("276bc93c49a4f37ffefdfb2e10f7d7e1ef57db9027c7ad0d3f2e4160f81a79be"),
     pin: "tests/granite/model_io.rs::ARTIFACT_SHA256",
     staged_by: "FinDIT-Studio/embedkit-coreml",
+    loader: "src/embeddings/mod.rs::granite",
     gate: "granite",
-    weights: Terms::Permissive(
-      "Apache-2.0. ibm-granite/granite-embedding-97m-multilingual-r2; the staged file is a format \
-       conversion with unchanged weight VALUES, so the upstream terms govern.",
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "ibm-granite/granite-embedding-97m-multilingual-r2; the staged file is a format conversion \
+       with unchanged weight VALUES, so the upstream terms govern.",
     ),
-    corpus: Terms::Unresolved(
-      "IBM describes the Granite embedding training mixture in the model card but does not state \
-       per-source licences for it, and NOTICE section 7a records the weights layer only. Resolve \
-       against ibm-granite/granite-embedding-97m-multilingual-r2's data statement.",
+    corpus: Terms::permissive(
+      PERMISSIVE_MIXTURE,
+      RETAIN_NOTICE_VENDOR_ASSERTED,
+      "IBM STATES the corpus terms, which is what this row used to miss: the model card's Data \
+       Collection section opens \"All training data is sourced under permissive, \
+       commercial-friendly licenses, making Granite Embedding R2 suitable for unrestricted \
+       enterprise deployment\", and records a data-clearance process behind it. That is a \
+       vendor ASSERTION over a mixture rather than a per-source licence list, and two of the \
+       four named sources (web-scraped title-body pairs, IBM-internal data) are not \
+       independently checkable — so the assertion is the restriction. Evidence pinned in the \
+       module doc.",
     ),
     source: "NOTICE section 7a",
   },
@@ -334,12 +783,19 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("4f2842d568e2724370aec203652a42ac783c7937f8347a1a2cc7506d71f1582f"),
     pin: "src/embeddings/granite/mod.rs::TOKENIZER_SHA256_HEX",
     staged_by: "FinDIT-Studio/embedkit-coreml",
+    loader: "src/embeddings/mod.rs::granite",
     gate: "granite",
-    weights: Terms::Permissive(
-      "Apache-2.0, the same terms as the model it indexes. Distributed WITH the artifact and read \
-       from disk, so whoever redistributes the artifact directory redistributes it.",
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "The same terms as the model it indexes. Distributed WITH the artifact and read from disk, \
+       so whoever redistributes the artifact directory redistributes it.",
     ),
-    corpus: Terms::Unresolved("Same open question as the granite weights row."),
+    corpus: Terms::permissive(
+      PERMISSIVE_MIXTURE,
+      RETAIN_NOTICE_VENDOR_ASSERTED,
+      "Fit on the same mixture as the weights, under the same vendor assertion; see that row.",
+    ),
     source: "NOTICE section 7b",
   },
   // --- siglip --------------------------------------------------------------
@@ -349,13 +805,16 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("31fc44e771553c5b28b7af6561b46650ce5e1e4711dfef9f471ed32d502077b6"),
     pin: "tests/siglip/model_io.rs::ARTIFACT_SHA256",
     staged_by: "FinDIT-Studio/siglip2-naflex-coreml",
+    loader: "src/embeddings/mod.rs::siglip",
     gate: "siglip",
-    weights: Terms::Permissive(
-      "Apache-2.0. google/siglip2-base-patch16-naflex; the artifact repo declares apache-2.0 too. \
-       The graph is RESTRUCTURED (the position-embedding resize is lifted host-side), which \
-       Apache-2.0 permits with the change stated — NOTICE section 8a states it.",
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "google/siglip2-base-patch16-naflex; the artifact repo declares apache-2.0 too. The graph \
+       is RESTRUCTURED (the position-embedding resize is lifted host-side), which Apache-2.0 \
+       permits with the change stated — NOTICE section 8a states it.",
     ),
-    corpus: Terms::Unresolved(
+    corpus: Terms::unresolved(
       "SigLIP 2 is trained on WebLI, which Google has not released and whose terms are not \
        stated. NOTICE section 8a records the weights layer only. This one cannot be resolved from \
        public material alone.",
@@ -368,9 +827,35 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("8b781500cc6a596fa3a27b16b56e3d81e675e642ecd3542722d1f185aa0a6f67"),
     pin: "tests/siglip/text_model_io.rs::ARTIFACT_SHA256",
     staged_by: "FinDIT-Studio/siglip2-naflex-coreml",
+    loader: "src/embeddings/mod.rs::siglip",
     gate: "siglip",
-    weights: Terms::Permissive("Apache-2.0; the vision tower's twin, same checkpoint."),
-    corpus: Terms::Unresolved("Same unreleased WebLI corpus as the vision tower; see that row."),
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "The vision tower's twin, same checkpoint and same declared terms at both layers of the \
+       conversion chain.",
+    ),
+    corpus: Terms::unresolved("Same unreleased WebLI corpus as the vision tower; see that row."),
+    source: "NOTICE section 8a",
+  },
+  Artifact {
+    file: "siglip2-naflex/siglip2-base-patch16-naflex-512/pos_embed_16x16x768.f32le.bin",
+    key: Key::Sha256("3ba1ba032ad8d97e0a1afebf4513615fbfedb56f646c14dcdb83d3c228c12860"),
+    pin: "tests/siglip/model_io.rs::SIDECAR_SHA256",
+    staged_by: "FinDIT-Studio/siglip2-naflex-coreml",
+    loader: "src/embeddings/mod.rs::siglip",
+    gate: "siglip",
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "The base position grid — the checkpoint's `position_embedding.weight` reshaped 16x16x768, \
+       little-endian f32. These are WEIGHT VALUES lifted out of the graph, not metadata, so they \
+       carry the checkpoint's own terms and need their own row.",
+    ),
+    corpus: Terms::unresolved(
+      "Same unreleased WebLI corpus as the towers these values were trained alongside; see the \
+       vision row.",
+    ),
     source: "NOTICE section 8a",
   },
   Artifact {
@@ -378,12 +863,15 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("58a1696e79c9d97937389ed116f552a15c84811d7b8023918b86f4bc5775b1b0"),
     pin: "src/embeddings/siglip/text/mod.rs::TOKENIZER_SHA256_HEX",
     staged_by: "FinDIT-Studio/siglip2-naflex-coreml",
+    loader: "src/embeddings/mod.rs::siglip",
     gate: "siglip",
-    weights: Terms::Permissive(
-      "Apache-2.0, the same terms as the model. The Gemma tokenizer as packaged with the SigLIP 2 \
-       checkpoint; distributed WITH the artifact, not compiled into the crate.",
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "The same terms as the model. The Gemma tokenizer as packaged with the SigLIP 2 checkpoint; \
+       distributed WITH the artifact, not compiled into the crate.",
     ),
-    corpus: Terms::Unresolved("Same unreleased WebLI corpus as the weights rows."),
+    corpus: Terms::unresolved("Same unreleased WebLI corpus as the weights rows."),
     source: "NOTICE section 8b",
   },
   // --- ced -----------------------------------------------------------------
@@ -392,37 +880,219 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("5635cd9f932583105d1bf40bd07eb54e3f715a70d8319923cd0617a1dea3db01"),
     pin: "tests/ced/model_io.rs::TINY_SHA256",
     staged_by: "FinDIT-Studio/cedkit-coreml",
+    loader: "src/audio/mod.rs::ced",
     gate: "ced",
-    weights: Terms::Permissive(
-      "Apache-2.0. mispeech/ced-tiny (Xiaomi); the CoreML graph is restructured from unchanged \
-       weight values, and NOTICE section 9 states the changes.",
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "mispeech/ced-tiny (Xiaomi); the CoreML graph is restructured from unchanged weight values, \
+       and NOTICE section 9 states the changes.",
     ),
-    corpus: Terms::Unresolved(
-      "CED is distilled on AudioSet. The AudioSet ONTOLOGY and label set are CC-BY-4.0, but the \
-       segments themselves are YouTube audio Google never redistributed, and the derived-weights \
-       question is not addressed by either. NOTICE section 9 records the weights layer only.",
+    corpus: Terms::unresolved(
+      "CED is distilled on AudioSet, and the row this replaces had AudioSet's two licences the \
+       WRONG WAY ROUND. Google's own download page states the DATASET (the labelled segment \
+       CSVs) is CC-BY-4.0 and the ONTOLOGY is CC-BY-SA-4.0 — share-alike, a materially different \
+       obligation. Neither covers the AUDIO: the segments are YouTube media Google never \
+       redistributed, and neither licence addresses whether anything reaches the DISTILLED \
+       weights. That last question is why this layer stays unresolved rather than becoming an \
+       attribution row. Evidence pinned in the module doc.",
     ),
     source: "NOTICE section 9",
   },
   // --- speaker: the FluidInference base layer ------------------------------
+  //
+  // Seven bundles arrive from here and nothing else publishes them
+  // (MODELS_LOCK's "layer 1 of 2" table). Only `wespeaker_v2.mlmodelc` carries
+  // a per-file SHA-256 manifest in this repository, so the other six are
+  // BUNDLE rows keyed `Key::Unmanifested` — present, described and gated, with
+  // the missing manifest recorded as the reason they cannot be keyed on bytes.
+  // Leaving them out entirely is what the repo-keyed coverage check used to
+  // permit: one row over this table made the other six invisible.
   Artifact {
     file: "speakerkit/wespeaker_v2.mlmodelc/weights/weight.bin",
     key: Key::Sha256("34004f6798d35cad7071e2fdc67e63faaa782f53697e1cb49bcb452cf81ae151"),
     pin: "tests/speaker/model_io.rs::int8_wespeaker_matches_fluidinference_pinned_sha256",
     staged_by: "FluidInference/speaker-diarization-coreml",
+    loader: "src/audio/mod.rs::speaker",
     gate: "speaker",
-    weights: Terms::Unresolved(
-      "The RETIRED int8 WeSpeaker embedder, kept for tests. NOTICE section 4 gives the \
-       FluidInference repo as \"SDK Apache-2.0; parent pyannote model cc-by-4.0\", but the \
-       WeSpeaker embedder itself it records only as \"see its model license \
-       (https://github.com/wenet-e2e/wespeaker)\" — it names no licence. Resolve against the \
-       wenet-e2e/wespeaker model licence before treating this as clear.",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "The RETIRED int8 WeSpeaker embedder, kept for tests. NOTICE section 4 names no licence for \
+       the WeSpeaker component and POINTS AT the toolkit's model licence — so the row is resolved \
+       by going there and reading it. WeSpeaker's rule is that a pretrained model follows the \
+       licence of its corpus, and it gives exactly one worked instance: VoxCeleb models follow \
+       CC BY 4.0. PROVENANCE, because the toolkit publishes a same-named CNCeleb ResNet34_LM \
+       whose terms it states nowhere: this repository's own parity oracle is \
+       `wespeaker_resnet34_lm.onnx`, the English pyannote/FluidAudio diarization lineage, which \
+       is the VoxCeleb `voxceleb_resnet34_LM` — the corpus-prefixed upstream name is what this \
+       repository does not pin, and that is the residue on this row. Evidence in the module doc.",
     ),
-    corpus: Terms::Unresolved(
-      "WeSpeaker's published embedders are trained on VoxCeleb. VoxCeleb's own terms are the \
-       thing to check, and they are the specific reason this row is not rounded to clear — a \
-       corpus restricted to non-commercial research would make the DERIVED weights research-only \
-       whatever the weights layer says. Not stated anywhere in this repository.",
+    corpus: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "VoxCeleb. WeSpeaker's own model-licence document places its VoxCeleb-trained pretrained \
+       models under CC BY 4.0, which is a grant rather than a research-only restriction — so the \
+       corpus layer does NOT disqualify the shipping path, but attribution is a condition of it. \
+       Evidence pinned in the module doc's EVIDENCE section.",
+    ),
+    source: "NOTICE section 4; wenet-e2e/wespeaker model licence (EVIDENCE, module doc)",
+  },
+  Artifact {
+    file: "speakerkit/wespeaker_int8.mlmodelc",
+    key: Key::Unmanifested(
+      "Byte-identical to `wespeaker_v2.mlmodelc` — `wespeaker_v2_and_wespeaker_int8_are_byte_\
+       identical` in tests/speaker/model_io.rs walks both trees and compares every file — but \
+       this repository writes no SHA-256 down under the int8 path itself. Keying this row on \
+       wespeaker_v2's manifest would be a lookup by BUNDLE-RELATIVE NAME across two different \
+       bundles, which is the repo-keyed mistake this table exists to refuse.",
+    ),
+    pin: "",
+    staged_by: "FluidInference/speaker-diarization-coreml",
+    loader: "src/audio/mod.rs::speaker",
+    gate: "speaker",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "The same bytes as `wespeaker_v2.mlmodelc` under a second name, so necessarily the same \
+       terms; see that row for the WeSpeaker model-licence chain and the provenance residue. \
+       MODELS_LOCK's overlay table deliberately keeps this bundle FluidInference's rather than \
+       taking the FinDIT re-palettization.",
+    ),
+    corpus: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "VoxCeleb, on WeSpeaker's stated CC BY 4.0 terms for its VoxCeleb-trained models — the same \
+       bytes and the same corpus as `wespeaker_v2.mlmodelc`; see that row.",
+    ),
+    source: "NOTICE section 4; wenet-e2e/wespeaker model licence (EVIDENCE, module doc)",
+  },
+  Artifact {
+    file: "speakerkit/Segmentation.mlmodelc",
+    key: Key::Unmanifested(
+      "FluidInference's repo ships no CHECKSUMS.sha256 and this repository pins no per-file \
+       manifest for this bundle: it is not a shipping candidate (tests/speaker/model_io.rs's \
+       DECISION picks `pyannote_segmentation.mlmodelc`), so only tests/fp16_guards.rs touches \
+       it, and that pins guard SITES rather than bytes. A per-file manifest here would close it.",
+    ),
+    pin: "",
+    staged_by: "FluidInference/speaker-diarization-coreml",
+    loader: "src/audio/mod.rs::speaker",
+    gate: "speaker",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR,
+      "The newer \"community-1\" conversion set (tests/speaker/model_io.rs, spec-vs-reality \
+       delta 1), so the parent is pyannote/speaker-diarization-community-1 — the model NOTICE \
+       section 4 records as CC-BY-4.0 and REQUIRING attribution, not the MIT segmentation-3.0 \
+       that `pyannote_segmentation.mlmodelc` derives from. Two different parents behind two \
+       similarly named bundles is exactly why this row exists.",
+    ),
+    corpus: Terms::unresolved(
+      "The pyannote training mixture (AMI, DIHARD, VoxConverse and others), whose members carry \
+       different terms and several of which are research-only. NOTICE section 4 records the \
+       weights layer only, and the community-1 mixture is not published per-source.",
+    ),
+    source: "NOTICE section 4",
+  },
+  Artifact {
+    file: "speakerkit/Embedding.mlmodelc",
+    key: Key::Unmanifested(
+      "The split-pipeline embedding backend, NOT targeted per spec section 2.4 and never loaded \
+       by the shipping path; no per-file manifest is pinned for it anywhere in this repository. \
+       A manifest here would close it.",
+    ),
+    pin: "",
+    staged_by: "FluidInference/speaker-diarization-coreml",
+    loader: "src/audio/mod.rs::speaker",
+    gate: "speaker",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "The WeSpeaker embedder split into a frontend/backend pair, published in the same \
+       conversion set, so the same CC BY 4.0 chain and the same provenance residue as \
+       `wespeaker_v2.mlmodelc`; see that row.",
+    ),
+    corpus: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "VoxCeleb, on WeSpeaker's stated CC BY 4.0 terms for its VoxCeleb-trained models; see the \
+       `wespeaker_v2.mlmodelc` row for the evidence.",
+    ),
+    source: "NOTICE section 4; wenet-e2e/wespeaker model licence (EVIDENCE, module doc)",
+  },
+  Artifact {
+    file: "speakerkit/FBank.mlmodelc",
+    key: Key::Unmanifested(
+      "The split-pipeline filterbank frontend, NOT targeted per spec section 2.4 and never loaded \
+       by the shipping path; no per-file manifest is pinned for it anywhere in this repository. \
+       A manifest here would close it.",
+    ),
+    pin: "",
+    staged_by: "FluidInference/speaker-diarization-coreml",
+    loader: "src/audio/mod.rs::speaker",
+    gate: "speaker",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "The frontend half of the same split WeSpeaker pipeline as `Embedding.mlmodelc`, so the \
+       same CC BY 4.0 chain governs it. Whether a mel frontend carries protectable weight values \
+       at all is a separate question this repository has not answered; recording the stricter \
+       answer costs an attribution line and risks nothing.",
+    ),
+    corpus: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "VoxCeleb, on WeSpeaker's stated CC BY 4.0 terms for its VoxCeleb-trained models; see the \
+       `wespeaker_v2.mlmodelc` row for the evidence.",
+    ),
+    source: "NOTICE section 4; wenet-e2e/wespeaker model licence (EVIDENCE, module doc)",
+  },
+  Artifact {
+    file: "speakerkit/PLDA.mlmodelc",
+    key: Key::Unmanifested(
+      "The community-1 PLDA projection, deliberately UNLOADED — clustering stays in `diaric`, \
+       which projects in f64 on the host (spec section 3 non-goal) — so nothing in this \
+       repository pins its bytes; tests/fp16_guards.rs pins its guard sites and nothing else \
+       reads it.",
+    ),
+    pin: "",
+    staged_by: "FluidInference/speaker-diarization-coreml",
+    loader: "src/audio/mod.rs::speaker",
+    gate: "speaker",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR,
+      "This is the artifact the CC-BY-4.0 in NOTICE section 4 actually belongs to: \
+       pyannote/speaker-diarization-community-1, the PLDA `diaric` clusters through. Attribution \
+       is a CONDITION of the commercial grant, which is why the section carries the citation \
+       block a shipping product has to reproduce.",
+    ),
+    corpus: Terms::unresolved(
+      "The pyannote community-1 training mixture, not published per-source; NOTICE section 4 \
+       records the weights layer only. Same open question as the `Segmentation.mlmodelc` row.",
+    ),
+    source: "NOTICE section 4",
+  },
+  Artifact {
+    file: "speakerkit/PldaRho.mlmodelc",
+    key: Key::Unmanifested(
+      "The rho companion to `PLDA.mlmodelc`, unloaded for the same reason and pinned by nothing \
+       but tests/fp16_guards.rs's guard sites.",
+    ),
+    pin: "",
+    staged_by: "FluidInference/speaker-diarization-coreml",
+    loader: "src/audio/mod.rs::speaker",
+    gate: "speaker",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR,
+      "The second half of the same community-1 PLDA projection as `PLDA.mlmodelc` — same parent, \
+       same CC-BY-4.0 grant, same attribution condition. See that row.",
+    ),
+    corpus: Terms::unresolved(
+      "The pyannote community-1 training mixture, not published per-source; see the \
+       `PLDA.mlmodelc` row.",
     ),
     source: "NOTICE section 4",
   },
@@ -432,14 +1102,19 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("0266f4ad4d843ecf31ef9220ad6b80616b3ec64a4404b64f3ea0371554e236ec"),
     pin: "tests/speaker/model_io.rs::fp16_safe_segmentation_matches_pinned_sha256",
     staged_by: "FinDIT-Studio/speakerkit-coreml",
+    loader: "src/audio/mod.rs::speaker",
     gate: "speaker",
-    weights: Terms::Permissive(
-      "MIT. An issue-#15 re-conversion of pyannote/segmentation-3.0 (MIT) with fp16-survivable \
-       guards; the artifact repo declares HF licence \"other\"/mixed-upstream, and NOTICE section \
-       4 records that the upstream MIT terms still govern because the weight values are the \
-       upstream ones.",
+    weights: Terms::permissive(
+      "MIT",
+      RETAIN_NOTICE,
+      "An issue-#15 re-conversion of pyannote/segmentation-3.0 (MIT) with fp16-survivable guards; \
+       the artifact repo declares HF licence \"other\"/mixed-upstream, and NOTICE section 4 \
+       records that the upstream MIT terms still govern because the weight values are the \
+       upstream ones. The upstream repository is GATED — obtaining it requires accepting access \
+       conditions — which is a condition on getting the bytes, not on the MIT grant over them, \
+       and this repository fetches the re-conversion rather than the gated original.",
     ),
-    corpus: Terms::Unresolved(
+    corpus: Terms::unresolved(
       "pyannote/segmentation-3.0 is trained on a mixture (AMI, DIHARD, VoxConverse and others) \
        whose members carry different terms, several of them research-only. NOTICE section 4 \
        records the weights layer only. This is the row most likely to become research-only once \
@@ -452,21 +1127,29 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("680837ec172d67c3197bba93800e1623eebfd35c3b17011802f5f98b8026a0aa"),
     pin: "tests/speaker/model_io.rs::fp16_safe_wespeaker_fp32_matches_pinned_sha256",
     staged_by: "FinDIT-Studio/speakerkit-coreml",
+    loader: "src/audio/mod.rs::speaker",
     gate: "speaker",
-    weights: Terms::Unresolved(
-      "The SHIPPING fp32 WeSpeaker embedder. NOTICE section 4 records the WeSpeaker embedder as \
-       \"see its model license (https://github.com/wenet-e2e/wespeaker)\" and names none; the \
-       artifact repo declares HF licence \"other\"/mixed-upstream. The CC-BY-4.0 in that section \
-       belongs to pyannote/speaker-diarization-community-1 (the PLDA `diaric` clusters through) \
-       and to FluidInference's parent pyannote model — NOT to these embedder weights, and \
-       reading it across is the mistake this row exists to stop.",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "The SHIPPING fp32 WeSpeaker embedder. It lands on CC-BY-4.0 by a DIFFERENT ROUTE from the \
+       PLDA rows, and the distinction is the point: NOTICE section 4's CC-BY-4.0 belongs to \
+       pyannote/speaker-diarization-community-1 and to FluidInference's parent pyannote model, \
+       NOT to these embedder weights, and reading it across is still the mistake this row exists \
+       to stop. What resolves this row is the document NOTICE section 4 POINTS AT — WeSpeaker's \
+       own model licence, CC BY 4.0 for its VoxCeleb models. Same identifier, unrelated grant, \
+       and the provenance residue on the `wespeaker_v2.mlmodelc` row applies here too.",
     ),
-    corpus: Terms::Unresolved(
-      "VoxCeleb, per the WeSpeaker toolkit's published recipes; terms not stated in this \
-       repository. Same open question as the retired int8 sibling — and the same reason it \
-       matters more than the weights layer.",
+    corpus: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_VOXCELEB,
+      "VoxCeleb, per the WeSpeaker toolkit's published recipes, and WeSpeaker's own model-licence \
+       document places its VoxCeleb-trained models under CC BY 4.0. That is the CORPUS-layer \
+       source — a different document from NOTICE section 4's weights-layer record, which is why \
+       resolving one says nothing about the other. Evidence pinned in the module doc's EVIDENCE \
+       section.",
     ),
-    source: "NOTICE section 4",
+    source: "NOTICE section 4; wenet-e2e/wespeaker model licence (EVIDENCE, module doc)",
   },
   // --- clap ----------------------------------------------------------------
   Artifact {
@@ -474,49 +1157,81 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("723fe6aab7c4af1c671a210a35c289c67763bc6a7532b9df155a0c3fc0c3c9d7"),
     pin: "tests/clap/model_io.rs::clap_audio_artifacts_match_pinned_sha256",
     staged_by: "FinDIT-Studio/clapkit-coreml",
+    loader: "src/embeddings/mod.rs::clap",
     gate: "clap",
-    weights: Terms::Attribution(
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR,
       "laion/clap-htsat-unfused. NOTICE section 6a records an upstream ambiguity — textclap's \
-       MODELS.md treats the checkpoints as CC-BY-4.0, the current HF card declares apache-2.0 — \
-       and BOTH require attribution, which is why this is attribution-required rather than \
-       permissive. The LAION citation in NOTICE section 4's style must ship with any binary that \
-       bundles these weights.",
+       MODELS.md treats the checkpoints as CC-BY-4.0, the HF card declares apache-2.0 — and BOTH \
+       require attribution, so the STRICTER of the two governs here: CC-BY-4.0's credit is a \
+       CONDITION of the grant where Apache-2.0's notice is not. The LAION citation in NOTICE \
+       section 4's style must ship with any binary that bundles these weights.",
     ),
-    corpus: Terms::Unresolved(
-      "LAION-Audio-630K is assembled from several audio-caption sources with differing terms, and \
-       NOTICE section 6a records the weights layer only.",
+    corpus: Terms::unresolved(
+      "LAION-Audio-630K. The upstream states the corpus terms and they are NEGATIVE: LAION-AI/CLAP's \
+       README says \"Due to copyright reasons, we cannot release the dataset we train this model \
+       on\" and that most of it \"has copyright restriction\" — only source links and captions \
+       were published. What that reaches is the open question: the upstream does not say whether \
+       the restriction travels to the DERIVED weights, and this is a stated restriction rather \
+       than the silence the row used to record. Evidence pinned in the module doc.",
     ),
-    source: "NOTICE section 6a",
+    source: "NOTICE section 6a; LAION-AI/CLAP README (EVIDENCE, module doc)",
   },
   Artifact {
     file: "clapkit/clap_audio_int8.mlmodelc/weights/weight.bin",
     key: Key::Sha256("b3a37ec5550dcdd6932b314b830275ebcba013748421e1a517760b9afeabafb8"),
     pin: "tests/clap/model_io.rs::clap_audio_int8_artifacts_match_pinned_sha256",
     staged_by: "FinDIT-Studio/clapkit-coreml",
+    loader: "src/embeddings/mod.rs::clap",
     gate: "clap",
-    weights: Terms::Attribution("A palettization of the fp16 audio tower; same terms as it."),
-    corpus: Terms::Unresolved("Same LAION-Audio-630K question as the fp16 audio tower."),
-    source: "NOTICE section 6a",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR,
+      "A palettization of the fp16 audio tower — different bytes, same checkpoint, same stricter \
+       CC-BY-4.0 reading; see the fp16 audio row.",
+    ),
+    corpus: Terms::unresolved(
+      "Same stated LAION-Audio-630K copyright restriction as the fp16 audio tower, and the same \
+       open question about whether it reaches derived weights; see that row.",
+    ),
+    source: "NOTICE section 6a; LAION-AI/CLAP README (EVIDENCE, module doc)",
   },
   Artifact {
     file: "clapkit/clap_text.mlmodelc/weights/weight.bin",
     key: Key::Sha256("7f4e15e9ccb0ffbc2341eec286e9d9934d3d3d8d6465dfddebed248bddc0e3dd"),
     pin: "tests/clap/text_model_io.rs::clap_text_artifacts_match_pinned_sha256",
     staged_by: "FinDIT-Studio/clapkit-coreml",
+    loader: "src/embeddings/mod.rs::clap",
     gate: "clap",
-    weights: Terms::Attribution("The audio tower's twin, same checkpoint and same terms."),
-    corpus: Terms::Unresolved("Same LAION-Audio-630K question as the audio tower."),
-    source: "NOTICE section 6a",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR,
+      "The audio tower's twin, same checkpoint and the same stricter CC-BY-4.0 reading of the \
+       upstream ambiguity; see the fp16 audio row.",
+    ),
+    corpus: Terms::unresolved(
+      "Same stated LAION-Audio-630K copyright restriction as the audio tower; see that row.",
+    ),
+    source: "NOTICE section 6a; LAION-AI/CLAP README (EVIDENCE, module doc)",
   },
   Artifact {
     file: "clapkit/clap_text_int8.mlmodelc/weights/weight.bin",
     key: Key::Sha256("f181a595cefce402335499c32ea2f9727ef334afea9c592a2eabebb4172350a0"),
     pin: "tests/clap/text_model_io.rs::clap_text_int8_artifacts_match_pinned_sha256",
     staged_by: "FinDIT-Studio/clapkit-coreml",
+    loader: "src/embeddings/mod.rs::clap",
     gate: "clap",
-    weights: Terms::Attribution("A palettization of the fp16 text tower; same terms as it."),
-    corpus: Terms::Unresolved("Same LAION-Audio-630K question as the fp16 text tower."),
-    source: "NOTICE section 6a",
+    weights: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR,
+      "A palettization of the fp16 text tower — different bytes, same checkpoint, same stricter \
+       CC-BY-4.0 reading; see the fp16 audio row.",
+    ),
+    corpus: Terms::unresolved(
+      "Same stated LAION-Audio-630K copyright restriction as the fp16 text tower; see that row.",
+    ),
+    source: "NOTICE section 6a; LAION-AI/CLAP README (EVIDENCE, module doc)",
   },
   // --- lid -----------------------------------------------------------------
   Artifact {
@@ -524,17 +1239,27 @@ const ARTIFACTS: &[Artifact] = &[
     key: Key::Sha256("81fbb61f6706c50e924a2ee2a4fc04e6408276df948117a1c6ac7675c23aac67"),
     pin: "tests/lid/common/mod.rs::ARTIFACT_SHA256",
     staged_by: "aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-CoreML",
+    loader: "src/audio/mod.rs::lid",
     gate: "lid",
-    weights: Terms::Permissive(
-      "Apache-2.0 at both layers of the chain: speechbrain/lang-id-voxlingua107-ecapa upstream, \
-       and the aufklarer CoreML export that MODELS_LOCK stages declares apache-2.0 too.",
+    weights: Terms::permissive(
+      "Apache-2.0",
+      RETAIN_NOTICE,
+      "Apache-2.0 at both layers of the chain, each confirmed against the repository's own \
+       declaration rather than inferred: speechbrain/lang-id-voxlingua107-ecapa upstream, and the \
+       aufklarer CoreML export MODELS_LOCK stages. Revisions pinned in the module doc's EVIDENCE \
+       section — the export's is the same commit MODELS_LOCK pins.",
     ),
-    corpus: Terms::Unresolved(
-      "VoxLingua107 is scraped YouTube speech. The dataset's own terms are the thing to check and \
-       NOTICE section 10a does not record them — it documents the weights layer and the export's \
-       stated changes only.",
+    corpus: Terms::attribution(
+      "CC-BY-4.0",
+      CREDIT_AUTHOR_SCRAPED,
+      "VoxLingua107, and its own distributor STATES the terms: \"The VoxLingua107 dataset is \
+       distributed under the Creative Commons Attribution 4.0 International License. The \
+       copyright remains with the original owners of the video.\" So the corpus layer is a \
+       GRANT with an attribution condition, not an unknown — and the retained third-party \
+       copyright and the published take-down policy are the two things the identifier alone does \
+       not carry, which is why they are restrictions here. Evidence pinned in the module doc.",
     ),
-    source: "NOTICE section 10a",
+    source: "NOTICE section 10a; VoxLingua107 distribution page (EVIDENCE, module doc)",
   },
 ];
 
@@ -546,9 +1271,28 @@ const ARTIFACTS: &[Artifact] = &[
 // below can drive exactly the same code the real-table checks do. A predicate
 // only the happy path ever reaches is not a predicate.
 
-/// Direction 1 — every staged repository is covered, and every row covers one.
-fn unmatched_coverage(tables: &[String], rows: &[Artifact]) -> Vec<String> {
-  let staged: BTreeSet<&str> = tables.iter().map(String::as_str).collect();
+/// **Direction 1, as it must be asked.** Every FILE the repository can name
+/// under a staged table is covered by a row, and every row names a file its
+/// own table actually stages.
+///
+/// The previous shape of this check compared MODELS_LOCK's repository NAMES
+/// against `staged_by`, which meant one row over a table made every other file
+/// that table stages invisible — the AuraFace lesson repeated at the mechanism
+/// level, on a table that is keyed by artifact PRECISELY because repo-keying
+/// gets individual files wrong. It passed while `openai/whisper-tiny` staged
+/// three files and the table carried one.
+///
+/// So the reconciliation runs at file granularity, in both directions, against
+/// what the lock literally says:
+///
+///   - a `files = "a b c"` table names every file it stages, so the check is
+///     an exact bijection — every listed file covered, every row one of them;
+///   - an `include = "<glob>"` table's file list only exists after a download,
+///     so the enumeration comes from the repository's OWN per-file SHA-256
+///     manifests: a row inside a `.mlmodelc` must name one, which is what
+///     makes it cover the whole bundle instead of the single file it keys on.
+fn unmatched_coverage(tables: &[StagedTable], rows: &[Covered<'_>]) -> Vec<String> {
+  let staged: BTreeSet<&str> = tables.iter().map(|t| t.name.as_str()).collect();
   let claimed: BTreeSet<&str> = rows.iter().map(|r| r.staged_by).collect();
   let mut failures = Vec::new();
   for repo in staged.difference(&claimed) {
@@ -564,17 +1308,184 @@ fn unmatched_coverage(tables: &[String], rows: &[Artifact]) -> Vec<String> {
        was removed and the row is describing bytes CI no longer fetches, or the name is a typo."
     ));
   }
+
+  for table in tables {
+    let mine: Vec<&Covered<'_>> = rows.iter().filter(|r| r.staged_by == table.name).collect();
+
+    // Reverse: a row must name a path its own table's SELECTOR picks up.
+    for row in &mine {
+      let Some(tail) = table.table_relative(row.file) else {
+        failures.push(format!(
+          "{}: table {:?} stages into {:?}, so the row's path must start with {}/",
+          row.file, table.name, table.vendor_dir, table.vendor_dir
+        ));
+        continue;
+      };
+      if !table.selects(tail) {
+        failures.push(format!(
+          "{}: table {:?} does not stage {tail:?}. Its selector is {}. A row attached to a path \
+           its own table never downloads is terms recorded against bytes that are not there.",
+          row.file,
+          table.name,
+          table.selector_description()
+        ));
+      }
+    }
+
+    // Forward: every file the table NAMES must be covered by some row.
+    if let Selection::Files(listed) = &table.selection {
+      for file in listed {
+        if !mine.iter().any(|r| r.covers(file)) {
+          failures.push(format!(
+            "MODELS_LOCK table {:?} stages {file:?} and no licence row covers it. The table names \
+             every file it stages, so this is not a granularity the check has to guess at: one \
+             row over the table is not coverage of the table, which is the whole reason the \
+             licence table is keyed by artifact rather than by repository.",
+            table.name
+          ));
+        }
+      }
+    }
+  }
   failures
 }
 
-/// Direction 2 — no research-only artifact is reachable without opting in.
+/// A MODELS_LOCK table reduced to what direction 1 needs: where it downloads
+/// to, and what it selects.
+struct StagedTable {
+  name: String,
+  /// `local-dir` with the leading `Models/` removed — the prefix every row on
+  /// this table must carry.
+  vendor_dir: String,
+  selection: Selection,
+}
+
+/// What one table stages, as the lock itself states it.
+enum Selection {
+  /// `files = "a b c"` — an exact, complete list of table-relative paths. The
+  /// repository can enumerate this without downloading anything.
+  Files(Vec<String>),
+  /// `include = "<patterns>"` — a space-separated glob list. The file list
+  /// exists only after a download, so a row on such a table is reconciled
+  /// against the patterns and against the repository's own per-file manifests.
+  Include(Vec<String>),
+}
+
+impl StagedTable {
+  /// `file` with this table's vendor directory stripped, or `None` when the
+  /// row does not live under it at all.
+  fn table_relative<'a>(&self, file: &'a str) -> Option<&'a str> {
+    file.strip_prefix(&format!("{}/", self.vendor_dir))
+  }
+
+  /// Whether this table's selector picks up `tail`.
+  ///
+  /// A row may name a `.mlmodelc` BUNDLE rather than a file inside it (that is
+  /// what a [`Key::Unmanifested`] row does), and every directory pattern in
+  /// this lock ends `/*`, so a bundle is selected when the pattern with that
+  /// suffix removed matches the bundle itself.
+  fn selects(&self, tail: &str) -> bool {
+    match &self.selection {
+      Selection::Files(listed) => listed
+        .iter()
+        .any(|f| f == tail || f.starts_with(&format!("{tail}/"))),
+      Selection::Include(patterns) => patterns.iter().any(|p| {
+        glob_matches(p, tail)
+          || p
+            .strip_suffix("/*")
+            .is_some_and(|dir| glob_matches(dir, tail))
+      }),
+    }
+  }
+
+  /// The selector, for a failure message.
+  fn selector_description(&self) -> String {
+    match &self.selection {
+      Selection::Files(listed) => format!("files = {:?}", listed.join(" ")),
+      Selection::Include(patterns) => format!("include = {:?}", patterns.join(" ")),
+    }
+  }
+}
+
+/// A row plus the table-relative file set it demonstrably covers.
 ///
-/// Two clauses, because `default = []` alone would make this vacuous forever:
-/// the row's gate must not be reachable from `default`, AND it must carry the
-/// [`COMMERCIAL_PREFIX`]. A research-only artifact behind a plain kit feature
-/// such as `speaker` is exactly as shipped as one in `default` — every
-/// downstream product enables the kit it uses.
-fn research_only_reachable(rows: &[Artifact], default_closure: &BTreeSet<String>) -> Vec<String> {
+/// Coverage is what makes direction 1 a FILE-level check: a row keyed on one
+/// file inside a `.mlmodelc` covers the whole bundle only because the pin it
+/// names is a per-file manifest of it, and the coverage set is read from that
+/// manifest rather than assumed.
+struct Covered<'a> {
+  file: &'a str,
+  staged_by: &'a str,
+  /// Table-relative paths. An entry ending `.mlmodelc` stands for everything
+  /// under that bundle, and is present only when the row demonstrably covers
+  /// the whole bundle — it named it, or its pin is a per-file manifest of it.
+  covered: BTreeSet<String>,
+}
+
+impl Covered<'_> {
+  /// Whether this row accounts for the table-relative path `file`.
+  fn covers(&self, file: &str) -> bool {
+    self
+      .covered
+      .iter()
+      .any(|c| c == file || (c.ends_with(".mlmodelc") && file.starts_with(&format!("{c}/"))))
+  }
+}
+
+/// `fnmatch` with `*` crossing `/`, which is what `huggingface_hub` applies to
+/// `--include` patterns and therefore what `MODELS_LOCK`'s selectors mean.
+///
+/// `?` is not used by any pattern in the lock and is not implemented: a
+/// silently-wrong match here would be a coverage hole, so an unsupported
+/// metacharacter is refused rather than treated as a literal.
+fn glob_matches(pattern: &str, text: &str) -> bool {
+  assert!(
+    !pattern.contains('?') && !pattern.contains('['),
+    "glob pattern {pattern:?} uses a metacharacter this matcher does not implement"
+  );
+  let parts: Vec<&str> = pattern.split('*').collect();
+  if parts.len() == 1 {
+    return pattern == text;
+  }
+  let Some(mut rest) = text.strip_prefix(parts[0]) else {
+    return false;
+  };
+  let last = parts.len() - 1;
+  for (i, part) in parts.iter().enumerate().skip(1) {
+    if i == last {
+      return rest.len() >= part.len() && rest.ends_with(part);
+    }
+    if part.is_empty() {
+      continue;
+    }
+    match rest.find(part) {
+      Some(at) => rest = &rest[at + part.len()..],
+      None => return false,
+    }
+  }
+  true
+}
+
+/// **Direction 2, driven by the feature graph rather than by the row.**
+/// No research-only artifact is reachable from any feature closure that is not
+/// itself a commercial opt-in.
+///
+/// The row's `gate` string is a CLAIM. What decides whether an artifact is
+/// loadable is the `#[cfg(feature = ...)]` on the module that loads it, plus
+/// cargo's feature graph — so `derived` is read from the tree by
+/// [`loader_gates`] and `closures` from the manifest by [`feature_closure`],
+/// and neither comes from the table.
+///
+/// Reading the claim is what let two shapes through. `default = []` with
+/// `speaker = ["commercial-face"]` passed, because only `default`'s closure was
+/// consulted and the claimed gate carried the prefix — while enabling the
+/// ordinary `speaker` feature reached the restricted artifact. Hence: EVERY
+/// non-commercial feature's closure, not just `default`'s.
+fn research_only_reachable(
+  rows: &[Artifact],
+  derived: &BTreeMap<&str, BTreeSet<String>>,
+  closures: &BTreeMap<String, BTreeSet<String>>,
+) -> Vec<String> {
   let mut failures = Vec::new();
   for row in rows {
     let Some(layer) = row.disqualifying_layer() else {
@@ -583,42 +1494,86 @@ fn research_only_reachable(rows: &[Artifact], default_closure: &BTreeSet<String>
     let terms = row
       .disqualifying_terms()
       .expect("a disqualified row has terms");
-    if default_closure.contains(row.gate) {
+    let empty = BTreeSet::new();
+    let gates = derived.get(row.file).unwrap_or(&empty);
+    if gates.is_empty() {
       failures.push(format!(
-        "{}: research-only at the {layer} layer, but its gate {:?} is reachable from `default`, \
-         so a plain `cargo add coremlit` turns it on. {}",
+        "{}: research-only at the {layer} layer, and the tree puts NO `#[cfg(feature = ...)]` on \
+         the module that loads it — it compiles unconditionally, so there is no gate to opt in \
+         to. {}",
         row.file,
-        row.gate,
         terms.detail()
       ));
+      continue;
     }
-    if !row.gate.starts_with(COMMERCIAL_PREFIX) {
-      failures.push(format!(
-        "{}: research-only at the {layer} layer, but its gate {:?} does not carry the {:?} \
-         prefix. A plain kit feature is not an opt-in — every product that uses the kit enables \
-         it. {}",
-        row.file,
-        row.gate,
-        COMMERCIAL_PREFIX,
-        terms.detail()
-      ));
+    for gate in gates {
+      if !gate.starts_with(COMMERCIAL_PREFIX) {
+        failures.push(format!(
+          "{}: research-only at the {layer} layer, but the tree gates its loader on {gate:?}, \
+           which does not carry the {COMMERCIAL_PREFIX:?} prefix. A plain kit feature is not an \
+           opt-in — every product that uses the kit enables it. {}",
+          row.file,
+          terms.detail()
+        ));
+      }
+      for (feature, closure) in closures {
+        if feature.starts_with(COMMERCIAL_PREFIX) || !closure.contains(gate) {
+          continue;
+        }
+        let via = if feature == "default" {
+          "a plain `cargo add coremlit` turns it on".to_string()
+        } else {
+          format!("enabling the ordinary feature {feature:?} turns it on")
+        };
+        failures.push(format!(
+          "{}: research-only at the {layer} layer behind {gate:?}, but {gate:?} is in the feature \
+           closure of {feature:?}, which is not a commercial opt-in — {via}. {}",
+          row.file,
+          terms.detail()
+        ));
+      }
     }
   }
   failures
 }
 
-/// Direction 3 — no `commercial-` feature gates only clear artifacts.
+/// **Direction 3.** No `commercial-` feature gates only clear artifacts — and
+/// no `commercial-` feature gates nothing at all in the SOURCE.
 ///
 /// The one people forget. A gate that protects nothing is worse than no gate:
 /// it reads as a live restriction, so nobody re-examines the artifacts behind
 /// it, and the next artifact added there inherits reassurance it never earned.
+///
+/// Three ways to be that, and the check refuses all three. The third is the one
+/// a row-driven version could not see: a feature declared in `[features]` that
+/// no `#[cfg(feature = ...)]` in the tree names compiles nothing differently
+/// whether it is on or off. It is a NAME, not a gate, and a restricted row
+/// naming it is behind no gate at all.
 fn commercial_features_gating_nothing_restricted(
   rows: &[Artifact],
+  derived: &BTreeMap<&str, BTreeSet<String>>,
   features: &BTreeSet<String>,
+  cfg_in_source: &BTreeSet<String>,
 ) -> Vec<String> {
   let mut failures = Vec::new();
   for feature in features.iter().filter(|f| f.starts_with(COMMERCIAL_PREFIX)) {
-    let gated: Vec<&Artifact> = rows.iter().filter(|r| r.gate == feature.as_str()).collect();
+    if !cfg_in_source.contains(feature) {
+      failures.push(format!(
+        "feature {feature:?} carries the {COMMERCIAL_PREFIX:?} prefix but NO \
+         `#[cfg(feature = ...)]` in the source tree names it, so enabling it compiles nothing \
+         differently and disabling it withholds nothing. It is a name, not a gate, and any row \
+         that claims it is behind no gate at all."
+      ));
+      continue;
+    }
+    let gated: Vec<&Artifact> = rows
+      .iter()
+      .filter(|r| {
+        derived
+          .get(r.file)
+          .is_some_and(|g| g.contains(feature.as_str()))
+      })
+      .collect();
     if gated.is_empty() {
       failures.push(format!(
         "feature {feature:?} carries the {COMMERCIAL_PREFIX:?} prefix but no licence row is gated \
@@ -642,6 +1597,13 @@ fn commercial_features_gating_nothing_restricted(
 }
 
 /// The documentation rule for [`COMMERCIAL_PREFIX`] features.
+///
+/// BEGINS WITH an affirmative warning, and carries no negation. A substring
+/// test over a `. `-split first sentence passed both
+/// "This feature no longer requires a commercial license" and
+/// "Cleared for commercial use! This feature requires a commercial license" —
+/// the first inverts the warning, the second buries it behind the exact
+/// misreading the prefix invites.
 fn commercial_features_without_the_phrase(
   features: &BTreeSet<String>,
   docs: &BTreeMap<String, String>,
@@ -657,25 +1619,66 @@ fn commercial_features_without_the_phrase(
       continue;
     }
     let first = first_sentence(doc);
-    if !normalise_spelling(&first).contains(COMMERCIAL_DOC_PHRASE) {
+    let normalised = normalise_spelling(&first);
+    if !COMMERCIAL_DOC_OPENINGS
+      .iter()
+      .any(|opening| normalised.starts_with(opening))
+    {
       failures.push(format!(
-        "feature {feature:?}: its first documented sentence is {first:?}, which does not say \
-         {COMMERCIAL_DOC_PHRASE:?}. The name reads as an ENDORSEMENT of commercial use; the \
-         sentence that corrects it has to be the first one, not a caveat further down."
+        "feature {feature:?}: its first documented sentence is {first:?}, which does not BEGIN \
+         with any of {COMMERCIAL_DOC_OPENINGS:?}. The name reads as an ENDORSEMENT of commercial \
+         use; the sentence that corrects it has to be the first one and has to open with the \
+         correction — a warning that arrives after a clause, or inside one, arrives after the \
+         misreading has settled."
+      ));
+      continue;
+    }
+    if let Some(word) = negation_in(&normalised) {
+      failures.push(format!(
+        "feature {feature:?}: its first documented sentence is {first:?}, which opens with the \
+         warning and then carries the negation {word:?}. A sentence that takes the warning back \
+         has not warned anybody; put the qualification in a later sentence."
       ));
     }
   }
   failures
 }
 
-/// The first sentence of a documentation block: everything up to the first
-/// full stop that ends a word, with the block's line breaks flattened.
+/// The first negating word in `text`, matched as a WORD.
+///
+/// Word-level, because a substring search finds "not" inside "notice" and
+/// would fail a correctly-worded feature.
+fn negation_in(text: &str) -> Option<&'static str> {
+  let words: BTreeSet<String> = text
+    .split_whitespace()
+    .map(|w| {
+      w.chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect::<String>()
+    })
+    .collect();
+  NEGATIONS.iter().copied().find(|n| words.contains(*n))
+}
+
+/// The first sentence of a documentation block: everything up to and including
+/// the first terminator that ends a word, with the block's line breaks
+/// flattened.
+///
+/// `.`, `!` and `?` all terminate. Recognising only `. ` is what let
+/// "Cleared for commercial use! This feature requires a commercial license"
+/// read as ONE sentence containing the warning.
 fn first_sentence(doc: &str) -> String {
   let flat = doc.split_whitespace().collect::<Vec<_>>().join(" ");
-  match flat.find(". ") {
-    Some(end) => flat[..=end].trim().to_string(),
-    None => flat.trim_end_matches('.').trim().to_string(),
+  let bytes = flat.as_bytes();
+  for (i, b) in bytes.iter().enumerate() {
+    if !matches!(b, b'.' | b'!' | b'?') {
+      continue;
+    }
+    if i + 1 == bytes.len() || bytes[i + 1] == b' ' {
+      return flat[..=i].trim().to_string();
+    }
   }
+  flat.trim().to_string()
 }
 
 /// Lowercase, with the British spelling folded onto the American one.
@@ -1009,18 +2012,236 @@ fn bundle_relative(file: &str) -> &str {
     .map_or_else(|| file.rsplit('/').next().unwrap_or(file), |(_, tail)| tail)
 }
 
+/// The cargo features the TREE makes a module declaration conditional on.
+///
+/// Reads `<crate-relative source>::<module>`, finds the one `mod <module>;`
+/// declaration in that file, and collects the `#[cfg(feature = "...")]`
+/// attributes directly above it. An empty result means the module compiles
+/// unconditionally — which is a finding, not a default.
+///
+/// This is the fact directions 2 and 3 run on. `Artifact::gate` is a claim
+/// about which feature controls an artifact; only the tree decides it, and a
+/// predicate that reads the claim is reconciling the table against itself.
+fn loader_gates(locator: &str) -> BTreeSet<String> {
+  let (rel, module) = locator
+    .split_once("::")
+    .unwrap_or_else(|| panic!("loader locator {locator:?} is not `<source>::<module>`"));
+  let text = read_rel(rel);
+
+  let bare = format!("mod {module};");
+  let public = format!("pub mod {module};");
+  let lines: Vec<&str> = text.lines().collect();
+  let declared: Vec<usize> = lines
+    .iter()
+    .enumerate()
+    .filter(|(_, l)| {
+      let trimmed = l.trim_start();
+      trimmed.starts_with(bare.as_str()) || trimmed.starts_with(public.as_str())
+    })
+    .map(|(i, _)| i)
+    .collect();
+  assert_eq!(
+    declared.len(),
+    1,
+    "loader locator {locator:?}: {rel} holds {} declarations of `{bare}`; exactly one must be \
+     present, or this reader could be reading the wrong module's gate",
+    declared.len()
+  );
+
+  let mut gates = BTreeSet::new();
+  for line in lines[..declared[0]].iter().rev() {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+      break;
+    }
+    if !trimmed.starts_with("#[") && !trimmed.starts_with("//") {
+      break;
+    }
+    let mut rest = trimmed;
+    while let Some(open) = rest.find("feature = \"") {
+      let tail = &rest[open + "feature = \"".len()..];
+      let Some(close) = tail.find('"') else { break };
+      gates.insert(tail[..close].to_string());
+      rest = &tail[close + 1..];
+    }
+  }
+  gates
+}
+
+/// Every feature name a `#[cfg(feature = "...")]` in this crate's `src/` tree
+/// actually names.
+///
+/// A feature declared in `[features]` that appears nowhere here compiles
+/// nothing differently whether it is on or off. That is the shape direction 3
+/// could not see while it only asked whether a ROW named the feature.
+fn cfg_features_in_source() -> BTreeSet<String> {
+  let mut found = BTreeSet::new();
+  let mut files = Vec::new();
+  collect_rust_files(
+    &Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+    &mut files,
+  );
+  assert!(
+    files.len() >= 100,
+    "only {} .rs files walked under src/; the walk is broken and every feature would read as \
+     ungated",
+    files.len()
+  );
+  for file in files {
+    let text = std::fs::read_to_string(&file).unwrap_or_else(|e| panic!("read {file:?}: {e}"));
+    let mut rest = text.as_str();
+    while let Some(at) = rest.find("feature = \"") {
+      let tail = &rest[at + "feature = \"".len()..];
+      let Some(close) = tail.find('"') else { break };
+      found.insert(tail[..close].to_string());
+      rest = &tail[close + 1..];
+    }
+  }
+  found
+}
+
+/// Every `.rs` file under `dir`, recursively.
+fn collect_rust_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+  let Ok(entries) = std::fs::read_dir(dir) else {
+    return;
+  };
+  for entry in entries.flatten() {
+    let path = entry.path();
+    if path.is_dir() {
+      collect_rust_files(&path, out);
+    } else if path.extension().is_some_and(|e| e == "rs") {
+      out.push(path);
+    }
+  }
+}
+
+/// `MODELS_LOCK`'s tables reduced to [`StagedTable`] — where each downloads to,
+/// and what it selects.
+fn staged_tables(tables: &[LockTable]) -> Vec<StagedTable> {
+  tables
+    .iter()
+    .map(|t| {
+      let local_dir = t
+        .fields
+        .get("local-dir")
+        .unwrap_or_else(|| panic!("MODELS_LOCK table {:?} has no `local-dir`", t.name));
+      let vendor_dir = local_dir
+        .strip_prefix("Models/")
+        .unwrap_or_else(|| panic!("`local-dir` {local_dir:?} does not start with `Models/`"))
+        .to_string();
+      let selection = match (t.fields.get("files"), t.fields.get("include")) {
+        (Some(files), None) => {
+          Selection::Files(files.split_whitespace().map(str::to_string).collect())
+        }
+        (None, Some(include)) => {
+          Selection::Include(include.split_whitespace().map(str::to_string).collect())
+        }
+        (Some(_), Some(_)) => panic!(
+          "MODELS_LOCK table {:?} declares BOTH `files` and `include`; this reader cannot say \
+           which selects, and guessing would decide coverage",
+          t.name
+        ),
+        (None, None) => panic!(
+          "MODELS_LOCK table {:?} declares neither `files` nor `include`, so nothing can be said \
+           about what it stages",
+          t.name
+        ),
+      };
+      StagedTable {
+        name: t.name.clone(),
+        vendor_dir,
+        selection,
+      }
+    })
+    .collect()
+}
+
+/// The table-relative file set a row demonstrably accounts for.
+///
+/// A row keyed on one file inside a `.mlmodelc` covers the WHOLE bundle only
+/// when the pin it names is a per-file manifest — the coverage set is then read
+/// out of that manifest, not assumed from the bundle path. A row that names a
+/// bundle directly ([`Key::Unmanifested`]) covers the bundle by declaration,
+/// which is exactly why that key carries a reason.
+fn row_coverage<'a>(row: &'a Artifact, table: &StagedTable) -> Covered<'a> {
+  let tail = table
+    .table_relative(row.file)
+    .unwrap_or_else(|| panic!("{}: not under {}/", row.file, table.vendor_dir));
+  let mut covered = BTreeSet::from([tail.to_string()]);
+  if !row.pin.is_empty()
+    && let Pins::Manifest(manifest) = pins_at(row.pin)
+    && let Some(bundle) = row.bundle()
+  {
+    let bundle_tail = table
+      .table_relative(bundle)
+      .unwrap_or_else(|| panic!("{bundle}: not under {}/", table.vendor_dir));
+    // The BUNDLE itself, because a manifest pin is what makes the row cover
+    // the whole of it rather than the one file it keys on. A row whose pin is
+    // a bare hex literal, or which has no pin, gets no bundle entry — and is
+    // then correctly NOT a row over its bundle.
+    covered.insert(bundle_tail.to_string());
+    for key in manifest.keys() {
+      covered.insert(format!("{bundle_tail}/{key}"));
+    }
+  }
+  Covered {
+    file: row.file,
+    staged_by: row.staged_by,
+    covered,
+  }
+}
+
+/// The rows, each paired with what it covers under its own table.
+fn coverage<'a>(rows: &'a [Artifact], tables: &[StagedTable]) -> Vec<Covered<'a>> {
+  rows
+    .iter()
+    .map(|row| {
+      tables.iter().find(|t| t.name == row.staged_by).map_or_else(
+        || Covered {
+          file: row.file,
+          staged_by: row.staged_by,
+          covered: BTreeSet::new(),
+        },
+        |table| row_coverage(row, table),
+      )
+    })
+    .collect()
+}
+
+/// Every row's loader gate, read from the tree — the map directions 2 and 3
+/// run on.
+fn derived_gates(rows: &[Artifact]) -> BTreeMap<&str, BTreeSet<String>> {
+  rows
+    .iter()
+    .map(|row| (row.file, loader_gates(row.loader)))
+    .collect()
+}
+
+/// Every declared feature's closure, keyed by the feature it is seeded from.
+fn feature_closures(block: &str) -> BTreeMap<String, BTreeSet<String>> {
+  feature_names(block)
+    .into_iter()
+    .map(|f| {
+      let closure = feature_closure(block, &f);
+      (f, closure)
+    })
+    .collect()
+}
+
 // ---------------------------------------------------------------------------
 // The live checks — the real table, the real lock, the real manifest
 // ---------------------------------------------------------------------------
 
-/// **Direction 1.** Every repository `MODELS_LOCK` stages is covered by a
-/// licence row, and every row names a repository that is actually staged.
+/// **Direction 1.** Every file the lock NAMES is covered by a licence row, and
+/// every row names a file its own table stages.
 ///
-/// Both halves, because either one alone rots: coverage-only lets a row
-/// outlive the table it describes, and reverse-only lets a new table arrive
-/// with nobody having asked what its bytes permit.
+/// Both halves, because either one alone rots: coverage-only lets a row outlive
+/// the table it describes, and reverse-only lets a new table arrive with nobody
+/// having asked what its bytes permit. And both at FILE granularity — see
+/// [`unmatched_coverage`] for why the repository-name comparison this replaces
+/// could not see three staged files behind one row.
 #[test]
-fn every_staged_repo_has_a_licence_row_and_every_row_names_a_staged_repo() {
+fn every_staged_file_has_a_licence_row_and_every_row_names_a_staged_file() {
   let Some(tables) = lock_tables() else {
     return;
   };
@@ -1030,33 +2251,238 @@ fn every_staged_repo_has_a_licence_row_and_every_row_names_a_staged_repo() {
      would pass vacuously",
     tables.len()
   );
-  let names: Vec<String> = tables.iter().map(|t| t.name.clone()).collect();
-  let failures = unmatched_coverage(&names, ARTIFACTS);
+  let staged = staged_tables(&tables);
+  let named: usize = staged
+    .iter()
+    .filter_map(|t| match &t.selection {
+      Selection::Files(files) => Some(files.len()),
+      Selection::Include(_) => None,
+    })
+    .sum();
+  assert!(
+    named >= 3,
+    "no MODELS_LOCK table names an explicit `files` list any more ({named} named files), so the \
+     exact-bijection half of this check sees nothing and would pass vacuously"
+  );
+  let rows = coverage(ARTIFACTS, &staged);
+  let failures = unmatched_coverage(&staged, &rows);
   assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
-/// **Direction 2.** No research-only artifact is reachable from `default`, and
-/// none is gated by a feature without the [`COMMERCIAL_PREFIX`].
+/// Bundles the fp16 sweep pins under a staged vendor directory that no licence
+/// row covers.
+///
+/// The forward half of direction 1 can only be exact where `MODELS_LOCK` names
+/// its files; a globbed table's contents exist only after a download. This is a
+/// SECOND, independent enumeration of what those globs bring in — the bundle
+/// paths `tests/fp16_guards.rs` pins guard sites for — and it is a repository
+/// fact rather than a restatement of this table. Without it, "every bundle a
+/// glob stages has a row" would rest on nobody having forgotten one.
+fn fp16_pinned_bundles_without_a_row(
+  pinned: &[String],
+  tables: &[StagedTable],
+  rows: &[Covered<'_>],
+) -> Vec<String> {
+  let mut failures = Vec::new();
+  for path in pinned {
+    // Two MODELS_LOCK tables can share a `local-dir` — speakerkit's base and
+    // overlay do — so the question is whether ANY of them has a row over this
+    // bundle, not whether the first one does.
+    let candidates: Vec<&StagedTable> = tables
+      .iter()
+      .filter(|t| path.starts_with(&format!("{}/", t.vendor_dir)))
+      .collect();
+    if candidates.is_empty() {
+      // Pinned under a vendor no MODELS_LOCK table stages. ci.yml's own
+      // `UNSTAGED_DEFECT_VENDORS` records that gap; it is not this file's.
+      continue;
+    }
+    let covered = candidates.iter().any(|table| {
+      let tail = table
+        .table_relative(path)
+        .expect("the prefix was just matched");
+      rows
+        .iter()
+        .any(|r| r.staged_by == table.name && r.covers(tail))
+    });
+    if !covered {
+      let names: Vec<&str> = candidates.iter().map(|t| t.name.as_str()).collect();
+      failures.push(format!(
+        "tests/fp16_guards.rs pins guard sites in {path:?}, which MODELS_LOCK stages ({}) and no \
+         licence row covers. A glob's contents cannot be enumerated from the lock, so this roster \
+         is the second enumeration that stops a staged bundle from having terms nobody wrote \
+         down.",
+        names.join(", ")
+      ));
+    }
+  }
+  failures
+}
+
+/// Every `.mlmodelc` path pinned by `tests/fp16_guards.rs`'s defect and
+/// load-bearing rosters.
+fn fp16_pinned_bundles() -> Vec<String> {
+  let text = read_rel("tests/fp16_guards.rs");
+  let mut paths = Vec::new();
+  for line in text.lines() {
+    let trimmed = line.trim();
+    let Some(rest) = trimmed.strip_prefix("path: \"") else {
+      continue;
+    };
+    let Some(end) = rest.find('"') else { continue };
+    let path = &rest[..end];
+    if path.ends_with(".mlmodelc") {
+      paths.push(path.to_string());
+    }
+  }
+  assert!(
+    paths.len() >= 8,
+    "only {} `.mlmodelc` paths read out of tests/fp16_guards.rs; the reader has stopped matching \
+     its rosters and this check would pass vacuously",
+    paths.len()
+  );
+  paths
+}
+
+/// **Direction 1's second enumeration.** Every bundle the fp16 sweep pins under
+/// a staged vendor directory has a licence row.
+#[test]
+fn every_fp16_pinned_bundle_under_a_staged_vendor_has_a_licence_row() {
+  let Some(tables) = lock_tables() else {
+    return;
+  };
+  let staged = staged_tables(&tables);
+  let pinned = fp16_pinned_bundles();
+  let matched = pinned
+    .iter()
+    .filter(|p| {
+      staged
+        .iter()
+        .any(|t| p.starts_with(&format!("{}/", t.vendor_dir)))
+    })
+    .count();
+  assert!(
+    matched >= 5,
+    "only {matched} of the {} fp16-pinned bundles sit under a staged vendor directory; the vendor \
+     names have diverged and this check would pass vacuously",
+    pinned.len()
+  );
+  let rows = coverage(ARTIFACTS, &staged);
+  let failures = fp16_pinned_bundles_without_a_row(&pinned, &staged, &rows);
+  assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// **Direction 2.** No research-only artifact is reachable from any feature
+/// closure that is not itself a commercial opt-in.
 ///
 /// Vacuous against today's table — nothing is research-only — and deliberately
 /// kept anyway: it is the check the first disqualifying artifact will meet.
-/// `falsifiers::direction_two_*` are what prove it can still fire.
+/// `falsifiers::direction_two_*` are what prove it can still fire. What is NOT
+/// vacuous here is the input: the gates come from `#[cfg(feature = ...)]` in
+/// the tree and the closures from the manifest, both read live.
 #[test]
 fn no_research_only_artifact_is_reachable_without_a_commercial_gate() {
   let block = features_block();
-  let closure = feature_closure(&block, "default");
-  let failures = research_only_reachable(ARTIFACTS, &closure);
+  let closures = feature_closures(&block);
+  let derived = derived_gates(ARTIFACTS);
+  let failures = research_only_reachable(ARTIFACTS, &derived, &closures);
   assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
 /// **Direction 3.** No `commercial-`prefixed feature gates only clear
-/// artifacts.
+/// artifacts, and none gates nothing at all in the source.
 #[test]
 fn every_commercial_feature_gates_a_research_only_artifact() {
   let block = features_block();
   let features = feature_names(&block);
-  let failures = commercial_features_gating_nothing_restricted(ARTIFACTS, &features);
+  let derived = derived_gates(ARTIFACTS);
+  let failures = commercial_features_gating_nothing_restricted(
+    ARTIFACTS,
+    &derived,
+    &features,
+    &cfg_features_in_source(),
+  );
   assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Every row's claimed `gate` is the feature the TREE puts on its loader, and
+/// that feature is one the manifest declares.
+///
+/// The row's claim is kept because it makes the table readable; this is what
+/// stops it from being believed. A row may claim `speaker` while the module
+/// that loads it is gated on something else, or on nothing, or on a feature no
+/// `[features]` entry declares — and directions 2 and 3 would then be reasoning
+/// about a gate that does not exist.
+#[test]
+fn every_rows_gate_matches_the_cfg_that_guards_its_loader() {
+  let declared = feature_names(&features_block());
+  for row in ARTIFACTS {
+    let gates = loader_gates(row.loader);
+    assert_eq!(
+      gates,
+      BTreeSet::from([row.gate.to_string()]),
+      "{}: the row claims gate {:?}, but {} puts {:?} on the module that loads it. The claim is \
+       not the fact — only the `#[cfg]` decides whether the shipping path can load these bytes.",
+      row.file,
+      row.gate,
+      row.loader,
+      gates
+    );
+    assert!(
+      declared.contains(row.gate),
+      "{}: gate {:?} is not declared in this crate's `[features]` ({declared:?}). A gate nobody \
+       can enable is not an opt-in, and a gate nobody can DISABLE is not a gate.",
+      row.file,
+      row.gate
+    );
+  }
+}
+
+/// Every row's loader module is the module named by its own `MODELS_LOCK`
+/// table's `kit`.
+///
+/// The third independent leg. `Artifact::loader` is still written down by hand,
+/// so on its own it could point at any module in the tree; tying it to the kit
+/// the LOCK declares means the row cannot borrow an unrelated module's
+/// `#[cfg]`. Lock, tree and manifest then have to agree before a gate is
+/// believed.
+#[test]
+fn every_rows_loader_module_is_the_kit_its_lock_table_names() {
+  let Some(tables) = lock_tables() else {
+    return;
+  };
+  let kits: BTreeMap<&str, &str> = tables
+    .iter()
+    .map(|t| {
+      (
+        t.name.as_str(),
+        t.fields
+          .get("kit")
+          .unwrap_or_else(|| panic!("MODELS_LOCK table {:?} has no `kit`", t.name))
+          .as_str(),
+      )
+    })
+    .collect();
+  for row in ARTIFACTS {
+    let kit = kits.get(row.staged_by).unwrap_or_else(|| {
+      panic!(
+        "{}: staged_by {:?} names no MODELS_LOCK table",
+        row.file, row.staged_by
+      )
+    });
+    let (_, module) = row.loader.split_once("::").unwrap_or_else(|| {
+      panic!(
+        "{}: loader {:?} is not `<source>::<module>`",
+        row.file, row.loader
+      )
+    });
+    assert_eq!(
+      module, *kit,
+      "{}: its lock table declares kit {kit:?} but the row's loader is the {module:?} module. A \
+       row that reads another kit's `#[cfg]` reads another kit's gate.",
+      row.file
+    );
+  }
 }
 
 /// Every `commercial-` feature's first documented sentence says a commercial
@@ -1080,10 +2506,10 @@ fn every_commercial_feature_says_it_requires_a_commercial_licence_first() {
 
 /// No `commercial-` feature is reachable from `default`.
 ///
-/// Stronger than direction 2's first clause and independent of any row: even
-/// before a research-only artifact exists, a gate that `default` turns on is
-/// not a gate. Today `default = []`, so the closure is `{"default"}` and this
-/// holds trivially; it stops holding the moment somebody adds one.
+/// Stronger than direction 2's clauses and independent of any row: even before
+/// a research-only artifact exists, a gate that `default` turns on is not a
+/// gate. Today `default = []`, so the closure is `{"default"}` and this holds
+/// trivially; it stops holding the moment somebody adds one.
 #[test]
 fn no_commercial_feature_is_reachable_from_default() {
   let block = features_block();
@@ -1122,37 +2548,56 @@ fn every_row_is_keyed_by_a_wellformed_sha256_or_a_reasoned_exemption() {
            first time the artifact is re-converted",
           row.file
         );
+        assert!(
+          !row.file.ends_with(".mlmodelc"),
+          "{}: a SHA-256 keys ONE file, and this row names a bundle directory. A bundle's \
+           identity is its whole manifest, not any one member's hash.",
+          row.file
+        );
       }
-      Key::Unpinned(reason) => {
+      Key::Unpinned(reason) | Key::Unmanifested(reason) => {
         assert!(
           !reason.trim().is_empty(),
-          "{}: an unpinned row with no reason is an exemption nobody can retire",
+          "{}: an exempt row with no reason is an exemption nobody can retire",
           row.file
         );
         assert!(
           row.pin.is_empty(),
-          "{}: an unpinned row names the pin {:?}. If those bytes are pinned, key on them.",
+          "{}: an exempt row names the pin {:?}. If those bytes are pinned, key on them.",
           row.file,
           row.pin
         );
       }
     }
+    if let Key::Unmanifested(_) = row.key {
+      assert!(
+        row.file.ends_with(".mlmodelc"),
+        "{}: `Key::Unmanifested` says this repository holds no per-file manifest for the bundle, \
+         so the row must NAME the bundle. Naming one file inside it claims a file identity the \
+         row has no way to check.",
+        row.file
+      );
+    }
   }
 }
 
 /// A row may be [`Key::Unpinned`] only while its table is on
-/// `revision = "main"`, and every row on a commit-pinned table must be hashed.
+/// `revision = "main"`, [`Key::Unmanifested`] only on a table that GLOBS, and
+/// every other row on a commit-pinned table must be hashed.
 ///
-/// The staleness half, in the `CHECKSUMLESS_KITS` style: the exemption is tied
+/// The staleness half, in the `CHECKSUMLESS_KITS` style: each exemption is tied
 /// to its cause in both directions, so `MODELS_LOCK`'s LOUD FOLLOW-UP landing —
 /// whisper's two tables moving from `main` to an immutable commit — turns this
-/// red and forces the hashes in, instead of leaving three rows describing bytes
-/// nobody can identify.
+/// red and forces the hashes in, instead of leaving rows describing bytes
+/// nobody can identify. And a table that stops globbing names every file it
+/// stages, at which point an unmanifested bundle row has to be replaced by
+/// per-file rows.
 #[test]
 fn unpinned_rows_exist_only_where_the_lock_pins_a_moving_revision() {
   let Some(tables) = lock_tables() else {
     return;
   };
+  let staged = staged_tables(&tables);
   let revisions: BTreeMap<&str, &str> = tables
     .iter()
     .map(|t| {
@@ -1163,6 +2608,7 @@ fn unpinned_rows_exist_only_where_the_lock_pins_a_moving_revision() {
     })
     .collect();
   let mut moving = 0usize;
+  let mut unmanifested = 0usize;
   for row in ARTIFACTS {
     let revision = revisions.get(row.staged_by).copied().unwrap_or_else(|| {
       panic!(
@@ -1187,12 +2633,39 @@ fn unpinned_rows_exist_only_where_the_lock_pins_a_moving_revision() {
          The reason for the exemption is gone — key this row on the bytes at that revision.",
         row.file, row.staged_by
       ),
+      Key::Unmanifested(_) => {
+        unmanifested += 1;
+        assert_ne!(
+          revision, "main",
+          "{}: `Key::Unmanifested` says the lock pins the bytes and only the MANIFEST is missing, \
+           but MODELS_LOCK's {:?} is on `revision = \"main\"`, so the bytes are not pinned either. \
+           That is `Key::Unpinned`.",
+          row.file, row.staged_by
+        );
+        let table = staged
+          .iter()
+          .find(|t| t.name == row.staged_by)
+          .expect("revision lookup above succeeded");
+        assert!(
+          matches!(table.selection, Selection::Include(_)),
+          "{}: exempt from hashing because no per-file manifest exists, but MODELS_LOCK's {:?} \
+           names its files explicitly — so the file list IS enumerable and this row must be \
+           replaced by per-file rows.",
+          row.file,
+          row.staged_by
+        );
+      }
     }
   }
   assert!(
     moving > 0,
     "no row sits on a `revision = \"main\"` table, so this check no longer sees the case it \
      exists for. Delete it, or the exemption it guards."
+  );
+  assert!(
+    unmanifested > 0,
+    "no row is `Key::Unmanifested` any more, so the glob-table half of this check sees nothing. \
+     Delete it, or the exemption it guards."
   );
 }
 
@@ -1244,6 +2717,68 @@ fn every_rows_sha256_matches_the_pin_it_names() {
   );
 }
 
+/// A pin locator belongs to the kit it is read for, and no two bundles share
+/// one.
+///
+/// [`bundle_relative`] looks a row's hash up by the path AFTER the last
+/// `.mlmodelc/`, and every CoreML bundle in the tree has a `weights/weight.bin`
+/// — so a row could name ANY per-file manifest in the repository and match on
+/// name alone. That is the repo-keyed mistake in miniature: the reader would
+/// verify a hash that belongs to different bytes. Two ties close it — the pin
+/// must live under a path component equal to the row's kit, and two rows in
+/// different bundles may not share a locator.
+#[test]
+fn every_pin_locator_belongs_to_the_kit_and_bundle_it_is_read_for() {
+  let Some(tables) = lock_tables() else {
+    return;
+  };
+  let kits: BTreeMap<&str, &str> = tables
+    .iter()
+    .map(|t| {
+      (
+        t.name.as_str(),
+        t.fields.get("kit").map_or("", String::as_str),
+      )
+    })
+    .collect();
+  let mut owner: BTreeMap<&str, &str> = BTreeMap::new();
+  let mut checked = 0usize;
+  for row in ARTIFACTS {
+    if row.pin.is_empty() {
+      continue;
+    }
+    let kit = kits.get(row.staged_by).copied().unwrap_or_else(|| {
+      panic!(
+        "{}: staged_by {:?} names no MODELS_LOCK table",
+        row.file, row.staged_by
+      )
+    });
+    let (source, _) = row.pin.split_once("::").expect("checked by pins_at");
+    assert!(
+      source.split('/').any(|component| component == kit),
+      "{}: its pin {:?} lives outside the {kit:?} kit's sources. A pin is matched by \
+       bundle-relative NAME, so a locator from another kit would verify a hash belonging to other \
+       bytes and read clean doing it.",
+      row.file,
+      row.pin
+    );
+    let scope = row.bundle().unwrap_or(row.file);
+    if let Some(previous) = owner.insert(row.pin, scope) {
+      assert_eq!(
+        previous, scope,
+        "{}: pin {:?} is already the pin for {previous:?}. Two different bundles reading one \
+         manifest means at least one of them is verifying a hash cut against other bytes.",
+        row.file, row.pin
+      );
+    }
+    checked += 1;
+  }
+  assert!(
+    checked >= 10,
+    "only {checked} pin locators checked; the table has shrunk and this would pass vacuously"
+  );
+}
+
 /// **The AuraFace rule.** Two rows over the same SHA-256 agree on what those
 /// bytes permit.
 ///
@@ -1260,6 +2795,11 @@ fn identical_bytes_carry_identical_terms() {
 }
 
 /// Rows that key on the same bytes and disagree about them.
+///
+/// Compares the EFFECTIVE terms — class, canonical identifier and obligation
+/// set — not the four-way class alone. Class-only comparison passed identical
+/// bytes called MIT by one row and Apache-2.0 by another (both `permissive`),
+/// and two research-only rows forbidding materially different things.
 fn contradictory_terms(rows: &[Artifact]) -> Vec<String> {
   let mut by_hash: BTreeMap<&str, Vec<&Artifact>> = BTreeMap::new();
   for row in rows {
@@ -1271,19 +2811,25 @@ fn contradictory_terms(rows: &[Artifact]) -> Vec<String> {
   for (hex, group) in by_hash {
     let first = group[0];
     for other in &group[1..] {
-      if first.weights.verdict() != other.weights.verdict()
-        || first.corpus.verdict() != other.corpus.verdict()
-      {
+      for (layer, a, b) in [
+        ("weights", first.weights, other.weights),
+        ("corpus", first.corpus, other.corpus),
+      ] {
+        if a.effective() == b.effective() {
+          continue;
+        }
         failures.push(format!(
-          "sha256 {hex} is claimed by {} (weights {}, corpus {}) and by {} (weights {}, corpus \
-           {}). Identical bytes cannot carry different terms — one row is repeating a repository \
-           tag rather than the licence of the artifact it re-hosts.",
+          "sha256 {hex}: {} records the {layer} layer as {} / {:?} / {:?} and {} records it as {} \
+           / {:?} / {:?}. Identical bytes cannot carry different terms — one row is repeating a \
+           repository tag rather than the licence of the artifact it re-hosts.",
           first.file,
-          first.weights.verdict(),
-          first.corpus.verdict(),
+          a.verdict(),
+          a.licence(),
+          a.restrictions(),
           other.file,
-          other.weights.verdict(),
-          other.corpus.verdict(),
+          b.verdict(),
+          b.licence(),
+          b.restrictions(),
         ));
       }
     }
@@ -1291,56 +2837,15 @@ fn contradictory_terms(rows: &[Artifact]) -> Vec<String> {
   failures
 }
 
-/// Every row's file lives under the directory its `MODELS_LOCK` table stages,
-/// and — where the table names explicit `files` — is one of them.
-///
-/// A row attached to a path its own table does not stage is terms recorded
-/// against the wrong bytes, which is the same class of error as keying by
-/// repository.
-#[test]
-fn every_row_lives_under_the_directory_its_table_stages() {
-  let Some(tables) = lock_tables() else {
-    return;
-  };
-  let by_name: BTreeMap<&str, &LockTable> = tables.iter().map(|t| (t.name.as_str(), t)).collect();
-  for row in ARTIFACTS {
-    let table = by_name.get(row.staged_by).unwrap_or_else(|| {
-      panic!(
-        "{}: staged_by {:?} names no MODELS_LOCK table",
-        row.file, row.staged_by
-      )
-    });
-    let local_dir = table
-      .fields
-      .get("local-dir")
-      .unwrap_or_else(|| panic!("MODELS_LOCK table {:?} has no `local-dir`", row.staged_by));
-    let vendor_path = local_dir
-      .strip_prefix("Models/")
-      .unwrap_or_else(|| panic!("`local-dir` {local_dir:?} does not start with `Models/`"));
-    let prefix = format!("{vendor_path}/");
-    let tail = row.file.strip_prefix(&prefix).unwrap_or_else(|| {
-      panic!(
-        "{}: staged_by {:?} downloads into {local_dir:?}, so the row's path must start with \
-         {prefix:?}",
-        row.file, row.staged_by
-      )
-    });
-    if let Some(files) = table.fields.get("files") {
-      assert!(
-        files.split_whitespace().any(|f| f == tail),
-        "{}: table {:?} stages the explicit file list {files:?}, which does not include {tail:?}",
-        row.file,
-        row.staged_by
-      );
-    }
-  }
-}
-
-/// Every verdict carries prose, and every unresolved one names what is open.
+/// Every verdict carries prose, every unresolved one names what is open, and
+/// every resolved one names the identifier it resolved to.
 ///
 /// An empty payload turns the table back into a bare SPDX list, which is the
 /// thing it was built not to be — and an `Unresolved` with nothing to follow
-/// is indistinguishable from nobody having looked.
+/// is indistinguishable from nobody having looked. The identifier rule is the
+/// other half: a resolved layer with no identifier cannot be compared against
+/// a second row over the same bytes, and an unresolved layer WITH one is
+/// claiming an answer it just said it did not have.
 #[test]
 fn every_verdict_carries_its_reasoning() {
   for row in ARTIFACTS {
@@ -1352,6 +2857,31 @@ fn every_verdict_carries_its_reasoning() {
         terms.verdict(),
         terms.detail()
       );
+      if matches!(terms, Terms::Unresolved(_)) {
+        assert!(
+          terms.licence().is_empty() && terms.restrictions().is_empty(),
+          "{}: the {layer} layer is unresolved but records the identifier {:?} and the \
+           restrictions {:?}. Nothing is established, so nothing may be recorded as established.",
+          row.file,
+          terms.licence(),
+          terms.restrictions()
+        );
+      } else {
+        assert!(
+          !terms.licence().trim().is_empty(),
+          "{}: the {layer} layer is {:?} but names no canonical identifier, so a second row over \
+           the same bytes has nothing to be compared against.",
+          row.file,
+          terms.verdict()
+        );
+        assert!(
+          !terms.restrictions().is_empty(),
+          "{}: the {layer} layer is {:?} but records no obligation at all. Even the most \
+           permissive licence here requires the notice to be retained.",
+          row.file,
+          terms.verdict()
+        );
+      }
     }
     assert!(
       !row.source.trim().is_empty(),
@@ -1373,13 +2903,16 @@ fn no_file_is_listed_twice() {
   );
 }
 
-/// The state of the table, asserted rather than remembered.
+/// The state of the table, asserted rather than remembered — as an EXACT
+/// census per layer.
 ///
-/// If this goes red because a row became research-only, that is the point: the
-/// module doc above says no row is, directions 2 and 3 are described as
-/// tripwires, and both statements have to be revisited together.
+/// The previous form of this asserted that EVERY corpus row was unresolved,
+/// which froze the table's weakest state into a passing test: resolving a
+/// corpus layer against its own upstream would have turned this red, so the
+/// check was an incentive to leave rows unresolved. A census records what is
+/// there instead, and still refuses a silent change in either direction.
 #[test]
-fn no_row_is_research_only_today_and_the_doc_says_so() {
+fn the_tables_verdict_census_is_what_this_file_says_it_is() {
   let restricted: Vec<&str> = ARTIFACTS
     .iter()
     .filter(|r| r.disqualifying_layer().is_some())
@@ -1391,15 +2924,29 @@ fn no_row_is_research_only_today_and_the_doc_says_so() {
      move them behind a `{COMMERCIAL_PREFIX}` feature and rewrite this file's module doc, which \
      currently tells the reader nothing is restricted."
   );
-  let unresolved = ARTIFACTS
-    .iter()
-    .filter(|r| matches!(r.corpus, Terms::Unresolved(_)))
-    .count();
+  let census = |pick: fn(&Artifact) -> Terms| {
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for row in ARTIFACTS {
+      *counts.entry(pick(row).verdict()).or_default() += 1;
+    }
+    counts
+  };
   assert_eq!(
-    unresolved,
-    ARTIFACTS.len(),
-    "the module doc says the corpus layer is unresolved for EVERY row because NOTICE documents \
-     none; that is no longer true, so say what changed."
+    census(|r| r.weights),
+    BTreeMap::from([("attribution-required", 12), ("permissive", 15)]),
+    "the weights-layer census changed. Say what moved and why in this file's module doc before \
+     re-baselining it — a licence verdict that changes silently is the failure this table exists \
+     to prevent."
+  );
+  assert_eq!(
+    census(|r| r.corpus),
+    BTreeMap::from([
+      ("attribution-required", 6),
+      ("permissive", 2),
+      ("unresolved", 19)
+    ]),
+    "the corpus-layer census changed. Say what moved and why in this file's module doc before \
+     re-baselining it."
   );
 }
 
@@ -1417,9 +2964,11 @@ mod falsifiers {
   use std::collections::{BTreeMap, BTreeSet};
 
   use super::{
-    Artifact, Key, Terms, commercial_features_gating_nothing_restricted,
-    commercial_features_without_the_phrase, contradictory_terms, feature_closure, feature_docs,
-    feature_names, first_sentence, research_only_reachable, unmatched_coverage,
+    Artifact, CREDIT_AUTHOR, Covered, Key, NOTHING_ESTABLISHED, RETAIN_NOTICE, Selection,
+    StagedTable, Terms, commercial_features_gating_nothing_restricted,
+    commercial_features_without_the_phrase, contradictory_terms, feature_closure, feature_closures,
+    feature_docs, feature_names, first_sentence, fp16_pinned_bundles_without_a_row, glob_matches,
+    research_only_reachable, unmatched_coverage,
   };
 
   /// A row with everything but the fields a given test is about.
@@ -1435,6 +2984,7 @@ mod falsifiers {
       key: Key::Sha256("0000000000000000000000000000000000000000000000000000000000000000"),
       pin: "a falsifier row, never resolved against the tree",
       staged_by,
+      loader: "a falsifier row, never resolved against the tree",
       gate,
       weights,
       corpus,
@@ -1442,46 +2992,371 @@ mod falsifiers {
     }
   }
 
-  const CLEAR: Terms = Terms::Permissive("clear, for a falsifier");
-  const RESTRICTED: Terms =
-    Terms::ResearchOnly("non-commercial research purposes only, for a falsifier");
+  const CLEAR: Terms = Terms::permissive("MIT", RETAIN_NOTICE, "clear, for a falsifier");
+  const RESTRICTED: Terms = Terms::research_only(
+    "LicenseRef-research-only",
+    RETAIN_NOTICE,
+    "non-commercial research purposes only, for a falsifier",
+  );
 
-  fn staged(names: &[&str]) -> Vec<String> {
-    names.iter().map(|n| (*n).to_string()).collect()
+  /// A roster of `Models/`-relative bundle paths, as a reader would return it.
+  fn staged_paths(paths: &[&str]) -> Vec<String> {
+    paths.iter().map(|p| (*p).to_string()).collect()
   }
 
   fn features(names: &[&str]) -> BTreeSet<String> {
     names.iter().map(|n| (*n).to_string()).collect()
   }
 
+  /// One `include`-globbed table, the shape every model bundle rides.
+  fn globbed(name: &str, vendor_dir: &str, patterns: &[&str]) -> StagedTable {
+    StagedTable {
+      name: name.to_string(),
+      vendor_dir: vendor_dir.to_string(),
+      selection: Selection::Include(patterns.iter().map(|p| (*p).to_string()).collect()),
+    }
+  }
+
+  /// One `files`-listed table — the shape `openai/whisper-tiny` has, and the
+  /// one the repository-keyed coverage check could not see into.
+  fn listed(name: &str, vendor_dir: &str, files: &[&str]) -> StagedTable {
+    StagedTable {
+      name: name.to_string(),
+      vendor_dir: vendor_dir.to_string(),
+      selection: Selection::Files(files.iter().map(|f| (*f).to_string()).collect()),
+    }
+  }
+
+  /// A row covering exactly the paths given, table-relative.
+  fn covering<'a>(file: &'a str, staged_by: &'a str, covers: &[&str]) -> Covered<'a> {
+    Covered {
+      file,
+      staged_by,
+      covered: covers.iter().map(|c| (*c).to_string()).collect(),
+    }
+  }
+
   // --- direction 1 ---------------------------------------------------------
 
   #[test]
   fn direction_one_passes_when_every_table_and_row_line_up() {
-    let rows = [row("a/w.bin", "vendor/one", "kit", CLEAR, CLEAR)];
-    assert!(unmatched_coverage(&staged(&["vendor/one"]), &rows).is_empty());
+    let tables = [globbed("vendor/one", "one", &["*.mlmodelc/*"])];
+    let rows = [covering(
+      "one/a.mlmodelc/weights/weight.bin",
+      "vendor/one",
+      &["a.mlmodelc/weights/weight.bin"],
+    )];
+    assert!(unmatched_coverage(&tables, &rows).is_empty());
   }
 
   #[test]
   fn direction_one_reds_when_a_staged_repo_has_no_row() {
-    let rows = [row("a/w.bin", "vendor/one", "kit", CLEAR, CLEAR)];
-    let failures = unmatched_coverage(&staged(&["vendor/one", "vendor/two"]), &rows);
+    let tables = [
+      globbed("vendor/one", "one", &["*.mlmodelc/*"]),
+      globbed("vendor/two", "two", &["*.mlmodelc/*"]),
+    ];
+    let rows = [covering(
+      "one/a.mlmodelc/weights/weight.bin",
+      "vendor/one",
+      &["a.mlmodelc/weights/weight.bin"],
+    )];
+    let failures = unmatched_coverage(&tables, &rows);
     assert_eq!(failures.len(), 1, "{failures:?}");
     assert!(failures[0].contains("vendor/two"), "{failures:?}");
   }
 
   #[test]
   fn direction_one_reds_when_a_row_names_no_staged_repo() {
+    let tables = [globbed("vendor/one", "one", &["*.mlmodelc/*"])];
     let rows = [
-      row("a/w.bin", "vendor/one", "kit", CLEAR, CLEAR),
-      row("b/w.bin", "vendor/gone", "kit", CLEAR, CLEAR),
+      covering(
+        "one/a.mlmodelc/weights/weight.bin",
+        "vendor/one",
+        &["a.mlmodelc/weights/weight.bin"],
+      ),
+      covering("gone/b.bin", "vendor/gone", &["b.bin"]),
     ];
-    let failures = unmatched_coverage(&staged(&["vendor/one"]), &rows);
+    let failures = unmatched_coverage(&tables, &rows);
     assert_eq!(failures.len(), 1, "{failures:?}");
     assert!(failures[0].contains("vendor/gone"), "{failures:?}");
   }
 
+  /// **The finding.** `openai/whisper-tiny`'s exact shape: a table that names
+  /// three files, and a table of licence rows that carries one. A check that
+  /// compares repository NAMES sees a covered repository and passes.
+  #[test]
+  fn direction_one_reds_when_a_files_table_stages_a_file_no_row_covers() {
+    let tables = [listed(
+      "openai/whisper-tiny",
+      "tokenizers/whisper-tiny",
+      &["tokenizer.json", "tokenizer_config.json", "config.json"],
+    )];
+    let rows = [covering(
+      "tokenizers/whisper-tiny/tokenizer.json",
+      "openai/whisper-tiny",
+      &["tokenizer.json"],
+    )];
+    let failures = unmatched_coverage(&tables, &rows);
+    assert_eq!(failures.len(), 2, "{failures:?}");
+    assert!(
+      failures.iter().any(|f| f.contains("tokenizer_config.json")),
+      "{failures:?}"
+    );
+    assert!(
+      failures.iter().any(|f| f.contains("config.json")),
+      "{failures:?}"
+    );
+  }
+
+  #[test]
+  fn direction_one_passes_when_every_named_file_has_a_row() {
+    let tables = [listed(
+      "openai/whisper-tiny",
+      "tokenizers/whisper-tiny",
+      &["tokenizer.json", "tokenizer_config.json", "config.json"],
+    )];
+    let rows = [
+      covering(
+        "tokenizers/whisper-tiny/tokenizer.json",
+        "openai/whisper-tiny",
+        &["tokenizer.json"],
+      ),
+      covering(
+        "tokenizers/whisper-tiny/tokenizer_config.json",
+        "openai/whisper-tiny",
+        &["tokenizer_config.json"],
+      ),
+      covering(
+        "tokenizers/whisper-tiny/config.json",
+        "openai/whisper-tiny",
+        &["config.json"],
+      ),
+    ];
+    assert!(
+      unmatched_coverage(&tables, &rows).is_empty(),
+      "{:?}",
+      unmatched_coverage(&tables, &rows)
+    );
+  }
+
+  /// A row inside a bundle covers the WHOLE bundle only because its pin is a
+  /// per-file manifest — so a bundle row satisfies a `files` entry under it.
+  #[test]
+  fn a_bundle_row_covers_every_file_beneath_it() {
+    let tables = [listed(
+      "vendor/one",
+      "one",
+      &["a.mlmodelc/model.mil", "a.mlmodelc/weights/weight.bin"],
+    )];
+    let rows = [covering("one/a.mlmodelc", "vendor/one", &["a.mlmodelc"])];
+    assert!(
+      unmatched_coverage(&tables, &rows).is_empty(),
+      "{:?}",
+      unmatched_coverage(&tables, &rows)
+    );
+  }
+
+  #[test]
+  fn direction_one_reds_when_a_row_names_a_file_its_table_does_not_stage() {
+    let tables = [listed(
+      "openai/whisper-tiny",
+      "tokenizers/whisper-tiny",
+      &["tokenizer.json"],
+    )];
+    let rows = [
+      covering(
+        "tokenizers/whisper-tiny/tokenizer.json",
+        "openai/whisper-tiny",
+        &["tokenizer.json"],
+      ),
+      covering(
+        "tokenizers/whisper-tiny/vocab.txt",
+        "openai/whisper-tiny",
+        &["vocab.txt"],
+      ),
+    ];
+    let failures = unmatched_coverage(&tables, &rows);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains("vocab.txt"), "{failures:?}");
+  }
+
+  #[test]
+  fn direction_one_reds_when_a_glob_table_does_not_select_the_rows_path() {
+    let tables = [globbed(
+      "vendor/one",
+      "one",
+      &["pyannote_segmentation.mlmodelc/*"],
+    )];
+    let rows = [covering(
+      "one/wespeaker.mlmodelc/weights/weight.bin",
+      "vendor/one",
+      &["wespeaker.mlmodelc/weights/weight.bin"],
+    )];
+    let failures = unmatched_coverage(&tables, &rows);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains("does not stage"), "{failures:?}");
+  }
+
+  #[test]
+  fn direction_one_reds_when_a_row_sits_outside_its_tables_vendor_directory() {
+    let tables = [globbed("vendor/one", "one", &["*.mlmodelc/*"])];
+    let rows = [covering(
+      "elsewhere/a.mlmodelc/weights/weight.bin",
+      "vendor/one",
+      &["a.mlmodelc/weights/weight.bin"],
+    )];
+    let failures = unmatched_coverage(&tables, &rows);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains("must start with"), "{failures:?}");
+  }
+
+  /// The selector semantics `MODELS_LOCK` inherits from `huggingface_hub`:
+  /// `*` crosses `/`, and a `dir/*` pattern also stands for the directory when
+  /// a row names the bundle rather than a file in it.
+  #[test]
+  fn the_glob_matcher_matches_what_hugging_face_would_select() {
+    assert!(glob_matches(
+      "*.mlmodelc/*",
+      "wespeaker_v2.mlmodelc/weights/weight.bin"
+    ));
+    assert!(glob_matches(
+      "openai_whisper-tiny/*",
+      "openai_whisper-tiny/AudioEncoder.mlmodelc/weights/weight.bin"
+    ));
+    assert!(glob_matches("CHECKSUMS.sha256", "CHECKSUMS.sha256"));
+    assert!(!glob_matches("*.mlmodelc/*", "CHECKSUMS.sha256"));
+    assert!(!glob_matches("*.mlmodelc/*", "wespeaker_v2.mlmodelc"));
+    assert!(!glob_matches(
+      "pyannote_segmentation.mlmodelc/*",
+      "wespeaker.mlmodelc/weights/weight.bin"
+    ));
+  }
+
+  #[test]
+  fn a_bundle_row_is_selected_by_the_glob_that_stages_its_files() {
+    let table = globbed("vendor/one", "one", &["*.mlmodelc/*"]);
+    assert!(table.selects("PLDA.mlmodelc"));
+    assert!(table.selects("PLDA.mlmodelc/weights/weight.bin"));
+    assert!(!table.selects("CHECKSUMS.sha256"));
+  }
+
+  /// A manifest-derived row covers its bundle AND every file in it; the
+  /// per-file entries alone do not answer "is this bundle covered", which is
+  /// the question the sweep roster asks. This pins the contract
+  /// [`super::row_coverage`] builds to, because a hand-written coverage set
+  /// that only ever names bundles would agree with a broken builder.
+  #[test]
+  fn a_manifest_derived_row_covers_its_bundle_and_every_file_in_it() {
+    let manifest_derived = covering(
+      "speakerkit/wespeaker_v2.mlmodelc/weights/weight.bin",
+      "vendor/one",
+      &[
+        "wespeaker_v2.mlmodelc",
+        "wespeaker_v2.mlmodelc/model.mil",
+        "wespeaker_v2.mlmodelc/weights/weight.bin",
+      ],
+    );
+    assert!(manifest_derived.covers("wespeaker_v2.mlmodelc"));
+    assert!(manifest_derived.covers("wespeaker_v2.mlmodelc/metadata.json"));
+
+    let one_file_only = covering(
+      "speakerkit/PLDA.mlmodelc/model.mil",
+      "vendor/one",
+      &["PLDA.mlmodelc/model.mil"],
+    );
+    assert!(one_file_only.covers("PLDA.mlmodelc/model.mil"));
+    assert!(
+      !one_file_only.covers("PLDA.mlmodelc"),
+      "a row over one file inside a bundle is not a row over the bundle"
+    );
+    assert!(!one_file_only.covers("PLDA.mlmodelc/weights/weight.bin"));
+  }
+
+  /// **The second enumeration.** A bundle the fp16 sweep pins under a staged
+  /// vendor directory, with no licence row over it — the shape that stays
+  /// invisible to a glob-table coverage check, because the lock cannot list
+  /// what a glob brings in.
+  #[test]
+  fn a_swept_bundle_with_no_licence_row_reds() {
+    let tables = [globbed("vendor/one", "speakerkit", &["*.mlmodelc/*"])];
+    let rows = [covering(
+      "speakerkit/wespeaker.mlmodelc",
+      "vendor/one",
+      &["wespeaker.mlmodelc"],
+    )];
+    let pinned = staged_paths(&["speakerkit/wespeaker.mlmodelc", "speakerkit/PLDA.mlmodelc"]);
+    let failures = fp16_pinned_bundles_without_a_row(&pinned, &tables, &rows);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains("PLDA.mlmodelc"), "{failures:?}");
+  }
+
+  #[test]
+  fn a_swept_bundle_with_a_row_passes_and_an_unstaged_vendor_is_left_alone() {
+    let tables = [globbed("vendor/one", "speakerkit", &["*.mlmodelc/*"])];
+    let rows = [covering(
+      "speakerkit/wespeaker.mlmodelc",
+      "vendor/one",
+      &["wespeaker.mlmodelc"],
+    )];
+    let pinned = staged_paths(&[
+      "speakerkit/wespeaker.mlmodelc",
+      // No MODELS_LOCK table stages `alignkit/`; ci.yml's own
+      // `UNSTAGED_DEFECT_VENDORS` records that gap, so this file must not
+      // claim it as a licence failure.
+      "alignkit/base960h_aligner.mlmodelc",
+    ]);
+    assert!(
+      fp16_pinned_bundles_without_a_row(&pinned, &tables, &rows).is_empty(),
+      "{:?}",
+      fp16_pinned_bundles_without_a_row(&pinned, &tables, &rows)
+    );
+  }
+
+  /// A row keyed on ONE file inside a bundle covers the bundle only through its
+  /// per-file manifest — so a swept bundle whose row covers just `model.mil`
+  /// is not covered.
+  #[test]
+  fn a_row_covering_one_file_does_not_cover_the_bundle_the_sweep_pins() {
+    let tables = [globbed("vendor/one", "speakerkit", &["*.mlmodelc/*"])];
+    let rows = [covering(
+      "speakerkit/PLDA.mlmodelc/model.mil",
+      "vendor/one",
+      &["PLDA.mlmodelc/model.mil"],
+    )];
+    let pinned = staged_paths(&["speakerkit/PLDA.mlmodelc"]);
+    let failures = fp16_pinned_bundles_without_a_row(&pinned, &tables, &rows);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+  }
+
   // --- direction 2 ---------------------------------------------------------
+
+  /// The gates directions 2 and 3 run on, as the tree would report them.
+  fn tree_gates(pairs: &[(&'static str, &[&str])]) -> BTreeMap<&'static str, BTreeSet<String>> {
+    pairs
+      .iter()
+      .map(|(file, gates)| (*file, gates.iter().map(|g| (*g).to_string()).collect()))
+      .collect()
+  }
+
+  /// A manifest whose `default` is empty and whose kit features are ordinary —
+  /// the shape this crate has today.
+  const CLEAN_FEATURES: &str = "\
+default = []
+speaker = [\"dep:diaric\"]
+# Requires a commercial licence from the weights' author.
+commercial-face = [\"dep:facelib\"]
+";
+
+  /// **The finding.** `default = []` while an ORDINARY kit feature pulls the
+  /// commercial gate in. Consulting only `default`'s closure sees nothing, and
+  /// the row's claimed gate carries the prefix, so a claim-driven check passes
+  /// while `cargo add coremlit --features speaker` ships the restricted bytes.
+  const REACHABLE_VIA_A_PLAIN_FEATURE: &str = "\
+default = []
+speaker = [\"dep:diaric\", \"commercial-face\"]
+# Requires a commercial licence from the weights' author.
+commercial-face = [\"dep:facelib\"]
+";
 
   #[test]
   fn direction_two_passes_when_a_restricted_row_sits_behind_an_opt_in_commercial_gate() {
@@ -1492,12 +3367,17 @@ mod falsifiers {
       CLEAR,
       RESTRICTED,
     )];
-    let closure = features(&["default"]);
-    assert!(research_only_reachable(&rows, &closure).is_empty());
+    let derived = tree_gates(&[("a/w.bin", &["commercial-face"])]);
+    let closures = feature_closures(CLEAN_FEATURES);
+    assert!(
+      research_only_reachable(&rows, &derived, &closures).is_empty(),
+      "{:?}",
+      research_only_reachable(&rows, &derived, &closures)
+    );
   }
 
   #[test]
-  fn direction_two_reds_when_a_research_only_row_is_reachable_from_default() {
+  fn direction_two_reds_when_a_plain_feature_closure_reaches_the_commercial_gate() {
     let rows = [row(
       "a/w.bin",
       "vendor/one",
@@ -1505,38 +3385,87 @@ mod falsifiers {
       CLEAR,
       RESTRICTED,
     )];
-    let closure = features(&["default", "commercial-face"]);
-    let failures = research_only_reachable(&rows, &closure);
+    let derived = tree_gates(&[("a/w.bin", &["commercial-face"])]);
+    let closures = feature_closures(REACHABLE_VIA_A_PLAIN_FEATURE);
+    let failures = research_only_reachable(&rows, &derived, &closures);
     assert_eq!(failures.len(), 1, "{failures:?}");
-    assert!(
-      failures[0].contains("reachable from `default`"),
-      "{failures:?}"
-    );
+    assert!(failures[0].contains("\"speaker\""), "{failures:?}");
     assert!(failures[0].contains("training corpus"), "{failures:?}");
   }
 
   #[test]
-  fn direction_two_reds_when_a_research_only_row_is_gated_by_a_plain_feature() {
-    let rows = [row("a/w.bin", "vendor/one", "speaker", RESTRICTED, CLEAR)];
-    let failures = research_only_reachable(&rows, &features(&["default"]));
+  fn direction_two_reds_when_a_research_only_row_is_reachable_from_default() {
+    const LEAKY: &str = "\
+default = [\"commercial-face\"]
+# Requires a commercial licence from the weights' author.
+commercial-face = [\"dep:facelib\"]
+";
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "commercial-face",
+      CLEAR,
+      RESTRICTED,
+    )];
+    let derived = tree_gates(&[("a/w.bin", &["commercial-face"])]);
+    let failures = research_only_reachable(&rows, &derived, &feature_closures(LEAKY));
     assert_eq!(failures.len(), 1, "{failures:?}");
-    assert!(failures[0].contains("does not carry"), "{failures:?}");
-    assert!(failures[0].contains("weights layer"), "{failures:?}");
+    assert!(
+      failures[0].contains("plain `cargo add coremlit`"),
+      "{failures:?}"
+    );
   }
 
+  /// The tree, not the row, decides. A row may CLAIM a commercial gate while
+  /// the module that loads it is gated on an ordinary kit feature.
   #[test]
-  fn direction_two_names_the_weights_layer_when_that_is_what_disqualifies() {
-    let rows = [row("a/w.bin", "vendor/one", "kit", RESTRICTED, CLEAR)];
-    let failures = research_only_reachable(&rows, &features(&["default"]));
-    assert!(failures[0].contains("weights layer"), "{failures:?}");
+  fn direction_two_reds_when_the_tree_gates_the_loader_on_a_plain_feature() {
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "commercial-face",
+      RESTRICTED,
+      CLEAR,
+    )];
+    let derived = tree_gates(&[("a/w.bin", &["speaker"])]);
+    let failures = research_only_reachable(&rows, &derived, &feature_closures(CLEAN_FEATURES));
+    assert!(
+      failures.iter().any(|f| f.contains("does not carry")),
+      "{failures:?}"
+    );
+    assert!(
+      failures.iter().any(|f| f.contains("weights layer")),
+      "{failures:?}"
+    );
+  }
+
+  /// And a row whose loader carries no `#[cfg]` at all is behind nothing,
+  /// however confident its `gate` field is.
+  #[test]
+  fn direction_two_reds_when_the_tree_gates_the_loader_on_nothing() {
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "commercial-face",
+      CLEAR,
+      RESTRICTED,
+    )];
+    let derived = tree_gates(&[("a/w.bin", &[])]);
+    let failures = research_only_reachable(&rows, &derived, &feature_closures(CLEAN_FEATURES));
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("compiles unconditionally"),
+      "{failures:?}"
+    );
   }
 
   #[test]
   fn direction_two_names_the_corpus_layer_when_that_is_what_disqualifies() {
-    let rows = [row("a/w.bin", "vendor/one", "kit", CLEAR, RESTRICTED)];
-    let failures = research_only_reachable(&rows, &features(&["default"]));
+    let rows = [row("a/w.bin", "vendor/one", "speaker", CLEAR, RESTRICTED)];
+    let derived = tree_gates(&[("a/w.bin", &["speaker"])]);
+    let failures = research_only_reachable(&rows, &derived, &feature_closures(CLEAN_FEATURES));
     assert!(
-      failures[0].contains("training corpus layer"),
+      failures.iter().any(|f| f.contains("training corpus layer")),
       "{failures:?}"
     );
   }
@@ -1546,11 +3475,12 @@ mod falsifiers {
     let rows = [row(
       "a/w.bin",
       "vendor/one",
-      "kit",
-      Terms::Unresolved("open question, for a falsifier"),
+      "speaker",
+      Terms::unresolved("open question, for a falsifier"),
       CLEAR,
     )];
-    assert!(research_only_reachable(&rows, &features(&["default"])).is_empty());
+    let derived = tree_gates(&[("a/w.bin", &["speaker"])]);
+    assert!(research_only_reachable(&rows, &derived, &feature_closures(CLEAN_FEATURES)).is_empty());
   }
 
   // --- direction 3 ---------------------------------------------------------
@@ -1564,8 +3494,13 @@ mod falsifiers {
       CLEAR,
       RESTRICTED,
     )];
+    let derived = tree_gates(&[("a/w.bin", &["commercial-face"])]);
     let declared = features(&["default", "commercial-face"]);
-    assert!(commercial_features_gating_nothing_restricted(&rows, &declared).is_empty());
+    let in_source = features(&["commercial-face"]);
+    assert!(
+      commercial_features_gating_nothing_restricted(&rows, &derived, &declared, &in_source)
+        .is_empty()
+    );
   }
 
   #[test]
@@ -1577,8 +3512,13 @@ mod falsifiers {
       CLEAR,
       CLEAR,
     )];
-    let declared = features(&["default", "commercial-face"]);
-    let failures = commercial_features_gating_nothing_restricted(&rows, &declared);
+    let derived = tree_gates(&[("a/w.bin", &["commercial-face"])]);
+    let failures = commercial_features_gating_nothing_restricted(
+      &rows,
+      &derived,
+      &features(&["default", "commercial-face"]),
+      &features(&["commercial-face"]),
+    );
     assert_eq!(failures.len(), 1, "{failures:?}");
     assert!(
       failures[0].contains("every artifact it gates is CLEAR"),
@@ -1589,8 +3529,13 @@ mod falsifiers {
   #[test]
   fn direction_three_reds_when_a_commercial_feature_gates_nothing_at_all() {
     let rows = [row("a/w.bin", "vendor/one", "speaker", CLEAR, CLEAR)];
-    let declared = features(&["default", "commercial-face"]);
-    let failures = commercial_features_gating_nothing_restricted(&rows, &declared);
+    let derived = tree_gates(&[("a/w.bin", &["speaker"])]);
+    let failures = commercial_features_gating_nothing_restricted(
+      &rows,
+      &derived,
+      &features(&["default", "commercial-face"]),
+      &features(&["commercial-face"]),
+    );
     assert_eq!(failures.len(), 1, "{failures:?}");
     assert!(
       failures[0].contains("no licence row is gated by it"),
@@ -1598,11 +3543,46 @@ mod falsifiers {
     );
   }
 
+  /// **The finding.** `commercial-face = []` declared in `[features]`, named by
+  /// a restricted row, and referenced by no `#[cfg(feature = ...)]` anywhere.
+  /// Enabling it compiles nothing differently — so the artifact is behind no
+  /// gate at all, while a row-driven check reports a protected artifact.
+  #[test]
+  fn direction_three_reds_when_a_commercial_feature_gates_no_code_at_all() {
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "commercial-face",
+      CLEAR,
+      RESTRICTED,
+    )];
+    let derived = tree_gates(&[("a/w.bin", &["commercial-face"])]);
+    let failures = commercial_features_gating_nothing_restricted(
+      &rows,
+      &derived,
+      &features(&["default", "commercial-face"]),
+      &features(&["speaker"]),
+    );
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("It is a name, not a gate"),
+      "{failures:?}"
+    );
+  }
+
   #[test]
   fn direction_three_leaves_plain_features_alone() {
     let rows = [row("a/w.bin", "vendor/one", "speaker", CLEAR, CLEAR)];
-    let declared = features(&["default", "speaker", "whisper"]);
-    assert!(commercial_features_gating_nothing_restricted(&rows, &declared).is_empty());
+    let derived = tree_gates(&[("a/w.bin", &["speaker"])]);
+    assert!(
+      commercial_features_gating_nothing_restricted(
+        &rows,
+        &derived,
+        &features(&["default", "speaker", "whisper"]),
+        &features(&["speaker", "whisper"]),
+      )
+      .is_empty()
+    );
   }
 
   // --- the documentation rule ---------------------------------------------
@@ -1640,8 +3620,54 @@ mod falsifiers {
     )]);
     let failures = commercial_features_without_the_phrase(&declared, &written);
     assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains("does not BEGIN with"), "{failures:?}");
+  }
+
+  /// **The finding, counterexample one.** A substring search finds the phrase
+  /// inside its own negation and passes the sentence that says the opposite.
+  #[test]
+  fn the_doc_rule_reds_on_a_first_sentence_that_negates_the_warning() {
+    let declared = features(&["commercial-face"]);
+    let written = docs(&[(
+      "commercial-face",
+      "This feature no longer requires a commercial license.",
+    )]);
+    let failures = commercial_features_without_the_phrase(&declared, &written);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains("does not BEGIN with"), "{failures:?}");
+  }
+
+  /// **The finding, counterexample two.** `!` is a sentence terminator, so the
+  /// FIRST sentence here is the endorsement — which is the reading the rule
+  /// exists to prevent, arriving before the correction.
+  #[test]
+  fn the_doc_rule_reds_when_an_endorsement_precedes_the_warning() {
+    let declared = features(&["commercial-face"]);
+    let written = docs(&[(
+      "commercial-face",
+      "Cleared for commercial use! This feature requires a commercial license.",
+    )]);
+    let failures = commercial_features_without_the_phrase(&declared, &written);
+    assert_eq!(failures.len(), 1, "{failures:?}");
     assert!(
-      failures[0].contains("has to be the first one"),
+      failures[0].contains("Cleared for commercial use!"),
+      "{failures:?}"
+    );
+  }
+
+  /// A warning that opens correctly and is then taken back in the same
+  /// sentence has not warned anybody.
+  #[test]
+  fn the_doc_rule_reds_when_the_opening_warning_is_qualified_away() {
+    let declared = features(&["commercial-face"]);
+    let written = docs(&[(
+      "commercial-face",
+      "Requires a commercial license unless you are an academic. Adds the face embedder.",
+    )]);
+    let failures = commercial_features_without_the_phrase(&declared, &written);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("takes the warning back"),
       "{failures:?}"
     );
   }
@@ -1665,14 +3691,26 @@ mod falsifiers {
   }
 
   #[test]
-  fn a_single_sentence_doc_is_read_whole() {
+  fn a_sentence_ends_at_a_full_stop_a_bang_or_a_question_mark() {
     assert_eq!(
       first_sentence("Requires a commercial licence."),
-      "Requires a commercial licence"
+      "Requires a commercial licence."
     );
     assert_eq!(
       first_sentence("Requires a commercial licence. And more."),
       "Requires a commercial licence."
+    );
+    assert_eq!(
+      first_sentence("Cleared for commercial use! Requires a commercial licence."),
+      "Cleared for commercial use!"
+    );
+    assert_eq!(
+      first_sentence("Commercial? Requires a commercial licence."),
+      "Commercial?"
+    );
+    assert_eq!(
+      first_sentence("No terminator at all"),
+      "No terminator at all"
     );
   }
 
@@ -1706,8 +3744,124 @@ mod falsifiers {
       },
     ];
     let failures = contradictory_terms(&rows);
+    assert_eq!(failures.len(), 2, "{failures:?}");
+    assert!(failures.iter().all(|f| f.contains(SHA)), "{failures:?}");
+  }
+
+  /// **The finding.** Both rows are `permissive`, so a verdict-class comparison
+  /// reads them as agreeing — while one says the bytes are MIT and the other
+  /// says Apache-2.0. Those are different grants over one file, and at most one
+  /// of them is the licence of the artifact.
+  #[test]
+  fn identical_bytes_called_mit_by_one_row_and_apache_by_another_red() {
+    const SHA: &str = "cccc000000000000000000000000000000000000000000000000000000000000";
+    let rows = [
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row(
+          "one/w.bin",
+          "vendor/one",
+          "kit",
+          Terms::permissive("MIT", RETAIN_NOTICE, "MIT, for a falsifier"),
+          Terms::unresolved("open, for a falsifier"),
+        )
+      },
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row(
+          "two/w.bin",
+          "vendor/two",
+          "kit",
+          Terms::permissive("Apache-2.0", RETAIN_NOTICE, "Apache-2.0, for a falsifier"),
+          Terms::unresolved("open, for a falsifier"),
+        )
+      },
+    ];
+    let failures = contradictory_terms(&rows);
     assert_eq!(failures.len(), 1, "{failures:?}");
-    assert!(failures[0].contains(SHA), "{failures:?}");
+    assert!(failures[0].contains("weights"), "{failures:?}");
+    assert!(failures[0].contains("MIT"), "{failures:?}");
+    assert!(failures[0].contains("Apache-2.0"), "{failures:?}");
+  }
+
+  /// **The finding, second half.** Two `research-only` rows over one SHA-256
+  /// that forbid materially different things are a contradiction, not
+  /// agreement — the class is identical and the obligations are not.
+  #[test]
+  fn two_research_only_rows_with_different_restrictions_red() {
+    const SHA: &str = "dddd000000000000000000000000000000000000000000000000000000000000";
+    const NO_REDISTRIBUTION: &[&str] = &["no-redistribution-of-the-weights"];
+    let rows = [
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row(
+          "one/w.bin",
+          "vendor/one",
+          "kit",
+          Terms::research_only(
+            "LicenseRef-research-only",
+            RETAIN_NOTICE,
+            "research only, redistribution permitted, for a falsifier",
+          ),
+          Terms::unresolved("open, for a falsifier"),
+        )
+      },
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row(
+          "two/w.bin",
+          "vendor/two",
+          "kit",
+          Terms::research_only(
+            "LicenseRef-research-only",
+            NO_REDISTRIBUTION,
+            "research only, redistribution FORBIDDEN, for a falsifier",
+          ),
+          Terms::unresolved("open, for a falsifier"),
+        )
+      },
+    ];
+    let failures = contradictory_terms(&rows);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("no-redistribution-of-the-weights"),
+      "{failures:?}"
+    );
+  }
+
+  /// And an attribution row and a permissive row over the same bytes disagree
+  /// even before the identifiers are read — one makes credit a condition of
+  /// the grant and the other does not.
+  #[test]
+  fn identical_bytes_with_different_obligations_red() {
+    const SHA: &str = "eeee000000000000000000000000000000000000000000000000000000000000";
+    let rows = [
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row(
+          "one/w.bin",
+          "vendor/one",
+          "kit",
+          Terms::attribution(
+            "CC-BY-4.0",
+            CREDIT_AUTHOR,
+            "credit required, for a falsifier",
+          ),
+          Terms::unresolved("open, for a falsifier"),
+        )
+      },
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row(
+          "two/w.bin",
+          "vendor/two",
+          "kit",
+          Terms::permissive("CC-BY-4.0", RETAIN_NOTICE, "notice only, for a falsifier"),
+          Terms::unresolved("open, for a falsifier"),
+        )
+      },
+    ];
+    assert_eq!(contradictory_terms(&rows).len(), 1);
   }
 
   #[test]
@@ -1724,6 +3878,22 @@ mod falsifiers {
       },
     ];
     assert!(contradictory_terms(&rows).is_empty());
+  }
+
+  /// An unresolved layer carries no identifier and no obligation, so two
+  /// unresolved rows over one hash agree by construction — which is correct:
+  /// neither has claimed anything to contradict.
+  #[test]
+  fn unresolved_rows_over_the_same_bytes_do_not_contradict() {
+    assert!(
+      Terms::unresolved("open, for a falsifier")
+        .licence()
+        .is_empty()
+    );
+    assert_eq!(
+      Terms::unresolved("open, for a falsifier").restrictions(),
+      NOTHING_ESTABLISHED.iter().copied().collect::<BTreeSet<_>>()
+    );
   }
 
   // --- the manifest readers ------------------------------------------------
@@ -1771,7 +3941,7 @@ lid = [\"dep:rustfft\"]
   }
 
   /// The same manifest with `default` pulling the commercial gate in — the
-  /// mutation direction 2's first clause exists for, read through the real
+  /// mutation direction 2's `default` clause exists for, read through the real
   /// manifest reader rather than a hand-built set.
   const LEAKY_FEATURES: &str = "\
 default = [\"commercial-face\"]
@@ -1791,7 +3961,6 @@ commercial-face = [\"dep:facelib\", \"speaker\"]
 
   #[test]
   fn the_leaky_manifest_reds_on_direction_two() {
-    let closure = feature_closure(LEAKY_FEATURES, "default");
     let rows = [row(
       "a/w.bin",
       "vendor/one",
@@ -1799,11 +3968,28 @@ commercial-face = [\"dep:facelib\", \"speaker\"]
       CLEAR,
       RESTRICTED,
     )];
-    let failures = research_only_reachable(&rows, &closure);
-    assert_eq!(failures.len(), 1, "{failures:?}");
+    let derived = tree_gates(&[("a/w.bin", &["commercial-face"])]);
+    let failures = research_only_reachable(&rows, &derived, &feature_closures(LEAKY_FEATURES));
     assert!(
-      failures[0].contains("reachable from `default`"),
+      failures
+        .iter()
+        .any(|f| f.contains("plain `cargo add coremlit`")),
       "{failures:?}"
+    );
+  }
+
+  /// Every closure the manifest reader builds, not just `default`'s — the
+  /// input direction 2 now runs on.
+  #[test]
+  fn the_closure_reader_covers_every_declared_feature() {
+    let closures = feature_closures(DOCTORED_FEATURES);
+    assert_eq!(
+      closures.keys().cloned().collect::<BTreeSet<_>>(),
+      features(&["default", "speaker", "commercial-face", "lid"])
+    );
+    assert_eq!(
+      closures["commercial-face"],
+      features(&["commercial-face", "speaker"])
     );
   }
 }

--- a/coremlit/tests/model_licences.rs
+++ b/coremlit/tests/model_licences.rs
@@ -1,0 +1,1809 @@
+//! **Which model artifacts a closed-source product may ship, enforced rather
+//! than remembered.**
+//!
+//! coremlit is MIT OR Apache-2.0, but the products built on it are not
+//! necessarily open source. A model whose WEIGHTS or whose TRAINING CORPUS
+//! forbids commercial use is therefore disqualifying for the shipping path,
+//! while still being perfectly legal for CI to fetch and test against: this
+//! repository redistributes no weight bytes at all (`NOTICE`'s "CI DOWNLOADS;
+//! IT DOES NOT REDISTRIBUTE", and `MODELS_LOCK` stages everything into a
+//! gitignored `Models/` for the duration of a job). Those are two different
+//! permissions, and only the first one gates a feature.
+//!
+//! # The table is keyed by ARTIFACT + SHA-256, never by repository
+//!
+//! This is the whole lesson of the investigation that produced this file.
+//! `fal/AuraFace-v1` is tagged `apache-2.0` on Hugging Face while four of its
+//! five ONNX files are byte-identical to InsightFace artifacts distributed for
+//! "non-commercial research purposes only". A repo-keyed table gets four rows
+//! wrong and reads clean while doing it. So [`Artifact::file`] plus
+//! [`Artifact::key`] is the identity, the repository is only where the bytes
+//! were fetched from, and
+//! [`identical_bytes_carry_identical_terms`] refuses the exact shape of that
+//! failure: two rows over the same SHA-256 that disagree about what the bytes
+//! permit.
+//!
+//! # The three directions
+//!
+//! Modelled on `CHECKSUMLESS_KITS` in `tests/whisper/models_lock.rs`, which
+//! this repository already uses precisely so an exemption cannot outlive its
+//! cause. Red on all three of:
+//!
+//!   1. a `MODELS_LOCK` artifact with no licence row — and the reverse, a row
+//!      naming a repository no table stages
+//!      ([`every_staged_repo_has_a_licence_row_and_every_row_names_a_staged_repo`]);
+//!   2. a research-only row reachable from `default`, or gated by a feature
+//!      that is not `commercial-` prefixed
+//!      ([`no_research_only_artifact_is_reachable_without_a_commercial_gate`]);
+//!   3. a `commercial-`prefixed feature gating an artifact whose row is
+//!      actually clear
+//!      ([`every_commercial_feature_gates_a_research_only_artifact`]).
+//!
+//! The third is the one people forget, and it is what keeps the table honest
+//! as artifacts change: the day an upstream relicenses, the gate that was
+//! protecting it becomes a gate protecting nothing, and it must be retired
+//! rather than left standing as false reassurance.
+//!
+//! # What a check that cannot fire proves
+//!
+//! **No row in the seeded table is research-only today, and no
+//! `commercial-`prefixed feature exists.** Directions 2 and 3 therefore cannot
+//! fire against the real repository right now — they are tripwires for the
+//! artifact that has not been added yet. A tripwire nobody has seen trip is not
+//! a tripwire, so every predicate below is ALSO driven by hermetic falsifiers
+//! over doctored input (`falsifiers::*`), which run everywhere, need no models
+//! and no repository files, and fail if the predicate ever stops detecting the
+//! thing it exists to detect. Direction 1, the SHA-256 pin cross-check and the
+//! same-bytes-same-terms rule DO bind live data today.
+//!
+//! # What this file can and cannot see
+//!
+//! `MODELS_LOCK` names repositories, selectors and revisions — not files. The
+//! file list only exists after a download, and these checks are hermetic. So
+//! direction 1 binds at TABLE granularity ("every table is covered by at least
+//! one row"), while the ROWS are per-file, which is what makes the AuraFace
+//! failure mode expressible at all. The seeding rule for rows is: one row per
+//! staged file this repository independently pins by SHA-256, plus the
+//! `revision = "main"` whisper artifacts that nothing can pin. Files inside a
+//! staged bundle that carry no independent pin (`Segmentation.mlmodelc`,
+//! `PLDA.mlmodelc` and the other FluidInference bundles) are not rows, and a
+//! research-only artifact could in principle hide in one; that is a real,
+//! named gap, and closing it needs a per-file manifest those bundles do not
+//! have.
+//!
+//! Hermetic: pure file reads, no network, no models, no feature needs
+//! enabling. The `MODELS_LOCK`-reading checks SKIP outside the repository
+//! workspace (the published tarball packages no lock file), exactly as
+//! `tests/whisper/models_lock.rs` does; the falsifiers never skip.
+
+// The workspace-root anchor, FOUND by searching upward for the `[workspace]`
+// manifest rather than counted in `../` hops — see its module doc.
+#[path = "support/workspace_root.rs"]
+#[allow(dead_code)]
+mod workspace_root;
+
+use std::{
+  collections::{BTreeMap, BTreeSet},
+  path::Path,
+};
+
+// ---------------------------------------------------------------------------
+// The table
+// ---------------------------------------------------------------------------
+
+/// What one licence layer permits, and the reading this repository has on it.
+///
+/// The payload is prose on purpose: a bare SPDX identifier answers "which
+/// licence" and never "and does that let us ship it", which is the only
+/// question this file is asking. Every variant is a NEWTYPE of exactly one
+/// payload — the workspace house rule
+/// (`no_enum_in_the_workspace_has_a_struct_shaped_or_multi_field_variant`).
+#[derive(Debug, Clone, Copy)]
+enum Terms {
+  /// Commercial use permitted with no condition beyond retaining notices —
+  /// MIT, Apache-2.0, BSD. Payload: the licence and where it is declared.
+  Permissive(&'static str),
+  /// Commercial use permitted, but attribution is a CONDITION of it, so
+  /// shipping without the notice is infringement rather than impoliteness.
+  /// Payload: the licence, and what has to be reproduced.
+  Attribution(&'static str),
+  /// **Disqualifying.** Forbids commercial use. Payload: the exact
+  /// restriction and where it is stated.
+  ResearchOnly(&'static str),
+  /// Not established. Payload: the open QUESTION and where to go to answer it.
+  ///
+  /// Deliberately distinct from [`Terms::Permissive`]: rounding an unknown to
+  /// "clear" is how a table stops being evidence. Unresolved is not
+  /// disqualifying either — it is a row that no shipping claim may rest on
+  /// until somebody resolves it.
+  Unresolved(&'static str),
+}
+
+impl Terms {
+  /// The verdict, without the prose — what two rows over identical bytes must
+  /// agree on.
+  const fn verdict(self) -> &'static str {
+    match self {
+      Self::Permissive(_) => "permissive",
+      Self::Attribution(_) => "attribution-required",
+      Self::ResearchOnly(_) => "research-only",
+      Self::Unresolved(_) => "unresolved",
+    }
+  }
+
+  /// Whether these terms forbid the shipping path outright.
+  const fn forbids_commercial_use(self) -> bool {
+    matches!(self, Self::ResearchOnly(_))
+  }
+
+  /// The prose payload.
+  const fn detail(self) -> &'static str {
+    match self {
+      Self::Permissive(d) | Self::Attribution(d) | Self::ResearchOnly(d) | Self::Unresolved(d) => d,
+    }
+  }
+}
+
+/// How a row addresses its bytes.
+enum Key {
+  /// The file's SHA-256, lowercase hex.
+  Sha256(&'static str),
+  /// No immutable byte identity exists for this artifact. Payload: why.
+  ///
+  /// Legal ONLY where the row's `MODELS_LOCK` table is still on
+  /// `revision = "main"` — a moving target, so there is no single set of bytes
+  /// to key on. Tied to that cause in both directions by
+  /// [`unpinned_rows_exist_only_where_the_lock_pins_a_moving_revision`]: the
+  /// day the LOUD FOLLOW-UP in `MODELS_LOCK` lands and those tables pin a
+  /// commit, this exemption goes red and has to be replaced by a hash.
+  Unpinned(&'static str),
+}
+
+/// One staged file, and what its bytes permit.
+struct Artifact {
+  /// Path under `Models/`, exactly as a `model-tests` shard stages it.
+  file: &'static str,
+  /// The bytes' identity — see [`Key`].
+  key: Key,
+  /// `<crate-relative source>::<identifier>` where this repository ALREADY
+  /// pins those bytes, or `""` for a [`Key::Unpinned`] row.
+  ///
+  /// The licence attaches to bytes, so a hash copied here and never checked
+  /// again is a hash that goes stale the first time an artifact is
+  /// re-converted. This field is what stops that: the identifier names a
+  /// `const` or a `fn` in the tree, and the SHA-256 in that pin has to be the
+  /// one in this row.
+  pin: &'static str,
+  /// The `MODELS_LOCK` table that stages the file.
+  staged_by: &'static str,
+  /// The cargo feature a caller must enable before the shipping path can load
+  /// it. Research-only artifacts must be gated by a `commercial-` feature; see
+  /// [`COMMERCIAL_PREFIX`].
+  gate: &'static str,
+  /// Terms on the weight bytes themselves.
+  weights: Terms,
+  /// Terms on the data the weights were TRAINED ON.
+  ///
+  /// A different question from [`Artifact::weights`], and the one nearly every
+  /// model fails: Apache-2.0 weights trained on a corpus licensed for research
+  /// only are still research only. `NOTICE` records the weights layer for every
+  /// component and the corpus layer for none, which is why so many rows below
+  /// are [`Terms::Unresolved`] here.
+  corpus: Terms,
+  /// Where the two verdicts above come from.
+  source: &'static str,
+}
+
+impl Artifact {
+  /// Which layer disqualifies the artifact, when one does.
+  fn disqualifying_layer(&self) -> Option<&'static str> {
+    if self.weights.forbids_commercial_use() {
+      Some("weights")
+    } else if self.corpus.forbids_commercial_use() {
+      Some("training corpus")
+    } else {
+      None
+    }
+  }
+
+  /// The terms of the layer named by [`Self::disqualifying_layer`].
+  fn disqualifying_terms(&self) -> Option<Terms> {
+    if self.weights.forbids_commercial_use() {
+      Some(self.weights)
+    } else if self.corpus.forbids_commercial_use() {
+      Some(self.corpus)
+    } else {
+      None
+    }
+  }
+
+  /// The row's SHA-256, or `None` when it is [`Key::Unpinned`].
+  const fn sha256(&self) -> Option<&'static str> {
+    match self.key {
+      Key::Sha256(hex) => Some(hex),
+      Key::Unpinned(_) => None,
+    }
+  }
+}
+
+/// The prefix that marks a feature as gating artifacts a commercial licence is
+/// needed for.
+///
+/// Chosen over the alternatives by the owner, and it can be READ BACKWARDS —
+/// `commercial-face` looks like "cleared for commercial use" to anyone who has
+/// not read this file. That is why
+/// [`every_commercial_feature_says_it_requires_a_commercial_licence_first`]
+/// exists and why it checks the FIRST sentence: the correction has to arrive
+/// before the misreading has time to settle.
+const COMMERCIAL_PREFIX: &str = "commercial-";
+
+/// The phrase every `commercial-` feature's documentation must open with,
+/// normalised (see [`normalise_spelling`]).
+const COMMERCIAL_DOC_PHRASE: &str = "requires a commercial license";
+
+/// Every artifact `MODELS_LOCK` stages that this repository pins by SHA-256,
+/// plus the whisper artifacts nothing can pin, and what each one permits.
+///
+/// Seeded from what the repository actually stages today. Every SHA-256 is
+/// copied from the pin named in the same row's [`Artifact::pin`] and checked
+/// against it by [`every_rows_sha256_matches_the_pin_it_names`], so the two
+/// cannot drift apart.
+///
+/// **No row here is research-only.** Every disqualification found so far sits
+/// in `Terms::Unresolved` on the CORPUS layer, because `NOTICE` documents the
+/// weights layer throughout and the corpus layer nowhere. That is a finding
+/// about this repository's records, not a clean bill of health.
+const ARTIFACTS: &[Artifact] = &[
+  // --- whisper -------------------------------------------------------------
+  Artifact {
+    file: "whisperkit-coreml/openai_whisper-tiny/AudioEncoder.mlmodelc/weights/weight.bin",
+    key: Key::Unpinned(
+      "`argmaxinc/whisperkit-coreml` is still on `revision = \"main\"` (MODELS_LOCK's LOUD \
+       FOLLOW-UP), so no immutable byte identity exists to key on; the same reason puts the \
+       `whisper` kit in CHECKSUMLESS_KITS.",
+    ),
+    pin: "",
+    staged_by: "argmaxinc/whisperkit-coreml",
+    gate: "whisper",
+    weights: Terms::Permissive(
+      "MIT. WhisperKit's CoreML conversion (argmaxinc/WhisperKit, MIT) of OpenAI Whisper (MIT).",
+    ),
+    corpus: Terms::Unresolved(
+      "OpenAI has published no terms for the ~680 000 hours of web audio Whisper was trained on, \
+       and it does not name the sources. NOTICE section 3 records the weights only. Resolve \
+       against openai/whisper's model card and paper before any shipping claim rests on the \
+       corpus layer.",
+    ),
+    source: "NOTICE section 3",
+  },
+  Artifact {
+    file: "whisperkit-coreml/openai_whisper-tiny/TextDecoder.mlmodelc/weights/weight.bin",
+    key: Key::Unpinned(
+      "`argmaxinc/whisperkit-coreml` is still on `revision = \"main\"` (MODELS_LOCK's LOUD \
+       FOLLOW-UP), so no immutable byte identity exists to key on; the same reason puts the \
+       `whisper` kit in CHECKSUMLESS_KITS.",
+    ),
+    pin: "",
+    staged_by: "argmaxinc/whisperkit-coreml",
+    gate: "whisper",
+    weights: Terms::Permissive(
+      "MIT. WhisperKit's CoreML conversion (argmaxinc/WhisperKit, MIT) of OpenAI Whisper (MIT).",
+    ),
+    corpus: Terms::Unresolved(
+      "Same undisclosed ~680 000-hour web-audio corpus as the encoder; see that row.",
+    ),
+    source: "NOTICE section 3",
+  },
+  Artifact {
+    file: "tokenizers/whisper-tiny/tokenizer.json",
+    key: Key::Unpinned(
+      "`openai/whisper-tiny` is still on `revision = \"main\"` (MODELS_LOCK's LOUD FOLLOW-UP), so \
+       no immutable byte identity exists to key on.",
+    ),
+    pin: "",
+    staged_by: "openai/whisper-tiny",
+    gate: "whisper",
+    weights: Terms::Permissive("MIT — OpenAI's own tokenizer artifact for whisper-tiny."),
+    corpus: Terms::Unresolved(
+      "The BPE vocabulary was fit on the same undisclosed corpus as the weights, so the corpus \
+       layer is open for the same reason. A vocabulary carries no weights, which narrows the \
+       exposure but does not close the question.",
+    ),
+    source: "NOTICE section 3",
+  },
+  // --- granite -------------------------------------------------------------
+  Artifact {
+    file: "embedkit-granite/granite-97m-multilingual-r2/granite_97m_512.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("276bc93c49a4f37ffefdfb2e10f7d7e1ef57db9027c7ad0d3f2e4160f81a79be"),
+    pin: "tests/granite/model_io.rs::ARTIFACT_SHA256",
+    staged_by: "FinDIT-Studio/embedkit-coreml",
+    gate: "granite",
+    weights: Terms::Permissive(
+      "Apache-2.0. ibm-granite/granite-embedding-97m-multilingual-r2; the staged file is a format \
+       conversion with unchanged weight VALUES, so the upstream terms govern.",
+    ),
+    corpus: Terms::Unresolved(
+      "IBM describes the Granite embedding training mixture in the model card but does not state \
+       per-source licences for it, and NOTICE section 7a records the weights layer only. Resolve \
+       against ibm-granite/granite-embedding-97m-multilingual-r2's data statement.",
+    ),
+    source: "NOTICE section 7a",
+  },
+  Artifact {
+    file: "embedkit-granite/granite-97m-multilingual-r2/tokenizer.json",
+    key: Key::Sha256("4f2842d568e2724370aec203652a42ac783c7937f8347a1a2cc7506d71f1582f"),
+    pin: "src/embeddings/granite/mod.rs::TOKENIZER_SHA256_HEX",
+    staged_by: "FinDIT-Studio/embedkit-coreml",
+    gate: "granite",
+    weights: Terms::Permissive(
+      "Apache-2.0, the same terms as the model it indexes. Distributed WITH the artifact and read \
+       from disk, so whoever redistributes the artifact directory redistributes it.",
+    ),
+    corpus: Terms::Unresolved("Same open question as the granite weights row."),
+    source: "NOTICE section 7b",
+  },
+  // --- siglip --------------------------------------------------------------
+  Artifact {
+    file: "siglip2-naflex/siglip2-base-patch16-naflex-512/siglip2_vision_512.mlmodelc/weights/\
+           weight.bin",
+    key: Key::Sha256("31fc44e771553c5b28b7af6561b46650ce5e1e4711dfef9f471ed32d502077b6"),
+    pin: "tests/siglip/model_io.rs::ARTIFACT_SHA256",
+    staged_by: "FinDIT-Studio/siglip2-naflex-coreml",
+    gate: "siglip",
+    weights: Terms::Permissive(
+      "Apache-2.0. google/siglip2-base-patch16-naflex; the artifact repo declares apache-2.0 too. \
+       The graph is RESTRUCTURED (the position-embedding resize is lifted host-side), which \
+       Apache-2.0 permits with the change stated — NOTICE section 8a states it.",
+    ),
+    corpus: Terms::Unresolved(
+      "SigLIP 2 is trained on WebLI, which Google has not released and whose terms are not \
+       stated. NOTICE section 8a records the weights layer only. This one cannot be resolved from \
+       public material alone.",
+    ),
+    source: "NOTICE section 8a",
+  },
+  Artifact {
+    file: "siglip2-naflex/siglip2-base-patch16-naflex-512/siglip2_text_64.mlmodelc/weights/\
+           weight.bin",
+    key: Key::Sha256("8b781500cc6a596fa3a27b16b56e3d81e675e642ecd3542722d1f185aa0a6f67"),
+    pin: "tests/siglip/text_model_io.rs::ARTIFACT_SHA256",
+    staged_by: "FinDIT-Studio/siglip2-naflex-coreml",
+    gate: "siglip",
+    weights: Terms::Permissive("Apache-2.0; the vision tower's twin, same checkpoint."),
+    corpus: Terms::Unresolved("Same unreleased WebLI corpus as the vision tower; see that row."),
+    source: "NOTICE section 8a",
+  },
+  Artifact {
+    file: "siglip2-naflex/siglip2-base-patch16-naflex-512/tokenizer.json",
+    key: Key::Sha256("58a1696e79c9d97937389ed116f552a15c84811d7b8023918b86f4bc5775b1b0"),
+    pin: "src/embeddings/siglip/text/mod.rs::TOKENIZER_SHA256_HEX",
+    staged_by: "FinDIT-Studio/siglip2-naflex-coreml",
+    gate: "siglip",
+    weights: Terms::Permissive(
+      "Apache-2.0, the same terms as the model. The Gemma tokenizer as packaged with the SigLIP 2 \
+       checkpoint; distributed WITH the artifact, not compiled into the crate.",
+    ),
+    corpus: Terms::Unresolved("Same unreleased WebLI corpus as the weights rows."),
+    source: "NOTICE section 8b",
+  },
+  // --- ced -----------------------------------------------------------------
+  Artifact {
+    file: "ced/ced-tiny/ced_tiny.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("5635cd9f932583105d1bf40bd07eb54e3f715a70d8319923cd0617a1dea3db01"),
+    pin: "tests/ced/model_io.rs::TINY_SHA256",
+    staged_by: "FinDIT-Studio/cedkit-coreml",
+    gate: "ced",
+    weights: Terms::Permissive(
+      "Apache-2.0. mispeech/ced-tiny (Xiaomi); the CoreML graph is restructured from unchanged \
+       weight values, and NOTICE section 9 states the changes.",
+    ),
+    corpus: Terms::Unresolved(
+      "CED is distilled on AudioSet. The AudioSet ONTOLOGY and label set are CC-BY-4.0, but the \
+       segments themselves are YouTube audio Google never redistributed, and the derived-weights \
+       question is not addressed by either. NOTICE section 9 records the weights layer only.",
+    ),
+    source: "NOTICE section 9",
+  },
+  // --- speaker: the FluidInference base layer ------------------------------
+  Artifact {
+    file: "speakerkit/wespeaker_v2.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("34004f6798d35cad7071e2fdc67e63faaa782f53697e1cb49bcb452cf81ae151"),
+    pin: "tests/speaker/model_io.rs::int8_wespeaker_matches_fluidinference_pinned_sha256",
+    staged_by: "FluidInference/speaker-diarization-coreml",
+    gate: "speaker",
+    weights: Terms::Unresolved(
+      "The RETIRED int8 WeSpeaker embedder, kept for tests. NOTICE section 4 gives the \
+       FluidInference repo as \"SDK Apache-2.0; parent pyannote model cc-by-4.0\", but the \
+       WeSpeaker embedder itself it records only as \"see its model license \
+       (https://github.com/wenet-e2e/wespeaker)\" — it names no licence. Resolve against the \
+       wenet-e2e/wespeaker model licence before treating this as clear.",
+    ),
+    corpus: Terms::Unresolved(
+      "WeSpeaker's published embedders are trained on VoxCeleb. VoxCeleb's own terms are the \
+       thing to check, and they are the specific reason this row is not rounded to clear — a \
+       corpus restricted to non-commercial research would make the DERIVED weights research-only \
+       whatever the weights layer says. Not stated anywhere in this repository.",
+    ),
+    source: "NOTICE section 4",
+  },
+  // --- speaker: the FinDIT-Studio overlay, the two SHIPPING artifacts ------
+  Artifact {
+    file: "speakerkit/pyannote_segmentation.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("0266f4ad4d843ecf31ef9220ad6b80616b3ec64a4404b64f3ea0371554e236ec"),
+    pin: "tests/speaker/model_io.rs::fp16_safe_segmentation_matches_pinned_sha256",
+    staged_by: "FinDIT-Studio/speakerkit-coreml",
+    gate: "speaker",
+    weights: Terms::Permissive(
+      "MIT. An issue-#15 re-conversion of pyannote/segmentation-3.0 (MIT) with fp16-survivable \
+       guards; the artifact repo declares HF licence \"other\"/mixed-upstream, and NOTICE section \
+       4 records that the upstream MIT terms still govern because the weight values are the \
+       upstream ones.",
+    ),
+    corpus: Terms::Unresolved(
+      "pyannote/segmentation-3.0 is trained on a mixture (AMI, DIHARD, VoxConverse and others) \
+       whose members carry different terms, several of them research-only. NOTICE section 4 \
+       records the weights layer only. This is the row most likely to become research-only once \
+       somebody resolves it.",
+    ),
+    source: "NOTICE section 4",
+  },
+  Artifact {
+    file: "speakerkit/wespeaker.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("680837ec172d67c3197bba93800e1623eebfd35c3b17011802f5f98b8026a0aa"),
+    pin: "tests/speaker/model_io.rs::fp16_safe_wespeaker_fp32_matches_pinned_sha256",
+    staged_by: "FinDIT-Studio/speakerkit-coreml",
+    gate: "speaker",
+    weights: Terms::Unresolved(
+      "The SHIPPING fp32 WeSpeaker embedder. NOTICE section 4 records the WeSpeaker embedder as \
+       \"see its model license (https://github.com/wenet-e2e/wespeaker)\" and names none; the \
+       artifact repo declares HF licence \"other\"/mixed-upstream. The CC-BY-4.0 in that section \
+       belongs to pyannote/speaker-diarization-community-1 (the PLDA `diaric` clusters through) \
+       and to FluidInference's parent pyannote model — NOT to these embedder weights, and \
+       reading it across is the mistake this row exists to stop.",
+    ),
+    corpus: Terms::Unresolved(
+      "VoxCeleb, per the WeSpeaker toolkit's published recipes; terms not stated in this \
+       repository. Same open question as the retired int8 sibling — and the same reason it \
+       matters more than the weights layer.",
+    ),
+    source: "NOTICE section 4",
+  },
+  // --- clap ----------------------------------------------------------------
+  Artifact {
+    file: "clapkit/clap_audio.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("723fe6aab7c4af1c671a210a35c289c67763bc6a7532b9df155a0c3fc0c3c9d7"),
+    pin: "tests/clap/model_io.rs::clap_audio_artifacts_match_pinned_sha256",
+    staged_by: "FinDIT-Studio/clapkit-coreml",
+    gate: "clap",
+    weights: Terms::Attribution(
+      "laion/clap-htsat-unfused. NOTICE section 6a records an upstream ambiguity — textclap's \
+       MODELS.md treats the checkpoints as CC-BY-4.0, the current HF card declares apache-2.0 — \
+       and BOTH require attribution, which is why this is attribution-required rather than \
+       permissive. The LAION citation in NOTICE section 4's style must ship with any binary that \
+       bundles these weights.",
+    ),
+    corpus: Terms::Unresolved(
+      "LAION-Audio-630K is assembled from several audio-caption sources with differing terms, and \
+       NOTICE section 6a records the weights layer only.",
+    ),
+    source: "NOTICE section 6a",
+  },
+  Artifact {
+    file: "clapkit/clap_audio_int8.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("b3a37ec5550dcdd6932b314b830275ebcba013748421e1a517760b9afeabafb8"),
+    pin: "tests/clap/model_io.rs::clap_audio_int8_artifacts_match_pinned_sha256",
+    staged_by: "FinDIT-Studio/clapkit-coreml",
+    gate: "clap",
+    weights: Terms::Attribution("A palettization of the fp16 audio tower; same terms as it."),
+    corpus: Terms::Unresolved("Same LAION-Audio-630K question as the fp16 audio tower."),
+    source: "NOTICE section 6a",
+  },
+  Artifact {
+    file: "clapkit/clap_text.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("7f4e15e9ccb0ffbc2341eec286e9d9934d3d3d8d6465dfddebed248bddc0e3dd"),
+    pin: "tests/clap/text_model_io.rs::clap_text_artifacts_match_pinned_sha256",
+    staged_by: "FinDIT-Studio/clapkit-coreml",
+    gate: "clap",
+    weights: Terms::Attribution("The audio tower's twin, same checkpoint and same terms."),
+    corpus: Terms::Unresolved("Same LAION-Audio-630K question as the audio tower."),
+    source: "NOTICE section 6a",
+  },
+  Artifact {
+    file: "clapkit/clap_text_int8.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("f181a595cefce402335499c32ea2f9727ef334afea9c592a2eabebb4172350a0"),
+    pin: "tests/clap/text_model_io.rs::clap_text_int8_artifacts_match_pinned_sha256",
+    staged_by: "FinDIT-Studio/clapkit-coreml",
+    gate: "clap",
+    weights: Terms::Attribution("A palettization of the fp16 text tower; same terms as it."),
+    corpus: Terms::Unresolved("Same LAION-Audio-630K question as the fp16 text tower."),
+    source: "NOTICE section 6a",
+  },
+  // --- lid -----------------------------------------------------------------
+  Artifact {
+    file: "lid/SpeechBrainECAPAVoxLingua107.mlmodelc/weights/weight.bin",
+    key: Key::Sha256("81fbb61f6706c50e924a2ee2a4fc04e6408276df948117a1c6ac7675c23aac67"),
+    pin: "tests/lid/common/mod.rs::ARTIFACT_SHA256",
+    staged_by: "aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-CoreML",
+    gate: "lid",
+    weights: Terms::Permissive(
+      "Apache-2.0 at both layers of the chain: speechbrain/lang-id-voxlingua107-ecapa upstream, \
+       and the aufklarer CoreML export that MODELS_LOCK stages declares apache-2.0 too.",
+    ),
+    corpus: Terms::Unresolved(
+      "VoxLingua107 is scraped YouTube speech. The dataset's own terms are the thing to check and \
+       NOTICE section 10a does not record them — it documents the weights layer and the export's \
+       stated changes only.",
+    ),
+    source: "NOTICE section 10a",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// The three directions, as predicates over data
+// ---------------------------------------------------------------------------
+//
+// Pure functions returning the failures they found, so the hermetic falsifiers
+// below can drive exactly the same code the real-table checks do. A predicate
+// only the happy path ever reaches is not a predicate.
+
+/// Direction 1 — every staged repository is covered, and every row covers one.
+fn unmatched_coverage(tables: &[String], rows: &[Artifact]) -> Vec<String> {
+  let staged: BTreeSet<&str> = tables.iter().map(String::as_str).collect();
+  let claimed: BTreeSet<&str> = rows.iter().map(|r| r.staged_by).collect();
+  let mut failures = Vec::new();
+  for repo in staged.difference(&claimed) {
+    failures.push(format!(
+      "MODELS_LOCK stages {repo:?} and no licence row covers it. Every staged repository needs at \
+       least one row: an artifact whose terms nobody wrote down is an artifact nobody can clear \
+       for the shipping path."
+    ));
+  }
+  for repo in claimed.difference(&staged) {
+    failures.push(format!(
+      "a licence row is staged_by {repo:?}, which no MODELS_LOCK table names. Either the table \
+       was removed and the row is describing bytes CI no longer fetches, or the name is a typo."
+    ));
+  }
+  failures
+}
+
+/// Direction 2 — no research-only artifact is reachable without opting in.
+///
+/// Two clauses, because `default = []` alone would make this vacuous forever:
+/// the row's gate must not be reachable from `default`, AND it must carry the
+/// [`COMMERCIAL_PREFIX`]. A research-only artifact behind a plain kit feature
+/// such as `speaker` is exactly as shipped as one in `default` — every
+/// downstream product enables the kit it uses.
+fn research_only_reachable(rows: &[Artifact], default_closure: &BTreeSet<String>) -> Vec<String> {
+  let mut failures = Vec::new();
+  for row in rows {
+    let Some(layer) = row.disqualifying_layer() else {
+      continue;
+    };
+    let terms = row
+      .disqualifying_terms()
+      .expect("a disqualified row has terms");
+    if default_closure.contains(row.gate) {
+      failures.push(format!(
+        "{}: research-only at the {layer} layer, but its gate {:?} is reachable from `default`, \
+         so a plain `cargo add coremlit` turns it on. {}",
+        row.file,
+        row.gate,
+        terms.detail()
+      ));
+    }
+    if !row.gate.starts_with(COMMERCIAL_PREFIX) {
+      failures.push(format!(
+        "{}: research-only at the {layer} layer, but its gate {:?} does not carry the {:?} \
+         prefix. A plain kit feature is not an opt-in — every product that uses the kit enables \
+         it. {}",
+        row.file,
+        row.gate,
+        COMMERCIAL_PREFIX,
+        terms.detail()
+      ));
+    }
+  }
+  failures
+}
+
+/// Direction 3 — no `commercial-` feature gates only clear artifacts.
+///
+/// The one people forget. A gate that protects nothing is worse than no gate:
+/// it reads as a live restriction, so nobody re-examines the artifacts behind
+/// it, and the next artifact added there inherits reassurance it never earned.
+fn commercial_features_gating_nothing_restricted(
+  rows: &[Artifact],
+  features: &BTreeSet<String>,
+) -> Vec<String> {
+  let mut failures = Vec::new();
+  for feature in features.iter().filter(|f| f.starts_with(COMMERCIAL_PREFIX)) {
+    let gated: Vec<&Artifact> = rows.iter().filter(|r| r.gate == feature.as_str()).collect();
+    if gated.is_empty() {
+      failures.push(format!(
+        "feature {feature:?} carries the {COMMERCIAL_PREFIX:?} prefix but no licence row is gated \
+         by it. Either it gates an artifact with no row (direction 1), or it is a gate left \
+         standing after the artifact it protected went away — retire it."
+      ));
+      continue;
+    }
+    if gated.iter().all(|r| r.disqualifying_layer().is_none()) {
+      let cleared: Vec<&str> = gated.iter().map(|r| r.file).collect();
+      failures.push(format!(
+        "feature {feature:?} carries the {COMMERCIAL_PREFIX:?} prefix, but every artifact it \
+         gates is CLEAR: {}. An upstream relicensed, or the terms were re-read — either way the \
+         gate now says a restriction exists that does not, so retire it and move the artifacts to \
+         a plain feature.",
+        cleared.join(", ")
+      ));
+    }
+  }
+  failures
+}
+
+/// The documentation rule for [`COMMERCIAL_PREFIX`] features.
+fn commercial_features_without_the_phrase(
+  features: &BTreeSet<String>,
+  docs: &BTreeMap<String, String>,
+) -> Vec<String> {
+  let mut failures = Vec::new();
+  for feature in features.iter().filter(|f| f.starts_with(COMMERCIAL_PREFIX)) {
+    let doc = docs.get(feature).map_or("", String::as_str);
+    if doc.trim().is_empty() {
+      failures.push(format!(
+        "feature {feature:?} has no documentation comment above it in Cargo.toml. The prefix can \
+         be read as \"cleared for commercial use\"; the first sentence is what stops that."
+      ));
+      continue;
+    }
+    let first = first_sentence(doc);
+    if !normalise_spelling(&first).contains(COMMERCIAL_DOC_PHRASE) {
+      failures.push(format!(
+        "feature {feature:?}: its first documented sentence is {first:?}, which does not say \
+         {COMMERCIAL_DOC_PHRASE:?}. The name reads as an ENDORSEMENT of commercial use; the \
+         sentence that corrects it has to be the first one, not a caveat further down."
+      ));
+    }
+  }
+  failures
+}
+
+/// The first sentence of a documentation block: everything up to the first
+/// full stop that ends a word, with the block's line breaks flattened.
+fn first_sentence(doc: &str) -> String {
+  let flat = doc.split_whitespace().collect::<Vec<_>>().join(" ");
+  match flat.find(". ") {
+    Some(end) => flat[..=end].trim().to_string(),
+    None => flat.trim_end_matches('.').trim().to_string(),
+  }
+}
+
+/// Lowercase, with the British spelling folded onto the American one.
+///
+/// Both spellings satisfy the rule. Failing a feature for writing "license"
+/// would be a trap with no safety value — the reader is warned either way.
+fn normalise_spelling(text: &str) -> String {
+  text.to_lowercase().replace("licence", "license")
+}
+
+// ---------------------------------------------------------------------------
+// Repository readers
+// ---------------------------------------------------------------------------
+
+/// One `["repo/name"]` table of `MODELS_LOCK`, reduced to what this file needs.
+struct LockTable {
+  name: String,
+  fields: BTreeMap<String, String>,
+}
+
+/// `MODELS_LOCK`, or `None` outside the repository workspace.
+///
+/// The lock is deliberately NOT packaged with the crate, so a `cargo test` run
+/// from the published tarball must SKIP rather than fail `NotFound` — the same
+/// contract `tests/whisper/models_lock.rs` documents.
+fn lock_tables() -> Option<Vec<LockTable>> {
+  let root = workspace_root::try_workspace_root()?;
+  let lock = root.join("MODELS_LOCK");
+  if !lock.is_file() {
+    eprintln!("model_licences checks skipped: not in the repository workspace");
+    return None;
+  }
+  let text = std::fs::read_to_string(&lock).unwrap_or_else(|e| panic!("read MODELS_LOCK: {e}"));
+  Some(parse_lock(&text))
+}
+
+/// A tiny hand-rolled reader over the lock's fixed `["repo/name"]` +
+/// `key = "value"` shape, mirroring the one in
+/// `tests/whisper/models_lock.rs` and the sed/awk block ci.yml runs at CI
+/// time. No TOML crate: the point is to read what the file literally says.
+fn parse_lock(contents: &str) -> Vec<LockTable> {
+  let mut tables: Vec<LockTable> = Vec::new();
+  for line in contents.lines() {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+      continue;
+    }
+    if let Some(name) = line.strip_prefix("[\"").and_then(|s| s.strip_suffix("\"]")) {
+      tables.push(LockTable {
+        name: name.to_string(),
+        fields: BTreeMap::new(),
+      });
+      continue;
+    }
+    let Some(table) = tables.last_mut() else {
+      continue; // a pre-table key (`cache-epoch`), not this reader's concern
+    };
+    let Some((key, value)) = line.split_once('=') else {
+      panic!("MODELS_LOCK: not a table header or `key = value`: {line:?}");
+    };
+    let value = value.trim();
+    let value = value
+      .strip_prefix('"')
+      .and_then(|v| v.strip_suffix('"'))
+      .unwrap_or_else(|| panic!("MODELS_LOCK: value for {key:?} is not quoted: {value:?}"));
+    table
+      .fields
+      .insert(key.trim().to_string(), value.to_string());
+  }
+  tables
+}
+
+/// A file addressed relative to this crate's manifest directory.
+fn read_rel(rel: &str) -> String {
+  std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(rel))
+    .unwrap_or_else(|e| panic!("read {rel}: {e}"))
+}
+
+/// The `[features]` block of this crate's manifest, comments included.
+fn features_block() -> String {
+  features_block_of(&read_rel("Cargo.toml"))
+}
+
+/// The same block, read from the manifest the REPOSITORY holds rather than the
+/// one the compiling package happens to sit next to.
+///
+/// `cargo package` re-serialises the manifest into the tarball and DROPS EVERY
+/// COMMENT doing it, so a feature's documentation exists only in the
+/// checked-in file. Checks that read comments must read that file; checks that
+/// need only names or entries are happy with either. `None` outside the
+/// repository workspace, where the comment-bearing manifest is not present at
+/// all and the rule is simply unverifiable.
+fn repository_features_block() -> Option<String> {
+  let root = workspace_root::try_workspace_root()?;
+  let manifest = root.join("coremlit/Cargo.toml");
+  if !manifest.is_file() {
+    eprintln!("model_licences: no comment-bearing manifest; the doc rule is skipped");
+    return None;
+  }
+  let text = std::fs::read_to_string(&manifest)
+    .unwrap_or_else(|e| panic!("read {}: {e}", manifest.display()));
+  Some(features_block_of(&text))
+}
+
+/// The `[features]` block of `manifest`, comments included.
+fn features_block_of(manifest: &str) -> String {
+  let mut out = String::new();
+  let mut inside = false;
+  for line in manifest.lines() {
+    if line.starts_with('[') {
+      inside = line.trim() == "[features]";
+      continue;
+    }
+    if inside {
+      out.push_str(line);
+      out.push('\n');
+    }
+  }
+  out
+}
+
+/// The declared feature names.
+fn feature_names(block: &str) -> BTreeSet<String> {
+  let mut names = BTreeSet::new();
+  for line in block.lines() {
+    if line.starts_with(char::is_whitespace) {
+      continue;
+    }
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+      continue;
+    }
+    if let Some((key, _)) = line.split_once('=') {
+      let key = key.trim();
+      if !key.is_empty() && !key.contains(char::is_whitespace) {
+        names.insert(key.to_string());
+      }
+    }
+  }
+  names
+}
+
+/// One feature's entries — the quoted contents of its `[..]` value, spread
+/// over as many lines as rustfmt/taplo left it on.
+fn feature_entries(block: &str, feature: &str) -> Vec<String> {
+  let mut collecting = false;
+  let mut buf = String::new();
+  for line in block.lines() {
+    if collecting {
+      buf.push('\n');
+      buf.push_str(line);
+      if line.contains(']') {
+        break;
+      }
+      continue;
+    }
+    if line.starts_with(char::is_whitespace) {
+      continue;
+    }
+    let Some((key, rest)) = line.split_once('=') else {
+      continue;
+    };
+    if key.trim() != feature {
+      continue;
+    }
+    collecting = true;
+    buf.push_str(rest);
+    if rest.contains(']') {
+      break;
+    }
+  }
+  buf
+    .split('"')
+    .skip(1)
+    .step_by(2)
+    .map(str::to_string)
+    .collect()
+}
+
+/// Every feature transitively enabled by `seed`, `seed` included.
+///
+/// Entries naming a dependency (`dep:x`) or a dependency's own feature (`x/y`)
+/// are not this crate's features and do not extend the closure.
+fn feature_closure(block: &str, seed: &str) -> BTreeSet<String> {
+  let mut seen = BTreeSet::new();
+  let mut queue = vec![seed.to_string()];
+  while let Some(feature) = queue.pop() {
+    if !seen.insert(feature.clone()) {
+      continue;
+    }
+    for entry in feature_entries(block, &feature) {
+      if !entry.starts_with("dep:") && !entry.contains('/') {
+        queue.push(entry);
+      }
+    }
+  }
+  seen
+}
+
+/// The contiguous `#` comment block immediately above each feature.
+///
+/// A blank line ends a block, so a comment about the section above cannot be
+/// mistaken for documentation of the feature below it.
+fn feature_docs(block: &str) -> BTreeMap<String, String> {
+  let mut docs = BTreeMap::new();
+  let mut pending: Vec<&str> = Vec::new();
+  for line in block.lines() {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+      pending.clear();
+      continue;
+    }
+    if let Some(comment) = trimmed.strip_prefix('#') {
+      pending.push(comment.trim());
+      continue;
+    }
+    if line.starts_with(char::is_whitespace) {
+      continue;
+    }
+    if let Some((key, _)) = line.split_once('=') {
+      let key = key.trim();
+      if !key.is_empty() && !key.contains(char::is_whitespace) {
+        docs.insert(key.to_string(), pending.join(" "));
+      }
+    }
+    pending.clear();
+  }
+  docs
+}
+
+/// The SHA-256 pins recorded at one [`Artifact::pin`] locator.
+///
+/// Either a path-keyed manifest (`&[("weights/weight.bin", "<hex>"), ..]`, the
+/// shape every per-kit `model_io` gate uses) or bare hex literals (the shape a
+/// scalar `TOKENIZER_SHA256_HEX` uses). Both are read as text: the pins live in
+/// other test binaries and in feature-gated modules, so they cannot be
+/// imported — but they CAN be read, which is what
+/// `tests/whisper/models_lock.rs` already does to hold the fp16 roster.
+enum Pins {
+  /// Bundle-relative path to SHA-256.
+  Manifest(BTreeMap<String, String>),
+  /// Bare SHA-256 literals.
+  Literals(BTreeSet<String>),
+}
+
+/// Cut markers for the end of a pinned item: the next thing that starts at
+/// column zero. A pin list never contains one, so the window is exactly the
+/// declaration that was anchored.
+const ITEM_END: &[&str] = &[
+  "\nconst ",
+  "\npub const ",
+  "\nfn ",
+  "\npub fn ",
+  "\nstatic ",
+  "\n#[",
+  "\n/// ",
+  "\n//!",
+  "\n}",
+];
+
+/// Reads `<crate-relative source>::<identifier>`.
+///
+/// The identifier is anchored on its DECLARATION (`const NAME:` or `fn NAME(`),
+/// not on a bare mention, and the declaration must occur exactly once — an
+/// ambiguous anchor is a reader that could silently read the wrong pin.
+fn pins_at(locator: &str) -> Pins {
+  let (rel, ident) = locator
+    .split_once("::")
+    .unwrap_or_else(|| panic!("pin locator {locator:?} is not `<source>::<identifier>`"));
+  let text = read_rel(rel);
+
+  let konst = format!("const {ident}:");
+  let func = format!("fn {ident}(");
+  let anchor = if text.matches(konst.as_str()).count() == 1 {
+    konst
+  } else if text.matches(func.as_str()).count() == 1 {
+    func
+  } else {
+    panic!(
+      "pin locator {locator:?}: {rel} holds {} declarations `{konst}` and {} declarations \
+       `{func}`; exactly one of the two must be present exactly once, or this reader could be \
+       reading the wrong pin",
+      text.matches(konst.as_str()).count(),
+      text.matches(func.as_str()).count()
+    )
+  };
+
+  let start = text.find(&anchor).expect("anchor counted above");
+  let rest = &text[start + 1..];
+  let end = ITEM_END
+    .iter()
+    .filter_map(|marker| rest.find(marker))
+    .min()
+    .unwrap_or(rest.len());
+  let window = &text[start..start + 1 + end];
+
+  let quoted: Vec<&str> = window.split('"').skip(1).step_by(2).collect();
+  let manifest: BTreeMap<String, String> = quoted
+    .windows(2)
+    .filter(|pair| is_sha256(pair[1]) && !is_sha256(pair[0]))
+    .map(|pair| (pair[0].to_string(), pair[1].to_string()))
+    .collect();
+  if manifest.is_empty() {
+    let literals: BTreeSet<String> = quoted
+      .iter()
+      .filter(|q| is_sha256(q))
+      .map(|q| (*q).to_string())
+      .collect();
+    assert!(
+      !literals.is_empty(),
+      "pin locator {locator:?}: no SHA-256 found under `{anchor}`. The reader anchored, so the \
+       declaration moved or stopped holding hashes."
+    );
+    Pins::Literals(literals)
+  } else {
+    Pins::Manifest(manifest)
+  }
+}
+
+/// Whether `s` is 64 lowercase hex digits.
+fn is_sha256(s: &str) -> bool {
+  s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// The bundle-relative key a row's pin manifest is looked up by: whatever
+/// follows the last `.mlmodelc/`, or the bare file name when the artifact is
+/// not inside a compiled bundle.
+fn bundle_relative(file: &str) -> &str {
+  file
+    .rsplit_once(".mlmodelc/")
+    .map_or_else(|| file.rsplit('/').next().unwrap_or(file), |(_, tail)| tail)
+}
+
+// ---------------------------------------------------------------------------
+// The live checks — the real table, the real lock, the real manifest
+// ---------------------------------------------------------------------------
+
+/// **Direction 1.** Every repository `MODELS_LOCK` stages is covered by a
+/// licence row, and every row names a repository that is actually staged.
+///
+/// Both halves, because either one alone rots: coverage-only lets a row
+/// outlive the table it describes, and reverse-only lets a new table arrive
+/// with nobody having asked what its bytes permit.
+#[test]
+fn every_staged_repo_has_a_licence_row_and_every_row_names_a_staged_repo() {
+  let Some(tables) = lock_tables() else {
+    return;
+  };
+  assert!(
+    tables.len() >= 8,
+    "only {} MODELS_LOCK tables parsed; this reader has stopped matching the lock's shape and \
+     would pass vacuously",
+    tables.len()
+  );
+  let names: Vec<String> = tables.iter().map(|t| t.name.clone()).collect();
+  let failures = unmatched_coverage(&names, ARTIFACTS);
+  assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// **Direction 2.** No research-only artifact is reachable from `default`, and
+/// none is gated by a feature without the [`COMMERCIAL_PREFIX`].
+///
+/// Vacuous against today's table — nothing is research-only — and deliberately
+/// kept anyway: it is the check the first disqualifying artifact will meet.
+/// `falsifiers::direction_two_*` are what prove it can still fire.
+#[test]
+fn no_research_only_artifact_is_reachable_without_a_commercial_gate() {
+  let block = features_block();
+  let closure = feature_closure(&block, "default");
+  let failures = research_only_reachable(ARTIFACTS, &closure);
+  assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// **Direction 3.** No `commercial-`prefixed feature gates only clear
+/// artifacts.
+#[test]
+fn every_commercial_feature_gates_a_research_only_artifact() {
+  let block = features_block();
+  let features = feature_names(&block);
+  let failures = commercial_features_gating_nothing_restricted(ARTIFACTS, &features);
+  assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Every `commercial-` feature's first documented sentence says a commercial
+/// licence is required — the correction for a prefix that can be read
+/// backwards.
+#[test]
+fn every_commercial_feature_says_it_requires_a_commercial_licence_first() {
+  let Some(block) = repository_features_block() else {
+    return;
+  };
+  assert!(
+    block.contains('#'),
+    "the `[features]` block read for the doc rule carries no comments at all, so the rule would \
+     pass vacuously. That is the stripped manifest `cargo package` writes, not the checked-in one."
+  );
+  let features = feature_names(&block);
+  let docs = feature_docs(&block);
+  let failures = commercial_features_without_the_phrase(&features, &docs);
+  assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// No `commercial-` feature is reachable from `default`.
+///
+/// Stronger than direction 2's first clause and independent of any row: even
+/// before a research-only artifact exists, a gate that `default` turns on is
+/// not a gate. Today `default = []`, so the closure is `{"default"}` and this
+/// holds trivially; it stops holding the moment somebody adds one.
+#[test]
+fn no_commercial_feature_is_reachable_from_default() {
+  let block = features_block();
+  let closure = feature_closure(&block, "default");
+  let leaked: Vec<&String> = closure
+    .iter()
+    .filter(|f| f.starts_with(COMMERCIAL_PREFIX))
+    .collect();
+  assert!(
+    leaked.is_empty(),
+    "`default` enables {leaked:?}. A {COMMERCIAL_PREFIX:?} feature is an opt-in by construction; \
+     reaching it from `default` means every `cargo add coremlit` consumer takes on a licence \
+     obligation without asking for it."
+  );
+}
+
+/// Every row is keyed by a well-formed SHA-256, or carries a reason it cannot
+/// be.
+///
+/// Well-formedness is not pedantry: a truncated or upper-case hash silently
+/// stops matching the pin it is supposed to equal, and a placeholder like
+/// `"TODO"` would sail through a check that only compared strings.
+#[test]
+fn every_row_is_keyed_by_a_wellformed_sha256_or_a_reasoned_exemption() {
+  for row in ARTIFACTS {
+    match row.key {
+      Key::Sha256(hex) => {
+        assert!(
+          is_sha256(hex),
+          "{}: key {hex:?} is not 64 lowercase hex digits",
+          row.file
+        );
+        assert!(
+          !row.pin.is_empty(),
+          "{}: a hashed row must name the pin its hash is copied from, or the hash goes stale the \
+           first time the artifact is re-converted",
+          row.file
+        );
+      }
+      Key::Unpinned(reason) => {
+        assert!(
+          !reason.trim().is_empty(),
+          "{}: an unpinned row with no reason is an exemption nobody can retire",
+          row.file
+        );
+        assert!(
+          row.pin.is_empty(),
+          "{}: an unpinned row names the pin {:?}. If those bytes are pinned, key on them.",
+          row.file,
+          row.pin
+        );
+      }
+    }
+  }
+}
+
+/// A row may be [`Key::Unpinned`] only while its table is on
+/// `revision = "main"`, and every row on a commit-pinned table must be hashed.
+///
+/// The staleness half, in the `CHECKSUMLESS_KITS` style: the exemption is tied
+/// to its cause in both directions, so `MODELS_LOCK`'s LOUD FOLLOW-UP landing —
+/// whisper's two tables moving from `main` to an immutable commit — turns this
+/// red and forces the hashes in, instead of leaving three rows describing bytes
+/// nobody can identify.
+#[test]
+fn unpinned_rows_exist_only_where_the_lock_pins_a_moving_revision() {
+  let Some(tables) = lock_tables() else {
+    return;
+  };
+  let revisions: BTreeMap<&str, &str> = tables
+    .iter()
+    .map(|t| {
+      (
+        t.name.as_str(),
+        t.fields.get("revision").map_or("", String::as_str),
+      )
+    })
+    .collect();
+  let mut moving = 0usize;
+  for row in ARTIFACTS {
+    let revision = revisions.get(row.staged_by).copied().unwrap_or_else(|| {
+      panic!(
+        "{}: staged_by {:?} names no MODELS_LOCK table",
+        row.file, row.staged_by
+      )
+    });
+    if revision == "main" {
+      moving += 1;
+    }
+    match row.key {
+      Key::Sha256(_) => assert_ne!(
+        revision, "main",
+        "{}: keyed by SHA-256, but MODELS_LOCK's {:?} is still on `revision = \"main\"`. The \
+         bytes CI fetches can change without the lock changing, so the hash is a claim about one \
+         download rather than about the artifact.",
+        row.file, row.staged_by
+      ),
+      Key::Unpinned(_) => assert_eq!(
+        revision, "main",
+        "{}: exempt from hashing, but MODELS_LOCK's {:?} pins an immutable revision {revision:?}. \
+         The reason for the exemption is gone — key this row on the bytes at that revision.",
+        row.file, row.staged_by
+      ),
+    }
+  }
+  assert!(
+    moving > 0,
+    "no row sits on a `revision = \"main\"` table, so this check no longer sees the case it \
+     exists for. Delete it, or the exemption it guards."
+  );
+}
+
+/// Every row's SHA-256 equals the pin it names.
+///
+/// The hash is the KEY; a key nothing verifies is a comment. This is what
+/// makes it a key: re-convert an artifact, re-pin its `model_io` gate, and this
+/// goes red until somebody re-reads the licence for the new bytes.
+#[test]
+fn every_rows_sha256_matches_the_pin_it_names() {
+  let mut checked = 0usize;
+  for row in ARTIFACTS {
+    let Some(expected) = row.sha256() else {
+      continue;
+    };
+    match pins_at(row.pin) {
+      Pins::Manifest(manifest) => {
+        let key = bundle_relative(row.file);
+        let pinned = manifest.get(key).unwrap_or_else(|| {
+          panic!(
+            "{}: pin {:?} holds no entry for {key:?} (it holds {:?}). The row names a file its \
+             own pin does not cover.",
+            row.file,
+            row.pin,
+            manifest.keys().collect::<Vec<_>>()
+          )
+        });
+        assert_eq!(
+          pinned, expected,
+          "{}: the licence row keys on {expected} but {} pins {pinned} for {key}. These are \
+           different bytes, and the licence attaches to bytes.",
+          row.file, row.pin
+        );
+      }
+      Pins::Literals(literals) => assert!(
+        literals.contains(expected),
+        "{}: the licence row keys on {expected}, which {} does not pin (it pins {:?}).",
+        row.file,
+        row.pin,
+        literals
+      ),
+    }
+    checked += 1;
+  }
+  assert!(
+    checked >= 10,
+    "only {checked} rows cross-checked against a pin; the table has shrunk or the readers have \
+     stopped matching, and this check would pass vacuously"
+  );
+}
+
+/// **The AuraFace rule.** Two rows over the same SHA-256 agree on what those
+/// bytes permit.
+///
+/// `fal/AuraFace-v1` is tagged `apache-2.0` while four of its five ONNX files
+/// are byte-identical to InsightFace artifacts distributed for non-commercial
+/// research only. Both statements cannot be true of the same bytes: one of them
+/// is the repository's claim about a file it did not train. Keying on the hash
+/// is what makes the contradiction visible instead of letting the second
+/// repository's tag quietly overwrite the first's restriction.
+#[test]
+fn identical_bytes_carry_identical_terms() {
+  let failures = contradictory_terms(ARTIFACTS);
+  assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Rows that key on the same bytes and disagree about them.
+fn contradictory_terms(rows: &[Artifact]) -> Vec<String> {
+  let mut by_hash: BTreeMap<&str, Vec<&Artifact>> = BTreeMap::new();
+  for row in rows {
+    if let Some(hex) = row.sha256() {
+      by_hash.entry(hex).or_default().push(row);
+    }
+  }
+  let mut failures = Vec::new();
+  for (hex, group) in by_hash {
+    let first = group[0];
+    for other in &group[1..] {
+      if first.weights.verdict() != other.weights.verdict()
+        || first.corpus.verdict() != other.corpus.verdict()
+      {
+        failures.push(format!(
+          "sha256 {hex} is claimed by {} (weights {}, corpus {}) and by {} (weights {}, corpus \
+           {}). Identical bytes cannot carry different terms — one row is repeating a repository \
+           tag rather than the licence of the artifact it re-hosts.",
+          first.file,
+          first.weights.verdict(),
+          first.corpus.verdict(),
+          other.file,
+          other.weights.verdict(),
+          other.corpus.verdict(),
+        ));
+      }
+    }
+  }
+  failures
+}
+
+/// Every row's file lives under the directory its `MODELS_LOCK` table stages,
+/// and — where the table names explicit `files` — is one of them.
+///
+/// A row attached to a path its own table does not stage is terms recorded
+/// against the wrong bytes, which is the same class of error as keying by
+/// repository.
+#[test]
+fn every_row_lives_under_the_directory_its_table_stages() {
+  let Some(tables) = lock_tables() else {
+    return;
+  };
+  let by_name: BTreeMap<&str, &LockTable> = tables.iter().map(|t| (t.name.as_str(), t)).collect();
+  for row in ARTIFACTS {
+    let table = by_name.get(row.staged_by).unwrap_or_else(|| {
+      panic!(
+        "{}: staged_by {:?} names no MODELS_LOCK table",
+        row.file, row.staged_by
+      )
+    });
+    let local_dir = table
+      .fields
+      .get("local-dir")
+      .unwrap_or_else(|| panic!("MODELS_LOCK table {:?} has no `local-dir`", row.staged_by));
+    let vendor_path = local_dir
+      .strip_prefix("Models/")
+      .unwrap_or_else(|| panic!("`local-dir` {local_dir:?} does not start with `Models/`"));
+    let prefix = format!("{vendor_path}/");
+    let tail = row.file.strip_prefix(&prefix).unwrap_or_else(|| {
+      panic!(
+        "{}: staged_by {:?} downloads into {local_dir:?}, so the row's path must start with \
+         {prefix:?}",
+        row.file, row.staged_by
+      )
+    });
+    if let Some(files) = table.fields.get("files") {
+      assert!(
+        files.split_whitespace().any(|f| f == tail),
+        "{}: table {:?} stages the explicit file list {files:?}, which does not include {tail:?}",
+        row.file,
+        row.staged_by
+      );
+    }
+  }
+}
+
+/// Every verdict carries prose, and every unresolved one names what is open.
+///
+/// An empty payload turns the table back into a bare SPDX list, which is the
+/// thing it was built not to be — and an `Unresolved` with nothing to follow
+/// is indistinguishable from nobody having looked.
+#[test]
+fn every_verdict_carries_its_reasoning() {
+  for row in ARTIFACTS {
+    for (layer, terms) in [("weights", row.weights), ("corpus", row.corpus)] {
+      assert!(
+        terms.detail().trim().len() > 40,
+        "{}: the {layer} verdict {:?} carries no reasoning ({:?})",
+        row.file,
+        terms.verdict(),
+        terms.detail()
+      );
+    }
+    assert!(
+      !row.source.trim().is_empty(),
+      "{}: no source recorded for its verdicts",
+      row.file
+    );
+  }
+}
+
+/// No file is listed twice; a second row would be unreachable and could
+/// silently disagree with the first.
+#[test]
+fn no_file_is_listed_twice() {
+  let files: BTreeSet<&str> = ARTIFACTS.iter().map(|r| r.file).collect();
+  assert_eq!(
+    files.len(),
+    ARTIFACTS.len(),
+    "the licence table lists a file twice"
+  );
+}
+
+/// The state of the table, asserted rather than remembered.
+///
+/// If this goes red because a row became research-only, that is the point: the
+/// module doc above says no row is, directions 2 and 3 are described as
+/// tripwires, and both statements have to be revisited together.
+#[test]
+fn no_row_is_research_only_today_and_the_doc_says_so() {
+  let restricted: Vec<&str> = ARTIFACTS
+    .iter()
+    .filter(|r| r.disqualifying_layer().is_some())
+    .map(|r| r.file)
+    .collect();
+  assert!(
+    restricted.is_empty(),
+    "these rows are now research-only: {restricted:?}. Directions 2 and 3 are live from here on: \
+     move them behind a `{COMMERCIAL_PREFIX}` feature and rewrite this file's module doc, which \
+     currently tells the reader nothing is restricted."
+  );
+  let unresolved = ARTIFACTS
+    .iter()
+    .filter(|r| matches!(r.corpus, Terms::Unresolved(_)))
+    .count();
+  assert_eq!(
+    unresolved,
+    ARTIFACTS.len(),
+    "the module doc says the corpus layer is unresolved for EVERY row because NOTICE documents \
+     none; that is no longer true, so say what changed."
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Falsifiers — the predicates against input built to trip them
+// ---------------------------------------------------------------------------
+
+/// A check nobody has watched fail is not a check.
+///
+/// Every predicate above is driven here against doctored data: the shape it
+/// must FLAG, and the shape it must not. These run everywhere — no models, no
+/// repository files, no features — so directions 2 and 3 stay demonstrably
+/// live even while the real table has nothing for them to catch.
+mod falsifiers {
+  use std::collections::{BTreeMap, BTreeSet};
+
+  use super::{
+    Artifact, Key, Terms, commercial_features_gating_nothing_restricted,
+    commercial_features_without_the_phrase, contradictory_terms, feature_closure, feature_docs,
+    feature_names, first_sentence, research_only_reachable, unmatched_coverage,
+  };
+
+  /// A row with everything but the fields a given test is about.
+  const fn row(
+    file: &'static str,
+    staged_by: &'static str,
+    gate: &'static str,
+    weights: Terms,
+    corpus: Terms,
+  ) -> Artifact {
+    Artifact {
+      file,
+      key: Key::Sha256("0000000000000000000000000000000000000000000000000000000000000000"),
+      pin: "a falsifier row, never resolved against the tree",
+      staged_by,
+      gate,
+      weights,
+      corpus,
+      source: "a falsifier, not a real record",
+    }
+  }
+
+  const CLEAR: Terms = Terms::Permissive("clear, for a falsifier");
+  const RESTRICTED: Terms =
+    Terms::ResearchOnly("non-commercial research purposes only, for a falsifier");
+
+  fn staged(names: &[&str]) -> Vec<String> {
+    names.iter().map(|n| (*n).to_string()).collect()
+  }
+
+  fn features(names: &[&str]) -> BTreeSet<String> {
+    names.iter().map(|n| (*n).to_string()).collect()
+  }
+
+  // --- direction 1 ---------------------------------------------------------
+
+  #[test]
+  fn direction_one_passes_when_every_table_and_row_line_up() {
+    let rows = [row("a/w.bin", "vendor/one", "kit", CLEAR, CLEAR)];
+    assert!(unmatched_coverage(&staged(&["vendor/one"]), &rows).is_empty());
+  }
+
+  #[test]
+  fn direction_one_reds_when_a_staged_repo_has_no_row() {
+    let rows = [row("a/w.bin", "vendor/one", "kit", CLEAR, CLEAR)];
+    let failures = unmatched_coverage(&staged(&["vendor/one", "vendor/two"]), &rows);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains("vendor/two"), "{failures:?}");
+  }
+
+  #[test]
+  fn direction_one_reds_when_a_row_names_no_staged_repo() {
+    let rows = [
+      row("a/w.bin", "vendor/one", "kit", CLEAR, CLEAR),
+      row("b/w.bin", "vendor/gone", "kit", CLEAR, CLEAR),
+    ];
+    let failures = unmatched_coverage(&staged(&["vendor/one"]), &rows);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains("vendor/gone"), "{failures:?}");
+  }
+
+  // --- direction 2 ---------------------------------------------------------
+
+  #[test]
+  fn direction_two_passes_when_a_restricted_row_sits_behind_an_opt_in_commercial_gate() {
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "commercial-face",
+      CLEAR,
+      RESTRICTED,
+    )];
+    let closure = features(&["default"]);
+    assert!(research_only_reachable(&rows, &closure).is_empty());
+  }
+
+  #[test]
+  fn direction_two_reds_when_a_research_only_row_is_reachable_from_default() {
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "commercial-face",
+      CLEAR,
+      RESTRICTED,
+    )];
+    let closure = features(&["default", "commercial-face"]);
+    let failures = research_only_reachable(&rows, &closure);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("reachable from `default`"),
+      "{failures:?}"
+    );
+    assert!(failures[0].contains("training corpus"), "{failures:?}");
+  }
+
+  #[test]
+  fn direction_two_reds_when_a_research_only_row_is_gated_by_a_plain_feature() {
+    let rows = [row("a/w.bin", "vendor/one", "speaker", RESTRICTED, CLEAR)];
+    let failures = research_only_reachable(&rows, &features(&["default"]));
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains("does not carry"), "{failures:?}");
+    assert!(failures[0].contains("weights layer"), "{failures:?}");
+  }
+
+  #[test]
+  fn direction_two_names_the_weights_layer_when_that_is_what_disqualifies() {
+    let rows = [row("a/w.bin", "vendor/one", "kit", RESTRICTED, CLEAR)];
+    let failures = research_only_reachable(&rows, &features(&["default"]));
+    assert!(failures[0].contains("weights layer"), "{failures:?}");
+  }
+
+  #[test]
+  fn direction_two_names_the_corpus_layer_when_that_is_what_disqualifies() {
+    let rows = [row("a/w.bin", "vendor/one", "kit", CLEAR, RESTRICTED)];
+    let failures = research_only_reachable(&rows, &features(&["default"]));
+    assert!(
+      failures[0].contains("training corpus layer"),
+      "{failures:?}"
+    );
+  }
+
+  #[test]
+  fn direction_two_ignores_unresolved_rows_rather_than_treating_them_as_restricted() {
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "kit",
+      Terms::Unresolved("open question, for a falsifier"),
+      CLEAR,
+    )];
+    assert!(research_only_reachable(&rows, &features(&["default"])).is_empty());
+  }
+
+  // --- direction 3 ---------------------------------------------------------
+
+  #[test]
+  fn direction_three_passes_when_a_commercial_gate_covers_a_restricted_row() {
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "commercial-face",
+      CLEAR,
+      RESTRICTED,
+    )];
+    let declared = features(&["default", "commercial-face"]);
+    assert!(commercial_features_gating_nothing_restricted(&rows, &declared).is_empty());
+  }
+
+  #[test]
+  fn direction_three_reds_when_a_commercial_feature_gates_only_clear_artifacts() {
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "commercial-face",
+      CLEAR,
+      CLEAR,
+    )];
+    let declared = features(&["default", "commercial-face"]);
+    let failures = commercial_features_gating_nothing_restricted(&rows, &declared);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("every artifact it gates is CLEAR"),
+      "{failures:?}"
+    );
+  }
+
+  #[test]
+  fn direction_three_reds_when_a_commercial_feature_gates_nothing_at_all() {
+    let rows = [row("a/w.bin", "vendor/one", "speaker", CLEAR, CLEAR)];
+    let declared = features(&["default", "commercial-face"]);
+    let failures = commercial_features_gating_nothing_restricted(&rows, &declared);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("no licence row is gated by it"),
+      "{failures:?}"
+    );
+  }
+
+  #[test]
+  fn direction_three_leaves_plain_features_alone() {
+    let rows = [row("a/w.bin", "vendor/one", "speaker", CLEAR, CLEAR)];
+    let declared = features(&["default", "speaker", "whisper"]);
+    assert!(commercial_features_gating_nothing_restricted(&rows, &declared).is_empty());
+  }
+
+  // --- the documentation rule ---------------------------------------------
+
+  fn docs(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+      .iter()
+      .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+      .collect()
+  }
+
+  #[test]
+  fn the_doc_rule_passes_on_a_first_sentence_that_says_it() {
+    let declared = features(&["commercial-face"]);
+    let written = docs(&[(
+      "commercial-face",
+      "Requires a commercial licence from the weights' author. Adds the face embedder.",
+    )]);
+    assert!(commercial_features_without_the_phrase(&declared, &written).is_empty());
+  }
+
+  #[test]
+  fn the_doc_rule_accepts_either_spelling() {
+    let declared = features(&["commercial-face"]);
+    let written = docs(&[("commercial-face", "Requires a commercial license. Adds it.")]);
+    assert!(commercial_features_without_the_phrase(&declared, &written).is_empty());
+  }
+
+  #[test]
+  fn the_doc_rule_reds_when_the_phrase_arrives_after_the_first_sentence() {
+    let declared = features(&["commercial-face"]);
+    let written = docs(&[(
+      "commercial-face",
+      "Adds the face embedder. Requires a commercial licence.",
+    )]);
+    let failures = commercial_features_without_the_phrase(&declared, &written);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("has to be the first one"),
+      "{failures:?}"
+    );
+  }
+
+  #[test]
+  fn the_doc_rule_reds_on_an_undocumented_commercial_feature() {
+    let declared = features(&["commercial-face"]);
+    let failures = commercial_features_without_the_phrase(&declared, &docs(&[]));
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("no documentation comment"),
+      "{failures:?}"
+    );
+  }
+
+  #[test]
+  fn the_doc_rule_leaves_plain_features_alone() {
+    let declared = features(&["speaker"]);
+    let written = docs(&[("speaker", "The CoreML segmentation and embedding backends.")]);
+    assert!(commercial_features_without_the_phrase(&declared, &written).is_empty());
+  }
+
+  #[test]
+  fn a_single_sentence_doc_is_read_whole() {
+    assert_eq!(
+      first_sentence("Requires a commercial licence."),
+      "Requires a commercial licence"
+    );
+    assert_eq!(
+      first_sentence("Requires a commercial licence. And more."),
+      "Requires a commercial licence."
+    );
+  }
+
+  // --- the AuraFace rule ---------------------------------------------------
+
+  /// The exact shape that produced this file: one repository tags bytes
+  /// `apache-2.0`, another distributes the same bytes for research only.
+  #[test]
+  fn the_auraface_collision_reds() {
+    const SHA: &str = "aaaa000000000000000000000000000000000000000000000000000000000000";
+    let rows = [
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row(
+          "auraface/glintr100.onnx",
+          "fal/AuraFace-v1",
+          "kit",
+          CLEAR,
+          CLEAR,
+        )
+      },
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row(
+          "insightface/glintr100.onnx",
+          "insightface/buffalo_l",
+          "kit",
+          RESTRICTED,
+          RESTRICTED,
+        )
+      },
+    ];
+    let failures = contradictory_terms(&rows);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].contains(SHA), "{failures:?}");
+  }
+
+  #[test]
+  fn agreeing_rows_over_the_same_bytes_pass() {
+    const SHA: &str = "bbbb000000000000000000000000000000000000000000000000000000000000";
+    let rows = [
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row("one/w.bin", "vendor/one", "kit", CLEAR, CLEAR)
+      },
+      Artifact {
+        key: Key::Sha256(SHA),
+        ..row("two/w.bin", "vendor/two", "kit", CLEAR, CLEAR)
+      },
+    ];
+    assert!(contradictory_terms(&rows).is_empty());
+  }
+
+  // --- the manifest readers ------------------------------------------------
+
+  const DOCTORED_FEATURES: &str = "\
+default = [\"speaker\"]
+speaker = [\"dep:diaric\"]
+# Requires a commercial licence from the weights' author.
+# Adds the face embedder.
+commercial-face = [\"dep:facelib\", \"speaker\"]
+
+# A comment about the section, not about the feature after the blank line.
+
+lid = [\"dep:rustfft\"]
+";
+
+  #[test]
+  fn the_feature_reader_finds_every_declared_name() {
+    assert_eq!(
+      feature_names(DOCTORED_FEATURES),
+      features(&["default", "speaker", "commercial-face", "lid"])
+    );
+  }
+
+  #[test]
+  fn the_closure_follows_this_crates_features_and_not_dependency_features() {
+    assert_eq!(
+      feature_closure(DOCTORED_FEATURES, "default"),
+      features(&["default", "speaker"])
+    );
+    assert_eq!(
+      feature_closure(DOCTORED_FEATURES, "commercial-face"),
+      features(&["commercial-face", "speaker"])
+    );
+  }
+
+  #[test]
+  fn a_doc_block_stops_at_the_blank_line_above_it() {
+    let written = feature_docs(DOCTORED_FEATURES);
+    assert_eq!(
+      written.get("commercial-face").map(String::as_str),
+      Some("Requires a commercial licence from the weights' author. Adds the face embedder.")
+    );
+    assert_eq!(written.get("lid").map(String::as_str), Some(""));
+  }
+
+  /// The same manifest with `default` pulling the commercial gate in — the
+  /// mutation direction 2's first clause exists for, read through the real
+  /// manifest reader rather than a hand-built set.
+  const LEAKY_FEATURES: &str = "\
+default = [\"commercial-face\"]
+speaker = [\"dep:diaric\"]
+# Requires a commercial licence from the weights' author.
+commercial-face = [\"dep:facelib\", \"speaker\"]
+";
+
+  #[test]
+  fn a_default_that_pulls_in_a_commercial_gate_is_visible_to_the_reader() {
+    let closure = feature_closure(LEAKY_FEATURES, "default");
+    assert_eq!(
+      closure,
+      features(&["default", "commercial-face", "speaker"])
+    );
+  }
+
+  #[test]
+  fn the_leaky_manifest_reds_on_direction_two() {
+    let closure = feature_closure(LEAKY_FEATURES, "default");
+    let rows = [row(
+      "a/w.bin",
+      "vendor/one",
+      "commercial-face",
+      CLEAR,
+      RESTRICTED,
+    )];
+    let failures = research_only_reachable(&rows, &closure);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+      failures[0].contains("reachable from `default`"),
+      "{failures:?}"
+    );
+  }
+}


### PR DESCRIPTION
Infrastructure for #115: a licence register keyed to artifacts, and a three-direction check that keeps it honest. **No face model, no `commercial-`gated artifact** — #115's model choice is still unresolved.

## Why it is keyed to artifacts and not repositories

The whole lesson of the #115 investigation: `fal/AuraFace-v1` is tagged `apache-2.0` while **four of its five ONNX files are byte-identical to InsightFace artifacts under "non-commercial research purposes only"**. A repo-keyed table gets four rows wrong and reads as clearance.

`ARTIFACTS` is 17 rows over all nine `MODELS_LOCK` tables. Each carries the file, its SHA-256 (or `Key::Unpinned` with a reason), **the pin it copied that hash from**, the staging repo, the gate, and `weights` / `corpus` terms as separate `Terms` values — because those are different questions and the second is where nearly every model fails.

## The three directions, and the one people forget

Red on all three, in the style of `CHECKSUMLESS_KITS`:

1. a staged artifact with no licence row — **and** a row naming no staged repo;
2. a research-only row reachable from `default`;
3. **a `commercial-`prefixed feature gating an artifact whose row is actually clear.**

Direction 3 is the one that keeps the table honest as artifacts change, and it is the one that gets left out.

Plus: the `commercial-` feature's documentation must say "requires a commercial licence" **in its first sentence** — because that prefix can be read backwards as "cleared for commercial use", and the sentence is what stops it.

## Nothing is research-only today, and that is a finding, not a clean bill of health

**Zero rows are research-only and no `commercial-` feature exists**, so directions 2 and 3 cannot fire against live data. Every disqualification candidate sits in `Terms::Unresolved` at the **corpus** layer — because `NOTICE` documents the weights layer for all ten components and the training-corpus layer for **none**. That is a fact about this repository's records.

Because a tripwire nobody has watched trip is not a tripwire, all three predicates are pure functions driven by **20 hermetic falsifiers over doctored input**, and a test asserts the "nothing is research-only" claim itself so it cannot go stale silently. What binds live data today: direction 1 both ways, the SHA↔pin cross-check over all 14 hashed rows, the `Unpinned`↔`revision = "main"` tie, row↔`local-dir` containment, and `no_commercial_feature_is_reachable_from_default`.

14 mutations, every one an assertion panic. Two classes — neuter a predicate and watch its falsifiers red, then mutate the real inputs and watch the live gate red:

- deleted the lid row → *"MODELS_LOCK stages … and no licence row covers it"*
- retyped a `staged_by` → *"a licence row is staged_by … which no MODELS_LOCK table names"*
- flipped the shipping wespeaker corpus to research-only → *"…but its gate `speaker` does not carry the `commercial-` prefix"*
- same row behind `commercial-speaker`, with `default = ["commercial-speaker"]` → *"reachable from `default`, so a plain `cargo add coremlit` turns it on"*
- `commercial-face` gating the clear lid row → *"every artifact it gates is CLEAR"*
- one nibble of a SHA → *"keys on …aac68 but tests/lid/common/mod.rs pins …aac67"*
- two rows sharing a hash with different terms → the AuraFace collision rule, on live rows

## Three things I had wrong, and one of them is the exact mistake this table exists to prevent

**`MODELS_LOCK` pins no SHA-256s at all.** I briefed "it already pins SHA-256s; key to the same hashes." It carries nine 40-hex git `revision`s (two of them the moving `"main"`) and mentions `CHECKSUMS.sha256` only in prose. The per-file digests live in the per-kit gates. So each row now names the pin it copied from and `every_rows_sha256_matches_the_pin_it_names` re-reads it — otherwise the hashes go stale at the next re-conversion. Whisper's three artifacts have no hash anywhere, which is what `Key::Unpinned` is for.

**I asserted the wespeaker weights are CC-BY-4.0 per `NOTICE` — and that is precisely the conflation this register exists to stop.** `NOTICE` §4 records the WeSpeaker embedder as *"see its model license"* and names none. The CC-BY-4.0 in that section belongs to `pyannote/speaker-diarization-community-1` — the PLDA — and to FluidInference's parent pyannote model, **not** to the embedder weights. Both wespeaker rows are `Unresolved`, with that mistake named in the payload so the next reader does not repeat it.

**`every_shipped_model_graph_survives_fp16` is not plain `#[ignore]`** but `#[cfg_attr(not(models_present), ignore)]`, driven by `build.rs`. On a checkout with a downloaded model tree it runs. The ignored count is machine-dependent, which is worth knowing before comparing baselines.

## Verification

All five gates 0 before and after. **74 → 75 binaries, 1813 → 1852 passed (+39, exactly the new file), 0 failed, 450 → 450 ignored — unchanged.** The file declares no `#[ignore]`, so ci.yml's per-kit `--list --ignored` census is unaffected in every shard. `--no-run` under default features went 6 → 7, confirming the gate builds and runs with `default = []`.
