### PR TITLE
feat(coremlit/whisper): every kept language probe reaches the result as a spanned LanguageObservation; the folded languages stay (#107)

### DIFF
--- a/coremlit/src/audio/whisper/audio/chunker/mod.rs
+++ b/coremlit/src/audio/whisper/audio/chunker/mod.rs
@@ -9,6 +9,7 @@ use crate::audio::whisper::{
   constants::SAMPLE_RATE,
   error::{AudioError, InvalidClipRange},
   result::{TranscriptionResult, TranscriptionSegment},
+  segment::shift_span,
 };
 
 #[cfg(test)]
@@ -117,28 +118,63 @@ pub fn prepare_seek_clips(
 /// (`TranscriptionUtilities.swift:55-69`) applied per segment as the
 /// chunker's `updateSeekOffsetsForResults` does (`AudioChunker.swift:14-39`).
 /// Re-anchors a whole per-chunk result: stamps [`TranscriptionResult`]'s
-/// `seek_time` and shifts every segment and word.
+/// `seek_time`, shifts every segment and word, and shifts every
+/// [`TranscriptionResult::language_observations_slice`] span.
 ///
 /// Ports the result-level half of `updateSeekOffsetsForResults`
 /// (`AudioChunker.swift:14-39`, `seekTime` assignment at `:29`);
 /// [`apply_seek_offsets`] is its per-segment core.
+///
+/// **Rust-only addition, no Swift counterpart:** the language-observation
+/// shift (coremlit issue #107). Those spans are stated in the same time base as
+/// the segments beside them, so re-anchoring one and not the other would leave a
+/// merged VAD transcript holding chunk-relative probe spans against absolute
+/// segment times — the exact confusion this function exists to prevent. Swift
+/// has nothing to shift here because it never carries the observations at all.
+///
+/// # One re-anchoring contract
+///
+/// Observations and segments both shift through
+/// [`crate::audio::whisper::segment`]'s `shift_span`, the far-side counterpart
+/// of the `window_span` that timed them: it preserves that helper's
+/// nonempty-window guarantee across the shift, so a short final window's probe
+/// and its segment still agree — and still have an extent — after a chunk
+/// offset large enough for the two endpoint additions to round onto each other.
+/// Adding the offset to each endpoint independently gave that guarantee back at
+/// the door: a valid local `0.0 .. 1/16000` shifted by 32_768_000 samples
+/// reached the merged result as `2048.0 .. 2048.0`.
 pub fn apply_result_seek_offset(result: &mut TranscriptionResult, seek_offset: usize) {
   let seek_seconds = seek_offset as f32 / crate::audio::whisper::constants::SAMPLE_RATE as f32;
   result.set_seek_time(seek_seconds);
   apply_seek_offsets(result.segments_slice_mut(), seek_offset);
+  for observation in result.language_observations_slice_mut() {
+    let (start, end) = shift_span(observation.start(), observation.end(), seek_seconds);
+    observation.set_start(start).set_end(end);
+  }
 }
 
 /// Shifts segments (seek, times, and word times) by an absolute chunk
 /// offset — the per-segment core of [`apply_result_seek_offset`].
 ///
 /// Ports `TranscriptionUtilities.updateSegmentTimings`
-/// (`TranscriptionUtilities.swift:55-69`).
+/// (`TranscriptionUtilities.swift:55-69`). The segment span re-anchors through
+/// [`crate::audio::whisper::segment`]'s `shift_span` — see
+/// [`apply_result_seek_offset`]'s own doc for the contract, and the body for
+/// why the word spans do not.
 pub fn apply_seek_offsets(segments: &mut [TranscriptionSegment], seek_offset: usize) {
   let seek_seconds = seek_offset as f32 / SAMPLE_RATE as f32;
   for segment in segments {
     segment.set_seek(segment.seek() + seek_offset);
-    segment.set_start(segment.start() + seek_seconds);
-    segment.set_end(segment.end() + seek_seconds);
+    let (start, end) = shift_span(segment.start(), segment.end(), seek_seconds);
+    segment.set_start(start).set_end(end);
+    // The WORDS keep the plain addition. Their spans carry a guarantee ACROSS
+    // the list -- `find_alignment`'s `w[i].end() <= w[i + 1].start() + 1e-4`
+    // (see `stream::agreement`'s module doc) -- and the nudge is per span, so
+    // applying it here would break that ordering in exactly the regime it
+    // fires in: two adjacent sub-ulp words both absorb onto the same shifted
+    // instant, and nudging each end alone puts `w[i].end()` one ulp (2.44e-4 s
+    // at 2048 s) ABOVE `w[i + 1].start()`, past the 1e-4 tolerance. The plain
+    // shift collapses them instead, which is degenerate but still ordered.
     for word in segment.words_slice_mut() {
       word.set_start(word.start() + seek_seconds);
       word.set_end(word.end() + seek_seconds);

--- a/coremlit/src/audio/whisper/audio/chunker/tests.rs
+++ b/coremlit/src/audio/whisper/audio/chunker/tests.rs
@@ -170,3 +170,81 @@ fn apply_result_seek_offset_stamps_seek_time_and_shifts_nested_times() {
   assert_eq!(segment.start(), 3.0);
   assert_eq!(segment.words_slice()[0].end(), 3.5);
 }
+
+#[test]
+fn apply_result_seek_offset_reanchors_a_short_window_without_collapsing_it() {
+  // coremlit issue #107, codex round 2. `segment::window_span` guarantees a
+  // window that held audio reports `end > start`, and BOTH the lump segment
+  // and the language observation for that window are timed through it -- but
+  // re-anchoring the chunk added the offset to each endpoint on its own, and
+  // the two additions round independently. A chunk starting at 32_768_000
+  // samples (2048 s) has an f32 ulp of 2.44e-4 s, above a one-sample duration
+  // of 6.25e-5 s, so every endpoint absorbs onto 2048.0 and a probe that saw
+  // audio reached the merged result as zero-width evidence.
+  //
+  // The audio a VAD run would need to reach that offset is 131 MB of f32, so
+  // this drives the offset utility the finding names directly, through the
+  // public constructors, with the spans a real short final window produces.
+  //
+  // Mutation proof: give `segment::shift_span` the per-endpoint body
+  // `(start + offset_seconds, end + offset_seconds)` and both the observation
+  // and the segment come back as `2048.0 .. 2048.0`.
+  use crate::audio::whisper::{
+    result::TranscriptionTimings,
+    segment::window_span,
+    transcribe::{LanguageDetection, LanguageObservation},
+  };
+
+  let (local_start, local_end) = window_span(0, 1);
+  assert!(local_end > local_start, "the local span is valid going in");
+  let mut segment = TranscriptionSegment::new();
+  segment.set_start(local_start).set_end(local_end);
+  let mut result = TranscriptionResult::new("hi", vec![segment], "es", TranscriptionTimings::new())
+    .with_language_observations(vec![LanguageObservation::new(
+      local_start,
+      local_end,
+      LanguageDetection::new("es", vec![("es".to_string(), 0.9)]),
+    )]);
+
+  apply_result_seek_offset(&mut result, 32_768_000);
+
+  let observation = &result.language_observations_slice()[0];
+  let segment = &result.segments_slice()[0];
+  assert_eq!(observation.start(), 2048.0, "the chunk begins at 2048 s");
+  assert!(
+    observation.end() > observation.start(),
+    "a kept probe cannot become zero-width evidence: {} .. {}",
+    observation.start(),
+    observation.end()
+  );
+  assert_eq!(
+    observation.end(),
+    observation.start().next_up(),
+    "one ulp above the shifted start, not on it"
+  );
+  // The point of the shared helper: the observation and the segment describing
+  // the SAME window stay equal by construction on the far side of the shift,
+  // exactly as `window_span` keeps them equal on the near side.
+  assert_eq!(
+    (observation.start(), observation.end()),
+    (segment.start(), segment.end()),
+    "one re-anchoring contract, not two"
+  );
+}
+
+#[test]
+fn apply_seek_offsets_leaves_a_zero_length_segment_zero_length() {
+  // The nudge is for a span that HAD an extent. A zero-length segment reaches
+  // the shift on the VAD path before `TranscribeTask::run`'s `:217-218` filter
+  // drops it, and inventing an extent for it here would hide it from that
+  // filter.
+  let mut segment = TranscriptionSegment::new();
+  segment.set_start(0.0).set_end(0.0);
+  let mut segments = vec![segment];
+  apply_seek_offsets(&mut segments, 32_768_000);
+  assert_eq!(
+    (segments[0].start(), segments[0].end()),
+    (2048.0, 2048.0),
+    "no extent going in, no spurious extent coming out"
+  );
+}

--- a/coremlit/src/audio/whisper/result/mod.rs
+++ b/coremlit/src/audio/whisper/result/mod.rs
@@ -30,6 +30,7 @@ use crate::audio::whisper::{
   constants::DEFAULT_LANGUAGE_CODE,
   options::DecodingOptions,
   task_facts::{SpanKnowledge, TaskFacts, TaskFactsAccumulator},
+  transcribe::LanguageObservation,
 };
 
 pub mod writer;
@@ -1229,11 +1230,45 @@ pub struct TranscriptionResult {
   segments: Vec<TranscriptionSegment>,
   /// Detected or configured spoken language (ISO code). Empty means
   /// undetermined (golden empty-means-absent).
+  ///
+  /// The Swift-faithful DISPLAY language, folded LAST-WRITE-WINS over the
+  /// decode's per-window language probes — plus, for a window that did not
+  /// probe, that window's own decoded language and finally the `"en"` fallback.
+  /// Those probes are no longer discarded by the fold:
+  /// [`Self::language_observations_slice`] carries them (coremlit issue #107).
   #[cfg_attr(
     feature = "serde",
     serde(default, skip_serializing_if = "String::is_empty")
   )]
   language: String,
+  /// Every language probe the decode ran AND kept, spanned, in window order —
+  /// the EVIDENCE the two folded languages were folded from (coremlit issue
+  /// #107).
+  ///
+  /// One entry per decode window whose automatic-language probe ran and belonged
+  /// to the attempt whose decode was kept; a window with no probe (detection
+  /// off, a configured language, a monolingual model) or whose kept attempt's
+  /// probe failed contributes nothing, so an empty list means "no kept probe",
+  /// never "probed and discarded". Spans share the segments' time base and are
+  /// re-anchored with them by
+  /// [`chunker::apply_result_seek_offset`](crate::audio::whisper::audio::chunker::apply_result_seek_offset);
+  /// a merge concatenates the children's lists in result order.
+  ///
+  /// **Relationship to the folded languages.** [`Self::language`] is
+  /// last-write-wins over these and
+  /// [`TaskFacts::observed_language`](crate::audio::whisper::task_facts::TaskFacts::observed_language)
+  /// first-genuine-wins over them; BOTH keep the exact rules they had before
+  /// this list existed, and this list is additive evidence, never an input to
+  /// either. Neither is a pure function of it, so do not re-derive them here: a
+  /// configured or fallback display language probes nothing at all, and a decode
+  /// that PREDICTS a `<|lang|>` token feeds `observed_language` with no probe
+  /// behind it. What the list does carry, and the scalars cannot, is the
+  /// per-window geography — where each probe fell and how confident it was.
+  #[cfg_attr(
+    feature = "serde",
+    serde(default, skip_serializing_if = "Vec::is_empty")
+  )]
+  language_observations: Vec<LanguageObservation>,
   /// Aggregated pipeline timings.
   #[cfg_attr(feature = "serde", serde(default))]
   timings: TranscriptionTimings,
@@ -1300,6 +1335,9 @@ impl TranscriptionResult {
       text: text.into(),
       segments: segments.into(),
       language: language.into(),
+      // A hand-built result ran no probe, so it witnessed none. The pipeline
+      // sets the real list via `with_language_observations`.
+      language_observations: Vec::new(),
       timings,
       seek_time: None,
       // A hand-built result controlled no decode, so it cannot OBSERVE whether a
@@ -1380,6 +1418,44 @@ impl TranscriptionResult {
   #[inline(always)]
   pub fn set_language(&mut self, language: impl Into<String>) -> &mut Self {
     self.language = language.into();
+    self
+  }
+
+  // -- language_observations (Vec<LanguageObservation>) ---------------------
+  /// Every language probe the decode ran and kept, spanned, in window order —
+  /// the evidence [`Self::language`] and
+  /// [`TaskFacts::observed_language`](crate::audio::whisper::task_facts::TaskFacts::observed_language)
+  /// were folded from, and empty when no probe was kept. See the field's doc
+  /// for the fold relationship and the span's time base.
+  #[inline(always)]
+  pub const fn language_observations_slice(&self) -> &[LanguageObservation] {
+    self.language_observations.as_slice()
+  }
+  /// Mutable view of the observations (fixed length; use
+  /// [`Self::set_language_observations`] to replace the collection) — chunk
+  /// re-anchoring shifts their spans directly, exactly as it does the
+  /// segments' through [`Self::segments_slice_mut`].
+  #[inline(always)]
+  pub const fn language_observations_slice_mut(&mut self) -> &mut [LanguageObservation] {
+    self.language_observations.as_mut_slice()
+  }
+  /// Builder form of [`Self::set_language_observations`].
+  #[must_use]
+  #[inline(always)]
+  pub fn with_language_observations(
+    mut self,
+    language_observations: impl Into<Vec<LanguageObservation>>,
+  ) -> Self {
+    self.set_language_observations(language_observations);
+    self
+  }
+  /// Sets [`Self::language_observations_slice`] in place.
+  #[inline(always)]
+  pub fn set_language_observations(
+    &mut self,
+    language_observations: impl Into<Vec<LanguageObservation>>,
+  ) -> &mut Self {
+    self.language_observations = language_observations.into();
     self
   }
 
@@ -2359,6 +2435,16 @@ fn min_timing(results: &[TranscriptionResult], f: impl Fn(&TranscriptionTimings)
 ///   re-anchors chunk results before its own call into this merge.
 /// - [`TranscriptionResult::language`][]: the first result's language, or
 ///   [`DEFAULT_LANGUAGE_CODE`] if `results` is empty (:104).
+/// - [`TranscriptionResult::language_observations_slice`][]: every child's
+///   observations, concatenated in result order — no Swift counterpart (this
+///   list is coremlit issue #107's own addition). Nothing is deduplicated or
+///   re-spanned: children are expected to already carry timeline-correct spans
+///   from [`crate::audio::whisper::audio::chunker::apply_result_seek_offset`],
+///   exactly as their segments are. Overlapping children therefore yield
+///   overlapping observations — the streaming finalize, whose children are
+///   successive re-transcriptions of one growing buffer, repeats a window's
+///   probe once per hypothesis that re-decoded it, precisely as it repeats that
+///   window's segments.
 /// - [`TranscriptionResult::timings`][]: [`TranscriptionTimings::model_loading`]/
 ///   [`prewarm_load_time`](TranscriptionTimings::prewarm_load_time)/
 ///   [`encoder_load_time`](TranscriptionTimings::encoder_load_time)/
@@ -2680,6 +2766,16 @@ fn merge_results(results: &[TranscriptionResult], skip_empty_texts: bool) -> Tra
     |first| first.language().to_string(),
   );
 
+  // Every child's kept probes, concatenated in result order (coremlit issue
+  // #107). The merged DISPLAY language above stays the first child's, unchanged
+  // — this list is the evidence, not a re-derivation of it, and a merge that
+  // silently dropped it would put the fold's information loss back at the VAD
+  // and streaming doors the merge exists to serve.
+  let language_observations: Vec<LanguageObservation> = results
+    .iter()
+    .flat_map(|result| result.language_observations_slice().iter().cloned())
+    .collect();
+
   let earliest_pipeline_start = min_timing(results, TranscriptionTimings::pipeline_start);
   let latest_pipeline_end = results
     .iter()
@@ -2847,7 +2943,9 @@ fn merge_results(results: &[TranscriptionResult], skip_empty_texts: bool) -> Tra
   }
   let task_facts = task_facts.into_facts();
 
-  TranscriptionResult::new(text, segments, language, timings).with_task_facts(task_facts)
+  TranscriptionResult::new(text, segments, language, timings)
+    .with_language_observations(language_observations)
+    .with_task_facts(task_facts)
 }
 
 // ---------------------------------------------------------------------

--- a/coremlit/src/audio/whisper/segment/mod.rs
+++ b/coremlit/src/audio/whisper/segment/mod.rs
@@ -47,6 +47,69 @@ use crate::{
   },
 };
 
+/// The seconds span of one decode window's own audio: `samples` unpadded
+/// samples starting `seek` samples into the run.
+///
+/// ONE rounding contract, shared by [`find_seek_point_and_segments`]'s segment
+/// timing and by the language observation
+/// [`crate::audio::whisper::transcribe::TranscribeTask::run`] records for the
+/// same window, so the two can never disagree about the window they both
+/// describe (coremlit issue #107).
+///
+/// The start is `seek` converted once; the end is that start PLUS the
+/// duration, never the sum `seek + samples` converted as a whole. Above 2^24
+/// samples (~17.5 min) adjacent sample indices share one f32, so converting
+/// the sum collapses a short final window onto its own start — a one-sample
+/// window at 1050 s reports `1050.0 .. 1050.0` although the decoder saw audio.
+///
+/// A nonempty window always gets `end > start`. From 2048 s on, one f32 ulp
+/// of the start exceeds a one-sample duration and even the addition absorbs
+/// it, so the end is nudged to the next representable value instead. Swift's
+/// `SegmentSeeker` computes the addition without that guard and reports the
+/// zero-length span (documented deviation, in a regime where the window did
+/// consume audio and Swift's own `:217-218` filter deletes what it produced).
+pub(crate) fn window_span(seek: usize, samples: usize) -> (f32, f32) {
+  let start = seek as f32 / SAMPLE_RATE as f32;
+  let end = start + samples as f32 / SAMPLE_RATE as f32;
+  if samples > 0 && end <= start {
+    return (start, start.next_up());
+  }
+  (start, end)
+}
+
+/// The same span re-anchored `offset_seconds` later — the ONE re-anchoring
+/// contract, shared by every span
+/// [`crate::audio::whisper::audio::chunker::apply_result_seek_offset`] lifts
+/// out of a VAD chunk's own timeline into the original one.
+///
+/// [`window_span`] guarantees a window that held audio reports `end > start`;
+/// adding the offset to each endpoint on its own throws that guarantee away
+/// again, because the two additions round independently. From 2048 s on, one
+/// f32 ulp of the shifted start (2.44e-4 s) exceeds a short window's whole
+/// duration, so a valid local span `0.0 .. 1/16000` shifted by 32_768_000
+/// samples lands on `2048.0 .. 2048.0` — a kept probe, or a lump segment,
+/// whose evidence is zero-width although the decoder saw audio. This helper
+/// preserves the guarantee across the shift: a span that came in nonempty
+/// leaves nonempty, its end nudged to the next representable value above the
+/// shifted start rather than onto it. Observations and segments both re-anchor
+/// through it, so the two can no more disagree about the window they describe
+/// after the shift than [`window_span`] lets them before it.
+///
+/// A span that came in EMPTY (`end == start`) is left exactly as shifted, with
+/// no nudge. The segment path can legitimately hold one — a zero-length
+/// segment survives until
+/// [`crate::audio::whisper::transcribe::TranscribeTask::run`]'s `:217-218`
+/// filter drops it — and inventing an extent here would hide it from that
+/// filter.
+pub(crate) fn shift_span(start: f32, end: f32, offset_seconds: f32) -> (f32, f32) {
+  let shifted_start = start + offset_seconds;
+  let shifted_end = end + offset_seconds;
+  if end > start && shifted_end <= shifted_start {
+    return (shifted_start, shifted_start.next_up());
+  }
+  (shifted_start, shifted_end)
+}
+
 /// Turns `decoding` — the just-decoded window starting at `current_seek`
 /// samples — into the next seek offset and, unless the window was silent,
 /// the [`TranscriptionSegment`]s it contains. `all_segments_count` seeds
@@ -93,7 +156,7 @@ pub fn find_seek_point_and_segments(
   let time_token = special.time_token_begin();
   let special_token_begin = special.special_token_begin();
   let mut seek = current_seek;
-  let time_offset = current_seek as f32 / SAMPLE_RATE as f32;
+  let (time_offset, window_end) = window_span(current_seek, segment_size);
 
   // :57-74 — silence skip: no-speech probability above threshold skips the
   // window entirely, unless overridden by high average confidence.
@@ -134,14 +197,15 @@ pub fn find_seek_point_and_segments(
   if slice_indexes.is_empty() {
     // :149-186 — no consecutive timestamps anywhere: lump the whole window
     // into one segment.
-    let mut duration_seconds = segment_size as f32 / SAMPLE_RATE as f32;
+    // The window's own span end, unless a timestamp token below refines it.
+    let mut segment_end = window_end;
     let timestamp_tokens: Vec<u32> = current_tokens
       .iter()
       .copied()
       .filter(|&t| t > time_token)
       .collect();
     if let Some(&last_timestamp) = timestamp_tokens.last() {
-      duration_seconds = (last_timestamp - time_token) as f32 * SECONDS_PER_TIME_TOKEN;
+      segment_end = time_offset + (last_timestamp - time_token) as f32 * SECONDS_PER_TIME_TOKEN;
     }
 
     let word_tokens: Vec<u32> = current_tokens
@@ -161,7 +225,7 @@ pub fn find_seek_point_and_segments(
         .with_id(all_segments_count + segments.len())
         .with_seek(seek)
         .with_start(time_offset)
-        .with_end(time_offset + duration_seconds)
+        .with_end(segment_end)
         .with_text(segment_text)
         .with_tokens(current_tokens)
         .with_token_log_probs(current_log_probs)
@@ -172,7 +236,7 @@ pub fn find_seek_point_and_segments(
     );
 
     // Model gave no consecutive-timestamp boundary, so the whole window is
-    // consumed regardless of the refined duration above (Swift's own
+    // consumed regardless of the refined end above (Swift's own
     // upstream TODO at `:184-185` notes the more accurate
     // `durationSeconds`-based advance is not yet used either).
     seek += segment_size;

--- a/coremlit/src/audio/whisper/segment/tests.rs
+++ b/coremlit/src/audio/whisper/segment/tests.rs
@@ -1453,3 +1453,171 @@ fn swift_parity_gather_truncates_final_alignment_row() {
   assert_eq!(complete_segment_end, complete_end);
   assert_eq!(parity_segment_end, parity_end);
 }
+
+#[test]
+fn window_span_never_collapses_a_short_final_window_onto_its_start() {
+  // coremlit issue #107. `seek` and `seek + samples` are distinct usize
+  // sample indices, but from 2^24 samples (~17.5 min) on they share one f32,
+  // so converting each endpoint separately reported a window that ended
+  // where it began -- although the decoder had just encoded and probed that
+  // sample. Converting the START once and ADDING the duration keeps them
+  // apart: one sample at 1050 s is over half an f32 ulp of the start, so the
+  // sum rounds to exactly the next representable value.
+  //
+  // Mutation proof: give `window_span` the per-endpoint body
+  // `(seek as f32 / SR, (seek + samples) as f32 / SR)` and both assertions
+  // below fail with `start == end == 1050.0`.
+  let (start, end) = window_span(16_800_000, 1);
+  assert_eq!(start, 1050.0, "1050 s is exactly representable in f32");
+  assert!(
+    end > start,
+    "a window that held audio cannot end where it began: {start} .. {end}"
+  );
+  assert_eq!(end, start.next_up(), "one ulp above the start, not on it");
+}
+
+#[test]
+fn window_span_nudges_an_end_the_addition_itself_absorbs() {
+  // From 2048 s on, one f32 ulp of the start (2.44e-4 s) exceeds a one-sample
+  // duration (6.25e-5 s), so even `start + samples / SAMPLE_RATE` rounds back
+  // onto `start` and the addition alone is no longer enough. 32_768_000
+  // samples is the first whole second where that happens; the guard nudges
+  // the end to the next representable value instead of reporting a window
+  // that consumed audio as empty.
+  let seek: usize = 32_768_000;
+  let start = seek as f32 / SAMPLE_RATE as f32;
+  assert_eq!(
+    start + 1.0 / SAMPLE_RATE as f32,
+    start,
+    "the unguarded addition absorbs a one-sample duration at 2048 s"
+  );
+  let (guarded_start, end) = window_span(seek, 1);
+  assert_eq!(guarded_start, 2048.0);
+  assert_eq!(
+    end,
+    start.next_up(),
+    "absorbed, so nudged rather than empty"
+  );
+}
+
+#[test]
+fn window_span_of_a_large_ordinary_window_is_its_own_duration() {
+  // 2^24 + 1 samples: the start is itself no longer exactly representable
+  // (it rounds down to 2^24), the regime the per-endpoint conversion broke
+  // in. A full 30 s window still spans 30 s, to within one ulp of the start.
+  let seek = (1usize << 24) + 1;
+  let (start, end) = window_span(seek, 480_000);
+  let ulp = start.next_up() - start;
+  assert!(
+    (end - start - 30.0).abs() <= ulp,
+    "a 30 s window spans 30 s within one ulp ({ulp}): {start} .. {end}"
+  );
+}
+
+#[test]
+fn window_span_of_an_empty_window_is_empty() {
+  // The nudge is for a window that HELD audio; a zero-sample window honestly
+  // ends where it begins, and `TranscribeTask::run` breaks before decoding
+  // one.
+  let (start, end) = window_span(16_800_000, 0);
+  assert_eq!(start, end, "no audio, no extent");
+}
+
+#[test]
+fn shift_span_never_collapses_a_span_the_shift_absorbs() {
+  // coremlit issue #107, codex round 2. `window_span` hands out a nonempty
+  // span; re-anchoring it by adding the chunk offset to each endpoint on its
+  // own gave that guarantee straight back, because the two additions round
+  // independently. At a 2048 s offset one f32 ulp of the shifted start
+  // (2.44e-4 s) exceeds a one-sample duration (6.25e-5 s), so BOTH endpoints
+  // absorb onto 2048.0 and a probe that saw audio reports zero width.
+  //
+  // Mutation proof: give `shift_span` the per-endpoint body
+  // `(start + offset_seconds, end + offset_seconds)` and the two assertions
+  // below fail with `shifted_start == shifted_end == 2048.0`.
+  let (start, end) = window_span(0, 1);
+  assert!(end > start, "the local span is valid before the shift");
+  let offset_seconds = 32_768_000f32 / SAMPLE_RATE as f32;
+  let (shifted_start, shifted_end) = shift_span(start, end, offset_seconds);
+  assert_eq!(
+    shifted_start, 2048.0,
+    "2048 s is exactly representable in f32"
+  );
+  assert!(
+    shifted_end > shifted_start,
+    "a span that had an extent cannot lose it to re-anchoring: \
+     {shifted_start} .. {shifted_end}"
+  );
+  assert_eq!(
+    shifted_end,
+    shifted_start.next_up(),
+    "one ulp above the shifted start, not on it"
+  );
+}
+
+#[test]
+fn shift_span_of_an_ordinary_shift_is_exact() {
+  // Away from the absorption regime the helper is the plain addition it
+  // replaced -- no epsilon, no nudge, exact values.
+  assert_eq!(shift_span(1.0, 2.0, 2.0), (3.0, 4.0));
+  assert_eq!(shift_span(0.5, 0.75, 0.25), (0.75, 1.0));
+  assert_eq!(
+    shift_span(1.0, 2.0, 0.0),
+    (1.0, 2.0),
+    "a zero offset moves nothing"
+  );
+}
+
+#[test]
+fn shift_span_leaves_an_originally_empty_span_empty() {
+  // The nudge is for a span that HAD an extent. A zero-length segment is a
+  // legitimate intermediate on the segment path -- `TranscribeTask::run`'s
+  // `:217-218` filter is what removes it -- so re-anchoring must not invent an
+  // extent that hides it from that filter.
+  //
+  // Mutation proof: drop the `end > start` precondition from `shift_span` --
+  // leaving `if shifted_end <= shifted_start` alone, which is TRUE here -- and
+  // the empty span comes back one ulp wide.
+  assert_eq!(shift_span(1.0, 1.0, 2.0), (3.0, 3.0), "an ordinary shift");
+  let offset_seconds = 32_768_000f32 / SAMPLE_RATE as f32;
+  let (start, end) = shift_span(1.0, 1.0, offset_seconds);
+  assert_eq!(
+    start, end,
+    "no extent going in, no spurious extent coming out: {start} .. {end}"
+  );
+  assert_eq!(start, 2049.0, "1 s into a chunk that begins at 2048 s");
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn lump_segment_carries_the_shared_window_span() {
+  // The segment half of the one-rounding-contract fix (coremlit issue #107):
+  // a timestamp-less window lumps into a single segment whose span is the
+  // window's own, and it is computed by the SAME `window_span` a language
+  // observation for that window is, at the offsets where the two used to be
+  // able to disagree.
+  //
+  // Mutation proof: the per-endpoint body reds this too -- the lump segment
+  // would be reported as ending at 1050.0, where it started.
+  let t = tiny_tokenizer();
+  let seek = 16_800_000usize;
+  let r = result_with_tokens(vec![50258, 100], 0.0, -0.2);
+  let (next_seek, segments) =
+    find_seek_point_and_segments(&r, &DecodingOptions::new(), 0, seek, 1, &t).unwrap();
+  let segments = segments.expect("a confident window is not silence-skipped");
+  assert_eq!(
+    segments.len(),
+    1,
+    "no timestamps at all -> one lump segment"
+  );
+  assert_eq!(next_seek, seek + 1, "the lump branch consumes the window");
+  assert_eq!(
+    (segments[0].start(), segments[0].end()),
+    window_span(seek, 1),
+    "the segment is timed through the observation's own helper"
+  );
+  assert!(
+    segments[0].end() > segments[0].start(),
+    "the window held a sample, so its segment has an extent"
+  );
+}

--- a/coremlit/src/audio/whisper/task_facts/mod.rs
+++ b/coremlit/src/audio/whisper/task_facts/mod.rs
@@ -373,6 +373,17 @@ pub struct TaskFacts {
   /// [`TranscriptionResult::language`](crate::audio::whisper::result::TranscriptionResult::language)
   /// carries — this is never that `"en"` display string, and never inferred.
   ///
+  /// **The evidence behind the fold** (coremlit issue #107): a decode's
+  /// per-window language probes now also reach the result WHOLE, as
+  /// [`TranscriptionResult::language_observations_slice`](crate::audio::whisper::result::TranscriptionResult::language_observations_slice)
+  /// — spans and probabilities included. This field's rule is UNCHANGED by that:
+  /// it stays the FIRST genuine observation, folded exactly as before. The two
+  /// are not redundant and neither replaces the other. This scalar can carry an
+  /// observation with no probe behind it (a decode that PREDICTED a `<|lang|>`
+  /// token) and survives a chunk that observed then errored and was dropped,
+  /// which the span-anchored list cannot; the list carries the per-window
+  /// geography and confidences, which one scalar cannot.
+  ///
   /// Required on deserialize (present, nullable): `None` is itself the fact
   /// ("this run witnessed no language"), so a reader must be able to tell it
   /// from a dropped key — hence the [`required_option`] bridge.
@@ -598,7 +609,11 @@ impl TaskFacts {
   }
 
   // -- observed_language --------------------------------------------------
-  /// The language a window actually observed, or `None`. See the field's doc.
+  /// The language a window actually observed, or `None` — the FIRST genuine
+  /// observation of the run. See the field's doc, including its relationship to
+  /// the per-window probe evidence
+  /// [`TranscriptionResult::language_observations_slice`](crate::audio::whisper::result::TranscriptionResult::language_observations_slice)
+  /// carries.
   #[inline(always)]
   pub fn observed_language(&self) -> Option<&str> {
     self.observed_language.as_deref()

--- a/coremlit/src/audio/whisper/transcribe/mod.rs
+++ b/coremlit/src/audio/whisper/transcribe/mod.rs
@@ -358,6 +358,19 @@ where
     // defaulted language was never *detected* (F3, codex round 3). It is THIS
     // task's own observation; the shared sink below carries it cross-chunk.
     let mut observed_language: Option<String> = None;
+    // The per-window EVIDENCE the two scalars above are folded from (coremlit
+    // issue #107): one entry per window whose automatic-language probe ran and
+    // belonged to the attempt whose decode was KEPT, spanned in this run's own
+    // time base, in window order. Deliberately NOT a re-derivation of either
+    // scalar and not an input to them — the fold rules above are untouched; this
+    // records the probes themselves, which folding into a last-write-wins display
+    // and a first-wins observation used to discard outright.
+    //
+    // Task-local, never the shared `facts_sink`: an observation is a SPAN into
+    // the result this call is building, so a chunk that probed and then errored
+    // has nowhere to anchor one — its scalar observation still reaches the sink,
+    // exactly as its segments are still lost with it.
+    let mut language_observations: Vec<LanguageObservation> = Vec::new();
     // The ONE sink for this task's error-fragile facts — the RNG draw (from the
     // sampler's own `drew_from_rng`, never inferred from a temperature), the
     // early-stop truncation (OR-ed across every attempt including a REJECTED one
@@ -484,18 +497,39 @@ where
         // function's own per-attempt concern. `captured_alignment` is the
         // accepted attempt's alignment-weight snapshot (see that
         // function's own doc); `None` unless `options.word_timestamps()`.
+        //
+        // `window_probe` is declared HERE, inside the window loop, so it is fresh
+        // per window by construction: the helper writes it once per probing
+        // attempt (last-write-wins, so the KEPT attempt's outcome stands) and
+        // never clears it, and a `None` must mean "this window had no kept probe",
+        // never a previous window's value left standing.
+        let mut window_probe: Option<LanguageDetection> = None;
         let (decoding_result, captured_alignment) = self.decode_with_fallback(
           &encoder_output,
           &mut state,
           &mut initial_prompt,
           &mut detected_language,
           &mut observed_language,
+          &mut window_probe,
           facts_sink,
           options,
           &mut timings,
           window_index,
         )?;
         window_index += 1;
+        // Record the kept probe against the window's OWN audio extent — `seek`
+        // still holds this window's start (the seeker below is what advances it),
+        // and `segment_size` is the unpadded content, so the span describes the
+        // audio the probe saw rather than the 30 s zero-pad it encoded.
+        // `segment::window_span` is the ONE rounding contract the seeker below
+        // times its own segments with, so the observation cannot disagree with
+        // the segments of its own window — not even past 2^24 samples, where
+        // converting `seek + segment_size` as a whole used to collapse a short
+        // final window onto its start (coremlit issue #107).
+        if let Some(detection) = window_probe {
+          let (start, end) = segment::window_span(seek, segment_size);
+          language_observations.push(LanguageObservation::new(start, end, detection));
+        }
 
         // THE reproducibility invariant, now unified. The RNG-draw AND early-stop
         // facts were merged into `facts_sink` INSIDE `decode_with_fallback` just
@@ -718,6 +752,11 @@ where
           .unwrap_or_else(|| DEFAULT_LANGUAGE_CODE.to_string()),
         timings,
       )
+      // The per-window probe evidence, in window order (coremlit issue #107).
+      // The display language above and the `observed_language` below are folded
+      // from these by the SAME rules as before — this list is what they were
+      // folded from, carried instead of discarded.
+      .with_language_observations(language_observations)
       // The decode-time facts this run controlled, assembled into the ONE
       // carried record (coremlit issue #14, codex round 6):
       //
@@ -882,6 +921,17 @@ where
   /// or the accepted attempt committed no alignment row this window (the
   /// `hasAlignment` gate; e.g. a model without the word-timestamp head).
   ///
+  /// `window_probe` is this window's KEPT automatic-language probe (coremlit
+  /// issue #107), written once per PROBING attempt and never cleared: `Some` with
+  /// the attempt's [`LanguageDetection`], `None` when its probe FAILED (the same
+  /// last-write-wins assignment Swift's `try?` gives the display language right
+  /// beside it). Because the accepted attempt is always the last one to run — the
+  /// ladder either `break`s on it or exhausts on it — what stands when this
+  /// returns is exactly the kept attempt's outcome, and a window that never
+  /// probed leaves the caller's fresh `None` untouched. It carries no span: the
+  /// window's extent is [`Self::run`]'s own `seek`/`segment_size`, so the caller
+  /// builds the [`LanguageObservation`] rather than this function.
+  ///
   /// **Rust-only addition, no Swift equivalent:** each attempt's sampler is
   /// seeded from `options.seed()` when set, via
   /// [`sampler::derive_attempt_seed`] over three domain-separated
@@ -903,6 +953,7 @@ where
     initial_prompt: &mut Vec<u32>,
     detected_language: &mut Option<String>,
     observed_language: &mut Option<String>,
+    window_probe: &mut Option<LanguageDetection>,
     facts_sink: &Mutex<TaskFacts>,
     options: &DecodingOptions,
     timings: &mut TranscriptionTimings,
@@ -1002,6 +1053,19 @@ where
           Ok(probe) => {
             window_options.set_language(probe.language().to_string());
             *detected_language = Some(probe.language().to_string());
+            // The probe ITSELF, kept for the window's observation (coremlit issue
+            // #107) — last-write-wins across attempts exactly like the display
+            // language it sits beside, so what survives the ladder is the KEPT
+            // attempt's probe and the window contributes exactly one entry. Recorded
+            // UNGATED by `language_probs`: unlike the first-wins `observed_language`
+            // promotion below — which must not fabricate a detection out of an
+            // all-masked probe's `"en"` display default (F3, codex round 14) — this
+            // is the probe's own testimony, and an empty `probs_slice()` is the
+            // honest, readable record that it sampled nothing.
+            *window_probe = Some(LanguageDetection::new(
+              probe.language(),
+              probe.language_probs_slice().to_vec(),
+            ));
             // A probe that actually SAMPLED a language token IS a genuine
             // detection (the observation), even when the sampled code fell back
             // to the display default. But an all-masked probe -- a valid
@@ -1023,6 +1087,12 @@ where
           Err(_) => {
             // DISPLAY: Swift's `try?` yields nil — last-write-wins.
             *detected_language = None;
+            // OBSERVATION LIST: a failed probe produced no detection, so if THIS
+            // is the attempt whose decode is kept, the window has no kept probe
+            // and contributes no entry (coremlit issue #107). Cleared rather than
+            // left, for the same reason the display is: an earlier attempt's probe
+            // belongs to a decode this ladder REJECTED.
+            *window_probe = None;
             // OBSERVATION: a FAILED probe witnessed nothing, so it must NOT
             // erase an earlier genuine observation (F2, codex round 4). Left
             // untouched; the post-decode promotion below still records THIS
@@ -1183,7 +1253,16 @@ where
 /// The result of a one-shot language-detection probe — Swift's
 /// `(language: String, langProbs: [String: Float])` tuple return from
 /// `detectLanguage`/`detectLangauge` (`WhisperKit.swift:520-581`).
+///
+/// Serializable under the `serde` feature because a
+/// [`LanguageObservation`] carries one INTO
+/// [`TranscriptionResult::language_observations_slice`], which
+/// `result::writer::json_content` writes as part of the JSON transcript
+/// (that function is itself `serde`-gated, so this is a plain reference, not a
+/// link that would dangle in a build without the feature).
+/// [`WhisperKit::detect_language`]'s own one-shot return is unaffected.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LanguageDetection {
   language: String,
   probs: Vec<(String, f32)>,
@@ -1212,6 +1291,104 @@ impl LanguageDetection {
   #[inline(always)]
   pub const fn probs_slice(&self) -> &[(String, f32)] {
     self.probs.as_slice()
+  }
+}
+
+// ---------------------------------------------------------------------
+// LanguageObservation
+// ---------------------------------------------------------------------
+
+/// One decode window's KEPT language probe: the window's own span, plus the
+/// [`LanguageDetection`] the probe produced for it (coremlit issue #107).
+///
+/// [`TranscribeTask::run`] appends one of these per window whose
+/// automatic-language probe ran AND belonged to the attempt whose decode was kept — the whole list is on
+/// the result as
+/// [`TranscriptionResult::language_observations_slice`](crate::audio::whisper::result::TranscriptionResult::language_observations_slice),
+/// in window order. A window with no probe (detection off, a configured
+/// language, a monolingual model) and a window whose KEPT attempt's probe
+/// FAILED contribute no entry, so the list is exactly "the probes that ran and
+/// were kept" — never a placeholder for one that did not.
+///
+/// # The evidence the two folded languages come from
+///
+/// The run folds its probes into two scalars, and this list is what they were
+/// folded FROM (see the result field's own doc for the full relationship):
+/// [`TranscriptionResult::language`](crate::audio::whisper::result::TranscriptionResult::language)
+/// is last-write-wins over them, and
+/// [`TaskFacts::observed_language`] first-genuine-wins. Neither fold is a pure
+/// function of this list — a configured or `"en"`-fallback display language
+/// never probes at all, and a decode that PREDICTS a `<|lang|>` token feeds
+/// `observed_language` without a probe — so read the list as the probe
+/// evidence, not as a re-derivation of either scalar.
+///
+/// # Span
+///
+/// [`Self::start`]/[`Self::end`] are seconds in the SAME time base as the
+/// result's own [`TranscriptionSegment::start`]/[`TranscriptionSegment::end`]:
+/// run-relative when [`TranscribeTask::run`] returns, absolute once
+/// [`chunker::apply_result_seek_offset`] has re-anchored a VAD chunk's result
+/// (which shifts these spans with the segments). They bound the window's own
+/// AUDIO — `seek .. seek + segment_size`, before the 30 s zero pad the probe
+/// actually encoded — so a final short window reports the audio it held, not a
+/// padded 30 s. [`crate::audio::whisper::segment`]'s `window_span` computes
+/// it — the same helper that module's own segment timing rounds through — and
+/// it guarantees [`Self::end`] is strictly greater than [`Self::start`] for a
+/// window that held any audio at all. That guarantee SURVIVES the re-anchoring:
+/// the chunker shifts this span and the segments' through the same module's
+/// `shift_span`, which keeps a nonempty span nonempty rather than letting the
+/// two endpoint additions round onto each other.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LanguageObservation {
+  start: f32,
+  end: f32,
+  detection: LanguageDetection,
+}
+
+impl LanguageObservation {
+  /// Builds an observation from the decode window's span, in seconds, and the
+  /// probe's own detection.
+  pub const fn new(start: f32, end: f32, detection: LanguageDetection) -> Self {
+    Self {
+      start,
+      end,
+      detection,
+    }
+  }
+
+  /// Window start, in seconds (see the type's span doc for the time base).
+  #[inline(always)]
+  pub const fn start(&self) -> f32 {
+    self.start
+  }
+  /// Sets [`Self::start`] in place —
+  /// [`chunker::apply_result_seek_offset`] re-anchors a chunk's observations
+  /// through this, exactly as it does its segments'.
+  #[inline(always)]
+  pub const fn set_start(&mut self, start: f32) -> &mut Self {
+    self.start = start;
+    self
+  }
+
+  /// Window end, in seconds (see the type's span doc for the time base).
+  #[inline(always)]
+  pub const fn end(&self) -> f32 {
+    self.end
+  }
+  /// Sets [`Self::end`] in place — the re-anchoring counterpart of
+  /// [`Self::set_start`].
+  #[inline(always)]
+  pub const fn set_end(&mut self, end: f32) -> &mut Self {
+    self.end = end;
+    self
+  }
+
+  /// The probe's detection for this window — the language it resolved and the
+  /// per-language probabilities behind it.
+  #[inline(always)]
+  pub const fn detection(&self) -> &LanguageDetection {
+    &self.detection
   }
 }
 

--- a/coremlit/src/audio/whisper/transcribe/tests.rs
+++ b/coremlit/src/audio/whisper/transcribe/tests.rs
@@ -734,6 +734,380 @@ fn genuine_observation_survives_a_later_failed_probe() {
   );
 }
 
+/// The logprob `decode::detect_language` records for a one-hot `token` step,
+/// measured through the probe itself rather than hand-derived from the
+/// vocabulary size — the oracle the observation tests compare their carried
+/// probabilities against (coremlit issue #107).
+fn probe_logprob_for(t: &WhisperTokenizer, token: u32) -> f32 {
+  use crate::audio::whisper::backend::InferenceBackend;
+  let mut mock = MockBackend::new();
+  mock.push_token_step(token);
+  let features = mock.extract_features(&[0.0f32; 16]).unwrap();
+  let encoded = mock.encode(&features).unwrap();
+  let mut state = mock.new_decoder_state().unwrap();
+  let mut sampler = GreedyTokenSampler::new(0.0, special().end_token(), &DecodingOptions::new());
+  let mut timings = TranscriptionTimings::new();
+  let probe =
+    decode::detect_language(&mock, &encoded, &mut state, t, &mut sampler, &mut timings).unwrap();
+  let probs = probe.language_probs_slice();
+  assert_eq!(
+    probs.len(),
+    1,
+    "a one-hot probe records exactly one language"
+  );
+  probs[0].1
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn every_kept_probe_reaches_the_result_as_a_spanned_observation() {
+  // coremlit issue #107. Two windows, two DIFFERENT successful probes: the run
+  // used to fold both into a last-write-wins display language and a first-wins
+  // `observed_language` and DISCARD the windows, their spans and their
+  // confidences. Both folds are unchanged -- the display is still window 2's
+  // "ja", the observation still window 1's "es" -- and the probes themselves now
+  // ride out as `language_observations`, in window order, spanned in the same
+  // seconds base as the segments.
+  //
+  // Mutation proof: drop the `language_observations.push(..)` in `run` (or the
+  // `.with_language_observations(..)` that carries it) and the list is empty
+  // while BOTH scalars still read exactly as asserted below -- which is the
+  // information loss this issue is about, invisible to every pre-existing
+  // assertion.
+  let t = tiny_tokenizer();
+  let s = special();
+  let es = t.token_to_id("<|es|>").unwrap();
+  let ja = t.token_to_id("<|ja|>").unwrap();
+  let hello = t.encode(" Hello").unwrap()[0];
+  // `with_continuous_script`: each window (and its probe) consumes the NEXT
+  // slice instead of replaying from 0, which is what lets window 2 probe a
+  // different language than window 1. Per window: 1 probe step, then the 7
+  // decode steps a `[SOT, <|lang|>, <|transcribe|>]` prefill takes to reach EOT.
+  // The ts(50) pair ends each window and advances seek 1 s, giving two windows
+  // over 3 s of audio.
+  let mut mock = MockBackend::new()
+    .with_dims(ModelDims::new().with_window_samples(16_000))
+    .with_continuous_script();
+  for language in [es, ja] {
+    mock.push_token_steps(&[
+      language, // the probe's own step
+      language,
+      s.transcribe_token(),
+      ts(0),
+      hello,
+      ts(50),
+      ts(50),
+      s.end_token(),
+    ]);
+  }
+  let options = DecodingOptions::new().with_detect_language();
+  let result = TranscribeTask::new(&mock, &t)
+    .run(&vec![0.1; 48_000], &options)
+    .unwrap();
+  assert_eq!(mock.counters().encode_calls(), 2, "two windows decoded");
+
+  // The folded scalars: UNCHANGED rules, now visible.
+  assert_eq!(
+    result.language(),
+    "ja",
+    "the DISPLAY language is still last-write-wins -- window 2's probe"
+  );
+  assert_eq!(
+    result.task_facts().observed_language(),
+    Some("es"),
+    "the OBSERVATION is still first-genuine-wins -- window 1's probe"
+  );
+
+  // The evidence they were folded from.
+  let observations = result.language_observations_slice();
+  assert_eq!(
+    observations.len(),
+    2,
+    "one entry per window that kept a probe"
+  );
+  let languages: Vec<&str> = observations
+    .iter()
+    .map(|observation| observation.detection().language())
+    .collect();
+  assert_eq!(languages, ["es", "ja"], "in window order, not fold order");
+  let spans: Vec<(f32, f32)> = observations
+    .iter()
+    .map(|observation| (observation.start(), observation.end()))
+    .collect();
+  for (index, (expected, actual)) in [(0.0f32, 1.0f32), (1.0, 2.0)]
+    .into_iter()
+    .zip(spans.iter().copied())
+    .enumerate()
+  {
+    assert!(
+      (expected.0 - actual.0).abs() < 1e-3 && (expected.1 - actual.1).abs() < 1e-3,
+      "window {index} spans the audio it decoded: expected {expected:?}, got {actual:?}"
+    );
+  }
+  for (observation, token) in observations.iter().zip([es, ja]) {
+    let probs = observation.detection().probs_slice();
+    assert_eq!(
+      probs.len(),
+      1,
+      "the probe records its single sampled language"
+    );
+    assert_eq!(probs[0].0, observation.detection().language());
+    assert!(
+      (probs[0].1 - probe_logprob_for(&t, token)).abs() < 1e-6,
+      "the carried confidence is the probe's own, got {}",
+      probs[0].1
+    );
+  }
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn an_observation_spans_exactly_what_its_own_window_segments_do() {
+  // coremlit issue #107, the one-rounding-contract half: the observation and
+  // the segments of the SAME window are both timed by
+  // `segment::window_span`, so a short final window can never report one
+  // extent to the observation list and a different one to the transcript.
+  //
+  // Two windows over 1.5 s with the end padding off: a full 1 s window, then
+  // a 0.5 s tail. Each decodes a timestamp-less lump, whose single segment
+  // therefore ends at the window's own end -- the exact quantity the
+  // observation carries, so the two spans are comparable for equality.
+  //
+  // Mutation proof: span the observation with `window_samples` (the 30 s zero
+  // pad's extent) instead of `segment_size` and window 2's observation ends
+  // at 2.0 while its segment ends at 1.5; re-deriving either endpoint with
+  // its own `as f32 / SAMPLE_RATE` division reds the helper tests in
+  // `segment::tests` that this one shares its contract with.
+  let t = tiny_tokenizer();
+  let s = special();
+  let es = t.token_to_id("<|es|>").unwrap();
+  let hello = t.encode(" Hello").unwrap()[0];
+  // Per window: 1 probe step, then the 4 decode steps a
+  // `[SOT, <|lang|>, <|transcribe|>]` prefill takes to reach EOT with no
+  // timestamp token anywhere -- which is what makes the segment a lump
+  // spanning the whole window.
+  let mut mock = MockBackend::new()
+    .with_dims(ModelDims::new().with_window_samples(16_000))
+    .with_continuous_script();
+  for _ in 0..2 {
+    mock.push_token_steps(&[es, es, s.transcribe_token(), hello, s.end_token()]);
+  }
+  // `window_clip_time` 0: the default 1 s of end padding would put
+  // `clip_guard` at 8_000 and the tail window would never be entered at all.
+  let options = DecodingOptions::new()
+    .with_detect_language()
+    .with_window_clip_time(0.0);
+  let result = TranscribeTask::new(&mock, &t)
+    .run(&vec![0.1; 24_000], &options)
+    .unwrap();
+  assert_eq!(
+    mock.counters().encode_calls(),
+    2,
+    "a full 1 s window and a 0.5 s tail"
+  );
+
+  let observations = result.language_observations_slice();
+  assert_eq!(observations.len(), 2, "both windows kept a probe");
+  let segments = result.segments_slice();
+  for (index, (seek, samples)) in [(0usize, 16_000usize), (16_000, 8_000)]
+    .into_iter()
+    .enumerate()
+  {
+    let expected = segment::window_span(seek, samples);
+    let observation = &observations[index];
+    assert_eq!(
+      (observation.start(), observation.end()),
+      expected,
+      "window {index} observation spans the audio it held, not the zero pad"
+    );
+    let window_segments: Vec<&TranscriptionSegment> = segments
+      .iter()
+      .filter(|segment| segment.seek() == seek)
+      .collect();
+    assert_eq!(
+      window_segments.len(),
+      1,
+      "window {index} lumps into one segment"
+    );
+    assert_eq!(
+      (window_segments[0].start(), window_segments[0].end()),
+      expected,
+      "window {index} segment carries the SAME span its observation does"
+    );
+  }
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn no_probe_records_no_observation() {
+  // coremlit issue #107. The list is exactly "the probes that ran and were
+  // kept": detection OFF runs none, so it stays EMPTY rather than gaining a
+  // placeholder built from the display language -- which would be the same
+  // fabrication the all-masked-probe gate (F3, codex round 14) refuses for
+  // `observed_language`, one door further out.
+  //
+  // Mutation proof: push an observation unconditionally (from
+  // `detected_language` rather than the kept probe) and this reads back one
+  // entry carrying the Swift-faithful `"en"` display default no probe ever
+  // produced.
+  let t = tiny_tokenizer();
+  let mut mock = MockBackend::new().with_dims(ModelDims::new().with_window_samples(16_000));
+  let hello = t.encode(" Hello").unwrap()[0];
+  script_clean_window(&mut mock, hello);
+  let options = DecodingOptions::new();
+  assert!(
+    !options.detect_language(),
+    "no probe: prefill is on by default"
+  );
+  let result = TranscribeTask::new(&mock, &t)
+    .run(&vec![0.1; 32_000], &options)
+    .unwrap();
+  assert_eq!(mock.counters().encode_calls(), 1, "one window decoded");
+  assert_eq!(result.language(), "en", "the display fallback is kept");
+  assert!(
+    result.language_observations_slice().is_empty(),
+    "no probe ran, so no observation may be recorded"
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn a_retried_window_records_only_the_kept_attempts_probe() {
+  // coremlit issue #107. The probe runs once per ATTEMPT, so a window the
+  // fallback ladder retries probes twice -- but only the attempt whose decode
+  // was KEPT produced the transcript, and the list is per-WINDOW evidence, not
+  // per-attempt. One window, two attempts, exactly one observation spanning the
+  // whole window.
+  //
+  // Mutation proof: push the observation inside `decode_with_fallback`'s attempt
+  // loop instead of once per window in `run`, and this reads back 2 entries with
+  // identical spans -- a code-switch geography that invents a switch out of a
+  // temperature retry.
+  let t = tiny_tokenizer();
+  let s = special();
+  let es = t.token_to_id("<|es|>").unwrap();
+  // `with_continuous_script` so the probe step and the decode steps are laid out
+  // explicitly per attempt rather than replayed from 0. Per attempt: the probe's
+  // `<|es|>` step, then the PROVEN catastrophic-avg-logprob decode (4 flat steps
+  // + EOT) that `fallback_ladder_retries_with_rising_temperature_then_accepts`
+  // derives -- it falls back on EVERY attempt, so the ladder exhausts and the
+  // final attempt's result stands.
+  let mut mock = MockBackend::new()
+    .with_dims(ModelDims::new().with_window_samples(16_000))
+    .with_continuous_script();
+  for _ in 0..2 {
+    mock.push_token_step(es);
+    for _ in 0..4 {
+      let mut flat = vec![0.0f32; 51865];
+      flat[s.end_token() as usize] = -20.0;
+      mock.push_step(flat);
+    }
+    mock.push_token_step(s.end_token());
+  }
+  let options = DecodingOptions::new()
+    .with_detect_language()
+    .with_without_timestamps()
+    .maybe_first_token_logprob_threshold(None)
+    .maybe_compression_ratio_threshold(None)
+    .with_temperature_fallback_count(1); // attempts 0 and 1
+  let result = TranscribeTask::new(&mock, &t)
+    .run(&vec![0.1; 32_000], &options)
+    .unwrap();
+  assert_eq!(mock.counters().encode_calls(), 1, "one window, retried");
+  assert_eq!(
+    mock.counters().decode_steps(),
+    12,
+    "two attempts, each a probe step plus five decode steps"
+  );
+  let observations = result.language_observations_slice();
+  assert_eq!(observations.len(), 1, "one window, one kept probe");
+  assert_eq!(observations[0].detection().language(), "es");
+  assert!(
+    (observations[0].start() - 0.0).abs() < 1e-3 && (observations[0].end() - 1.0).abs() < 1e-3,
+    "the observation spans the window, not an attempt: got {:?}",
+    (observations[0].start(), observations[0].end())
+  );
+}
+
+#[test]
+#[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
+fn vad_chunked_observations_reanchor_and_concatenate() {
+  // coremlit issue #107, at the VAD door -- the one the issue's own bilingual
+  // long-track use case goes through. The same three-chunk audio as
+  // `vad_chunked_transcribe_reanchors_and_merges`, with the probe on: each
+  // chunk's `run` spans its observation CHUNK-relative, so the merged result is
+  // only honest if `apply_result_seek_offset` shifts those spans with the
+  // segments and the merge concatenates them.
+  //
+  // Mutation proof: drop the observation loop in `apply_result_seek_offset` and
+  // all three starts read 0.0 against absolute segment times; drop the
+  // concatenation in `merge_results` and the merged list is empty while each
+  // chunk still probed.
+  let t = tiny_tokenizer();
+  let s = special();
+  let es = t.token_to_id("<|es|>").unwrap();
+  let hello = t.encode(" Hello").unwrap()[0];
+  let mut mock = MockBackend::new().with_dims(ModelDims::new().with_window_samples(48_000));
+  // `script_clean_window` with the leading `<|en|>` replaced by `<|es|>`: the
+  // probe reads step 0 and the reset rewinds the cursor, so the decode replays
+  // the same slice and each chunk decodes one "Hello" window as before.
+  mock.push_token_steps(&[
+    es,
+    s.transcribe_token(),
+    ts(0),
+    hello,
+    ts(100),
+    ts(100),
+    s.end_token(),
+  ]);
+  let kit = WhisperKit::with_backend(mock, t);
+  let mut audio = vec![0.1f32; 96_000];
+  audio[32_000..35_200].fill(0.0);
+  audio[64_000..67_200].fill(0.0);
+  let options = DecodingOptions::new()
+    .with_chunking_strategy(ChunkingStrategy::Vad)
+    .with_detect_language();
+  let result = kit.transcribe(&audio, &options).unwrap();
+  assert_eq!(result.text(), "Hello Hello Hello", "per-chunk texts joined");
+  let observations = result.language_observations_slice();
+  assert_eq!(observations.len(), 3, "every chunk's kept probe is carried");
+  for observation in observations {
+    assert_eq!(observation.detection().language(), "es");
+  }
+  // Chunk offsets 0 / 33_600 / 65_600 -> 0.0 / 2.1 / 4.1 s. The .1 offsets are
+  // the chunk boundaries and CANNOT come from an un-re-anchored chunk-relative
+  // span (which would start every observation at 0.0).
+  let starts: Vec<f32> = observations
+    .iter()
+    .map(crate::audio::whisper::transcribe::LanguageObservation::start)
+    .collect();
+  for (index, expected) in [0.0f32, 2.1, 4.1].into_iter().enumerate() {
+    assert!(
+      (starts[index] - expected).abs() < 1e-3,
+      "chunk {index} observation re-anchored to {expected}, got {}",
+      starts[index]
+    );
+  }
+  // Each chunk spans its own content (33_600 / 32_000 / 30_400 samples), shifted
+  // onto the absolute timeline: the spans tile the audio with no gap.
+  let ends: Vec<f32> = observations
+    .iter()
+    .map(crate::audio::whisper::transcribe::LanguageObservation::end)
+    .collect();
+  for (index, expected) in [2.1f32, 4.1, 6.0].into_iter().enumerate() {
+    assert!(
+      (ends[index] - expected).abs() < 1e-3,
+      "chunk {index} observation ends at {expected}, got {}",
+      ends[index]
+    );
+  }
+  assert_eq!(
+    result.task_facts().observed_language(),
+    Some("es"),
+    "the folded observation is unchanged by the list beside it"
+  );
+}
+
 #[test]
 #[ignore = "requires local tokenizer (WHISPERKIT_TEST_MODELS)"]
 fn a_predicted_language_is_recorded_over_the_forced_display_language() {


### PR DESCRIPTION
Closes #107.