### PR TITLE
perf(coremlit/granite): exact BPE counts inside one pre-token — a merge-process mirror with a cut certificate ends the whole-range re-encodes on separatorless text (#72)

### DIFF
--- a/coremlit/Cargo.toml
+++ b/coremlit/Cargo.toml
@@ -64,7 +64,10 @@ vad = ["dep:zuoer"]
 # crate depends on serde_json itself, so this pulls nothing new into the graph.
 clap = ["dep:rustfft", "dep:tokenizers", "dep:windit", "dep:serde_json"]
 
-granite = ["dep:tokenizers", "dep:windit", "windit/text", "dep:sha2"]
+# `dep:serde_json` reads the BPE merge table back out of the loaded model for
+# `embeddings::granite::token_index`'s separatorless fast lane (#72); tokenizers
+# itself depends on serde_json, so this pulls nothing new into the graph.
+granite = ["dep:tokenizers", "dep:windit", "windit/text", "dep:sha2", "dep:serde_json"]
 
 # LICENSE PREREQUISITE (owner-gated, NOT resolved by this change): `pixon` is
 # currently licensed GPL-3.0-or-later; the owner will relicense it permissive

--- a/coremlit/src/embeddings/granite/mod.rs
+++ b/coremlit/src/embeddings/granite/mod.rs
@@ -102,7 +102,7 @@ use tokenizers::{
 use crate::embeddings::granite::{
   embedding::{EMBEDDING_DIM, check_finite_output},
   error::Result,
-  token_index::{IndexMeasure, TokenIndex},
+  token_index::{IndexMeasure, LazyTable, MergeTable, TokenIndex},
 };
 
 /// File name of the granite `tokenizer.json` sidecar inside the model artifact
@@ -453,6 +453,15 @@ pub struct TextEmbedder {
   /// window; measurement must see the true, untruncated count. Lazy so
   /// embed-only callers pay nothing, and shared across every `embed_long` call.
   measure_tokenizer: OnceLock<Tokenizer>,
+  /// The merge table behind the separatorless fast lane (#72), built from
+  /// the stored tokenizer on the lane's first engagement — the first chunking
+  /// probe longer than any token into a qualifying pre-token (a letter run the
+  /// Split regex glues whole), so an embedder that never meets separatorless
+  /// text never pays the build (about half a second, ~74
+  /// MB transient, ~10 MB retained; see `token_index::bpe_mirror`) — and
+  /// `None` when the tokenizer is not the configuration the lane is pinned
+  /// to, in which case chunking measures as before.
+  merge_table: OnceLock<Option<MergeTable>>,
 }
 
 impl TextEmbedder {
@@ -611,6 +620,7 @@ impl TextEmbedder {
       tokenizer,
       pad_id,
       measure_tokenizer: OnceLock::new(),
+      merge_table: OnceLock::new(),
     })
   }
 
@@ -815,7 +825,12 @@ impl TextEmbedder {
   pub fn embed_long_with(&self, text: &str, opts: &LongTextOptions) -> Result<Embedding> {
     validate_long_input(text, opts)?;
     let wopts = opts.window_options();
-    let chunks = chunk_long(self.measuring_tokenizer()?, text, &wopts)?;
+    let chunks = chunk_long(
+      self.measuring_tokenizer()?,
+      LazyTable::new(&self.merge_table, &self.tokenizer),
+      text,
+      &wopts,
+    )?;
     match chunks.len() {
       // Only `""` chunks to nothing (`chunk_long` gives contentless nonempty
       // text a single whole-input chunk); `embed` defines the empty-input
@@ -1251,6 +1266,7 @@ fn validate_long_input(text: &str, opts: &LongTextOptions) -> Result<()> {
 /// tokenizer fails to encode such a run.
 fn chunk_long(
   measure_tok: &Tokenizer,
+  table: LazyTable<'_>,
   text: &str,
   opts: &WindowOptions,
 ) -> Result<Vec<windit::split::Chunk>> {
@@ -1266,7 +1282,13 @@ fn chunk_long(
   // the old descent's first whole-input measure carried.
   let index = TokenIndex::build(measure_tok, text)?;
   // windit measures through this adapter — a real `MeasureText` impl, not a
-  // blanket closure. It recovers each subslice's byte range by pointer offset and
+  // blanket closure. Probes strictly inside a single letter-run pre-token
+  // longer than any token (the separatorless regime of #72) engage the fast
+  // lane — `table` is built on the first such probe, once per embedder — and
+  // are answered from that pre-token's recorded merge process instead of a
+  // whole-range re-encode; every other probe, and every probe when the
+  // tokenizer cannot be mirrored, measures as before. It recovers each
+  // subslice's byte range by pointer offset and
   // folds an encode error to `usize::MAX` ("does not fit"), so windit descends to
   // a smaller range and a persistent failure resurfaces from the per-chunk
   // `token_ids` later — the same behaviour the old infallible `measure` closure
@@ -1275,7 +1297,7 @@ fn chunk_long(
   // rather than a bogus `ContentlessInputOverBudget { tokens: usize::MAX }` — the
   // same split the old `measure` / `measure_checked` pair drew, deliberately not
   // unified.
-  let measurer = IndexMeasure::new(text, &index, measure_tok);
+  let measurer = IndexMeasure::new(text, &index, measure_tok, table, opts.window());
   let measure_checked =
     |a: usize, b: usize| -> Result<usize> { index.measure_range(measure_tok, text, a, b) };
   let chunks = windit::split::ContentAware::new(&measurer)

--- a/coremlit/src/embeddings/granite/tests.rs
+++ b/coremlit/src/embeddings/granite/tests.rs
@@ -1,5 +1,52 @@
+use std::sync::{Mutex, OnceLock, PoisonError};
+
 use super::*;
-use tokenizers::{PaddingDirection, PaddingParams, PaddingStrategy};
+use tokenizers::{Model, ModelWrapper, PaddingDirection, PaddingParams, PaddingStrategy};
+
+/// The cell production hands `chunk_long` for `mt` — [`TextEmbedder`] keeps
+/// one per embedder, and the lane builds the table into it on its first
+/// engagement with production's own `MergeTable::from_tokenizer` — cached
+/// here per BPE vocabulary size so the artifact's table (~0.5 s to build) is
+/// built once per process. Every non-BPE tokenizer shares one cell that
+/// `from_tokenizer` leaves `None`, so a hermetic test with a tiny WordLevel
+/// tokenizer never touches the staged artifact. A test that MUTATES the
+/// artifact's merges must call `super::chunk_long` with a cell of its own.
+fn table_cell(mt: &Tokenizer) -> &'static OnceLock<Option<MergeTable>> {
+  type Cell = &'static OnceLock<Option<MergeTable>>;
+  static NON_BPE: OnceLock<Option<MergeTable>> = OnceLock::new();
+  static CELLS: Mutex<Vec<(usize, Cell)>> = Mutex::new(Vec::new());
+  let ModelWrapper::BPE(bpe) = mt.get_model() else {
+    return &NON_BPE;
+  };
+  let key = bpe.get_vocab_size();
+  let mut cells = CELLS.lock().unwrap_or_else(PoisonError::into_inner);
+  if let Some((_, cell)) = cells.iter().find(|(k, _)| *k == key) {
+    return cell;
+  }
+  let cell: Cell = Box::leak(Box::new(OnceLock::new()));
+  cells.push((key, cell));
+  cell
+}
+
+/// The staged artifact's merge table, built once (see [`table_cell`]): the
+/// tests that time the fast lane pre-build it so the one-time cost stays out
+/// of the stopwatch.
+fn merge_table() -> &'static MergeTable {
+  let mt = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
+  table_cell(&mt)
+    .get_or_init(|| MergeTable::from_tokenizer(&mt))
+    .as_ref()
+    .expect("the artifact's BPE is mirrorable")
+}
+
+/// [`super::chunk_long`] with the fast lane enabled — what production runs.
+fn chunk_long(
+  mt: &Tokenizer,
+  text: &str,
+  opts: &WindowOptions,
+) -> Result<Vec<windit::split::Chunk>> {
+  super::chunk_long(mt, LazyTable::new(table_cell(mt), mt), text, opts)
+}
 
 use super::test_artifact::{
   GOLDEN_SOURCE_TOKENIZER_SHA256, tokenizer_bytes as artifact_tokenizer_bytes,
@@ -2193,13 +2240,16 @@ fn cjk_doc(target_bytes: usize) -> String {
 /// however long — parses to exactly one pre-token.
 ///
 /// `TokenIndex` is indexed BY pre-token, so a one-pre-token text gives it no
-/// interior boundary: every `measure_range(a, b)` with `a` inside that pre-token
-/// has to re-encode `[a, b)` in full, which is the pre-index cost. The single-pass
-/// property the sibling gate asserts is therefore a property of the CORPUS (short
-/// pre-tokens), not of the index alone.
+/// interior boundary: before #72 every `measure_range(a, b)` with `a` inside that
+/// pre-token re-encoded `[a, b)` in full, the pre-index cost; the separatorless
+/// fast lane (`token_index::suffix_session`) now answers those probes from the
+/// chunk suffix's recorded merge process. The single-pass property the sibling
+/// 1.5× gate asserts is still a property of the CORPUS (short pre-tokens); the
+/// separatorless regime has its own 8× gate below.
 ///
 /// Goes red if the pinned tokenizer's pre-tokenization ever splits such a run —
-/// at which point the separatorless cost characterization below is stale too.
+/// at which point the separatorless re-encode gate below measures a different
+/// regime than it was written for.
 /// "Cheap" is about the work, not about reach: like every gate that needs REAL
 /// granite tokenization, it reads the staged artifact sidecar and is `#[ignore]`d
 /// on it, so it runs where the sibling 1.5× gate runs and nowhere else.
@@ -2230,36 +2280,50 @@ fn separatorless_text_is_one_pretoken() {
   }
 }
 
-/// CHARACTERIZATION (`#[ignore]`, quadratic — too slow for CI): on separatorless
-/// text the measurement path re-encodes ORDERS OF MAGNITUDE more than the 1.5× the
-/// sibling gate asserts for whitespace-delimited prose, and the `TokenIndex` fast
-/// path is no faster than the pre-index slow twin.
+/// GATE (separatorless, `#[ignore]` — the slow twin is quadratic, and the
+/// staged tokenizer is needed): on text the Split regex glues into ONE
+/// pre-token, the measurement path no longer re-encodes the growing prefix.
+/// Every probe inside such a pre-token is answered from the recorded merge
+/// process of the chunk's suffix (`token_index::suffix_session`, #72), so the
+/// bytes the tokenizer encodes are the index build (1×) plus one bounded
+/// suffix encode per chunk — the session's own cross-check against the crate —
+/// and never a whole-range re-encode per atom.
 ///
-/// Measured on this branch (release, Apple Silicon, 31,374 CJK bytes → 18 chunks):
-/// fast 2,316 ms vs slow 2,298 ms — a 1.0× speedup — at a 584× re-encode ratio,
-/// against 1.007× and ~10× on `natural_doc` at the same size. The cause is
-/// `separatorless_text_is_one_pretoken`; windit's `char` fallback then issues one
-/// growing-prefix measure per `char`, so the whole-range re-encodes are quadratic
-/// in the chunk length.
-///
-/// Asserts the regime is still degenerate rather than a target to beat: it goes red
-/// once the measure path stops direct-encoding separatorless ranges, which is the
-/// signal to retire this test and widen the sibling gate's corpus.
+/// Before the fix (this machine, release): CJK 15,666 B → 9 chunks at a
+/// **565.9×** re-encode ratio, `"x"×7,833` → 2 chunks at **1,964×**, both at
+/// 1.0× or WORSE than the direct-encode twin. The bound below is 8×: at most
+/// one 8 KiB session encode per chunk over these ~1.7 KB chunks. Chunks stay
+/// byte-identical to the twin's.
 #[test]
-#[ignore = "quadratic on separatorless text, and the staged granite tokenizer.json \
-            (run locally); characterizes the open cost"]
-fn measure_path_reencode_ratio_on_separatorless_text() {
+#[ignore = "quadratic slow twin, and the staged granite tokenizer.json (run locally); \
+            the separatorless re-encode gate"]
+fn separatorless_measure_path_reencodes_at_most_8x_input() {
   let mt = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
   let opts = WindowOptions::new(MAX_TOKENS);
   for (label, doc) in [
     ("cjk", cjk_doc(15_666)),
     ("ascii-letters", "x".repeat(7_833)),
   ] {
+    // The merge table is a one-time cost per embedder (built on the lane's
+    // first engagement); it is not what this gate times.
+    let _ = merge_table();
     super::token_index::encode_meter::reset();
+    super::token_index::build_meter::reset();
     let t0 = std::time::Instant::now();
     let fast = chunk_long(&mt, &doc, &opts).expect("fast chunk");
     let fast_ms = t0.elapsed().as_secs_f64() * 1e3;
     let ratio = super::token_index::encode_meter::get() as f64 / doc.len() as f64;
+    let builds = super::token_index::build_meter::builds();
+    let mut sizes = super::token_index::encode_meter::sizes();
+    sizes.sort_unstable_by(|a, b| b.cmp(a));
+    let big: Vec<usize> = sizes.iter().copied().filter(|&n| n > 512).collect();
+    println!(
+      "[separatorless:{label}:encodes] calls={} over512={} over512_bytes={} top={:?}",
+      sizes.len(),
+      big.len(),
+      big.iter().sum::<usize>(),
+      &sizes[..sizes.len().min(12)]
+    );
 
     let t1 = std::time::Instant::now();
     let slow = chunk_long_slow(&mt, &doc, &opts).expect("slow chunk");
@@ -2268,15 +2332,17 @@ fn measure_path_reencode_ratio_on_separatorless_text() {
     assert_eq!(fast, slow, "{label}: fast/slow chunk mismatch");
     println!(
       "[separatorless:{label}] bytes={} chunks={} fast={fast_ms:.1}ms slow={slow_ms:.1}ms \
-       speedup={:.1}x reencode_ratio={ratio:.1}x",
+       speedup={:.1}x reencode_ratio={ratio:.1}x sessions={} session_bytes={}",
       doc.len(),
       fast.len(),
       slow_ms / fast_ms,
+      builds.len(),
+      builds.iter().map(|&(s, e)| e - s).sum::<usize>(),
     );
     assert!(
-      ratio > 10.0,
-      "{label}: re-encode ratio {ratio:.1}x is no longer degenerate — the separatorless measure \
-       cost was fixed; retire this characterization and widen the 1.5x gate's corpus"
+      ratio <= 8.0,
+      "{label}: measure path re-encoded {ratio:.1}x the input (> 8x) — the separatorless fast \
+       lane stopped engaging"
     );
   }
 }
@@ -2294,6 +2360,7 @@ fn big_document_fast_matches_slow_with_timing() {
   for size in [1usize << 20, 4usize << 20] {
     let doc = natural_doc(size);
 
+    let _ = merge_table();
     super::token_index::encode_meter::reset();
     let t0 = std::time::Instant::now();
     let fast = chunk_long(&mt, &doc, &opts).expect("fast chunk");
@@ -2398,4 +2465,380 @@ fn the_defective_template_fixture_really_panics_at_encode() {
     panicked,
     "applying the template panics inside the dependency"
   );
+}
+
+// ─── #72 codex round 1: the early-stop floor and dropped bytes ──────────────
+
+/// RED-FIRST: `"\0\0"` encodes to exactly the two template specials — the
+/// pinned tokenizer has no ByteLevel symbol for NUL and no unk fallback, so
+/// both bytes are DROPPED and contribute no content token. A floor that counted
+/// bytes as at-least-one-token said 3 > window 2, refused the exact-fit chunk,
+/// and windit split where the direct-encode twin keeps one chunk — with
+/// `max_windows = 1` that surfaced as `TooManyWindows`. The floor now applies
+/// only where the index proved byte coverage; the fast path must equal the twin
+/// here in shape and in chunks.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn dropped_byte_text_chunks_like_the_slow_twin_at_an_exact_fit_window() {
+  let mt = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
+  assert_eq!(
+    mt.encode("\0\0", true).expect("encode").get_ids().len(),
+    2,
+    "premise: both NULs are dropped, only the specials remain"
+  );
+  let opts = WindowOptions::new(2).with_max_windows(1);
+  let fast = chunk_long(&mt, "\0\0", &opts);
+  let slow = chunk_long_slow(&mt, "\0\0", &opts);
+  match (&fast, &slow) {
+    (Ok(f), Ok(s)) => assert_eq!(f, s, "fast/slow chunk mismatch on dropped bytes"),
+    (f, s) => panic!("fast {f:?} vs slow {s:?}"),
+  }
+  assert_eq!(fast.expect("one chunk").len(), 1);
+}
+
+/// RED-FIRST: 65,281 NULs at the default window — one window on the twin (the
+/// text has no content tokens at all), so one window here too.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn a_document_of_dropped_bytes_stays_one_window() {
+  let mt = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
+  let text = "\0".repeat(65_281);
+  let opts = WindowOptions::new(MAX_TOKENS);
+  let fast = chunk_long(&mt, &text, &opts).expect("fast");
+  let slow = chunk_long_slow(&mt, &text, &opts).expect("slow");
+  assert_eq!(fast, slow);
+  assert_eq!(fast.len(), 1);
+}
+
+/// RED-FIRST: NUL bytes interleaved in CJK. With dropped bytes DOMINATING —
+/// runs of 300 NULs between single ideographs — a slice of two ideographs and
+/// the run between them is 306 bytes for two content tokens: it measures 4
+/// and fits window 4, while a byte-count floor said 2 + ceil(306 / 128) = 5
+/// and refused it, so the old fast path split every ideograph apart where the
+/// twin packs pairs. The index is `direct_only` (a dropped byte voids its
+/// offset reconstruction), so every probe takes the exact path and the chunks
+/// must equal the twin's here and across a geometry grid of the
+/// single-NUL interleaving.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn dropped_bytes_interleaved_in_cjk_chunk_like_the_slow_twin() {
+  let mt = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
+  let nul_run = "\0".repeat(300);
+  let dominated: String = "你好世界模型推理"
+    .chars()
+    .map(|c| format!("{c}{nul_run}"))
+    .collect();
+  assert_eq!(
+    mt.encode(&dominated[..306], true)
+      .expect("encode")
+      .get_ids()
+      .len(),
+    4,
+    "premise: two ideographs and the dropped run between them are two content tokens"
+  );
+  for window in [4usize, 5, 8] {
+    let opts = WindowOptions::new(window);
+    let fast = chunk_long(&mt, &dominated, &opts);
+    let slow = chunk_long_slow(&mt, &dominated, &opts);
+    match (&fast, &slow) {
+      (Ok(f), Ok(s)) => assert_eq!(f, s, "dominated, window {window}: fast/slow chunk mismatch"),
+      (f, s) => panic!("dominated, window {window}: fast {f:?} vs slow {s:?}"),
+    }
+  }
+  let single: String = "你好世界模型推理文本嵌入检索"
+    .chars()
+    .flat_map(|c| [c, '\0'])
+    .collect::<String>()
+    .repeat(40);
+  for window in [2usize, 3, 7, 32, 128, MAX_TOKENS] {
+    let opts = WindowOptions::new(window);
+    let fast = chunk_long(&mt, &single, &opts);
+    let slow = chunk_long_slow(&mt, &single, &opts);
+    match (&fast, &slow) {
+      (Ok(f), Ok(s)) => assert_eq!(f, s, "single, window {window}: fast/slow chunk mismatch"),
+      (f, s) => panic!("single, window {window}: fast {f:?} vs slow {s:?}"),
+    }
+  }
+}
+
+/// Fast and slow twin on one document, both shapes compared.
+#[track_caller]
+fn assert_twin(mt: &Tokenizer, what: &str, text: &str, opts: &WindowOptions) {
+  let fast = chunk_long(mt, text, opts);
+  let slow = chunk_long_slow(mt, text, opts);
+  match (&fast, &slow) {
+    (Ok(f), Ok(s)) => assert_eq!(f, s, "{what}: fast/slow chunk mismatch"),
+    (f, s) => panic!("{what}: fast {f:?} vs slow {s:?}"),
+  }
+}
+
+/// RED-FIRST (Opus review, F1): CJK×k ++ `UCCESS` ++ CJK×1600 is ONE
+/// pre-token (`HEAD* TAIL+`: `\p{Lo}` and `\p{Lu}` are both head chars and
+/// the last ideograph is a tail char), and windit's word atoms end exactly at
+/// the end of `UCCESS`, so the packer probes a prefix that ends inside the
+/// uppercase run — which re-parses as `…中` and `UCCESS`, a vocabulary entry
+/// the merge process does not reproduce. A lane engaged on that pre-token
+/// over-counted the probe and closed the chunk a word early: at the default
+/// window the first chunk ended at byte 2,439 instead of 2,445 (k = 813, 814,
+/// 815), at window 16 (k = 20) and 32 (k = 45) there was one chunk more. The
+/// gate must refuse the pre-token; the chunks must equal the twin's.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn an_uppercase_run_inside_cjk_chunks_like_the_slow_twin() {
+  let mt = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
+  let cycle = "你好世界模型推理";
+  let tail = cycle.repeat(200);
+  for (window, ks) in [
+    (MAX_TOKENS, &[813usize, 814, 815][..]),
+    (32, &[45][..]),
+    (16, &[20][..]),
+  ] {
+    for &k in ks {
+      let head: String = cycle.chars().cycle().take(k).collect();
+      let doc = format!("{head}UCCESS{tail}");
+      assert_twin(
+        &mt,
+        &format!("window {window}, k {k}"),
+        &doc,
+        &WindowOptions::new(window),
+      );
+    }
+  }
+  // The reviewer's repeating patterns (an uppercase run followed by a
+  // lowercase char, so the run sits strictly inside the pre-token) over a
+  // window sweep.
+  for pat in [
+    "你好世界UCCESSa模型推理",
+    "你UCCESSa",
+    "你好UCCESSa模",
+    "你好世WARRANTIESa模",
+  ] {
+    let doc = pat.repeat(3_000 / pat.len() + 1);
+    for window in [8usize, 11, 16, 24, 32, 45, 64, 100, 128, 160] {
+      assert_twin(
+        &mt,
+        &format!("{pat:?} at window {window}"),
+        &doc,
+        &WindowOptions::new(window),
+      );
+    }
+  }
+}
+
+/// A seeded corpus that mixes `\p{Lu}` and `\p{Lt}` runs (`UCCESS`, `API`,
+/// `Windows`, the titlecase digraphs and Greek titlecase vowels) into CJK and
+/// lowercase Latin, with combining marks, digits, spaces, CJK punctuation and
+/// an apostrophe suffix — pre-tokens of every letter-branch shape, some longer
+/// than the lane's engagement length and some not — chunks like the twin at
+/// every window.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn mixed_case_scripts_chunk_like_the_slow_twin() {
+  let mt = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
+  let pieces: [&str; 28] = [
+    "你好世界",
+    "模型推理",
+    "文本嵌入",
+    "检索",
+    "返回",
+    "hello",
+    "world",
+    "granite",
+    "embedding",
+    "UCCESS",
+    "WARRANTIES",
+    "API",
+    "ABC",
+    "Windows",
+    "SUCCESS",
+    "ǅ",
+    "ǈ",
+    "ᾈ",
+    "ǲ",
+    "\u{301}",
+    "\u{5bf}",
+    " ",
+    " ",
+    "12",
+    "。",
+    "'s",
+    "\n",
+    "αβγ",
+  ];
+  let mut seed = 0x9E37_79B9_7F4A_7C15u64;
+  let mut next = move || {
+    seed = seed
+      .wrapping_mul(6_364_136_223_846_793_005)
+      .wrapping_add(1_442_695_040_888_963_407);
+    (seed >> 33) as usize
+  };
+  for round in 0..6 {
+    let mut doc = String::new();
+    // Alternate long separatorless stretches with short mixed ones.
+    while doc.len() < 2_500 {
+      let stretch = 1 + next() % 40;
+      for _ in 0..stretch {
+        doc.push_str(pieces[next() % pieces.len()]);
+      }
+      if next() % 3 == 0 {
+        doc.push(' ');
+      }
+    }
+    for window in [16usize, 32, 128, MAX_TOKENS] {
+      assert_twin(
+        &mt,
+        &format!("round {round}, window {window}"),
+        &doc,
+        &WindowOptions::new(window),
+      );
+    }
+  }
+}
+
+/// RED-FIRST (Opus re-review, F5): a pre-token longer than any token whose
+/// chars can never qualify — an uppercase run, a rule of `=` or `-`, a
+/// newline or space run — must not build the merge table (~0.4 s, ~74 MB
+/// transient) on the first probe into it: the class test runs before the
+/// build, on a tail-class regex the lane compiles for itself. The chunks
+/// equal the twin's either way; a qualifying run (CJK) does build it.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn runs_that_cannot_qualify_never_build_the_table() {
+  let mt = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
+  let opts = WindowOptions::new(64);
+  for (label, doc) in [
+    ("uppercase-4000", format!("intro {} body", "A".repeat(4000))),
+    (
+      "equals-rule-4000",
+      format!("intro\n{}\nbody\n", "=".repeat(4000)),
+    ),
+    (
+      "dash-rule-200",
+      format!("intro text\n{}\nbody text\n", "-".repeat(200)),
+    ),
+    (
+      "newline-run-4000",
+      format!("intro{}body", "\n".repeat(4000)),
+    ),
+    ("space-run-4000", format!("intro{}body", " ".repeat(4000))),
+    (
+      "titlecase-then-upper",
+      format!("x {}{} y", "ǅ", "B".repeat(300)),
+    ),
+  ] {
+    let cell: OnceLock<Option<MergeTable>> = OnceLock::new();
+    let fast = super::chunk_long(&mt, LazyTable::new(&cell, &mt), &doc, &opts);
+    assert!(
+      cell.get().is_none(),
+      "{label}: a pre-token that cannot qualify must not build the table"
+    );
+    let slow = chunk_long_slow(&mt, &doc, &opts);
+    match (&fast, &slow) {
+      (Ok(f), Ok(s)) => assert_eq!(f, s, "{label}: fast/slow chunk mismatch"),
+      (f, s) => panic!("{label}: fast {f:?} vs slow {s:?}"),
+    }
+  }
+  let cell: OnceLock<Option<MergeTable>> = OnceLock::new();
+  let doc = "你好世界模型推理文本嵌入检索".repeat(60);
+  let fast = super::chunk_long(&mt, LazyTable::new(&cell, &mt), &doc, &opts).expect("fast");
+  assert!(
+    cell.get().is_some_and(Option::is_some),
+    "a qualifying separatorless pre-token engages the lane and builds the table"
+  );
+  assert_eq!(fast, chunk_long_slow(&mt, &doc, &opts).expect("slow"));
+}
+
+/// The end-to-end form of the F4 falsifier: with the added spelling present
+/// the lane-on chunking equals the twin's.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn an_added_token_spelled_like_a_word_chunks_like_the_slow_twin() {
+  let base = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
+  let spelled = merge_table().spell(b" zzqxjkw");
+  let mut value: serde_json::Value =
+    serde_json::from_slice(artifact_tokenizer_bytes()).expect("parse");
+  let next_id = u64::try_from(base.get_vocab_size(true)).expect("id");
+  value["added_tokens"]
+    .as_array_mut()
+    .expect("array")
+    .push(serde_json::json!({
+      "id": next_id, "content": spelled, "single_word": false, "lstrip": false,
+      "rstrip": false, "normalized": false, "special": false
+    }));
+  let hacked = Tokenizer::from_bytes(serde_json::to_vec(&value).expect("serialize")).expect("load");
+  let cell: OnceLock<Option<MergeTable>> = OnceLock::new();
+  let doc = format!(
+    "{} zzqxjkw{}",
+    "你好世界模型推理".repeat(30),
+    "你好世界".repeat(30)
+  );
+  for window in [16usize, 64, MAX_TOKENS] {
+    let opts = WindowOptions::new(window);
+    let fast = super::chunk_long(&hacked, LazyTable::new(&cell, &hacked), &doc, &opts);
+    let slow = chunk_long_slow(&hacked, &doc, &opts);
+    match (&fast, &slow) {
+      (Ok(f), Ok(s)) => assert_eq!(f, s, "window {window}: fast/slow chunk mismatch"),
+      (f, s) => panic!("window {window}: fast {f:?} vs slow {s:?}"),
+    }
+  }
+  assert!(cell.get().is_some_and(Option::is_some), "the lane engaged");
+}
+
+/// RED-FIRST (codex round 3): the engagement guard keyed on the ENCLOSING
+/// pre-token's length, so a tiny probe inside a qualifying pre-token of 129
+/// bytes built the whole merge table — 129 caller bytes at a tiny window
+/// forcing the ~74 MB transient build. Engagement is keyed on the PROBE now:
+/// `"a" × 129` at window 3 chunks like the twin with the cell still empty,
+/// while a probe longer than any token inside a qualifying pre-token still
+/// builds it.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn a_small_probe_inside_a_long_word_never_builds_the_table() {
+  let mt = measuring_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("measuring");
+  for (label, doc, window, max_windows) in [
+    ("129 a's, window 3", "a".repeat(129), 3usize, None),
+    (
+      "129 a's, window 3, no windows allowed",
+      "a".repeat(129),
+      3,
+      Some(0usize),
+    ),
+    ("400 a's, window 8", "a".repeat(400), 8, None),
+    (
+      "CJK 129 bytes, window 4",
+      "你好世界模型推理".repeat(6),
+      4,
+      None,
+    ),
+  ] {
+    let mut opts = WindowOptions::new(window);
+    if let Some(cap) = max_windows {
+      opts = opts.with_max_windows(cap);
+    }
+    let cell: OnceLock<Option<MergeTable>> = OnceLock::new();
+    let fast = super::chunk_long(&mt, LazyTable::new(&cell, &mt), &doc, &opts);
+    assert!(
+      cell.get().is_none(),
+      "{label}: no probe longer than a token, so no table"
+    );
+    let slow = chunk_long_slow(&mt, &doc, &opts);
+    match (&fast, &slow) {
+      (Ok(f), Ok(s)) => assert_eq!(f, s, "{label}: fast/slow chunk mismatch"),
+      (Err(f), Err(s)) => assert_eq!(format!("{f:?}"), format!("{s:?}"), "{label}: error shape"),
+      (f, s) => panic!("{label}: fast {f:?} vs slow {s:?}"),
+    }
+  }
+  // A probe longer than any token inside a qualifying pre-token builds it:
+  // unspaced CJK at window 64 grows a char-fallback slice to ~190 bytes
+  // before the window overflows. (A run of `a`s is no such control: 400 of
+  // them merge into a few long tokens and fit one window outright.)
+  let cell: OnceLock<Option<MergeTable>> = OnceLock::new();
+  let doc = "你好世界模型推理文本嵌入检索".repeat(60);
+  let opts = WindowOptions::new(64);
+  let fast = super::chunk_long(&mt, LazyTable::new(&cell, &mt), &doc, &opts).expect("fast");
+  assert!(
+    cell.get().is_some_and(Option::is_some),
+    "a long probe engages the lane"
+  );
+  assert_eq!(fast, chunk_long_slow(&mt, &doc, &opts).expect("slow"));
 }

--- a/coremlit/src/embeddings/granite/token_index/bpe_mirror/mod.rs
+++ b/coremlit/src/embeddings/granite/token_index/bpe_mirror/mod.rs
@@ -1,0 +1,446 @@
+//! A mirror of the `tokenizers` BPE merge process that also records HOW the
+//! tokens formed — the merge (pop) sequence and each final token's spines —
+//! which is what [`super::suffix_session`] needs to decide, without re-encoding,
+//! whether a cut inside one pre-token is a boundary of the substring's own
+//! tokenization.
+//!
+//! # What is mirrored, exactly
+//!
+//! `tokenizers::models::bpe::Word::merge_all` (0.23): every adjacent pair that
+//! is in the merge table goes into a min-heap keyed by `(rank, position)`; the
+//! minimum is popped, skipped if stale (its left symbol is dead, is the last
+//! symbol, or no longer forms the pair the entry was pushed for), else merged,
+//! after which the pair with the previous symbol and the pair with the next
+//! symbol are pushed. Positions are the ORIGINAL symbol indices, so "leftmost
+//! first" among equal ranks means what it means in the crate. `merge_word`'s
+//! symbol construction is mirrored for the artifact's configuration only: no
+//! `continuing_subword_prefix`, no `end_of_word_suffix`, no `unk_token`, no
+//! `byte_fallback`, no dropout — [`MergeTable::from_tokenizer`] refuses any
+//! other configuration. A byte whose byte-level single-char token the
+//! vocabulary lacks is one the crate silently DROPS; [`MergeTable::process`]
+//! refuses a word containing one instead (the index's byte-coverage guard has
+//! already routed such a text to direct encoding, so none reaches here).
+//!
+//! `ignore_merges` (a whole word that is itself a vocabulary entry is returned
+//! as one token, no merges) is NOT applied by [`MergeTable::process`]: this
+//! module models the merge PROCESS as it runs inside a longer word, where the
+//! shortcut never fires for a sub-range. The caller applies the shortcut to the
+//! whole query itself through [`MergeTable::whole_word_id`] — the MODEL
+//! vocabulary, the map `BPE::tokenize` reads for `ignore_merges`, never
+//! `Tokenizer::token_to_id`, which resolves the ADDED vocabulary first: an
+//! added token whose content is the byte-level spelling of a word would answer
+//! that lookup while the crate, matching added tokens against the raw text and
+//! finding no such literal, runs the merges.
+//!
+//! # Where the table comes from
+//!
+//! `BPE::merges` is crate-private in `tokenizers`, so the table is rebuilt from
+//! the model's serde form (`serde_json::to_value` of the loaded model — the same
+//! JSON the artifact file holds), pairing each merge's two strings through the
+//! vocabulary exactly as the crate's builder does, later duplicates of a pair
+//! overwriting earlier ones as `HashMap::insert` does there. Built once per
+//! embedder, on the fast lane's FIRST ENGAGEMENT (the first probe longer than
+//! any token can be into a QUALIFYING pre-token — see the index docs), not on
+//! the first `embed_long`: about half a second and ~74 MB transient (the serde
+//! value of the whole model plus a vocabulary clone), retaining the merge map
+//! alone — one 16-byte entry per merge, about 10 MB with the map's overhead
+//! for the artifact's 413,540 merges — for the embedder's lifetime.
+//!
+//! # The configuration the lane is pinned to
+//!
+//! [`MergeTable::from_tokenizer`] returns `None` — the lane stays off and every
+//! probe keeps the exact index path — unless the tokenizer is EXACTLY what the
+//! lane's arguments are about: a BPE with `ignore_merges` (the whole-word
+//! vocabulary lookups mirror it), no dropout / unk / affixes / byte fallback
+//! (the merge process is mirrored for that configuration only), NO normalizer
+//! (the bytes tokenized are the text's own, which the index's pointer/offset
+//! recovery reads), and the pre-tokenizer `Split(`[`SPLIT_PATTERN`]`,
+//! Isolated) → ByteLevel { add_prefix_space: false, use_regex: false }`
+//! verbatim — the lane's engagement gate is a lemma about THAT pattern's two
+//! letter branches, and a second regex pass or a prefixed space would void it.
+//! NOT pinned here: the post-processor. The lane's `+ 2` for the template
+//! specials — inherited from `measure_range`, whose count it must equal — is
+//! held by #48's tokenizer SHA gate, not by this table.
+
+use std::{
+  cmp::Reverse,
+  collections::{BinaryHeap, HashMap},
+};
+
+use tokenizers::{Model, ModelWrapper, Tokenizer, utils::SysRegex};
+
+/// The Split regex of the pre-tokenizer the lane is built for — o200k's,
+/// pinned verbatim from the artifact. Its first two alternatives are the
+/// letter branches `LEAD? HEAD* TAIL+ SUFFIX?` and `LEAD? HEAD+ TAIL* SUFFIX?`
+/// ([`LEAD_CLASS`], [`HEAD_CLASS`], [`TAIL_CLASS`], and the apostrophe
+/// contractions), in that order; the engagement lemma in the index docs is
+/// about exactly this pattern, and [`MergeTable::from_tokenizer`] refuses any
+/// other.
+pub(crate) const SPLIT_PATTERN: &str = r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+/// The letter branches' optional single leading char: anything that is not a
+/// letter, a digit, CR or LF. Named for the test that pins the pattern's
+/// structure; the lane itself needs only [`TAIL_CLASS`].
+#[cfg(test)]
+pub(crate) const LEAD_CLASS: &str = r"[^\r\n\p{L}\p{N}]";
+/// The letter branches' HEAD class — note `\p{Lu}` and `\p{Lt}`, which the
+/// tail class lacks. Named for the test that pins the pattern's structure.
+#[cfg(test)]
+pub(crate) const HEAD_CLASS: &str = r"[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]";
+/// The letter branches' TAIL class: the chars a pre-token may hold after its
+/// first for the lane to engage on it ([`TailClass`]).
+pub(crate) const TAIL_CLASS: &str = r"[\p{Ll}\p{Lm}\p{Lo}\p{M}]";
+
+/// [`TAIL_CLASS`] anchored to one whole string, compiled by the regex engine
+/// the tokenizer's own Split runs on — hence over the same Unicode tables —
+/// and independent of the merge table, so the lane can test a pre-token
+/// BEFORE deciding whether the table is worth building.
+pub(crate) struct TailClass(SysRegex);
+
+impl TailClass {
+  /// Compile the class; `None` only if the engine refuses the constant.
+  pub(crate) fn new() -> Option<Self> {
+    SysRegex::new(&format!(r"\A{TAIL_CLASS}\z")).ok().map(Self)
+  }
+
+  /// Whether `c` is in the tail class — decided by the tokenizer's own regex
+  /// engine, so exactly as its Split sees it.
+  pub(crate) fn contains(&self, c: char) -> bool {
+    let mut buf = [0u8; 4];
+    self.0.find_iter(c.encode_utf8(&mut buf)).next().is_some()
+  }
+}
+
+/// The pre-tokenizer configuration the lane is pinned to, in the tokenizer's
+/// serde form (what `serde_json::to_value` of the loaded pre-tokenizer yields,
+/// and what the artifact file holds).
+pub(crate) fn expected_pre_tokenizer() -> serde_json::Value {
+  serde_json::json!({
+    "type": "Sequence",
+    "pretokenizers": [
+      {
+        "type": "Split",
+        "pattern": { "Regex": SPLIT_PATTERN },
+        "behavior": "Isolated",
+        "invert": false
+      },
+      {
+        "type": "ByteLevel",
+        "add_prefix_space": false,
+        "trim_offsets": true,
+        "use_regex": false
+      }
+    ]
+  })
+}
+
+/// One executed merge of the process, in execution order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Pop {
+  /// The merge's rank (its index in the merge list; the heap key).
+  pub(crate) rank: u32,
+  /// Exclusive byte end, relative to the word start, of the token the merge
+  /// produced. A pop lies left of a boundary `q` of the final tokenization iff
+  /// `end <= q` — tokens never straddle a final boundary.
+  pub(crate) end: u32,
+  /// The vocabulary id of the produced token.
+  pub(crate) new_id: u32,
+}
+
+/// The recorded process of one word: its final tokens and every merge that
+/// formed them, plus each final token's two spines.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct WordRun {
+  /// Exclusive byte ends of the final tokens, relative to the word start,
+  /// strictly increasing, last `== word.len()`.
+  pub(crate) ends: Vec<u32>,
+  /// The final tokens' vocabulary ids, parallel to `ends`.
+  pub(crate) ids: Vec<u32>,
+  /// Every executed merge, in execution order.
+  pub(crate) pops: Vec<Pop>,
+  /// Per final token, the pop indices along its RIGHT spine, increasing: the
+  /// merges that successively produced the token containing the token's LAST
+  /// byte. State `j` of that byte's token is the initial single-byte symbol for
+  /// `j == 0` and `pops[rspine[j - 1]].new_id` after; it lives until pop
+  /// `rspine[j]` absorbs it.
+  pub(crate) rspine: Vec<Vec<u32>>,
+  /// Per final token, the pop indices along its LEFT spine — the same for the
+  /// token containing the token's FIRST byte.
+  pub(crate) lspine: Vec<Vec<u32>>,
+}
+
+/// The merge table of the artifact's BPE, plus the byte-level symbol map.
+pub(crate) struct MergeTable {
+  /// `(left id, right id) -> (rank, produced id)`.
+  merges: HashMap<(u32, u32), (u32, u32)>,
+  /// Raw byte -> vocabulary id of its byte-level single-char token, `None`
+  /// for a byte the vocabulary lacks (the crate DROPS such a char; the index's
+  /// byte-coverage guard keeps any text containing one off this path, and
+  /// [`MergeTable::process`] refuses such a word regardless).
+  byte_symbol: [Option<u32>; 256],
+  /// Raw byte -> its byte-level char, for spelling a word the way the vocabulary
+  /// does (the whole-word lookup).
+  byte_char: [char; 256],
+  /// The longest token in bytes the crate can emit — the model's vocabulary
+  /// (byte-level chars, one per byte) or an added token (raw bytes) — so a
+  /// whole-word lookup is skipped past it, and the measure floor's per-token
+  /// byte bound is over everything the crate can produce.
+  max_token_bytes: usize,
+}
+
+impl core::fmt::Debug for MergeTable {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.debug_struct("MergeTable")
+      .field("merges", &self.merges.len())
+      .field("max_token_bytes", &self.max_token_bytes)
+      .finish_non_exhaustive()
+  }
+}
+
+impl MergeTable {
+  /// Rebuild the merge table from the tokenizer's loaded BPE model. `None` when
+  /// the model is not a BPE, when the tokenizer is not the configuration the
+  /// lane is pinned to (see the module docs: `ignore_merges`, no normalizer,
+  /// the exact Split + ByteLevel pre-tokenizer), or when its serde form cannot
+  /// be read — in every case the caller simply keeps today's direct-encode
+  /// measurement. Not pinned: the post-processor — the lane's `+ 2` for the
+  /// template specials is what `measure_range` already assumes, held by #48's
+  /// tokenizer SHA gate (with `post_processor: null` the lane and the index
+  /// agree with each other and both differ from a direct encode).
+  pub(crate) fn from_tokenizer(tok: &Tokenizer) -> Option<Self> {
+    let bpe = match tok.get_model() {
+      ModelWrapper::BPE(bpe) => bpe,
+      _ => return None,
+    };
+    if bpe.dropout.is_some_and(|d| d > 0.0)
+      || bpe.unk_token.is_some()
+      || bpe.continuing_subword_prefix.is_some()
+      || bpe.end_of_word_suffix.is_some()
+      || bpe.byte_fallback
+      || !bpe.ignore_merges
+      || tok.get_normalizer().is_some()
+    {
+      return None;
+    }
+    if serde_json::to_value(tok.get_pre_tokenizer()?).ok()? != expected_pre_tokenizer() {
+      return None;
+    }
+    let vocab: HashMap<String, u32> = bpe.get_vocab();
+    let value = serde_json::to_value(tok.get_model()).ok()?;
+    let merges_json = value.get("merges")?.as_array()?;
+    let mut merges: HashMap<(u32, u32), (u32, u32)> = HashMap::with_capacity(merges_json.len());
+    for (rank, entry) in merges_json.iter().enumerate() {
+      // Two serde spellings exist: `["a", "b"]` (current) and `"a b"` (legacy).
+      let (a, b) = match entry {
+        serde_json::Value::Array(pair) if pair.len() == 2 => {
+          (pair[0].as_str()?.to_owned(), pair[1].as_str()?.to_owned())
+        }
+        serde_json::Value::String(s) => {
+          let (a, b) = s.split_once(' ')?;
+          (a.to_owned(), b.to_owned())
+        }
+        _ => return None,
+      };
+      let a_id = *vocab.get(&a)?;
+      let b_id = *vocab.get(&b)?;
+      let new_id = *vocab.get(&format!("{a}{b}"))?;
+      merges.insert((a_id, b_id), (u32::try_from(rank).ok()?, new_id));
+    }
+    let byte_char = bytes_char();
+    let mut byte_symbol = [None; 256];
+    for b in 0..=255u8 {
+      let mut s = String::new();
+      s.push(byte_char[b as usize]);
+      byte_symbol[b as usize] = vocab.get(&s).copied();
+    }
+    // One byte-level char per original byte, so a token's byte length is its
+    // char count — over the model's vocabulary AND the added vocabulary, since
+    // the crate can emit either (an added literal in the text sends the index
+    // to direct encoding anyway, but the bound must not depend on that).
+    let added = tok.get_added_vocabulary().get_vocab();
+    let max_token_bytes = vocab
+      .keys()
+      .map(|k| k.chars().count())
+      .chain(added.keys().map(|k| k.len()))
+      .max()?;
+    Some(Self {
+      merges,
+      byte_symbol,
+      byte_char,
+      max_token_bytes,
+    })
+  }
+
+  /// The MODEL vocabulary's id of `word` as one token — the lookup
+  /// `ignore_merges` makes (`BPE::tokenize` reads the model's `vocab` alone),
+  /// which every whole-word shortcut of the lane must mirror. NOT
+  /// `Tokenizer::token_to_id`: that resolves the ADDED vocabulary first, and
+  /// an added token whose content is the byte-level spelling of a word
+  /// (`"Ġzzqxjkw"` for `" zzqxjkw"`) would answer it while the crate, which
+  /// matches added tokens against the RAW text and finds no such literal,
+  /// runs the merges. A word longer than any token is never one.
+  pub(crate) fn whole_word_id(&self, tok: &Tokenizer, word: &[u8]) -> Option<u32> {
+    if word.len() > self.max_token_bytes {
+      return None;
+    }
+    tok.get_model().token_to_id(&self.spell(word))
+  }
+
+  /// The number of merges the table holds (its retained footprint is one
+  /// 16-byte entry each, plus the map's overhead).
+  #[cfg(test)]
+  pub(crate) fn merge_count(&self) -> usize {
+    self.merges.len()
+  }
+
+  /// The longest token the crate can emit, in bytes (model and added
+  /// vocabularies alike).
+  #[inline]
+  pub(crate) const fn max_token_bytes(&self) -> usize {
+    self.max_token_bytes
+  }
+
+  /// The merge rank and produced id of the pair `(left, right)`, if it is one.
+  #[inline]
+  pub(crate) fn merge(&self, left: u32, right: u32) -> Option<(u32, u32)> {
+    self.merges.get(&(left, right)).copied()
+  }
+
+  /// The vocabulary id of `byte`'s byte-level single-char token, `None` when
+  /// the vocabulary lacks it.
+  #[inline]
+  pub(crate) fn symbol(&self, byte: u8) -> Option<u32> {
+    self.byte_symbol[byte as usize]
+  }
+
+  /// `word` spelled as the vocabulary spells it (byte-level chars), for the
+  /// whole-word lookup that mirrors `ignore_merges`.
+  pub(crate) fn spell(&self, word: &[u8]) -> String {
+    word.iter().map(|&b| self.byte_char[b as usize]).collect()
+  }
+
+  /// Run the merge process over `word` (raw bytes, one symbol per byte) and
+  /// record it. Never applies the whole-word shortcut (see the module docs).
+  /// `None` when a byte has no single-char token — the crate would drop that
+  /// char, which this process does not model.
+  pub(crate) fn process(&self, word: &[u8]) -> Option<WordRun> {
+    struct Sym {
+      c: u32,
+      prev: i32,
+      next: i32,
+      len: u32,
+      start: u32,
+      lspine: Vec<u32>,
+      rspine: Vec<u32>,
+    }
+    let n = word.len();
+    let mut syms: Vec<Sym> = Vec::with_capacity(n);
+    for (i, &b) in word.iter().enumerate() {
+      syms.push(Sym {
+        c: self.symbol(b)?,
+        prev: i as i32 - 1,
+        next: if i + 1 < n { (i + 1) as i32 } else { -1 },
+        len: 1,
+        start: i as u32,
+        lspine: Vec::new(),
+        rspine: Vec::new(),
+      });
+    }
+    // Min-heap on (rank, pos): the crate's `Merge` ordering.
+    let mut heap: BinaryHeap<Reverse<(u32, u32, u32)>> = BinaryHeap::with_capacity(n);
+    for i in 0..n.saturating_sub(1) {
+      if let Some((rank, new_id)) = self.merge(syms[i].c, syms[i + 1].c) {
+        heap.push(Reverse((rank, i as u32, new_id)));
+      }
+    }
+    let mut pops: Vec<Pop> = Vec::new();
+    while let Some(Reverse((rank, pos, new_id))) = heap.pop() {
+      let p = pos as usize;
+      if syms[p].len == 0 || syms[p].next == -1 {
+        continue;
+      }
+      let nx = syms[p].next as usize;
+      match self.merge(syms[p].c, syms[nx].c) {
+        Some((_, id)) if id == new_id => {}
+        _ => continue,
+      }
+      // Merge slot `nx` into slot `p`.
+      let right_len = syms[nx].len;
+      let right_next = syms[nx].next;
+      let right_rspine = std::mem::take(&mut syms[nx].rspine);
+      syms[nx].len = 0;
+      let pop_idx = pops.len() as u32;
+      {
+        let left = &mut syms[p];
+        left.c = new_id;
+        left.len += right_len;
+        left.next = right_next;
+        left.rspine = right_rspine;
+        left.rspine.push(pop_idx);
+        left.lspine.push(pop_idx);
+      }
+      if right_next >= 0 {
+        syms[right_next as usize].prev = p as i32;
+      }
+      pops.push(Pop {
+        rank,
+        end: syms[p].start + syms[p].len,
+        new_id,
+      });
+      let prev = syms[p].prev;
+      if prev >= 0 {
+        let pv = prev as usize;
+        if let Some((r, id)) = self.merge(syms[pv].c, syms[p].c) {
+          heap.push(Reverse((r, pv as u32, id)));
+        }
+      }
+      let next = syms[p].next;
+      if next >= 0 {
+        let nn = next as usize;
+        if let Some((r, id)) = self.merge(syms[p].c, syms[nn].c) {
+          heap.push(Reverse((r, p as u32, id)));
+        }
+      }
+    }
+    let mut run = WordRun {
+      pops,
+      ..WordRun::default()
+    };
+    for s in syms.into_iter().filter(|s| s.len != 0) {
+      run.ends.push(s.start + s.len);
+      run.ids.push(s.c);
+      run.rspine.push(s.rspine);
+      run.lspine.push(s.lspine);
+    }
+    Some(run)
+  }
+}
+
+/// The byte-level map the crate's `ByteLevel` pre-tokenizer uses: printable
+/// bytes map to themselves, the rest to `U+0100 + n` in order.
+fn bytes_char() -> [char; 256] {
+  let mut printable = [false; 256];
+  for b in b'!'..=b'~' {
+    printable[b as usize] = true;
+  }
+  for b in 0xA1u8..=0xAC {
+    printable[b as usize] = true;
+  }
+  for b in 0xAEu8..=0xFF {
+    printable[b as usize] = true;
+  }
+  let mut out = ['\0'; 256];
+  let mut n = 0u32;
+  for b in 0..=255usize {
+    out[b] = if printable[b] {
+      char::from(b as u8)
+    } else {
+      let c = char::from_u32(256 + n).expect("256..512 are scalar values");
+      n += 1;
+      c
+    };
+  }
+  out
+}
+
+#[cfg(test)]
+mod tests;

--- a/coremlit/src/embeddings/granite/token_index/bpe_mirror/tests.rs
+++ b/coremlit/src/embeddings/granite/token_index/bpe_mirror/tests.rs
@@ -1,0 +1,359 @@
+//! The mirror is exact: its final tokens equal the crate's over every word the
+//! artifact tokenizer can be handed, and its recorded process is internally
+//! consistent (spines, pop ends, tiling).
+
+use tokenizers::{Tokenizer, utils::SysRegex};
+
+use super::{HEAD_CLASS, LEAD_CLASS, MergeTable, SPLIT_PATTERN, TAIL_CLASS, TailClass};
+use crate::embeddings::granite::{measuring_tokenizer_from_bytes, test_artifact};
+
+fn measuring_tok() -> Tokenizer {
+  measuring_tokenizer_from_bytes(test_artifact::tokenizer_bytes()).expect("measuring tokenizer")
+}
+
+fn table(tok: &Tokenizer) -> MergeTable {
+  MergeTable::from_tokenizer(tok).expect("the artifact's BPE is mirrorable")
+}
+
+/// Crate tokens of a single pre-token `s` (no specials), as `(id, end)`.
+fn crate_tokens(tok: &Tokenizer, s: &str) -> Vec<(u32, usize)> {
+  let enc = tok.encode(s, false).expect("encode");
+  enc
+    .get_ids()
+    .iter()
+    .zip(enc.get_offsets())
+    .map(|(&id, &(_, e))| (id, e))
+    .collect()
+}
+
+struct Rng(u64);
+impl Rng {
+  fn next_u64(&mut self) -> u64 {
+    self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = self.0;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+  }
+  fn below(&mut self, n: usize) -> usize {
+    (self.next_u64() % (n as u64)) as usize
+  }
+}
+
+/// Words that pre-tokenize as ONE piece (all-alphabetic runs), so the crate's
+/// encode of the word IS the BPE of its bytes: CJK runs of every length, Latin
+/// lowercase runs, Cyrillic, Greek, Thai, mixed scripts, and random draws from
+/// a CJK alphabet.
+fn single_piece_words() -> Vec<String> {
+  const CJK: &str = "你好世界模型推理文本嵌入检索的一是不了人我在有他这中大来上国个到说们为子和你地出道也时年得就那要下以生会自着去之过家学对可她里后小么心多天而能好都然没日于起还发成事只作当想看文无开手十用主行方又如前所本见经头面公同三已老从动两长知民样现分将外但身些与高意进把法此实回二理美点月明其种向死去所有";
+  let cjk: Vec<char> = CJK.chars().collect();
+  let mut words = vec![
+    "你".to_string(),
+    "你好".to_string(),
+    "你好世界".to_string(),
+    "模型推理文本嵌入检索".to_string(),
+    "internationalization".to_string(),
+    "x".repeat(300),
+    "ab".repeat(200),
+    "привет".to_string(),
+    "καλημέρα".to_string(),
+    "สวัสดี".to_string(),
+    "你好hello世界world".to_string(),
+  ];
+  let mut rng = Rng(7);
+  for len in [2usize, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610] {
+    for _ in 0..8 {
+      let w: String = (0..len).map(|_| cjk[rng.below(cjk.len())]).collect();
+      words.push(w);
+    }
+  }
+  words
+}
+
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn mirrored_process_matches_the_crate_on_single_piece_words() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  for w in single_piece_words() {
+    let run = table
+      .process(w.as_bytes())
+      .expect("every byte of the word has a token");
+    let want = crate_tokens(&tok, &w);
+    // `ignore_merges`: a whole word in the vocabulary is one token to the
+    // crate; the mirror deliberately runs the process instead (module docs).
+    if tok.token_to_id(&table.spell(w.as_bytes())).is_some() {
+      assert_eq!(want.len(), 1, "{w:?}: crate applies ignore_merges");
+      continue;
+    }
+    // Ids must agree token for token. Ends agree wherever the crate's offsets
+    // are byte-exact; a byte token INSIDE a multi-byte char is reported by the
+    // crate at the whole char's offsets, so only the ends of tokens that close
+    // a char are compared.
+    let got_ids: Vec<u32> = run.ids.clone();
+    let want_ids: Vec<u32> = want.iter().map(|&(id, _)| id).collect();
+    assert_eq!(got_ids, want_ids, "mirror diverges from the crate on {w:?}");
+    for (&e, &(_, we)) in run.ends.iter().zip(&want) {
+      if w.is_char_boundary(e as usize) {
+        assert_eq!(e as usize, we, "{w:?}: end of a char-closing token");
+      }
+    }
+  }
+}
+
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn recorded_process_is_internally_consistent() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  for w in single_piece_words() {
+    let run = table
+      .process(w.as_bytes())
+      .expect("every byte of the word has a token");
+    // Tiling: ends strictly increase and cover the word.
+    assert!(run.ends.windows(2).all(|p| p[0] < p[1]), "{w:?}: ends");
+    assert_eq!(
+      *run.ends.last().unwrap() as usize,
+      w.len(),
+      "{w:?}: coverage"
+    );
+    assert_eq!(run.ends.len(), run.ids.len());
+    assert_eq!(run.ends.len(), run.rspine.len());
+    assert_eq!(run.ends.len(), run.lspine.len());
+    // Pops: as many as symbols minus tokens; each pop's end is a token end of
+    // SOME later or final state — in particular the last pop of each spine
+    // produces that final token.
+    assert_eq!(run.pops.len(), w.len() - run.ends.len(), "{w:?}: pop count");
+    for (t, (&end, &id)) in run.ends.iter().zip(&run.ids).enumerate() {
+      let start = if t == 0 { 0 } else { run.ends[t - 1] };
+      for spine in [&run.rspine[t], &run.lspine[t]] {
+        assert!(spine.windows(2).all(|p| p[0] < p[1]), "{w:?}: spine order");
+        if end - start == 1 {
+          assert!(spine.is_empty(), "{w:?}: a single-byte token has no merges");
+        } else {
+          let last = *spine.last().expect("multi-byte token was merged") as usize;
+          assert_eq!(run.pops[last].new_id, id, "{w:?}: spine ends at the token");
+          assert_eq!(
+            run.pops[last].end, end,
+            "{w:?}: spine's last pop ends the token"
+          );
+        }
+      }
+      // Right-spine pops all end at the token's end (they absorb the last byte);
+      // left-spine pops all start at the token's start (the produced token's end
+      // grows monotonically along it).
+      for &i in &run.rspine[t] {
+        assert_eq!(run.pops[i as usize].end, end, "{w:?}: right spine end");
+      }
+      let mut prev = start;
+      for &i in &run.lspine[t] {
+        let e = run.pops[i as usize].end;
+        assert!(
+          e > prev && e <= end,
+          "{w:?}: left spine grows within the token"
+        );
+        prev = e;
+      }
+    }
+  }
+}
+
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn the_table_reads_the_artifacts_geometry() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  assert_eq!(table.max_token_bytes(), 128);
+  assert_eq!(table.merge_count(), 413_540, "the artifact's merge list");
+  // The byte-level single-char tokens the vocabulary has are exactly the ones
+  // the table maps (the crate's own vocabulary is the oracle), and the artifact
+  // is missing some — NUL among them — as the index's coverage guard documents.
+  for b in 0..=255u8 {
+    let s = table.spell(&[b]);
+    assert_eq!(tok.token_to_id(&s), table.symbol(b), "byte {b:#04x}");
+  }
+  assert_eq!(
+    table.symbol(0),
+    None,
+    "NUL has no single-char token in the artifact"
+  );
+  assert!(table.symbol(b'a').is_some());
+  assert!(
+    table.process(b"a\0b").is_none(),
+    "a word with a token-less byte is refused, not silently dropped"
+  );
+}
+
+/// TIMING (run locally for PR notes): building the merge table from the loaded
+/// model — the one-time cost an embedder pays on the lane's first engagement.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS); timing"]
+fn merge_table_build_time() {
+  let tok = measuring_tok();
+  let t0 = std::time::Instant::now();
+  let table = table(&tok);
+  let ms = t0.elapsed().as_secs_f64() * 1e3;
+  println!(
+    "[merge-table] build={ms:.1}ms max_token_bytes={}",
+    table.max_token_bytes()
+  );
+}
+
+/// The pinned Split pattern IS the pattern the lane's lemma is about: its two
+/// letter branches, in this order, built from the three classes the gate is
+/// derived from.
+#[test]
+fn the_pinned_split_pattern_opens_with_the_two_letter_branches() {
+  let suffix = "(?i:'s|'t|'re|'ve|'m|'ll|'d)?";
+  let letters = format!(
+    "{LEAD_CLASS}?{HEAD_CLASS}*{TAIL_CLASS}+{suffix}|{LEAD_CLASS}?{HEAD_CLASS}+{TAIL_CLASS}*{suffix}|"
+  );
+  assert!(SPLIT_PATTERN.starts_with(&letters), "{SPLIT_PATTERN}");
+  assert!(
+    SysRegex::new(SPLIT_PATTERN).is_ok(),
+    "the pinned pattern compiles on the crate's engine"
+  );
+  assert!(TailClass::new().is_some());
+}
+
+/// The tail class, compiled on the crate's engine, agrees with the pinned
+/// Split regex itself — `"a" + c` is ONE pre-token exactly when `c` is a tail
+/// char (the first letter branch's `TAIL+` runs through it, and no branch can
+/// glue anything else to a lowercase `a`) — over every scalar below U+3400
+/// (Latin, Greek, Cyrillic, the Semitic and Indic scripts with their marks,
+/// the titlecase digraphs and Greek titlecase vowels, all of the C0/C1
+/// controls, digits and punctuation), a stride of the rest of the space, and
+/// hand-picked exemplars of every general category. Hermetic: the pinned
+/// pattern is a constant.
+#[test]
+fn the_tail_class_agrees_with_the_split_regex_over_a_dense_sample_of_scalars() {
+  let tail = TailClass::new().expect("compiles");
+  let split = SysRegex::new(SPLIT_PATTERN).expect("compiles");
+  let is_tail = |c: char| tail.contains(c);
+  let glued = |c: char| {
+    let s = format!("a{c}");
+    split.find_iter(&s).next() == Some((0, s.len()))
+  };
+  let exemplars = [
+    0x41, 0x391, 0x410, 0x1C4, 0x1F08, 0x1F88, // Lu / Lt
+    0x1C5, 0x1C8, 0x1CB, 0x1F2, 0x1F98, 0x1FA8, 0x1FBC, 0x1FCC, 0x1FFC, // Lt
+    0x61, 0x3B1, 0x430, 0xDF, 0x1E9F, 0x1D00, // Ll
+    0x2B0, 0x2C6, 0x3005, 0x309D, 0x30FC, 0xA015, 0xFF70, // Lm
+    0x4E2D, 0x5D0, 0xAC00, 0x3042, 0x20000, 0x2A6D6, 0x10400, // Lo
+    0x300, 0x5BF, 0x903, 0x20DD, 0xFE0F, 0xE0100, // Mn / Mc / Me
+    0x30, 0x660, 0xB2, 0x2160, 0x3007, // Nd / No / Nl
+    0x20, 0x9, 0xA, 0xD, 0xA0, 0x2028, 0x3000, // whitespace
+    0x27, 0x2E, 0x3002, 0xFF01, 0x24, 0x2B, 0x1F600, 0x200D, // punctuation / symbols / format
+    0x0, 0x7F, 0x85, 0xE000, 0x10FFFF, // controls, private use, the last scalar
+  ];
+  let scalars = (0u32..0x3400)
+    .chain((0x3400..0x110000).step_by(97))
+    .chain(exemplars);
+  let (mut total, mut tails) = (0usize, 0usize);
+  for cp in scalars {
+    let Some(c) = char::from_u32(cp) else {
+      continue;
+    };
+    if c == 'a' {
+      continue;
+    }
+    let t = is_tail(c);
+    assert_eq!(t, glued(c), "U+{cp:04X} {c:?}");
+    total += 1;
+    tails += usize::from(t);
+  }
+  assert!(
+    tails > 5_000 && total - tails > 5_000,
+    "{tails} tail chars of {total}"
+  );
+  for cp in [
+    0x61u32, 0x3B1, 0x430, 0x2B0, 0x3005, 0x4E2D, 0x5D0, 0xAC00, 0x300, 0x903, 0x20DD,
+  ] {
+    assert!(
+      is_tail(char::from_u32(cp).expect("scalar")),
+      "U+{cp:04X} is a tail char"
+    );
+  }
+  for cp in [
+    0x41u32, 0x391, 0x410, 0x1C5, 0x1F88, 0x1FFC, 0x30, 0x20, 0x27, 0x3002, 0xA, 0x0,
+  ] {
+    assert!(
+      !is_tail(char::from_u32(cp).expect("scalar")),
+      "U+{cp:04X} is not a tail char"
+    );
+  }
+}
+
+/// A tokenizer that is the artifact's in every way but one of the pinned
+/// configuration points gets NO table — the lane stays off, the exact path
+/// stays — while the unmutated artifact does (the premise).
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn the_table_refuses_a_configuration_the_lane_is_not_pinned_to() {
+  fn mutated(mutate: impl FnOnce(&mut serde_json::Value)) -> Tokenizer {
+    let mut value: serde_json::Value =
+      serde_json::from_slice(test_artifact::tokenizer_bytes()).expect("parse the artifact");
+    mutate(&mut value);
+    Tokenizer::from_bytes(serde_json::to_vec(&value).expect("serialize")).expect("load")
+  }
+  assert!(
+    MergeTable::from_tokenizer(&mutated(|_| {})).is_some(),
+    "premise: the re-serialized artifact is mirrorable"
+  );
+  let swapped = {
+    let (first, rest) = SPLIT_PATTERN.split_once('|').expect("alternation");
+    let (second, tail) = rest.split_once('|').expect("alternation");
+    format!("{second}|{first}|{tail}")
+  };
+  type Mutation = Box<dyn FnOnce(&mut serde_json::Value)>;
+  let cases: [(&str, Mutation); 8] = [
+    (
+      "ignore_merges off",
+      Box::new(|v| v["model"]["ignore_merges"] = serde_json::json!(false)),
+    ),
+    (
+      "a normalizer",
+      Box::new(|v| v["normalizer"] = serde_json::json!({ "type": "NFC" })),
+    ),
+    (
+      "ByteLevel add_prefix_space",
+      Box::new(|v| {
+        v["pre_tokenizer"]["pretokenizers"][1]["add_prefix_space"] = serde_json::json!(true)
+      }),
+    ),
+    (
+      "ByteLevel use_regex",
+      Box::new(|v| v["pre_tokenizer"]["pretokenizers"][1]["use_regex"] = serde_json::json!(true)),
+    ),
+    (
+      "the letter branches swapped",
+      Box::new(move |v| {
+        v["pre_tokenizer"]["pretokenizers"][0]["pattern"]["Regex"] = serde_json::json!(swapped)
+      }),
+    ),
+    (
+      "Split behavior Removed",
+      Box::new(|v| {
+        v["pre_tokenizer"]["pretokenizers"][0]["behavior"] = serde_json::json!("Removed")
+      }),
+    ),
+    (
+      "ByteLevel alone",
+      Box::new(|v| {
+        v["pre_tokenizer"] = serde_json::json!({
+          "type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true, "use_regex": true
+        });
+      }),
+    ),
+    (
+      "byte_fallback",
+      Box::new(|v| v["model"]["byte_fallback"] = serde_json::json!(true)),
+    ),
+  ];
+  for (what, mutate) in cases {
+    assert!(
+      MergeTable::from_tokenizer(&mutated(mutate)).is_none(),
+      "{what}: no table"
+    );
+  }
+}

--- a/coremlit/src/embeddings/granite/token_index/mod.rs
+++ b/coremlit/src/embeddings/granite/token_index/mod.rs
@@ -70,6 +70,23 @@
 //!      (end-of-substring), so `b` on a pre-token boundary is not enough — the run
 //!      must be re-encoded looking beyond `b`.
 //!
+//! # The separatorless fast lane (#72)
+//!
+//! A text the Split regex glues into ONE pre-token (unspaced CJK, `"x"×n`)
+//! gives this index no interior boundary, so every packer probe `[a, b)` with
+//! `a` inside it would re-encode `[a, b)` whole — quadratic in the chunk, 500–
+//! 2000× the input. [`TokenIndex::measure_range_fast`] routes such probes
+//! (strictly inside a pre-token longer than any token, whose every char after
+//! the first is in the Split regex's tail class `[\p{Ll}\p{Lm}\p{Lo}\p{M}]` —
+//! the shape whose every substring is again ONE pre-token, the lemma in that
+//! method's docs) to [`suffix_session`], which answers them from one recorded
+//! merge process of the chunk's suffix ([`bpe_mirror`]) plus a bounded
+//! certificate per probe; every other probe takes
+//! [`TokenIndex::measure_range`] unchanged. The lane is pinned to the
+//! artifact's exact tokenizer configuration ([`bpe_mirror`]'s docs) and its
+//! merge table is built on the lane's first engagement — the first probe
+//! longer than any token into a qualifying pre-token — once per embedder.
+//!
 //! # Build-time fallback guards
 //!
 //! Two conditions void the offset reconstruction the range machinery reads back;
@@ -108,9 +125,21 @@
 //!    over-coverage: no per-flag proof, harmless since added literals are
 //!    vanishingly rare in real text.
 
+use std::{cell::RefCell, collections::HashMap, sync::OnceLock};
+
 use tokenizers::Tokenizer;
 
+pub(crate) use self::bpe_mirror::MergeTable;
+#[cfg(test)]
+pub(crate) use self::suffix_session::build_meter;
+use self::{
+  bpe_mirror::TailClass,
+  suffix_session::{INITIAL_CAP, Prefix, Session},
+};
 use crate::embeddings::granite::error::{Error, Result};
+
+mod bpe_mirror;
+mod suffix_session;
 
 /// Counts the UTF-8 bytes handed to every internal `encode` on the measurement
 /// path (index build + edge fragments + the zone-overlap/`direct_only` direct
@@ -124,12 +153,20 @@ pub(crate) mod encode_meter {
   thread_local! {
     static BYTES: Cell<usize> = const { Cell::new(0) };
     static CALLS: Cell<usize> = const { Cell::new(0) };
+    static SIZES: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
   }
 
   /// Zero the per-thread counters before a measured run.
   pub(crate) fn reset() {
     BYTES.with(|b| b.set(0));
     CALLS.with(|c| c.set(0));
+    SIZES.with(|s| s.borrow_mut().clear());
+  }
+
+  /// The byte length of every measurement-path `encode` since the last
+  /// [`reset`], in call order — the shape of the cost, not just its total.
+  pub(crate) fn sizes() -> Vec<usize> {
+    SIZES.with(|s| s.borrow().clone())
   }
 
   /// The bytes encoded since the last [`reset`].
@@ -149,6 +186,7 @@ pub(crate) mod encode_meter {
   pub(crate) fn add(n: usize) {
     BYTES.with(|b| b.set(b.get().saturating_add(n)));
     CALLS.with(|c| c.set(c.get().saturating_add(1)));
+    SIZES.with(|s| s.borrow_mut().push(n));
   }
 }
 
@@ -392,6 +430,13 @@ impl TokenIndex {
     })
   }
 
+  /// Whether every measure answers by a direct substring encode — set when the
+  /// build could not prove byte coverage or tiling (see the module docs), in
+  /// which case no bound derived from byte length holds either.
+  pub(crate) const fn is_direct_only(&self) -> bool {
+    self.direct_only
+  }
+
   /// The fail-safe index: every measure answers by direct substring encode.
   fn direct_only() -> Self {
     Self {
@@ -580,6 +625,247 @@ impl TokenIndex {
     Ok(total + 2)
   }
 
+  /// [`Self::measure_range`] with the separatorless fast lane in front of it
+  /// (#72). A probe strictly inside one pre-token whose every char after the
+  /// first is in the Split regex's TAIL class — the shape the regex glues into
+  /// ONE pre-token however long, unspaced CJK or `"x".repeat(n)` — is
+  /// answered from the pre-token's recorded merge process
+  /// ([`suffix_session`]) instead of the whole-range re-encode
+  /// [`Self::left_resync`] falls back to there. Every other probe takes
+  /// [`Self::measure_range`] unchanged.
+  ///
+  /// # Why "every char after the first is a tail-class char" is the gate
+  ///
+  /// The Split regex ([`bpe_mirror::SPLIT_PATTERN`]) opens with two letter
+  /// branches, tried in this order at every position; the engine's
+  /// alternation is ordered, so the FIRST branch that matches wins:
+  ///
+  /// ```text
+  /// LEAD? HEAD* TAIL+ SUFFIX?       LEAD   = [^\r\n\p{L}\p{N}]
+  /// LEAD? HEAD+ TAIL* SUFFIX?       HEAD   = [\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]
+  ///                                 TAIL   = [\p{Ll}\p{Lm}\p{Lo}\p{M}]
+  ///                                 SUFFIX = (?i:'s|'t|'re|'ve|'m|'ll|'d)
+  /// ```
+  ///
+  /// `\p{Lm}`, `\p{Lo}` and `\p{M}` are in BOTH classes; `\p{Lu}` and `\p{Lt}`
+  /// are in the head class only. So a pre-token may hold an uppercase run
+  /// AFTER a tail char — `中UCCESSa` is one pre-token (`HEAD* = 中UCCESS`,
+  /// `TAIL+ = a`) — and a substring that ENDS in that run is NOT one
+  /// pre-token: `中UCCESS` parses as `中` by the first branch (which must end
+  /// on a tail char) and then `UCCESS` by the second, each half BPE'd on its
+  /// own with `ignore_merges` applied to each, which no merge process over the
+  /// whole substring models (`UCCESS` is a vocabulary entry the merges do not
+  /// reproduce). Hence the gate below, and its lemma:
+  ///
+  /// **Lemma.** Let `w = c₀ c₁ … cₙ₋₁` be a pre-token with `cᵢ ∈ TAIL` for every
+  /// `i ≥ 1`. Then every nonempty char-aligned substring `s = w[a..b]` other
+  /// than `w` itself is matched by the Split regex as exactly one pre-token —
+  /// so `encode(s)` is the BPE of `s`'s bytes as one word: the whole-word
+  /// lookup when `s` is a vocabulary entry (`ignore_merges`), else the merge
+  /// process — which is exactly what both lane arms compute.
+  ///
+  /// *Proof.* Every char of `s` after its first is a tail char. (i) If `s`'s
+  /// first char is a tail char too (always when `a ≥ 1`), the first branch
+  /// matches `s` whole from position 0: `LEAD?` may take a leading mark (a
+  /// mark is not a letter), `HEAD*` takes the chars in both classes, and
+  /// `TAIL+`, greedy, runs to the end because every remaining char is a tail
+  /// char — backtracking only ever shortens `HEAD*` to hand `TAIL+` its first
+  /// char, never the match's end — while `SUFFIX?` finds no apostrophe. (ii)
+  /// If `a = 0` and `c₀` is a head-only char (`\p{Lu}`, `\p{Lt}`) or a `LEAD`
+  /// char: with `b ≥ 2` the first branch again matches whole (`c₀` by `HEAD*`
+  /// or `LEAD?`, the rest as in (i)); with `b = 1`, `s = c₀` alone is one
+  /// pre-token — by the second branch (`HEAD+`) for a letter, by the
+  /// punctuation or whitespace branches for a `LEAD` char — a lone char no
+  /// branch can split. `c₀` cannot be a digit, CR or LF: a digit run and a
+  /// newline run are pre-tokens of their own branches, in which every char
+  /// after the first is a digit or whitespace, not a tail char. ∎
+  ///
+  /// The gate is the lemma's hypothesis, decided once per pre-token: every
+  /// char after the first is in `TAIL`, with membership answered by the
+  /// tokenizer's OWN regex engine over the same Unicode tables its Split uses
+  /// ([`TailClass`]) — never by `char::is_alphabetic`, a different
+  /// property that also accepts the uppercase and titlecase letters the lemma
+  /// must exclude. A pre-token with a contraction suffix, a digit, an
+  /// uppercase or titlecase letter after its first char, or a lone char never
+  /// qualifies and takes the exact path. In debug builds every lane answer is
+  /// also checked against the crate's own encode of the probe.
+  ///
+  /// # Errors
+  /// As [`Self::measure_range`].
+  pub(crate) fn measure_range_fast(
+    &self,
+    tok: &Tokenizer,
+    text: &str,
+    a: usize,
+    b: usize,
+    lane: &mut FastLane<'_>,
+  ) -> Result<usize> {
+    if self.direct_only || a >= b {
+      return self.measure_range(tok, text, a, b);
+    }
+    let ends = &self.pretoken_ends;
+    // The pre-token containing `a`; the probe qualifies when it lies within
+    // that one pre-token and is not the whole of it (the whole pre-token is a
+    // prefix-sum answer in `measure_range`). `a` may be the pre-token's start:
+    // `measure_range` handles a boundary start with an interior END by a
+    // direct encode too, which is the first chunk's cost on separatorless
+    // text, so the lane takes it.
+    let p = ends.partition_point(|&e| e <= a as u32);
+    if p >= ends.len() {
+      return self.measure_range(tok, text, a, b);
+    }
+    let p_start = if p == 0 { 0 } else { ends[p - 1] as usize };
+    let p_end = ends[p] as usize;
+    if b > p_end || (a == p_start && b == p_end) {
+      return self.measure_range(tok, text, a, b);
+    }
+    // Until a table exists, a probe no longer than any single token is one
+    // cheap direct encode — never a reason to build the table (~0.4 s, ~74 MB
+    // transient; 129 caller bytes at a tiny window must not force it). The
+    // lane engages on the first LONGER probe inside a pre-token that
+    // QUALIFIES — decided first, on the lane's own tail-class regex, so a
+    // long run that can never qualify (uppercase, a rule of `=`, a newline
+    // run) never pays for the table either. Once the table exists, short
+    // probes take the short arm below. Only WHEN the table is built depends
+    // on this ordering, never what is answered.
+    if lane.table.is_none() && b - a <= FastLane::ENGAGE_BYTES {
+      return self.measure_range(tok, text, a, b);
+    }
+    let qualifies = match lane.class_ok.get(&p) {
+      Some(&q) => q,
+      None => {
+        let q = match &lane.tail {
+          Some(tail) => {
+            let memo = &mut lane.tail_memo;
+            text[p_start..p_end]
+              .chars()
+              .skip(1)
+              .all(|c| *memo.entry(c).or_insert_with(|| tail.contains(c)))
+          }
+          None => false,
+        };
+        lane.class_ok.insert(p, q);
+        q
+      }
+    };
+    if !qualifies {
+      return self.measure_range(tok, text, a, b);
+    }
+    if lane.table.is_none() {
+      lane.table = Some(lane.lazy.get());
+    }
+    let Some(table) = lane.table.flatten() else {
+      return self.measure_range(tok, text, a, b);
+    };
+    // A probe no longer than the longest vocabulary entry — every single-atom
+    // probe of the word level, one CJK char, and the first few packer probes
+    // of a chunk — is answered without a session: the whole-word lookup first
+    // (`ignore_merges`), else the mirrored process over those few bytes. Exact
+    // by the same argument as the session (the probe is one pre-token, so its
+    // count is the BPE count of its bytes), and free of the crate's per-call
+    // encode overhead, which dominated once the whole-range re-encodes were
+    // gone; a session per atom start would have been the old cost back.
+    if b - a <= table.max_token_bytes() {
+      let bytes = &text.as_bytes()[a..b];
+      if table.whole_word_id(tok, bytes).is_some() {
+        lane_oracle(tok, text.get(a..b), 1 + 2);
+        return Ok(1 + 2);
+      }
+      return match table.process(bytes) {
+        Some(run) => {
+          let answer = run.ends.len() + 2;
+          lane_oracle(tok, text.get(a..b), answer);
+          Ok(answer)
+        }
+        None => self.measure_range(tok, text, a, b),
+      };
+    }
+    if lane.dead_start == Some(a) {
+      return self.measure_range(tok, text, a, b);
+    }
+    lane.uses += 1;
+    let now = lane.uses;
+    // The suffix has to end on a char boundary (it is sliced as `&str` for the
+    // crate's cross-check), so a cap is snapped DOWN to one.
+    let snap = |mut end: usize| -> usize {
+      end = end.min(p_end);
+      while end > a && !text.is_char_boundary(end) {
+        end -= 1;
+      }
+      end
+    };
+    // Find (or make) the session for this start.
+    let slot = match lane.sessions.iter().position(|(s, _)| s.start() == a) {
+      Some(i) => i,
+      None => {
+        if lane.sessions.len() >= FastLane::SESSIONS {
+          let lru = lane
+            .sessions
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, (_, used))| *used)
+            .map_or(0, |(i, _)| i);
+          lane.sessions.swap_remove(lru);
+        }
+        // Initial cap: the window's worth of this pre-token's bytes at its
+        // measured density, with a quarter of headroom — the probes of one
+        // chunk stop at the first overflow, so this covers them in one build
+        // on the typical chunk and a doubling covers the rest; floored so a
+        // tiny window still amortizes, ceilinged by the fixed cap.
+        let cap = {
+          let tokens = (self.count_prefix[p + 1] - self.count_prefix[p]).max(1) as usize;
+          let bytes = p_end - p_start;
+          let per_token = bytes.div_ceil(tokens).max(1);
+          (lane.window.saturating_mul(per_token).saturating_mul(5) / 4).clamp(1024, INITIAL_CAP)
+        };
+        let end = snap(a.saturating_add(cap));
+        let built = if end > a {
+          Session::build(tok, table, text, a, end)?
+        } else {
+          None
+        };
+        match built {
+          Some(s) => {
+            lane.sessions.push((s, now));
+            lane.sessions.len() - 1
+          }
+          None => {
+            lane.dead_start = Some(a);
+            return self.measure_range(tok, text, a, b);
+          }
+        }
+      }
+    };
+    lane.sessions[slot].1 = now;
+    // A probe past the session's cap rebuilds it twice as long, until it covers
+    // `b` or the pre-token's end is reached.
+    while b > lane.sessions[slot].0.end() {
+      let have = lane.sessions[slot].0.end();
+      let end = snap(a.saturating_add((have - a).saturating_mul(2)));
+      let grown = if end > have {
+        Session::build(tok, table, text, a, end)?
+      } else {
+        None
+      };
+      match grown {
+        Some(s) => lane.sessions[slot].0 = s,
+        None => {
+          lane.dead_start = Some(a);
+          lane.sessions.swap_remove(slot);
+          return self.measure_range(tok, text, a, b);
+        }
+      }
+    }
+    let session = &mut lane.sessions[slot].0;
+    match session.measure_prefix(tok, table, b) {
+      Prefix::Count(content) => {
+        lane_oracle(tok, text.get(a..b), content + 2);
+        Ok(content + 2)
+      }
+      Prefix::Direct | Prefix::PastCap => Ok(encode_content_len(tok, &text[a..b])? + 2),
+    }
+  }
+
   /// The inside-pre-token re-sync: re-encode a bounded window from `a` and report a
   /// [`Resync`]. On [`Resync::Boundary`], `z` is the first position
   /// that is a pre-token boundary of BOTH `text[a..]`'s parse (a word-id change)
@@ -693,6 +979,115 @@ fn scan_back_whitespace(text: &str, from: usize) -> usize {
   y
 }
 
+/// Debug-build oracle for a fast-lane answer: the crate's own encode of the
+/// probe, which every lane arm must equal exactly. Compiled to nothing in
+/// release builds, and calls the tokenizer directly rather than through the
+/// test-only encode meter, so the meter keeps counting production encodes
+/// alone.
+#[cfg(debug_assertions)]
+fn lane_oracle(tok: &Tokenizer, probe: Option<&str>, answer: usize) {
+  if let Some(s) = probe
+    && let Ok(enc) = tok.encode(s, true)
+  {
+    debug_assert_eq!(answer, enc.get_ids().len(), "fast-lane answer for {s:?}");
+  }
+}
+
+#[cfg(not(debug_assertions))]
+#[inline]
+const fn lane_oracle(_: &Tokenizer, _: Option<&str>, _: usize) {}
+
+/// The merge table behind the fast lane, built by [`MergeTable::from_tokenizer`]
+/// on the lane's first engagement and kept in the embedder's cell for every
+/// later `chunk_long` — so an embedder that never meets a separatorless
+/// pre-token never pays the build (see [`bpe_mirror`]'s docs for its cost).
+#[derive(Clone, Copy)]
+pub(crate) struct LazyTable<'t> {
+  cell: &'t OnceLock<Option<MergeTable>>,
+  tok: &'t Tokenizer,
+}
+
+impl<'t> LazyTable<'t> {
+  /// The table `cell` holds, or will hold once built from `tok`.
+  pub(crate) const fn new(cell: &'t OnceLock<Option<MergeTable>>, tok: &'t Tokenizer) -> Self {
+    Self { cell, tok }
+  }
+
+  /// The table, building it on the first call; `None` when `tok` is not a
+  /// configuration the lane is pinned to.
+  pub(crate) fn get(&self) -> Option<&'t MergeTable> {
+    self
+      .cell
+      .get_or_init(|| MergeTable::from_tokenizer(self.tok))
+      .as_ref()
+  }
+}
+
+/// Per-`chunk_long` state of the separatorless fast lane
+/// ([`TokenIndex::measure_range_fast`]): the table once engaged, the live
+/// [`Session`]s, the chunk start whose session could not be built (so it is
+/// not rebuilt on every probe), and the per-pre-token qualification cache.
+pub(crate) struct FastLane<'t> {
+  lazy: LazyTable<'t>,
+  /// `None` until the lane engages; then the table, or `Some(None)` — the lane
+  /// is off for this call and every probe takes the exact index path.
+  table: Option<Option<&'t MergeTable>>,
+  /// The gate's char test, compiled per lane (microseconds) and independent
+  /// of the table, so qualification is decided BEFORE the table is built;
+  /// `None` (the engine refused the constant) means nothing qualifies.
+  tail: Option<TailClass>,
+  /// At most [`FastLane::SESSIONS`] live sessions, each for one chunk start.
+  /// Two are needed, not one: windit interleaves the atom builder's probes (a
+  /// growing slice from the current atom's start) with the packer's (a growing
+  /// prefix from the chunk's start), and a single slot would rebuild a session
+  /// on every alternation — a full suffix encode per probe, the old cost back.
+  sessions: Vec<(Session, u64)>,
+  /// Monotone use counter for the least-recently-used eviction.
+  uses: u64,
+  dead_start: Option<usize>,
+  class_ok: HashMap<usize, bool>,
+  /// Per-char memo of the tail-class test behind `class_ok`.
+  tail_memo: HashMap<char, bool>,
+  /// The chunk window in tokens, which sizes a session's initial cap: a
+  /// chunk's probes never run past the first overflow, about `window` tokens
+  /// of the pre-token, whose byte density the index already knows.
+  window: usize,
+}
+
+impl<'t> FastLane<'t> {
+  /// Live sessions kept: the atom builder's start and the packer's.
+  const SESSIONS: usize = 2;
+  /// Before any table exists, a probe no longer than this is answered by one
+  /// cheap direct encode; the lane (and the table build behind it) engages on
+  /// the first longer probe inside a qualifying pre-token. The artifact's
+  /// longest token is exactly this long, so a longer probe is one BPE could
+  /// never take whole. Once the table exists, short probes take the short arm.
+  const ENGAGE_BYTES: usize = 128;
+
+  fn new(window: usize, lazy: LazyTable<'t>) -> Self {
+    Self {
+      lazy,
+      table: None,
+      tail: TailClass::new(),
+      sessions: Vec::new(),
+      uses: 0,
+      dead_start: None,
+      class_ok: HashMap::new(),
+      tail_memo: HashMap::new(),
+      window,
+    }
+  }
+
+  /// A lane already engaged (the table resolved), so a test can drive the
+  /// lane's arms on pre-tokens shorter than [`Self::ENGAGE_BYTES`].
+  #[cfg(test)]
+  pub(crate) fn engaged(window: usize, lazy: LazyTable<'t>) -> Self {
+    let mut lane = Self::new(window, lazy);
+    lane.table = Some(lazy.get());
+    lane
+  }
+}
+
 /// windit [`MeasureText`](windit::split::MeasureText) adapter backed by a
 /// [`TokenIndex`]: recovers the `(a, b)` byte range of each queried subslice by
 /// pointer arithmetic against `text` and answers from the index.
@@ -705,12 +1100,30 @@ pub(crate) struct IndexMeasure<'a> {
   text: &'a str,
   index: &'a TokenIndex,
   tok: &'a Tokenizer,
+  /// The separatorless fast lane's state, over the embedder's lazily built
+  /// merge table. windit measures through `&self`, and the lane mutates per
+  /// probe (engagement, session build, activation), hence the cell; the
+  /// adapter is used from one thread by one `chunk_long` call.
+  lane: RefCell<FastLane<'a>>,
 }
 
 impl<'a> IndexMeasure<'a> {
-  /// Adapter over `text`, its prebuilt `index`, and the measuring `tok`.
-  pub(crate) fn new(text: &'a str, index: &'a TokenIndex, tok: &'a Tokenizer) -> Self {
-    Self { text, index, tok }
+  /// Adapter over `text`, its prebuilt `index`, the measuring `tok`, the fast
+  /// lane's lazily built merge table, and the chunk window in tokens (which
+  /// sizes the lane's sessions).
+  pub(crate) fn new(
+    text: &'a str,
+    index: &'a TokenIndex,
+    tok: &'a Tokenizer,
+    table: LazyTable<'a>,
+    window: usize,
+  ) -> Self {
+    Self {
+      text,
+      index,
+      tok,
+      lane: RefCell::new(FastLane::new(window, table)),
+    }
   }
 }
 
@@ -727,10 +1140,13 @@ impl windit::split::MeasureText for IndexMeasure<'_> {
       && off <= self.text.len()
       && off + s.len() <= self.text.len()
     {
-      return self
-        .index
-        .measure_range(self.tok, self.text, off, off + s.len())
-        .unwrap_or(usize::MAX);
+      let measured = {
+        let mut lane = self.lane.borrow_mut();
+        self
+          .index
+          .measure_range_fast(self.tok, self.text, off, off + s.len(), &mut lane)
+      };
+      return measured.unwrap_or(usize::MAX);
     }
     // Unreachable from windit; fold an encode error to `usize::MAX` ("does not
     // fit"), exactly as the old closure did.
@@ -741,10 +1157,71 @@ impl windit::split::MeasureText for IndexMeasure<'_> {
       .unwrap_or(usize::MAX)
   }
 
-  // `measure_within` keeps the default (full `measure` + compare): `measure` is
-  // already O(log n) here, so the early-stop the trait offers buys nothing, and
-  // the default trivially satisfies the "must agree with `measure`" contract that
-  // keeps chunk boundaries put.
+  /// The trait's early stop, from an EXACT floor rather than a partial read.
+  ///
+  /// # The bound and its premises
+  ///
+  /// For a subslice `s` of the indexed text, `measure(s) = encode(s, true).len()`
+  /// is at least `2 + ceil(len(s) / longest)`, where
+  ///
+  /// * `2` is the template's two specials, present for every `s` including the
+  ///   empty one (`<|startoftext|> A <|return|>`; the index's exactness argument
+  ///   pins `encode(s, true).len() == encode(s, false).len() + 2`);
+  /// * `len(s)` is BYTES, and every byte of `s` lies inside some content token
+  ///   — which is exactly the byte-coverage the index's build proved for the
+  ///   whole text (each ByteLevel char has a single-byte token, so no byte is
+  ///   DROPPED), and a drop is a per-byte property, so it holds for every
+  ///   subslice of that text too;
+  /// * `longest` is the longest token in bytes over the vocabulary the crate
+  ///   can emit — the model's AND the added vocabulary's (the merge table takes
+  ///   the max of both), one byte-level char per byte, so a content token
+  ///   covers at most `longest` bytes and a covered `len` needs at least
+  ///   `ceil(len / longest)` of them. Before the lane has engaged (no table
+  ///   yet) the floor uses one content token, which coverage alone gives.
+  ///
+  /// Where coverage is NOT proven the bound is FALSE, not merely loose: the
+  /// pinned tokenizer has no ByteLevel symbol for NUL and no unk fallback, so
+  /// `"\0\0"` encodes to the two specials alone — `measure == 2` while the
+  /// floor would say 3. That is precisely the `direct_only` mode the build
+  /// enters, so the floor is consulted only for an in-range subslice of the
+  /// indexed text on an index that is not `direct_only`; a foreign string, or
+  /// any probe on a `direct_only` index, takes the full measure. Under those
+  /// conditions a floor above `limit` is a `None` the full measure would also
+  /// have given — the contract ("`Some` exactly when the measure is `<=
+  /// limit`") holds by the inequality, never by a heuristic.
+  ///
+  /// This is what retires the second separatorless blow-up (#72): windit's
+  /// overlap search walks EVERY atom of a closed chunk asking whether the
+  /// suffix from that atom fits the overlap budget, which at the default
+  /// overlap of zero nothing ever does (two specials already exceed it); each
+  /// such ask used to be a whole-suffix encode from a different start.
+  fn measure_within(&self, s: &str, limit: usize) -> Option<usize> {
+    let covered_subslice = !self.index.is_direct_only() && {
+      let base = self.text.as_ptr() as usize;
+      let sp = s.as_ptr() as usize;
+      sp.checked_sub(base)
+        .is_some_and(|off| off <= self.text.len() && off + s.len() <= self.text.len())
+    };
+    if covered_subslice {
+      let content_floor = if s.is_empty() {
+        0
+      } else {
+        // At least one content token; `ceil(len / longest)` of them once the
+        // lane has engaged and the table's `longest` is known.
+        self
+          .lane
+          .borrow()
+          .table
+          .flatten()
+          .map_or(1, |t| s.len().div_ceil(t.max_token_bytes().max(1)))
+      };
+      if 2 + content_floor > limit {
+        return None;
+      }
+    }
+    let measured = self.measure(s);
+    (measured <= limit).then_some(measured)
+  }
 }
 
 #[cfg(test)]

--- a/coremlit/src/embeddings/granite/token_index/suffix_session/mod.rs
+++ b/coremlit/src/embeddings/granite/token_index/suffix_session/mod.rs
@@ -1,0 +1,479 @@
+//! The separatorless fast lane: exact prefix measures inside ONE pre-token
+//! without re-encoding the growing prefix.
+//!
+//! # The problem this solves
+//!
+//! On text the Split regex parses as a single document-spanning pre-token
+//! (unspaced CJK, `"x".repeat(n)`), [`super::TokenIndex`] has no interior
+//! boundary, so every packer probe `[a, b)` with `a` inside that pre-token
+//! re-encoded `[a, b)` whole — quadratic in the chunk length, 500–2000× the
+//! input (#72). The probes come in one shape: a FIXED start `a` (the chunk
+//! start) and an end `b` that grows one atom at a time. This module answers them
+//! from one recorded merge process over the suffix `Z = text[a..]` (capped, see
+//! [`Session::build`]) plus, per probe, a tiny re-run over the last token.
+//!
+//! # Why a cut inside a pre-token is hard
+//!
+//! Inside one pre-token the count is the BPE token count of the byte string,
+//! and BPE is not prefix-stable: with `rank(bc) < rank(ab)`, `encode("ab")` is
+//! not a prefix of `encode("abc")`. What IS true is the independence lemma —
+//! stated and proved on [`Session::cut_is_boundary`]: if `q` is a boundary of
+//! the tokenization of `w`, the two sides tokenize as they would in isolation,
+//! so `T(w) = T(w[..q]) ++ T(w[q..])`. For a probe `Z_b = Z[..b]` the question
+//! is therefore only: which boundary `q` of `T(Z)` is ALSO a boundary of
+//! `T(Z_b)`? Then `count(Z_b) = (tokens of T(Z) before q) + |T(Z[q..b])|`, the
+//! second term a re-run over at most one token's worth of bytes. Deciding that
+//! needs the merge PROCESS, not the final tokens — which is what
+//! [`super::bpe_mirror`] records.
+//!
+//! # Exactness guards, in production
+//!
+//! * The session's process over `Z` is checked token-for-token against the
+//!   crate's own `encode` of the same bytes; a mismatch voids the session and
+//!   the query takes today's direct encode.
+//! * `ignore_merges` — a whole query that is itself a vocabulary entry is one
+//!   token, whatever the merges say — is applied through the tokenizer's own
+//!   vocabulary lookup before any process result is consulted.
+//! * A cascade that walks back to the start of `Z` is answered by the direct
+//!   encode, never by a guess.
+
+use tokenizers::Tokenizer;
+
+use super::bpe_mirror::{MergeTable, WordRun};
+
+/// Test-only record of every session built — `(start, end)` in order — so a
+/// gate can see how many suffix encodes a chunking really performed and from
+/// which starts, not just their byte total.
+#[cfg(test)]
+pub(crate) mod build_meter {
+  use std::cell::RefCell;
+
+  thread_local! {
+    static BUILDS: RefCell<Vec<(usize, usize)>> = const { RefCell::new(Vec::new()) };
+  }
+
+  /// Forget every recorded build.
+  pub(crate) fn reset() {
+    BUILDS.with(|b| b.borrow_mut().clear());
+  }
+
+  /// The builds recorded since the last [`reset`].
+  pub(crate) fn builds() -> Vec<(usize, usize)> {
+    BUILDS.with(|b| b.borrow().clone())
+  }
+
+  pub(crate) fn add(start: usize, end: usize) {
+    BUILDS.with(|b| b.borrow_mut().push((start, end)));
+  }
+}
+use crate::embeddings::granite::error::{Error, Result};
+
+/// Initial suffix cap: how many bytes of `text[a..]` one session records. A
+/// window of `MAX_TOKENS` tokens is far shorter than this on every real
+/// tokenizer (tokens are ≥ 1 byte), and a probe past the cap rebuilds a session
+/// twice as long, so the cap is a cost bound, not a limit.
+pub(crate) const INITIAL_CAP: usize = 8192;
+
+/// A range-max tree over the recorded pops of `Z`, holding `rank + 1` for an
+/// ACTIVE pop (one whose token ends at or before the current cut `q`, i.e. a pop
+/// of the left side `Z[..q]`) and `0` otherwise. Pops become active as the cut
+/// moves right and never deactivate, because the cut only moves right across
+/// the probes of one session.
+struct MaxTree {
+  size: usize,
+  node: Vec<u32>,
+}
+
+impl MaxTree {
+  fn new(len: usize) -> Self {
+    let size = len.max(1).next_power_of_two();
+    Self {
+      size,
+      node: vec![0; 2 * size],
+    }
+  }
+
+  fn set(&mut self, i: usize, v: u32) {
+    let mut k = i + self.size;
+    self.node[k] = v;
+    while k > 1 {
+      k /= 2;
+      self.node[k] = self.node[2 * k].max(self.node[2 * k + 1]);
+    }
+  }
+
+  /// Max over `[lo, hi)`; `0` when empty.
+  fn max(&self, lo: usize, hi: usize) -> u32 {
+    let (mut l, mut r) = (lo + self.size, hi.min(self.size) + self.size);
+    let mut best = 0;
+    while l < r {
+      if l & 1 == 1 {
+        best = best.max(self.node[l]);
+        l += 1;
+      }
+      if r & 1 == 1 {
+        r -= 1;
+        best = best.max(self.node[r]);
+      }
+      l /= 2;
+      r /= 2;
+    }
+    best
+  }
+
+  /// Largest index `k` with `max(0..=k) <= t`, as `Option<usize>` (`None` when
+  /// even index 0 exceeds `t`). Prefix maxima are monotone, so this bisects.
+  fn last_prefix_at_most(&self, t: u32, len: usize) -> Option<usize> {
+    if len == 0 || self.max(0, 1) > t {
+      return None;
+    }
+    let (mut lo, mut hi) = (0usize, len - 1);
+    while lo < hi {
+      let mid = lo + (hi - lo).div_ceil(2);
+      if self.max(0, mid + 1) <= t {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    Some(lo)
+  }
+}
+
+/// One recorded suffix `Z = text[start..end]` and the machinery to answer exact
+/// prefix counts over it.
+pub(crate) struct Session {
+  /// Absolute byte start of `Z` — the chunk start every probe shares.
+  start: usize,
+  /// Absolute exclusive byte end of `Z` (the cap, or the pre-token's end).
+  end: usize,
+  /// `text[start..end]`, owned so the session carries no borrow.
+  word: Vec<u8>,
+  /// The recorded merge process over `word`.
+  z: WordRun,
+  /// Pop indices of `z` ordered by their token's byte end — the activation order.
+  by_end: Vec<u32>,
+  /// How many of `by_end` are active; `active_q` is the cut they were activated
+  /// for.
+  activated: usize,
+  active_q: u32,
+  tree: MaxTree,
+  /// How many cuts the last probe's cascade walk moved left before a cut was
+  /// certified (0: the cut at the token containing `b` was a boundary, or the
+  /// probe was answered before any walk). Test-visible, so the refusal branch
+  /// of the certificate is provably exercised.
+  last_cascade_depth: usize,
+}
+
+/// What a probe resolved to.
+pub(crate) enum Prefix {
+  /// The exact content-token count of `text[start..b]`.
+  Count(usize),
+  /// `b` lies past this session's cap; the caller rebuilds a longer session.
+  PastCap,
+  /// The cascade reached the start of `Z`: encode the whole probe directly.
+  Direct,
+}
+
+impl Session {
+  /// Absolute byte start of `Z`.
+  pub(crate) const fn start(&self) -> usize {
+    self.start
+  }
+
+  /// Absolute exclusive byte end of `Z`.
+  pub(crate) const fn end(&self) -> usize {
+    self.end
+  }
+
+  /// Record the process over `text[start..end]`, or `None` when the fast lane
+  /// must not be used for this suffix: the suffix is itself a vocabulary entry
+  /// (`ignore_merges` would answer, and the process view is not what the
+  /// tokenizer runs), or the mirrored process disagrees with the tokenizer's
+  /// own tokenization of the same bytes.
+  ///
+  /// # Errors
+  /// [`Error::Tokenize`] if the checking encode fails.
+  pub(crate) fn build(
+    tok: &Tokenizer,
+    table: &MergeTable,
+    text: &str,
+    start: usize,
+    end: usize,
+  ) -> Result<Option<Self>> {
+    let word = text.as_bytes()[start..end].to_vec();
+    if word.is_empty() {
+      return Ok(None);
+    }
+    if table.whole_word_id(tok, &word).is_some() {
+      return Ok(None);
+    }
+    let Some(z) = table.process(&word) else {
+      return Ok(None);
+    };
+    // Cross-check against the tokenizer: the same ids in the same order. Equal
+    // ids fix the byte ends (every id has one byte length), so the ends need no
+    // separate comparison — and could not get one: the crate reports a byte
+    // token that sits inside a multi-byte char at the CHAR's offsets, not the
+    // byte's. An encode error is "cannot use", never "use".
+    #[cfg(test)]
+    super::encode_meter::add(end - start);
+    let enc = tok
+      .encode(&text[start..end], false)
+      .map_err(Error::Tokenize)?;
+    if enc.get_ids() != z.ids.as_slice() {
+      return Ok(None);
+    }
+    #[cfg(test)]
+    build_meter::add(start, end);
+    let mut by_end: Vec<u32> = (0..z.pops.len() as u32).collect();
+    by_end.sort_by_key(|&i| z.pops[i as usize].end);
+    let tree = MaxTree::new(z.pops.len());
+    Ok(Some(Self {
+      start,
+      end,
+      word,
+      z,
+      by_end,
+      activated: 0,
+      active_q: 0,
+      tree,
+      last_cascade_depth: 0,
+    }))
+  }
+
+  /// Make the active set exactly the pops whose token ends at or before `q`
+  /// (relative). `by_end` orders pops by end, so moving the cut right activates
+  /// a prefix of it and moving it left — the cascade walk stepping one token
+  /// back — deactivates the tail, each pop touched once per move.
+  fn activate_upto(&mut self, q: u32) {
+    while self.activated < self.by_end.len() {
+      let i = self.by_end[self.activated] as usize;
+      if self.z.pops[i].end > q {
+        break;
+      }
+      self.tree.set(i, self.z.pops[i].rank + 1);
+      self.activated += 1;
+    }
+    while self.activated > 0 {
+      let i = self.by_end[self.activated - 1] as usize;
+      if self.z.pops[i].end <= q {
+        break;
+      }
+      self.tree.set(i, 0);
+      self.activated -= 1;
+    }
+    self.active_q = q;
+  }
+
+  /// The exact content-token count of `text[start..b]`.
+  ///
+  /// Order of decision: the whole-word shortcut (the tokenizer's own vocabulary,
+  /// mirroring `ignore_merges`); a `b` on a boundary of `T(Z)` (the independence
+  /// lemma: the prefix tokenizes as its own tokens); otherwise the cascade walk
+  /// of [`Self::cut_is_boundary`] from the token containing `b` leftward.
+  pub(crate) fn measure_prefix(&mut self, tok: &Tokenizer, table: &MergeTable, b: usize) -> Prefix {
+    self.last_cascade_depth = 0;
+    if b > self.end {
+      return Prefix::PastCap;
+    }
+    let rel = b - self.start;
+    if rel == 0 {
+      return Prefix::Count(0);
+    }
+    let rel32 = rel as u32;
+    if table.whole_word_id(tok, &self.word[..rel]).is_some() {
+      return Prefix::Count(1);
+    }
+    // Index of the first token whose end is >= rel: the token containing rel,
+    // or the token ending exactly at rel.
+    let t = self.z.ends.partition_point(|&e| e < rel32);
+    if self.z.ends[t] == rel32 {
+      return Prefix::Count(t + 1);
+    }
+    // `t` tokens end strictly before `rel`; the cut candidates are their ends,
+    // walked leftward while the cut proves not to be a boundary of `T(Z_b)`.
+    let mut cut_token = t; // the cut is the START of token `cut_token`
+    loop {
+      if cut_token == 0 {
+        return Prefix::Direct;
+      }
+      let q = self.z.ends[cut_token - 1];
+      let Some(y) = table.process(&self.word[q as usize..rel]) else {
+        return Prefix::Direct;
+      };
+      if self.cut_is_boundary(table, q, cut_token - 1, &y) {
+        return Prefix::Count(cut_token + y.ends.len());
+      }
+      cut_token -= 1;
+      self.last_cascade_depth += 1;
+    }
+  }
+
+  /// Cuts the last probe's cascade walk moved left (see the field).
+  #[cfg(test)]
+  pub(crate) const fn last_cascade_depth(&self) -> usize {
+    self.last_cascade_depth
+  }
+
+  /// Whether `q` — a boundary of `T(Z)` at the end of token `x_token` — is also
+  /// a boundary of `T(Z[..b])`, where `y` is the recorded process over
+  /// `Y = Z[q..b]` in isolation.
+  ///
+  /// # The argument
+  ///
+  /// **Independence.** BPE pops the pending adjacent pair of least `(rank,
+  /// position)` and merges it, until none is pending. Take `w = XY`. As long as
+  /// no pop has merged across the `X|Y` seam, the pending pairs are the X-pairs,
+  /// the Y-pairs and the one seam pair `(x, y)` formed by X's last and Y's first
+  /// token; the X-pairs' pending set equals what X's isolated process has pending
+  /// at the same number of X-pops, likewise Y, because pops on one side never
+  /// touch the other. So, until a seam merge, the process is exactly X's and Y's
+  /// isolated pop sequences interleaved by taking, at each step, the least of
+  /// (X's next pop, the seam pair, Y's next pop) — X before the seam before Y on
+  /// equal rank, by position. If no seam pair is ever popped, `q` is a boundary
+  /// of `T(w)` and `T(w) = T(X) ++ T(Y)` (merges never split). Conversely a seam
+  /// merge makes a token straddle `q`, so `q` is a boundary iff no seam pair is
+  /// ever popped. Since `q` IS a boundary of `T(Z)` (never crossed there), X's
+  /// isolated sequence is exactly the pops of the recorded `Z`-process whose
+  /// token ends at or before `q`, in order — the ACTIVE pops.
+  ///
+  /// **Deciding the seam.** The seam pair changes only when a side's fringe
+  /// token changes: X's fringe walks the right spine of its last token, Y's the
+  /// left spine of its first. With `(x, y)` the current fringe pair and `ρ` its
+  /// merge rank (none ⇒ it cannot pop), and both sides at some position in
+  /// their sequences: the seam pops iff it becomes the least pending, i.e. iff X
+  /// reaches a next pop of rank `> ρ` while `x` is still alive AND Y reaches a
+  /// next pop of rank `>= ρ` (the seam is left of every Y pair, so it wins ties
+  /// with Y and loses them to X) while `y` is still alive. Each side's clause
+  /// depends on that side alone: X runs its pops of rank `<= ρ` first whatever Y
+  /// does, so `x` survives iff some pop between X's current position and the pop
+  /// that absorbs `x` (inclusive) has rank `> ρ`, or nothing ever absorbs `x`
+  /// (X's sequence ends, its next rank being `+∞`). Symmetrically for Y with
+  /// `>= ρ`. Both clauses true ⇒ the seam pops ⇒ not a boundary. Otherwise the
+  /// side that fails the clause absorbs its fringe first, a new pair forms, and
+  /// the question repeats for it.
+  ///
+  /// **Ordering the fringe events.** Two sequences interleaved by least-next-
+  /// rank emit their elements in order of *prefix maximum* rank (an element pops
+  /// when the running maximum of what has popped reaches it), the left side first
+  /// on ties. So fringe events are visited in order of their side's prefix-max at
+  /// the event's pop, X first on ties; a side's "current position" at a foreign
+  /// event of prefix-max `t` is its last pop with prefix-max `<= t`. That is
+  /// [`MaxTree::last_prefix_at_most`] over the active pops for X, and a scan of
+  /// the short recorded Y process for Y.
+  fn cut_is_boundary(&mut self, table: &MergeTable, q: u32, x_token: usize, y: &WordRun) -> bool {
+    self.activate_upto(q);
+    let n_pops = self.z.pops.len();
+    let x_spine = &self.z.rspine[x_token];
+    let y_spine = &y.lspine[0];
+    // Prefix maxima of the isolated Y process, in rank+1 space.
+    let mut y_prefix: Vec<u32> = Vec::with_capacity(y.pops.len());
+    let mut run = 0u32;
+    for p in &y.pops {
+      run = run.max(p.rank + 1);
+      y_prefix.push(run);
+    }
+    let y_max = |lo: usize, hi: usize| -> u32 {
+      y.pops[lo..hi.min(y.pops.len())]
+        .iter()
+        .map(|p| p.rank + 1)
+        .max()
+        .unwrap_or(0)
+    };
+    // Fringe states.
+    // A byte without a single-char token cannot occur here (`process` refused
+    // it); `u32::MAX` is not a vocabulary id, so it merges with nothing.
+    let x_state = |j: usize| -> u32 {
+      if j == 0 {
+        table.symbol(self.word[q as usize - 1]).unwrap_or(u32::MAX)
+      } else {
+        self.z.pops[x_spine[j - 1] as usize].new_id
+      }
+    };
+    let y_state = |j: usize| -> u32 {
+      if j == 0 {
+        table.symbol(self.word[q as usize]).unwrap_or(u32::MAX)
+      } else {
+        y.pops[y_spine[j - 1] as usize].new_id
+      }
+    };
+    // Event times (prefix-max at the forming pop), rank+1 space.
+    let x_time = |j: usize| -> u32 {
+      let idx = x_spine[j - 1] as usize;
+      self.tree.max(0, idx + 1)
+    };
+    let y_time = |j: usize| -> u32 { y_prefix[y_spine[j - 1] as usize] };
+
+    let (mut jx, mut jy) = (0usize, 0usize);
+    // The side that produced the current event and the pop index it stood at,
+    // or the initial state (no pops on either side).
+    enum At {
+      Init,
+      X(usize),
+      Y(usize),
+    }
+    let mut at = At::Init;
+    loop {
+      // Evaluate the current seam pair.
+      if let Some((rank, _)) = table.merge(x_state(jx), y_state(jy)) {
+        let rho = rank + 1;
+        let (x_pos, y_pos): (Option<usize>, Option<usize>) = match at {
+          At::Init => (None, None),
+          At::X(i) => {
+            // X wins ties: at an X event of time `t`, Y's pops of time `t` have
+            // NOT happened yet, so Y stands at its last pop of time `< t`.
+            let t = self.tree.max(0, i + 1);
+            (Some(i), y_last_at_most(&y_prefix, t.saturating_sub(1)))
+          }
+          At::Y(i) => (self.tree.last_prefix_at_most(y_prefix[i], n_pops), Some(i)),
+        };
+        let x_from = x_pos.map_or(0, |p| p + 1);
+        let x_alive = match x_spine.get(jx) {
+          None => true,
+          Some(&e) => self.tree.max(x_from, e as usize + 1) > rho,
+        };
+        let y_from = y_pos.map_or(0, |p| p + 1);
+        let y_alive = match y_spine.get(jy) {
+          None => true,
+          Some(&e) => y_max(y_from, e as usize + 1) >= rho,
+        };
+        if x_alive && y_alive {
+          return false;
+        }
+      }
+      // Advance to the next fringe event in time order, X first on ties.
+      let nx = (jx < x_spine.len()).then(|| x_time(jx + 1));
+      let ny = (jy < y_spine.len()).then(|| y_time(jy + 1));
+      match (nx, ny) {
+        (None, None) => return true,
+        (Some(_), None) => {
+          jx += 1;
+          at = At::X(x_spine[jx - 1] as usize);
+        }
+        (None, Some(_)) => {
+          jy += 1;
+          at = At::Y(y_spine[jy - 1] as usize);
+        }
+        (Some(tx), Some(ty)) => {
+          if tx <= ty {
+            jx += 1;
+            at = At::X(x_spine[jx - 1] as usize);
+          } else {
+            jy += 1;
+            at = At::Y(y_spine[jy - 1] as usize);
+          }
+        }
+      }
+    }
+  }
+}
+
+/// Largest index `k` with `prefix[k] <= t`, or `None`.
+fn y_last_at_most(prefix: &[u32], t: u32) -> Option<usize> {
+  let n = prefix.partition_point(|&p| p <= t);
+  n.checked_sub(1)
+}
+
+#[cfg(test)]
+mod tests;

--- a/coremlit/src/embeddings/granite/token_index/suffix_session/tests.rs
+++ b/coremlit/src/embeddings/granite/token_index/suffix_session/tests.rs
@@ -1,0 +1,381 @@
+//! The fast lane is exact: every prefix count it answers equals the crate's
+//! `encode` of the same bytes, over the separatorless corpora of #72, random
+//! CJK draws, mixed scripts, and words built to make BPE non-prefix-stable —
+//! and the cascade walk really does fire (the certificate is not vacuous).
+
+use tokenizers::Tokenizer;
+
+use super::{INITIAL_CAP, Prefix, Session};
+use crate::embeddings::granite::{
+  measuring_tokenizer_from_bytes, test_artifact, token_index::MergeTable,
+};
+
+fn measuring_tok() -> Tokenizer {
+  measuring_tokenizer_from_bytes(test_artifact::tokenizer_bytes()).expect("measuring tokenizer")
+}
+
+fn table(tok: &Tokenizer) -> MergeTable {
+  MergeTable::from_tokenizer(tok).expect("the artifact's BPE is mirrorable")
+}
+
+/// Content-token count the crate reports for a single-piece word.
+fn oracle(tok: &Tokenizer, s: &str) -> usize {
+  tok.encode(s, false).expect("encode").get_ids().len()
+}
+
+struct Rng(u64);
+impl Rng {
+  fn next_u64(&mut self) -> u64 {
+    self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = self.0;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+  }
+  fn below(&mut self, n: usize) -> usize {
+    (self.next_u64() % (n as u64)) as usize
+  }
+}
+
+fn cjk_run(len_chars: usize, seed: u64) -> String {
+  const CJK: &str = "你好世界模型推理文本嵌入检索的一是不了人我在有他这中大来上国个到说们为子和地出道也时年得就那要下以生会自着去之过家学对可她里后小么心多天而能好都然没日于起还发成事只作当想看文无开手十用主行方又如前所本见经头面公同三已老从动两长知民样现分将外但身些与高意进把法此实回二理美点月明其种向";
+  let cjk: Vec<char> = CJK.chars().collect();
+  let mut rng = Rng(seed);
+  (0..len_chars).map(|_| cjk[rng.below(cjk.len())]).collect()
+}
+
+/// Every char-aligned prefix of `text[start..]` measured through a session,
+/// against the crate. Returns how many probes the cascade answered from a cut
+/// strictly left of the token containing `b` (the certificate refused at least
+/// one cut), and how many fell through to `Direct`.
+#[track_caller]
+fn check_every_prefix(
+  tok: &Tokenizer,
+  table: &MergeTable,
+  text: &str,
+  start: usize,
+) -> (usize, usize) {
+  let end = text.len().min(start + INITIAL_CAP);
+  let mut session = Session::build(tok, table, text, start, end)
+    .expect("build")
+    .expect("session usable");
+  let (mut cascaded, mut direct) = (0usize, 0usize);
+  for b in (start + 1..=end).filter(|&b| text.is_char_boundary(b)) {
+    let want = oracle(tok, &text[start..b]);
+    match session.measure_prefix(tok, table, b) {
+      Prefix::Count(got) => {
+        assert_eq!(got, want, "prefix [{start}, {b}) of {:?}", &text[start..b]);
+        if session.last_cascade_depth() > 0 {
+          cascaded += 1;
+        }
+      }
+      Prefix::Direct => direct += 1,
+      Prefix::PastCap => panic!("b={b} within the cap"),
+    }
+  }
+  (cascaded, direct)
+}
+
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn every_prefix_of_the_issue_corpora_measures_like_the_crate() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  let cjk = "你好世界模型推理文本嵌入检索".repeat(120); // 5,040 bytes
+  let xs = "x".repeat(3000);
+  for (label, text) in [("cjk", cjk.as_str()), ("x", xs.as_str())] {
+    for start in [0usize, 3, 7, 30, 301] {
+      let start = (start..).find(|&i| text.is_char_boundary(i)).unwrap();
+      let (cascaded, direct) = check_every_prefix(&tok, &table, text, start);
+      println!("[fast-lane:{label}] start={start} cascaded={cascaded} direct={direct}");
+      // A cascade that walks back to the start of `Z` is answered by the direct
+      // encode — exact, and only ever seen on the first few bytes of the `x`
+      // run (the prefix sits inside the first token). It must stay rare: a
+      // lane that fell through routinely would be the old cost back.
+      assert!(
+        direct <= 4,
+        "{label}: {direct} probes walked back to the start of Z"
+      );
+    }
+  }
+}
+
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn every_prefix_of_random_cjk_measures_like_the_crate() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  for seed in 1..=6u64 {
+    let text = cjk_run(900, seed);
+    for start in [0usize, 3, 6, 33, 150] {
+      check_every_prefix(&tok, &table, &text, start);
+    }
+  }
+}
+
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn every_prefix_of_mixed_script_runs_measures_like_the_crate() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  let texts = [
+    "internationalizationinternationalization".repeat(20),
+    "приветмирпривет".repeat(60),
+    "καλημέρακόσμε".repeat(60),
+    "สวัสดีชาวโลก".repeat(50),
+    "你好hello世界world".repeat(60),
+    "ab".repeat(600),
+    "abcabcabd".repeat(150),
+  ];
+  for text in &texts {
+    for start in [0usize, 1, 5, 17] {
+      let start = (start..).find(|&i| text.is_char_boundary(i)).unwrap();
+      check_every_prefix(&tok, &table, text, start);
+    }
+  }
+}
+
+/// The certificate's non-trivial branch is exercised: on the issue's own CJK
+/// corpus, some probe ends inside a token whose cut is NOT a boundary of the
+/// prefix's tokenization, so the walk moved a cut left and still matched the
+/// crate. (If no corpus ever cascaded, the branch would be untested — and BPE
+/// non-prefix-stability guarantees it happens on real vocabularies.)
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn the_cascade_walk_fires_and_stays_exact() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  let mut total = 0usize;
+  for seed in 1..=12u64 {
+    let text = cjk_run(600, seed);
+    total += check_every_prefix(&tok, &table, &text, 0).0;
+  }
+  let issue = "你好世界模型推理文本嵌入检索".repeat(120);
+  total += check_every_prefix(&tok, &table, &issue, 0).0;
+  assert!(
+    total > 0,
+    "no probe cascaded — the certificate's refusal branch is unexercised"
+  );
+}
+
+/// A whole probe that is itself a vocabulary entry is ONE token however the
+/// merges would tile it (`ignore_merges`), and the session says so.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn a_probe_that_is_a_vocabulary_entry_is_one_token() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  let text = "你好世界模型推理文本嵌入检索".repeat(4);
+  let mut session = Session::build(&tok, &table, &text, 0, text.len())
+    .expect("build")
+    .expect("usable");
+  // "你好" is a vocabulary entry of the artifact.
+  assert!(tok.token_to_id(&table.spell("你好".as_bytes())).is_some());
+  match session.measure_prefix(&tok, &table, "你好".len()) {
+    Prefix::Count(1) => {}
+    other => panic!("expected Count(1), got {}", describe(&other)),
+  }
+}
+
+/// A suffix that is itself a vocabulary entry is not a session: the crate would
+/// answer it with the whole-word shortcut, not the process.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn a_suffix_that_is_a_vocabulary_entry_gets_no_session() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  let text = "模型推理你好";
+  let start = "模型推理".len();
+  assert!(
+    Session::build(&tok, &table, text, start, text.len())
+      .expect("build")
+      .is_none()
+  );
+}
+
+fn describe(p: &Prefix) -> String {
+  match p {
+    Prefix::Count(n) => format!("Count({n})"),
+    Prefix::Direct => "Direct".into(),
+    Prefix::PastCap => "PastCap".into(),
+  }
+}
+
+// ─── Adversarial corpora derived from the merge ranks ────────────────────────
+
+/// Single-CJK-char vocabulary tokens: `(char, id)`.
+fn cjk_char_tokens(tok: &Tokenizer, table: &MergeTable) -> Vec<(char, u32)> {
+  let mut out = Vec::new();
+  for cp in 0x4E00u32..=0x9FFF {
+    let Some(ch) = char::from_u32(cp) else {
+      continue;
+    };
+    let mut buf = [0u8; 4];
+    let s = ch.encode_utf8(&mut buf);
+    if let Some(id) = tok.token_to_id(&table.spell(s.as_bytes())) {
+      out.push((ch, id));
+    }
+  }
+  out
+}
+
+/// Non-prefix-stability witnesses mined from the merge table: triples
+/// `(A, B, C)` of single-char tokens with merges `A·B` and `B·C` such that
+/// `rank(B·C) < rank(A·B)`. Then `T("ABC")` starts `A, BC` while `T("AB")` is
+/// `AB`: the prefix `"AB"` of `"ABC"` does NOT tokenize as the prefix of
+/// `T("ABC")`. A probe ending after `B` inside such a run lands inside the
+/// token `BC`, whose cut (the start of `BC`) is NOT a boundary of the prefix's
+/// tokenization — exactly the case the certificate must refuse and the cascade
+/// must walk past.
+fn merge_rank_witnesses(
+  tok: &Tokenizer,
+  table: &MergeTable,
+  limit: usize,
+) -> Vec<(char, char, char)> {
+  let chars = cjk_char_tokens(tok, table);
+  // Index pair merges by their left operand so the triple search is linear
+  // in the number of pair merges rather than cubic in the alphabet.
+  let mut right_of: std::collections::HashMap<u32, Vec<(char, u32, u32)>> =
+    std::collections::HashMap::new();
+  for &(_, ib) in &chars {
+    for &(c, ic) in &chars {
+      if let Some((rank, _)) = table.merge(ib, ic) {
+        right_of.entry(ib).or_default().push((c, ic, rank));
+      }
+    }
+  }
+  let mut out = Vec::new();
+  'outer: for &(a, ia) in &chars {
+    for &(b, ib) in &chars {
+      let Some((rank_ab, _)) = table.merge(ia, ib) else {
+        continue;
+      };
+      if let Some(nexts) = right_of.get(&ib) {
+        for &(c, _, rank_bc) in nexts {
+          if rank_bc < rank_ab {
+            out.push((a, b, c));
+            if out.len() >= limit {
+              break 'outer;
+            }
+          }
+        }
+      }
+    }
+  }
+  out
+}
+
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn merge_rank_witnesses_exist_and_break_prefix_stability() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  let witnesses = merge_rank_witnesses(&tok, &table, 64);
+  assert!(
+    witnesses.len() >= 16,
+    "expected many witnesses, got {}",
+    witnesses.len()
+  );
+  let mut broke = 0usize;
+  for &(a, b, c) in &witnesses {
+    let abc: String = [a, b, c].iter().collect();
+    let ab: String = [a, b].iter().collect();
+    let t_abc = tok
+      .encode(abc.as_str(), false)
+      .expect("encode")
+      .get_ids()
+      .to_vec();
+    let t_ab = tok
+      .encode(ab.as_str(), false)
+      .expect("encode")
+      .get_ids()
+      .to_vec();
+    // The crate's own view: the prefix's tokens are not a prefix of the whole's.
+    if !t_abc.starts_with(&t_ab) {
+      broke += 1;
+    }
+  }
+  assert!(
+    broke * 2 >= witnesses.len(),
+    "witnesses should mostly break prefix stability under the crate: {broke}/{}",
+    witnesses.len()
+  );
+}
+
+/// Texts woven from the witnesses — every prefix from several starts measures
+/// like the crate, and the cascade walk fires on them.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn every_prefix_of_witness_woven_text_measures_like_the_crate() {
+  let tok = measuring_tok();
+  let table = table(&tok);
+  let witnesses = merge_rank_witnesses(&tok, &table, 200);
+  assert!(!witnesses.is_empty());
+  let mut rng = Rng(0x7212);
+  let filler = cjk_run(40, 99);
+  let filler: Vec<char> = filler.chars().collect();
+  let mut texts: Vec<String> = Vec::new();
+  // 1. witnesses back to back; 2. witnesses separated by one filler char;
+  // 3. overlapping chains A B C B' C' ... where consecutive witnesses share a
+  //    char when they can; 4. witnesses embedded in random filler.
+  texts.push(
+    witnesses
+      .iter()
+      .map(|&(a, b, c)| [a, b, c].iter().collect::<String>())
+      .collect(),
+  );
+  texts.push(
+    witnesses
+      .iter()
+      .enumerate()
+      .map(|(i, &(a, b, c))| {
+        let mut s: String = [a, b, c].iter().collect();
+        s.push(filler[i % filler.len()]);
+        s
+      })
+      .collect(),
+  );
+  {
+    let mut s = String::new();
+    for &(a, b, c) in &witnesses {
+      if s.ends_with(a) {
+        s.push(b);
+        s.push(c);
+      } else {
+        s.push(a);
+        s.push(b);
+        s.push(c);
+      }
+    }
+    texts.push(s);
+  }
+  {
+    let mut s = String::new();
+    for &(a, b, c) in witnesses.iter().take(80) {
+      for _ in 0..rng.below(4) {
+        s.push(filler[rng.below(filler.len())]);
+      }
+      s.push(a);
+      s.push(b);
+      s.push(c);
+    }
+    texts.push(s);
+  }
+  let mut cascaded = 0usize;
+  for text in &texts {
+    for start in [0usize, 3, 6, 9, 30] {
+      let start = (start..).find(|&i| text.is_char_boundary(i)).unwrap();
+      let (c, direct) = check_every_prefix(&tok, &table, text, start);
+      cascaded += c;
+      assert_eq!(direct, 0);
+    }
+  }
+  assert!(
+    cascaded > 0,
+    "the witnesses must make the cascade walk fire"
+  );
+  println!(
+    "[witness-corpus] texts={} cascaded_probes={cascaded}",
+    texts.len()
+  );
+}

--- a/coremlit/src/embeddings/granite/token_index/tests.rs
+++ b/coremlit/src/embeddings/granite/token_index/tests.rs
@@ -10,9 +10,11 @@
 //! is small, (ii) all `(0, b)` / `(a, len)` hot-path shapes, and (iii) thousands
 //! of seeded-random `char`-boundary pairs.
 
+use std::sync::OnceLock;
+
 use tokenizers::Tokenizer;
 
-use super::TokenIndex;
+use super::{LazyTable, TokenIndex};
 use crate::embeddings::granite::{measuring_tokenizer_from_bytes, test_artifact};
 
 /// The truncation-disabled MEASURING tokenizer — the exact one `chunk_long` builds
@@ -993,5 +995,341 @@ fn oversized_single_pretoken_encodes_each_probe_once() {
       oracle(&tok, &text[a..b]),
       "reused whole-query count must equal encode(&text[{a}..{b}], true).len()"
     );
+  }
+}
+
+// ─── The separatorless fast lane (#72) ───────────────────────────────────────
+
+/// Assert `measure_range_fast == encode` at one `(a, b)`, through a live lane.
+#[track_caller]
+fn check_fast(
+  index: &TokenIndex,
+  tok: &Tokenizer,
+  lane: &mut super::FastLane<'_>,
+  text: &str,
+  a: usize,
+  b: usize,
+) {
+  let got = index
+    .measure_range_fast(tok, text, a, b, lane)
+    .expect("measure_range_fast must not fail on the granite tokenizer");
+  let want = oracle(tok, &text[a..b]);
+  assert_eq!(
+    got,
+    want,
+    "measure_range_fast({a}, {b}) = {got} but encode({:?}) = {want}",
+    &text[a..b]
+  );
+}
+
+fn merge_table(tok: &Tokenizer) -> super::MergeTable {
+  super::MergeTable::from_tokenizer(tok).expect("the artifact's BPE is mirrorable")
+}
+
+/// A cell already holding the artifact's table, for lanes and measurers that
+/// should be engaged from their first probe.
+fn built(tok: &Tokenizer) -> OnceLock<Option<super::MergeTable>> {
+  OnceLock::from(Some(merge_table(tok)))
+}
+
+/// The packer's probe shape — a fixed chunk start and an end that grows one
+/// char at a time, restarting at a later start when a chunk closes — over the
+/// issue's corpora, every answer equal to the direct encode. The lane engages
+/// on every one of these probes (the pre-token is a single alphabetic run), so
+/// this is the fast lane's own differential, not the slow path's.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn fast_lane_matches_encode_over_packer_shaped_probes() {
+  let tok = measuring_tok();
+  let cell = built(&tok);
+  let cjk = "你好世界模型推理文本嵌入检索".repeat(60);
+  let xs = "x".repeat(1500);
+  let mixed = "你好hello世界world".repeat(40);
+  for text in [cjk.as_str(), xs.as_str(), mixed.as_str()] {
+    let index = TokenIndex::build(&tok, text).expect("build");
+    let mut lane = super::FastLane::engaged(512, LazyTable::new(&cell, &tok));
+    let bounds = char_boundaries(text);
+    // Chunk starts at several interior boundaries; each grows to the end or to
+    // 400 chars, whichever first.
+    for &start_i in &[1usize, 2, 5, 17, 60, 200] {
+      if start_i >= bounds.len() - 1 {
+        continue;
+      }
+      let a = bounds[start_i];
+      for &b in bounds[start_i + 1..].iter().take(400) {
+        check_fast(&index, &tok, &mut lane, text, a, b);
+      }
+    }
+  }
+}
+
+/// Random ranges inside alphabetic pre-tokens of a prose document: the lane
+/// engages on those inside a qualifying pre-token and defers to
+/// `measure_range` on every other range; both agree with the direct encode.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn fast_lane_matches_encode_over_random_ranges_of_prose() {
+  let tok = measuring_tok();
+  let cell = built(&tok);
+  let mut rng = Rng(0x5EED_5EED_0072_0072);
+  let mut doc = String::new();
+  for p in 0..30u32 {
+    doc.push_str(&format!(
+      "internationalization{p} 你好世界模型推理文本嵌入检索 can't 12345 \
+       supercalifragilisticexpialidocious résumé ",
+    ));
+    if p % 5 == 4 {
+      doc.push_str("\n\n");
+    }
+  }
+  let index = TokenIndex::build(&tok, &doc).expect("build");
+  let mut lane = super::FastLane::engaged(512, LazyTable::new(&cell, &tok));
+  let bounds = char_boundaries(&doc);
+  for _ in 0..3000 {
+    let i = rng.below(bounds.len() - 1);
+    let span = 1 + rng.below(40.min(bounds.len() - 1 - i));
+    let (a, b) = (bounds[i], bounds[i + span]);
+    check_fast(&index, &tok, &mut lane, &doc, a, b);
+  }
+}
+
+/// A lane whose session was refused (a suffix that is itself a vocabulary
+/// entry, here) answers through `measure_range` and stays exact.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn fast_lane_falls_back_when_the_suffix_is_a_vocabulary_entry() {
+  let tok = measuring_tok();
+  let cell = built(&tok);
+  let text = "模型推理你好";
+  let index = TokenIndex::build(&tok, text).expect("build");
+  let mut lane = super::FastLane::engaged(512, LazyTable::new(&cell, &tok));
+  let a = "模型推理".len();
+  for b in ["模型推理你".len(), text.len()] {
+    check_fast(&index, &tok, &mut lane, text, a, b);
+  }
+}
+
+/// `measure_within`'s floor is exact: at every limit it returns `Some` exactly
+/// when the direct measure is `<= limit`, over ranges of every shape — and the
+/// overlap-zero ask is answered without any encode.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn measure_within_floor_agrees_with_measure_at_every_limit() {
+  use windit::split::MeasureText;
+  let tok = measuring_tok();
+  let cell = built(&tok);
+  let text = "你好世界模型推理文本嵌入检索 hello world, it's 12345 x".repeat(20);
+  let index = TokenIndex::build(&tok, &text).expect("build");
+  let m = super::IndexMeasure::new(&text, &index, &tok, LazyTable::new(&cell, &tok), 512);
+  let bounds = char_boundaries(&text);
+  let mut rng = Rng(0x0072_0072);
+  for _ in 0..400 {
+    let i = rng.below(bounds.len() - 1);
+    let span = 1 + rng.below((bounds.len() - 1 - i).min(60));
+    let s = &text[bounds[i]..bounds[i + span]];
+    let truth = oracle(&tok, s);
+    for limit in [
+      0usize,
+      1,
+      2,
+      3,
+      truth.saturating_sub(1),
+      truth,
+      truth + 1,
+      10_000,
+    ] {
+      let got = m.measure_within(s, limit);
+      assert_eq!(
+        got,
+        (truth <= limit).then_some(truth),
+        "{s:?} at limit {limit}"
+      );
+    }
+  }
+  // The overlap-zero ask costs no encode.
+  super::encode_meter::reset();
+  let (lo, hi) = (bounds[1], bounds[100]);
+  assert_eq!(m.measure_within(&text[lo..hi], 0), None);
+  assert_eq!(super::encode_meter::calls(), 0);
+}
+
+/// The floor is never consulted on a `direct_only` index (dropped bytes void
+/// byte coverage, the floor's premise): `"\0\0"` measures exactly the two
+/// specials and `measure_within(_, 2)` must say so.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn measure_within_never_applies_the_floor_without_byte_coverage() {
+  use windit::split::MeasureText;
+  let tok = measuring_tok();
+  let cell = built(&tok);
+  let text = "\0\0";
+  let index = TokenIndex::build(&tok, text).expect("build");
+  assert!(
+    index.is_direct_only(),
+    "premise: NUL has no symbol, so the index is direct_only"
+  );
+  let m = super::IndexMeasure::new(text, &index, &tok, LazyTable::new(&cell, &tok), 2);
+  assert_eq!(oracle(&tok, text), 2);
+  assert_eq!(m.measure_within(text, 2), Some(2));
+  assert_eq!(m.measure_within(text, 1), None);
+  // A foreign string (not a subslice of the indexed text) never gets the floor
+  // either: its coverage is unknown.
+  let covered = TokenIndex::build(&tok, "abc").expect("build");
+  let mc = super::IndexMeasure::new("abc", &covered, &tok, LazyTable::new(&cell, &tok), 2);
+  assert!(!covered.is_direct_only());
+  let foreign = String::from("\0\0");
+  assert_eq!(mc.measure_within(&foreign, 2), Some(2));
+}
+
+/// RED-FIRST (Opus review, F1): a pre-token may hold an UPPERCASE run after
+/// its first char — the first letter branch `HEAD* TAIL+` glues `中UCCESSa`
+/// into ONE pre-token, `\p{Lo}` being in both classes and `\p{Lu}` in the
+/// head — but a probe that ENDS inside that run re-parses as TWO (`中`, then
+/// `UCCESS` by the second branch), each BPE'd on its own with `ignore_merges`,
+/// and `UCCESS` is a vocabulary entry the merge process does not reproduce.
+/// A lane that measured the probe as one word over-counted. The gate must
+/// refuse such a pre-token: every char-aligned probe inside these equals the
+/// crate's encode of the probe.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn the_lane_refuses_a_pre_token_with_an_uppercase_run_after_its_first_char() {
+  let tok = measuring_tok();
+  let cell = built(&tok);
+  for text in [
+    "中UCCESSa",
+    "中中中UCCESSa中中",
+    "中WARRANTIESa",
+    "检索文本SUCCESS返回",
+    "检索文本WARRANTY条款",
+    "检索文本MERCHANTABILITY条款",
+    "检索文本Windows系统",
+    "检索文本API接口",
+    "检索文本ǅa",
+    "检索文本ᾈ返回",
+    "aUCCESSa",
+    "Abc中文",
+  ] {
+    let index = TokenIndex::build(&tok, text).expect("build");
+    assert!(
+      !index.is_direct_only(),
+      "{text:?} is a covered, added-token-free text"
+    );
+    let mut lane = super::FastLane::engaged(512, LazyTable::new(&cell, &tok));
+    let bounds = char_boundaries(text);
+    for (i, &a) in bounds.iter().enumerate() {
+      for &b in &bounds[i + 1..] {
+        check_fast(&index, &tok, &mut lane, text, a, b);
+      }
+    }
+  }
+}
+
+/// The gate's char test is the Split regex's own tail class on the
+/// tokenizer's own engine: `\p{Lu}` / `\p{Lt}` refused, `\p{Ll}` / `\p{Lm}`
+/// / `\p{Lo}` / `\p{M}` accepted, digits, spaces and punctuation refused —
+/// checked on the artifact's table over every char of its vocabulary against
+/// the pre-tokenizer itself (`"a" + c` is one pre-token exactly when `c` is a
+/// tail char).
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn the_tail_class_agrees_with_the_pre_tokenizer_over_the_vocabularys_chars() {
+  use tokenizers::{OffsetReferential, OffsetType, PreTokenizedString, PreTokenizer};
+  let tok = measuring_tok();
+  let tail = super::bpe_mirror::TailClass::new().expect("compiles");
+  let pre = tok
+    .get_pre_tokenizer()
+    .expect("the artifact has a pre-tokenizer");
+  let glued = |c: char| {
+    let mut p = PreTokenizedString::from(format!("a{c}").as_str());
+    pre.pre_tokenize(&mut p).expect("pre-tokenize");
+    p.get_splits(OffsetReferential::Original, OffsetType::Byte)
+      .len()
+      == 1
+  };
+  // Vocabulary keys are byte-level spellings; decode each token to the bytes
+  // it stands for (lossily: a token may hold part of a UTF-8 sequence) to get
+  // the real chars the vocabulary covers.
+  let mut chars: std::collections::BTreeSet<char> = (0..tok.get_vocab_size(true))
+    .filter_map(|id| tok.decode(&[u32::try_from(id).expect("id")], false).ok())
+    .flat_map(|s| s.chars().collect::<Vec<_>>())
+    .collect();
+  chars.extend("ǅǈǋǲᾈᾘᾨᾼῌῼAΑАaαаʰ々中א가\u{301}\u{903}\u{20dd}0 \t\r\n'.。！".chars());
+  let (mut tails, mut total) = (0usize, 0usize);
+  for c in chars {
+    if c == 'a' {
+      continue;
+    }
+    assert_eq!(tail.contains(c), glued(c), "U+{:04X} {c:?}", c as u32);
+    total += 1;
+    tails += usize::from(tail.contains(c));
+  }
+  assert!(
+    tails > 1_000 && total - tails > 200,
+    "{tails} tail chars of {total}"
+  );
+  for c in [
+    'a', 'α', 'а', 'ʰ', '々', '中', 'א', '가', '\u{301}', '\u{903}', '\u{20dd}',
+  ] {
+    assert!(tail.contains(c), "{c:?} is a tail char");
+  }
+  for c in ['A', 'Α', 'А', 'ǅ', 'ᾈ', 'ῼ', '0', ' ', '\'', '。', '\n'] {
+    assert!(!tail.contains(c), "{c:?} is not a tail char");
+  }
+}
+
+/// RED-FIRST (Opus re-review, F4): the whole-word `ignore_merges` shortcut
+/// must consult the MODEL vocabulary — the map `BPE::tokenize` reads — not
+/// `Tokenizer::token_to_id`, which resolves the ADDED vocabulary first. An
+/// added token whose content is the byte-level spelling of a qualifying word
+/// (`"Ġzzqxjkw"` for `" zzqxjkw"`) passes every pin, and the index's
+/// added-literal guard scans the text for the LITERAL (absent: the text holds
+/// a real space), so a lane looking the SPELLING up through the tokenizer
+/// answered one token where the crate, finding no literal, ran the merges.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn an_added_token_spelled_like_a_word_does_not_fool_the_whole_word_shortcut() {
+  let base = measuring_tok();
+  let spelled = merge_table(&base).spell(b" zzqxjkw");
+  assert_eq!(spelled, "\u{120}zzqxjkw");
+  assert!(
+    base.token_to_id(&spelled).is_none(),
+    "premise: not a token yet"
+  );
+  let mut value: serde_json::Value =
+    serde_json::from_slice(test_artifact::tokenizer_bytes()).expect("parse");
+  let next_id = u64::try_from(base.get_vocab_size(true)).expect("id");
+  value["added_tokens"]
+    .as_array_mut()
+    .expect("array")
+    .push(serde_json::json!({
+      "id": next_id, "content": spelled, "single_word": false, "lstrip": false,
+      "rstrip": false, "normalized": false, "special": false
+    }));
+  let hacked = Tokenizer::from_bytes(serde_json::to_vec(&value).expect("serialize")).expect("load");
+  assert_eq!(
+    hacked.token_to_id(&spelled),
+    Some(u32::try_from(next_id).expect("id"))
+  );
+  let cell = OnceLock::from(Some(
+    super::MergeTable::from_tokenizer(&hacked).expect("premise: the pins accept it"),
+  ));
+  for text in ["1 zzqxjkwabc1", "1 zzqxjkw1", "中文 zzqxjkw中文"] {
+    let index = TokenIndex::build(&hacked, text).expect("build");
+    assert!(
+      !index.is_direct_only(),
+      "premise: the literal {spelled:?} is absent from {text:?}, so the guard does not fire"
+    );
+    let mut lane = super::FastLane::engaged(512, LazyTable::new(&cell, &hacked));
+    assert_eq!(
+      oracle(&hacked, " zzqxjkw"),
+      6,
+      "premise: the crate runs the merges"
+    );
+    let bounds = char_boundaries(text);
+    for (i, &a) in bounds.iter().enumerate() {
+      for &b in &bounds[i + 1..] {
+        check_fast(&index, &hacked, &mut lane, text, a, b);
+      }
+    }
   }
 }

--- a/coremlit/tests/feature_map.rs
+++ b/coremlit/tests/feature_map.rs
@@ -100,7 +100,16 @@ fn expected_features() -> Vec<(&'static str, Vec<&'static str>)> {
     ),
     (
       "granite",
-      vec!["dep:tokenizers", "dep:windit", "windit/text", "dep:sha2"],
+      // `dep:serde_json`: the BPE merge table read back out of the loaded model
+      // for token_index's separatorless fast lane (#72); tokenizers depends on
+      // serde_json itself, so no crate is added to the graph.
+      vec![
+        "dep:tokenizers",
+        "dep:windit",
+        "windit/text",
+        "dep:sha2",
+        "dep:serde_json",
+      ],
     ),
     (
       "ced",

--- a/coremlit/tests/granite/embed_long.rs
+++ b/coremlit/tests/granite/embed_long.rs
@@ -237,3 +237,39 @@ fn a_drop_below_min_geometry_embeds_and_never_drops_the_text() {
     "the whole-input fallback must match embed"
   );
 }
+
+/// TIMING (`#[ignore]`, run locally for PR notes — #72): `embed_long` over the
+/// issue's separatorless CJK corpus (31,374 bytes, ~18 windows), against the
+/// per-window prediction cost measured on one window-sized slice through
+/// `embed`. The difference is the chunking overhead; before #72 it was ~89 % of
+/// the total on this corpus.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS); timing for PR notes"]
+fn separatorless_cjk_embed_long_timing() {
+  let emb = embedder();
+  const RUN: &str = "你好世界模型推理文本嵌入检索";
+  let mut doc = String::new();
+  while doc.len() < 31_374 {
+    doc.push_str(RUN);
+  }
+  // Warm the graph and the lazily built merge table.
+  emb.embed_long(&doc).expect("warm-up");
+  let runs = 3;
+  let t0 = std::time::Instant::now();
+  for _ in 0..runs {
+    emb.embed_long(&doc).expect("embed_long");
+  }
+  let total_ms = t0.elapsed().as_secs_f64() * 1e3 / runs as f64;
+  // One window's worth of the same text (~512 tokens; CJK here tokenizes at
+  // roughly 2 bytes per token, so ~1.7 KB): the per-prediction cost.
+  let window: String = doc.chars().take(560).collect();
+  let t1 = std::time::Instant::now();
+  for _ in 0..runs {
+    emb.embed(&window).expect("embed");
+  }
+  let pred_ms = t1.elapsed().as_secs_f64() * 1e3 / runs as f64;
+  println!(
+    "[embed_long:cjk] bytes={} total={total_ms:.1}ms one_window_prediction={pred_ms:.1}ms",
+    doc.len()
+  );
+}


### PR DESCRIPTION
Closes #72.