### PR TITLE
fix(coremlit/whisper): a transcript stem and a model name are one path component, refused otherwise (#114, #120)

### DIFF
--- a/coremlit/src/audio/whisper/error/mod.rs
+++ b/coremlit/src/audio/whisper/error/mod.rs
@@ -38,6 +38,39 @@ impl InvalidState {
   }
 }
 
+/// A model name is not one plain path component.
+///
+/// Payload of [`ModelError::ModelName`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelName {
+  /// The name the caller passed.
+  name: String,
+  /// Why it is not one path component, as a phrase completing
+  /// `` `{name}` ... ``.
+  reason: &'static str,
+}
+
+impl ModelName {
+  /// Construct from the offending name and the phrase naming its defect.
+  #[inline(always)]
+  pub const fn new(name: String, reason: &'static str) -> Self {
+    Self { name, reason }
+  }
+
+  /// The name the caller passed.
+  #[inline(always)]
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  /// Why it is not one path component, as a phrase completing
+  /// `` `{name}` ... ``.
+  #[inline(always)]
+  pub const fn reason(&self) -> &'static str {
+    self.reason
+  }
+}
+
 /// Failure locating, loading, or using a CoreML-backed Whisper model.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
@@ -56,6 +89,15 @@ pub enum ModelError {
   /// A [`crate::audio::whisper::model::ModelInfo`] was constructed with an empty name.
   #[error("model info name must not be empty")]
   EmptyName,
+  /// The model name handed to
+  /// [`detect_model_url`](crate::audio::whisper::model::detect_model_url) is
+  /// not one plain path component, so `{folder}/{name}.mlmodelc` would resolve
+  /// somewhere other than the folder the caller named. Nothing on disk was
+  /// looked at. Distinct from [`Self::EmptyName`], which is
+  /// [`ModelInfo`](crate::audio::whisper::model::ModelInfo)'s own constructor
+  /// guard over a different name.
+  #[error("model name `{}` {}", .0.name(), .0.reason())]
+  ModelName(ModelName),
   /// A [`crate::audio::whisper::model::SupportConfig`] JSON document was malformed or had
   /// an unexpected shape. Carries a rendered message rather than the
   /// originating `serde_json::Error` because that type implements

--- a/coremlit/src/audio/whisper/mod.rs
+++ b/coremlit/src/audio/whisper/mod.rs
@@ -355,6 +355,9 @@ pub mod error;
 pub mod log;
 pub mod model;
 pub mod options;
+/// The one rule every door here that joins a caller's string to a directory
+/// asks first: is that string ONE plain path component? (#114, #120.)
+pub(crate) mod path_component;
 pub mod provenance;
 pub mod result;
 pub mod segment;

--- a/coremlit/src/audio/whisper/model/mod.rs
+++ b/coremlit/src/audio/whisper/model/mod.rs
@@ -50,7 +50,10 @@ use std::path::{Path, PathBuf};
 use crate::ComputeUnits;
 use serde_json::Value;
 
-use crate::audio::whisper::error::ModelError;
+use crate::audio::whisper::{
+  error::{ModelError, ModelName},
+  path_component::single_path_component,
+};
 
 // ---------------------------------------------------------------------
 // ModelState
@@ -289,9 +292,20 @@ pub const fn detect_variant(logits_dim: usize, encoder_dim: usize) -> Option<Mod
 /// caller in this crate needs ([`LocalModelLoader::resolve`] in
 /// particular).
 ///
+/// `name` names a bundle DIRECTLY inside `folder`, so it must be one plain
+/// path component — non-empty, holding no `/`, no `\` and no NUL byte, and
+/// neither `.` nor `..`. Every candidate is `name` plus a fixed suffix joined
+/// to `folder`, so a `name` carrying path syntax joins to a bundle in another
+/// directory entirely: `../other` to `folder`'s parent, an absolute one to
+/// wherever it points (#120). The check runs before any filesystem access,
+/// under both `recursive` settings.
+///
 /// # Errors
+/// [`ModelError::ModelName`] if `name` is not one plain path component;
 /// [`ModelError::NotFound`] if no matching bundle exists.
 pub fn detect_model_url(folder: &Path, name: &str, recursive: bool) -> Result<PathBuf, ModelError> {
+  let name = single_path_component(name)
+    .map_err(|defect| ModelError::ModelName(ModelName::new(name.to_owned(), defect.reason())))?;
   let compiled = folder.join(format!("{name}.mlmodelc"));
 
   if recursive {
@@ -327,6 +341,12 @@ pub fn detect_model_url(folder: &Path, name: &str, recursive: bool) -> Result<Pa
 /// subdirectories are silently skipped rather than aborting the whole
 /// search (matches the enumerator's own default error-handling, which
 /// simply omits entries it cannot read).
+///
+/// `target_name` is one plain path component, because [`detect_model_url`]
+/// builds it from a `name` it has already checked. The comparison below is
+/// against [`Path::file_name`], which a string carrying a separator can never
+/// equal, so an unchecked name would turn this into a full walk of the tree
+/// guaranteed to find nothing.
 fn find_named_recursive(folder: &Path, target_name: &str) -> Option<PathBuf> {
   // Iterative worklist, descending only into REAL directories
   // (`DirEntry::file_type` does not follow symlinks): a self-referential

--- a/coremlit/src/audio/whisper/model/tests.rs
+++ b/coremlit/src/audio/whisper/model/tests.rs
@@ -516,3 +516,59 @@ fn recursive_detection_survives_symlink_cycles() {
   std::fs::create_dir_all(&nested).unwrap();
   assert_eq!(detect_model_url(dir.path(), "Found", true).unwrap(), nested);
 }
+
+// ---------------------------------------------------------------------
+// the model name is ONE path component (#120)
+// ---------------------------------------------------------------------
+
+/// A bed whose model `folder` is a SUBdirectory, holding, OUTSIDE that folder,
+/// exactly the bundle an escaping name reaches: `<root>/other.mlmodelc` for
+/// `../other`, `<folder>/sub/model.mlmodelc` for `sub/model`.
+fn name_bed() -> (tempfile::TempDir, PathBuf) {
+  let root = tempfile::tempdir().unwrap();
+  let folder = root.path().join("models");
+  std::fs::create_dir_all(root.path().join("other.mlmodelc")).unwrap();
+  std::fs::create_dir_all(folder.join("sub/model.mlmodelc")).unwrap();
+  (root, folder)
+}
+
+#[test]
+fn detect_model_url_refuses_a_name_that_is_not_one_path_component() {
+  // Before the guard (#120) `../other` resolved to `<bed>/other.mlmodelc` and
+  // an absolute name to whatever it pointed at -- a bundle OUTSIDE the folder
+  // the caller named -- under BOTH `recursive` settings.
+  for recursive in [false, true] {
+    let (bed, _) = name_bed();
+    let absolute_inside_the_bed = bed.path().join("other").display().to_string();
+    for name in [
+      "../other",
+      "sub/model",
+      "/abs",
+      &absolute_inside_the_bed,
+      ".",
+      "..",
+      "",
+      "back\\slash",
+      "nul\0byte",
+    ] {
+      let (_root, folder) = name_bed();
+      let err = detect_model_url(&folder, name, recursive).unwrap_err();
+      match err {
+        ModelError::ModelName(ref payload) => {
+          assert_eq!(payload.name(), name, "wrong name reported");
+          assert!(!payload.reason().is_empty(), "no reason reported");
+        }
+        other => panic!("recursive={recursive} accepted {name:?}: {other:?}"),
+      }
+    }
+  }
+
+  // The guard refuses the SPELLING, not the bundle: the nested
+  // `<folder>/sub/model.mlmodelc` the refused `sub/model` aimed at is still
+  // reachable the documented way -- its own plain name, recursively.
+  let (_root, folder) = name_bed();
+  assert_eq!(
+    detect_model_url(&folder, "model", true).unwrap(),
+    folder.join("sub/model.mlmodelc")
+  );
+}

--- a/coremlit/src/audio/whisper/path_component/mod.rs
+++ b/coremlit/src/audio/whisper/path_component/mod.rs
@@ -1,0 +1,104 @@
+//! One rule, asked by every door here that builds a path out of a caller's
+//! string: is that string ONE plain path component?
+//!
+//! Two doors take a caller-controlled string, append a fixed suffix, and join
+//! the result to a directory the caller configured earlier —
+//! [`ResultWriter::write`](crate::audio::whisper::result::writer::ResultWriter::write)'s
+//! `file_stem` under the writer's `output_dir` (#114), and
+//! [`detect_model_url`](crate::audio::whisper::model::detect_model_url)'s
+//! `name` under its `folder` (#120). A join is not a concatenation:
+//! `dir.join("../x")` names a file in `dir`'s PARENT and `dir.join("/x")`
+//! discards `dir` altogether, so a string carrying path syntax silently
+//! redirects the write, or the read, to a directory other than the one the
+//! caller configured.
+//!
+//! [`single_path_component`] refuses exactly the spellings that change WHICH
+//! directory a join resolves into, and nothing else: no Unicode
+//! normalisation, no length cap, no reserved-name list, no case folding.
+//! Whether the surviving name is one this filesystem will actually accept —
+//! too long, already taken, on a read-only mount — is the filesystem's
+//! business, reported by the `std::fs` call that runs into it.
+//!
+//! `.` and `..` are refused as the components they are, even though both call
+//! sites append a suffix before joining (`..` in fact reaches
+//! `folder/...mlmodelc`, an ordinary file, and escapes nothing). The rule is a
+//! property of the caller's STRING, not of one caller's suffix: a door that
+//! ever joins the string bare must get the same answer from it.
+//!
+//! `\` is refused alongside `/` though macOS treats it as an ordinary
+//! filename byte. A transcript stem and a model name both travel — into an
+//! archive entry, onto an SMB share, to a Windows client — and are read as
+//! two components wherever they land; neither of these two doors has a caller
+//! that wants one, so refusing it costs nothing here.
+
+#[cfg(test)]
+mod tests;
+
+/// Why a caller's string is not one plain path component.
+///
+/// Crate-private on purpose: each door maps this into ITS own public error
+/// ([`WriteError::FileStem`](crate::audio::whisper::result::writer::WriteError::FileStem),
+/// [`ModelError::ModelName`](crate::audio::whisper::error::ModelError::ModelName)),
+/// which is what a caller matches on. [`Self::reason`] is the phrase those
+/// errors render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum PathComponentDefect {
+  /// The string is empty, so it names nothing to join.
+  Empty,
+  /// The string holds `/` or `\`, so joining it descends or escapes.
+  Separator,
+  /// The string holds a NUL byte, which no filesystem path can carry.
+  Nul,
+  /// The string is `.`, which names a directory rather than an entry in one.
+  CurrentDirectory,
+  /// The string is `..`, which names the parent directory.
+  ParentDirectory,
+}
+
+impl PathComponentDefect {
+  /// The phrase a door's error renders after the offending string, as
+  /// `` `{string}` {reason} ``.
+  pub(crate) const fn reason(self) -> &'static str {
+    match self {
+      Self::Empty => "is empty",
+      Self::Separator => "contains a path separator (`/` or `\\`)",
+      Self::Nul => "contains a NUL byte",
+      Self::CurrentDirectory => "is `.`, which names a directory rather than an entry in one",
+      Self::ParentDirectory => "is `..`, which names the parent directory",
+    }
+  }
+}
+
+/// `s` unchanged when it is one plain path component; its defect otherwise.
+///
+/// Accepted iff `s` is non-empty, holds no `/`, no `\` and no NUL byte, and is
+/// neither `.` nor `..`. That is the whole rule — see this module's doc for
+/// why nothing else belongs in it.
+///
+/// # Errors
+/// The [`PathComponentDefect`] the string tripped, whose
+/// [`reason`](PathComponentDefect::reason) each caller renders into its own
+/// error type.
+pub(crate) fn single_path_component(s: &str) -> Result<&str, PathComponentDefect> {
+  if s.is_empty() {
+    return Err(PathComponentDefect::Empty);
+  }
+  // A BYTE scan is exactly a scan for these three characters: `/`, `\` and NUL
+  // are ASCII, and no byte of a multi-byte UTF-8 sequence is ever below 0x80,
+  // so no `char` boundary can hide one and none can be spelled accidentally by
+  // a continuation byte.
+  for byte in s.bytes() {
+    match byte {
+      b'/' | b'\\' => return Err(PathComponentDefect::Separator),
+      0 => return Err(PathComponentDefect::Nul),
+      _ => {}
+    }
+  }
+  // After the scan, so `../x` reports the separator that actually escapes
+  // rather than a `..` prefix that does not appear on its own.
+  match s {
+    "." => Err(PathComponentDefect::CurrentDirectory),
+    ".." => Err(PathComponentDefect::ParentDirectory),
+    _ => Ok(s),
+  }
+}

--- a/coremlit/src/audio/whisper/path_component/tests.rs
+++ b/coremlit/src/audio/whisper/path_component/tests.rs
@@ -1,0 +1,94 @@
+use super::{
+  PathComponentDefect::{CurrentDirectory, Empty, Nul, ParentDirectory, Separator},
+  *,
+};
+
+#[test]
+fn one_plain_component_is_accepted_and_every_other_spelling_names_its_defect() {
+  // ACCEPTED: everything that joins to exactly one entry of the given
+  // directory, however unusual it looks.
+  for accepted in [
+    "talk",
+    "MelSpectrogram",
+    "a.b",
+    "a b",
+    "文件",
+    "...",
+    ".hidden",
+    "..a",
+    "a..",
+    "-",
+    "a-b_c.d",
+    "with:colon",
+    "with*star",
+    "a\tb",
+    "a\nb",
+  ] {
+    assert_eq!(
+      single_path_component(accepted),
+      Ok(accepted),
+      "refused a plain component {accepted:?}"
+    );
+  }
+
+  // REFUSED: every spelling that changes WHICH directory the join resolves
+  // into, each reported as the defect it actually trips.
+  for (refused, defect) in [
+    ("", Empty),
+    ("/", Separator),
+    ("/abs", Separator),
+    ("a/b", Separator),
+    ("a/", Separator),
+    ("./a", Separator),
+    ("../escape", Separator),
+    ("..//..", Separator),
+    ("sub/dir", Separator),
+    ("\\", Separator),
+    ("back\\slash", Separator),
+    ("..\\escape", Separator),
+    (".", CurrentDirectory),
+    ("..", ParentDirectory),
+    ("\0", Nul),
+    ("nul\0byte", Nul),
+  ] {
+    assert_eq!(
+      single_path_component(refused),
+      Err(defect),
+      "wrong verdict for {refused:?}"
+    );
+  }
+}
+
+#[test]
+fn the_rule_is_only_about_which_directory_a_join_resolves_into() {
+  // No length cap: a name too long for the filesystem is the filesystem's
+  // `ENAMETOOLONG` to report, not this rule's.
+  let long = "x".repeat(64 * 1024);
+  assert_eq!(single_path_component(&long), Ok(long.as_str()));
+
+  // No reserved-name list: these are ordinary names where this crate runs, and
+  // none of them redirects a join.
+  for name in ["CON", "NUL", "aux", "COM1", "$MFT", "lost+found"] {
+    assert_eq!(single_path_component(name), Ok(name));
+  }
+
+  // No Unicode normalisation: the composed and decomposed spellings of `café`
+  // are different strings and stay different names, which is exactly what
+  // `std::fs` will do with them.
+  let nfc = "caf\u{e9}";
+  let nfd = "cafe\u{301}";
+  assert_ne!(nfc, nfd);
+  assert_eq!(single_path_component(nfc), Ok(nfc));
+  assert_eq!(single_path_component(nfd), Ok(nfd));
+}
+
+#[test]
+fn every_defect_renders_a_distinct_reason() {
+  let defects = [Empty, Separator, Nul, CurrentDirectory, ParentDirectory];
+  for (i, a) in defects.iter().enumerate() {
+    assert!(!a.reason().is_empty());
+    for b in &defects[i + 1..] {
+      assert_ne!(a.reason(), b.reason(), "{a:?} and {b:?} render the same");
+    }
+  }
+}

--- a/coremlit/src/audio/whisper/result/writer/mod.rs
+++ b/coremlit/src/audio/whisper/result/writer/mod.rs
@@ -22,7 +22,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::audio::whisper::result::TranscriptionResult;
+use crate::audio::whisper::{path_component::single_path_component, result::TranscriptionResult};
 
 #[cfg(test)]
 mod tests;
@@ -206,6 +206,39 @@ impl Write {
   }
 }
 
+/// The transcript file stem is not one plain path component.
+///
+/// Payload of [`WriteError::FileStem`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileStem {
+  /// The stem the caller passed.
+  stem: String,
+  /// Why it is not one path component, as a phrase completing
+  /// `` `{stem}` ... ``.
+  reason: &'static str,
+}
+
+impl FileStem {
+  /// Construct from the offending stem and the phrase naming its defect.
+  #[inline(always)]
+  pub const fn new(stem: String, reason: &'static str) -> Self {
+    Self { stem, reason }
+  }
+
+  /// The stem the caller passed.
+  #[inline(always)]
+  pub fn stem(&self) -> &str {
+    &self.stem
+  }
+
+  /// Why it is not one path component, as a phrase completing
+  /// `` `{stem}` ... ``.
+  #[inline(always)]
+  pub const fn reason(&self) -> &'static str {
+    self.reason
+  }
+}
+
 /// Failure writing a rendered transcript to disk. Swift's `ResultWriting`
 /// protocol has no equivalent typed error -- every conformer folds every
 /// failure into `Result<String, Error>`'s boxed existential `Error`
@@ -220,6 +253,11 @@ pub enum WriteError {
   /// forwards both of through `#[error(transparent)]`.
   #[error(transparent)]
   Write(#[from] Write),
+  /// The `file_stem` is not one plain path component, so
+  /// `{output_dir}/{file_stem}.{ext}` would resolve outside the writer's
+  /// `output_dir`. Nothing was rendered and nothing was written.
+  #[error("transcript file stem `{}` {}", .0.stem(), .0.reason())]
+  FileStem(FileStem),
   /// Serializing the result to JSON failed.
   #[cfg(feature = "serde")]
   #[error("failed to serialize result: {0}")]
@@ -243,7 +281,14 @@ pub trait ResultWriter {
   /// Renders `result` and writes it to `{output_dir}/{file_stem}.{ext}`,
   /// returning the written path.
   ///
+  /// `file_stem` is joined to `output_dir`, so it must be one plain path
+  /// component: a stem carrying path syntax picks a destination outside the
+  /// configured directory — `../escape` its parent, an absolute stem anywhere
+  /// at all — and the atomic rename then replaces whatever is there (#114).
+  ///
   /// # Errors
+  /// [`WriteError::FileStem`] if `file_stem` is not one plain path component,
+  /// checked before anything is rendered or written;
   /// [`WriteError::Write`] if the underlying file write fails.
   fn write(&self, result: &TranscriptionResult, file_stem: &str) -> Result<PathBuf, WriteError>;
 }
@@ -266,6 +311,15 @@ impl SrtWriter {
       output_dir: output_dir.into(),
     }
   }
+}
+
+/// The stem guard every writer runs FIRST: `file_stem` is joined to
+/// `output_dir`, so it must be one plain path component (see
+/// [`crate::audio::whisper::path_component`]). Returns the stem unchanged, or
+/// the refusal as this module's own error.
+fn checked_stem(file_stem: &str) -> Result<&str, WriteError> {
+  single_path_component(file_stem)
+    .map_err(|defect| WriteError::FileStem(FileStem::new(file_stem.to_owned(), defect.reason())))
 }
 
 /// Writes `contents` to `path` atomically: staged into a sibling
@@ -320,7 +374,9 @@ impl ResultWriter for SrtWriter {
   }
 
   fn write(&self, result: &TranscriptionResult, file_stem: &str) -> Result<PathBuf, WriteError> {
-    let path = self.output_dir.join(format!("{file_stem}.srt"));
+    let path = self
+      .output_dir
+      .join(format!("{}.srt", checked_stem(file_stem)?));
     write_atomic(&path, &srt_content(result))?;
     Ok(path)
   }
@@ -348,7 +404,9 @@ impl ResultWriter for VttWriter {
   }
 
   fn write(&self, result: &TranscriptionResult, file_stem: &str) -> Result<PathBuf, WriteError> {
-    let path = self.output_dir.join(format!("{file_stem}.vtt"));
+    let path = self
+      .output_dir
+      .join(format!("{}.vtt", checked_stem(file_stem)?));
     write_atomic(&path, &vtt_content(result))?;
     Ok(path)
   }
@@ -379,8 +437,9 @@ impl ResultWriter for JsonWriter {
   }
 
   fn write(&self, result: &TranscriptionResult, file_stem: &str) -> Result<PathBuf, WriteError> {
+    let stem = checked_stem(file_stem)?;
     let content = json_content(result)?;
-    let path = self.output_dir.join(format!("{file_stem}.json"));
+    let path = self.output_dir.join(format!("{stem}.json"));
     write_atomic(&path, &content)?;
     Ok(path)
   }

--- a/coremlit/src/audio/whisper/result/writer/tests.rs
+++ b/coremlit/src/audio/whisper/result/writer/tests.rs
@@ -208,3 +208,126 @@ fn write_error_is_transparent_over_its_payload_and_keeps_the_chain_at_depth_one(
   }
   assert_eq!(depth, 1, "the source chain must stay at depth 1");
 }
+
+// ---------------------------------------------------------------------
+// file_stem is ONE path component (#114)
+// ---------------------------------------------------------------------
+
+/// A bed whose `output_dir` is a SUBdirectory: an escaping stem lands inside
+/// `root`, which the `TempDir` still removes, so no falsifier here writes
+/// outside its own temporary tree.
+fn escape_bed() -> (tempfile::TempDir, PathBuf) {
+  let root = tempfile::tempdir().unwrap();
+  let out = root.path().join("out");
+  std::fs::create_dir(&out).unwrap();
+  (root, out)
+}
+
+/// Every entry under `root`, relative and sorted -- what the falsifiers compare
+/// against to prove NOTHING was written.
+fn tree(root: &Path) -> Vec<PathBuf> {
+  let mut found = Vec::new();
+  let mut work = vec![root.to_path_buf()];
+  while let Some(dir) = work.pop() {
+    for entry in std::fs::read_dir(&dir).unwrap().flatten() {
+      let path = entry.path();
+      found.push(path.strip_prefix(root).unwrap().to_path_buf());
+      if entry.file_type().unwrap().is_dir() {
+        work.push(path);
+      }
+    }
+  }
+  found.sort();
+  found
+}
+
+/// One boxed writer per shipped format, all pointed at `dir`.
+fn every_writer(dir: &Path) -> Vec<(&'static str, Box<dyn ResultWriter>)> {
+  #[allow(unused_mut)]
+  let mut writers: Vec<(&'static str, Box<dyn ResultWriter>)> = vec![
+    ("srt", Box::new(SrtWriter::new(dir))),
+    ("vtt", Box::new(VttWriter::new(dir))),
+  ];
+  #[cfg(feature = "serde")]
+  writers.push(("json", Box::new(JsonWriter::new(dir))));
+  writers
+}
+
+#[test]
+fn writers_refuse_a_file_stem_that_is_not_one_path_component() {
+  // Before the guard (#114) every one of these was joined to `output_dir` and
+  // written: `../escape` landed at `<bed>/escape.srt`, one level ABOVE the
+  // configured directory, and an absolute stem landed wherever it pointed --
+  // the atomic rename replacing whatever was already there.
+  let result = result_with_segment(vec![]);
+  let (bed, _) = escape_bed();
+  let absolute_inside_the_bed = bed.path().join("absolute").display().to_string();
+  for stem in [
+    "../escape",
+    "sub/dir",
+    "/abs",
+    &absolute_inside_the_bed,
+    ".",
+    "..",
+    "",
+    "back\\slash",
+    "nul\0byte",
+  ] {
+    let (root, out) = escape_bed();
+    // `out/sub` EXISTS, so `sub/dir` is a destination the unguarded join
+    // reached successfully: what refuses it here is the rule, not the
+    // filesystem running out of directories.
+    std::fs::create_dir(out.join("sub")).unwrap();
+    let before = tree(root.path());
+    for (ext, writer) in every_writer(&out) {
+      let err = writer.write(&result, stem).unwrap_err();
+      match err {
+        WriteError::FileStem(ref payload) => {
+          assert_eq!(payload.stem(), stem, "{ext} reported the wrong stem");
+          assert!(!payload.reason().is_empty(), "{ext} reported no reason");
+        }
+        other => panic!("{ext} accepted stem {stem:?}: {other:?}"),
+      }
+    }
+    assert_eq!(
+      tree(root.path()),
+      before,
+      "a refused stem {stem:?} still wrote something"
+    );
+  }
+  // An ABSOLUTE stem ignores `output_dir` entirely, so it targets this bed
+  // rather than the per-case one the loop compares: prove it is untouched too.
+  assert_eq!(tree(bed.path()), vec![PathBuf::from("out")]);
+}
+
+#[test]
+fn writers_keep_writing_plain_stems() {
+  let result = result_with_segment(vec![]);
+  for stem in ["talk", "a.b", "文件", "a b"] {
+    let (root, out) = escape_bed();
+    for (ext, writer) in every_writer(&out) {
+      let path = writer.write(&result, stem).unwrap();
+      assert_eq!(path, out.join(format!("{stem}.{ext}")), "{ext} {stem:?}");
+      let expected = match ext {
+        "srt" => srt_content(&result),
+        "vtt" => vtt_content(&result),
+        #[cfg(feature = "serde")]
+        "json" => json_content(&result).unwrap(),
+        other => unreachable!("unknown writer {other}"),
+      };
+      assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        expected,
+        "{ext} {stem:?}"
+      );
+    }
+    let mut expected = vec![PathBuf::from("out")];
+    expected.extend(
+      every_writer(&out)
+        .iter()
+        .map(|(ext, _)| PathBuf::from("out").join(format!("{stem}.{ext}"))),
+    );
+    expected.sort();
+    assert_eq!(tree(root.path()), expected, "stem {stem:?}");
+  }
+}

--- a/coremlit/src/embeddings/clap/text/mod.rs
+++ b/coremlit/src/embeddings/clap/text/mod.rs
@@ -212,6 +212,10 @@ impl TextEncoder {
   /// [`TEXT_MAX_TOKENS`], pre-padding, RoBERTa special tokens included) — the
   /// sequence that is identity-comparable to textclap (`tests/clap/tokenizer_identity.rs`).
   ///
+  /// Tokenization runs over the whole of `text` before any truncation, so the
+  /// cost is linear in the input's length and the input budget is the caller's
+  /// (#118).
+  ///
   /// # Errors
   /// [`Error::EmptyText`] if `text` is empty; [`Error::Tokenize`] on a tokenizer
   /// failure.
@@ -224,6 +228,10 @@ impl TextEncoder {
   }
 
   /// Embeds one text query into a unit-norm [`Embedding`].
+  ///
+  /// Tokenization runs over the whole of `text` before any truncation, so the
+  /// cost is linear in the input's length and the input budget is the caller's
+  /// (#118).
   ///
   /// # Errors
   /// [`Error::EmptyText`] if `text` is empty; [`Error::Tokenize`] on a tokenizer

--- a/coremlit/src/embeddings/granite/mod.rs
+++ b/coremlit/src/embeddings/granite/mod.rs
@@ -501,6 +501,10 @@ impl TextEmbedder {
   /// identity-comparable to the committed goldens
   /// (`tests/granite/tokenizer_identity.rs`).
   ///
+  /// Tokenization runs over the whole of `text` before any truncation, so the
+  /// cost is linear in the input's length and the input budget is the caller's
+  /// (#118).
+  ///
   /// # Errors
   /// [`Error::EmptyText`] if `text` is empty; [`Error::Tokenize`] on a tokenizer
   /// failure.
@@ -514,6 +518,10 @@ impl TextEmbedder {
 
   /// Embeds one text into a unit-norm [`Embedding`]. Prompt-free: feed the raw
   /// string.
+  ///
+  /// Tokenization runs over the whole of `text` before any truncation, so the
+  /// cost is linear in the input's length and the input budget is the caller's
+  /// (#118).
   ///
   /// # Errors
   /// [`Error::EmptyText`] if `text` is empty; [`Error::Tokenize`] on a tokenizer
@@ -616,6 +624,11 @@ impl TextEmbedder {
   /// `embed_long_with(text, &LongTextOptions::new())`.
   ///
   /// Text that fits a single window returns exactly [`Self::embed`]'s embedding.
+  ///
+  /// Tokenization runs over the whole of `text` before any chunking, so the cost
+  /// is linear in the input's length and the input budget is the caller's
+  /// ([`LongTextOptions::max_input_bytes`], on [`Self::embed_long_with`], is the
+  /// bound to set for untrusted input) (#118).
   ///
   /// # Errors
   /// As [`Self::embed_long_with`].

--- a/coremlit/src/embeddings/siglip/text/mod.rs
+++ b/coremlit/src/embeddings/siglip/text/mod.rs
@@ -391,6 +391,10 @@ impl TextEmbedder {
   /// UNPADDED ids): SigLIP attends every position and pools the final one, so the
   /// pad positions are part of the semantic input and belong in the window (D6).
   ///
+  /// Tokenization runs over the whole of `text` before any truncation, so the
+  /// cost is linear in the input's length and the input budget is the caller's
+  /// (#118).
+  ///
   /// # Errors
   /// [`Error::EmptyText`] if `text` is empty; [`Error::Tokenize`] on a tokenizer
   /// failure; [`Error::TokenCount`] if the tokenized input exceeds the window
@@ -410,6 +414,10 @@ impl TextEmbedder {
   }
 
   /// Embeds one text into a unit-norm [`Embedding`].
+  ///
+  /// Tokenization runs over the whole of `text` before any truncation, so the
+  /// cost is linear in the input's length and the input budget is the caller's
+  /// (#118).
   ///
   /// # Errors
   /// [`Error::EmptyText`] if `text` is empty; [`Error::Tokenize`] on a tokenizer


### PR DESCRIPTION
Closes #114, closes #120.