### PR TITLE
feat(coremlit/granite): embed_windows returns one embedding per planned window with its byte and token spans; embed_long is their coverage-weighted mean, and says what it is not for (#160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,7 @@ jobs:
             checksum-file: CHECKSUMS.sha256
             fp16-vendors: vadkit,embedkit-granite
             gates: |
-              granite|granite_model_io granite_parity_embed granite_placement granite_embed_long granite_tokenizer_identity @lib
+              granite|granite_model_io granite_parity_embed granite_placement granite_embed_long granite_embed_windows granite_tokenizer_identity @lib
           # 448 MB — the four compiled `.mlmodelc` towers, NOT the four
           # `.mlpackage` siblings (see MODELS_LOCK: byte-duplicate weights,
           # nothing resolves a `.mlpackage` path, and they would take the

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -305,7 +305,7 @@ jobs:
           # their lines are unreachable without this leg.
           - kit: granite
             gates: |
-              granite|granite_model_io granite_parity_embed granite_placement granite_embed_long granite_tokenizer_identity @lib
+              granite|granite_model_io granite_parity_embed granite_placement granite_embed_long granite_embed_windows granite_tokenizer_identity @lib
           # `clap_tokenizer_identity` is deliberately absent: the Xenova
           # tokenizer IS embedded in the crate, so that suite is hermetic, lists
           # ZERO ignored tests, and would (correctly) trip the anti-vacuum guard.

--- a/coremlit/Cargo.toml
+++ b/coremlit/Cargo.toml
@@ -479,6 +479,11 @@ path = "tests/granite/embed_long.rs"
 required-features = ["granite"]
 
 [[test]]
+name = "granite_embed_windows"
+path = "tests/granite/embed_windows.rs"
+required-features = ["granite"]
+
+[[test]]
 name = "siglip_tokenizer_identity"
 path = "tests/siglip/tokenizer_identity.rs"
 required-features = ["siglip"]

--- a/coremlit/src/embeddings/granite/mod.rs
+++ b/coremlit/src/embeddings/granite/mod.rs
@@ -89,10 +89,12 @@ pub use windit::plan::WindowOptions;
 /// was otherwise unnameable through a re-exporting consumer.
 ///
 /// On granite's own path it moves a boundary and never drops text: see
-/// [`LongTextOptions::tail_policy`] for what each variant does to `embed_long`.
+/// [`LongTextOptions::tail_policy`] for what each variant does — the same
+/// geometry, and the same tail behavior, governs both `embed_long` and
+/// `embed_windows`.
 pub use windit::TailPolicy;
 
-use std::{path::Path, sync::OnceLock};
+use std::{ops::Range, path::Path, sync::OnceLock};
 
 use crate::{ComputeUnits, DataType, Model, MultiArray};
 use tokenizers::{
@@ -172,6 +174,41 @@ mod contract {
 /// position 0 (never a pad), so the pad token value never reaches the output.
 pub const MAX_TOKENS: usize = 512;
 
+/// Special tokens the pinned tokenizer's post-processor adds to EVERY sequence:
+/// `2`, the `<|startoftext|> A <|return|>` single-sequence template of the
+/// artifact `tokenizer.json` ([`TOKENIZER_FILE_NAME`]).
+///
+/// Every encoding on this door's paths runs `encode(s, add_special_tokens =
+/// true)` — [`TextEmbedder::token_ids`], the chunker's measurement, and the
+/// sentinel gate alike — so this overhead is charged against [`MAX_TOKENS`]
+/// unconditionally, leaving [`CONTENT_TOKENS_PER_WINDOW`] for the caller's own
+/// text.
+///
+/// Not a knob: the tokenizer is pinned by SHA-256, so this is a fact about the
+/// one artifact this door accepts, re-measured from it rather than asserted —
+/// `special_token_overhead_matches_the_pinned_template` (model-gated) reads it
+/// three independent ways: the post-processor's own `added_tokens(false)`, the
+/// length of `encode("", true)`, and the difference an `add_special_tokens`
+/// makes to one encoding.
+pub const SPECIAL_TOKENS_PER_WINDOW: usize = 2;
+
+/// Raw-content token budget of one window: [`MAX_TOKENS`] −
+/// [`SPECIAL_TOKENS_PER_WINDOW`] = `510`.
+///
+/// The most tokens of the CALLER'S OWN text that fit one prediction — and the
+/// tokenizer's own effective text window, since this module configures
+/// truncation at [`MAX_TOKENS`] and `tokenizers` truncates at `max_length −
+/// post_processor.added_tokens(false)`.
+///
+/// [`LongTextOptions::window_options`] is stated in TOTAL tokens, not in these:
+/// `WindowOptions::window()` is compared against a measure that counts the
+/// specials too (chunk measurement and per-chunk embedding run the same
+/// `encode(s, true)`), so a `window()` of `w` admits
+/// `w − `[`SPECIAL_TOKENS_PER_WINDOW`] content tokens and the default
+/// `window() == MAX_TOKENS` admits exactly this many. Set `window()` as a total;
+/// read the content budget off this constant.
+pub const CONTENT_TOKENS_PER_WINDOW: usize = MAX_TOKENS - SPECIAL_TOKENS_PER_WINDOW;
+
 /// Default [`TextEmbedderOptions::compute`]: [`ComputeUnits::All`]. The granite
 /// ModernBERT graph is ANE-capable (T1's `CPU_AND_NE` compile plan: 97.8% of ops
 /// ANE-preferred); `All` lets CoreML schedule it — T1 saw the planner pick the
@@ -229,9 +266,10 @@ impl TextEmbedderOptions {
   }
 }
 
-/// Options for [`TextEmbedder::embed_long_with`] (rust-options-pattern): windit's
-/// chunk geometry ([`WindowOptions`]) plus granite's pre-tokenization input
-/// bound.
+/// Options for [`TextEmbedder::embed_long_with`] and
+/// [`TextEmbedder::embed_windows_with`] (rust-options-pattern) — both share this
+/// one type: windit's chunk geometry ([`WindowOptions`]) plus granite's
+/// pre-tokenization input bound.
 ///
 /// The geometry is reachable whole ([`Self::window_options`]) and, for the tail
 /// policy, one field at a time ([`Self::tail_policy`]). Neither requires naming
@@ -259,8 +297,9 @@ impl TextEmbedderOptions {
 /// `window_options`. Defaulted fields and a tolerated stray key compose into a
 /// silent hole: `{"max_input_byte":4096}` — the plural dropped — would
 /// otherwise deserialize to `max_input_bytes: None`, and
-/// [`TextEmbedder::embed_long_with`] would then run with NO size gate on its
-/// input, which is the one bound a caller sets for untrusted text. The
+/// [`TextEmbedder::embed_long_with`] (or, sharing this same options type,
+/// [`TextEmbedder::embed_windows_with`]) would then run with NO size gate on
+/// its input, which is the one bound a caller sets for untrusted text. The
 /// misspelling is a hard error naming the key instead.
 ///
 /// That refusal makes this type UNFLATTENABLE: serde's `deny_unknown_fields`
@@ -318,7 +357,8 @@ impl From<WindowOptions> for LongTextOptions {
 }
 
 impl LongTextOptions {
-  /// Options matching [`TextEmbedder::embed_long`]: a full-window geometry
+  /// Options matching [`TextEmbedder::embed_long`] and
+  /// [`TextEmbedder::embed_windows`] alike: a full-window geometry
   /// (`WindowOptions::new(MAX_TOKENS)`) and no input byte limit.
   pub const fn new() -> Self {
     Self {
@@ -351,8 +391,8 @@ impl LongTextOptions {
   /// The [`TailPolicy`] carried by [`Self::window_options`] — what windit does
   /// with a final chunk that does not fill a whole window.
   ///
-  /// **It moves a boundary on `embed_long`; it never drops text.** The two
-  /// cases differ, and both are windit 0.5's:
+  /// **It moves a boundary on `embed_long` and `embed_windows` alike; it never
+  /// drops text.** The two cases differ, and both are windit 0.5's:
   ///
   /// - [`TailPolicy::PadFull`] is a NAMED GAP in windit's `ContentAware`
   ///   chunker — there is nothing to pad a byte range with, so it keeps the tail
@@ -361,25 +401,31 @@ impl LongTextOptions {
   /// - [`TailPolicy::DropBelowMin`] IS honoured by `ContentAware` from windit
   ///   0.5 (0.4 read every other geometry field and skipped `tail`): windit
   ///   discards a final chunk whose measure is below the minimum unless it fills
-  ///   a whole window. What reaches a caller of `embed_long` is not that drop,
-  ///   though — the separator-reattachment repair behind `embed_long` exists to
-  ///   cover every byte windit leaves out, and the discarded tail is exactly
-  ///   such a gap. It comes back as its own chunk, because a dropped tail is by
-  ///   construction the content that would not fit its predecessor, so the
-  ///   repair can never fuse it left. **Measured across a window × minimum
-  ///   grid: the chunk COUNT is unchanged and coverage is unchanged; what moves
-  ///   is the last boundary** —
+  ///   a whole window. What reaches a caller — of `embed_long`, or of a window
+  ///   from `embed_windows` — is not that drop, though: the
+  ///   separator-reattachment repair behind both exists to cover every byte
+  ///   windit leaves out, and the discarded tail is exactly such a gap. It
+  ///   comes back as its own chunk, because a dropped tail is by construction
+  ///   the content that would not fit its predecessor, so the repair can never
+  ///   fuse it left. **Measured across a window × minimum grid: the chunk
+  ///   COUNT is unchanged and coverage is unchanged; what moves is the last
+  ///   boundary** —
   ///   the separator run between the final two chunks, absorbed rightwards into
   ///   the tail instead of leftwards into its predecessor (e.g. window 4, a
   ///   `\n\n` break: `[(0,8),(8,17),(17,20)]` becomes
   ///   `[(0,8),(8,15),(15,20)]`). The embedding of the last chunk therefore
-  ///   changes; the number of CoreML predictions does not.
+  ///   changes; the number of CoreML predictions does not. For
+  ///   [`TextEmbedder::embed_windows`], that changed last chunk is a moved
+  ///   [`WindowEmbedding::byte_range`] on the last window — geometry a consumer
+  ///   who persists spans alongside an index should expect to change under
+  ///   `DropBelowMin`.
   ///
   /// One shape has no chunks to move: when the whole input is a single chunk
   /// below the minimum, windit returns NO chunks at all (its own documented
-  /// consequence). [`TextEmbedder::embed_long`] still embeds it — the non-empty
-  /// fallback emits the whole input as one chunk, the same escape whitespace-only
-  /// text already took — so this knob cannot make a non-empty text embed to
+  /// consequence). [`TextEmbedder::embed_long`] and
+  /// [`TextEmbedder::embed_windows`] still embed it — the non-empty fallback
+  /// emits the whole input as one chunk, the same escape whitespace-only text
+  /// already took — so this knob cannot make a non-empty text embed to
   /// nothing.
   #[inline]
   pub const fn tail_policy(&self) -> TailPolicy {
@@ -397,7 +443,8 @@ impl LongTextOptions {
   /// Sets [`Self::tail_policy`] on the carried [`Self::window_options`] in
   /// place, leaving its window, hop and cap alone.
   ///
-  /// `DropBelowMin` moves `embed_long`'s last chunk boundary, `PadFull` does
+  /// `DropBelowMin` moves `embed_long`'s and `embed_windows`'s last chunk
+  /// boundary (a moved `byte_range` on the last window), `PadFull` does
   /// nothing, and neither drops text — see [`Self::tail_policy`].
   #[inline]
   pub const fn set_tail_policy(&mut self, tail_policy: TailPolicy) -> &mut Self {
@@ -426,6 +473,147 @@ impl LongTextOptions {
   pub const fn set_max_input_bytes(&mut self, max_input_bytes: usize) -> &mut Self {
     self.max_input_bytes = Some(max_input_bytes);
     self
+  }
+}
+
+/// One planned window of a long text and the embedding of exactly that window —
+/// the element type of [`TextEmbedder::embed_windows`].
+///
+/// It carries what a consumer needs to score windows independently and attach
+/// its own provenance to a hit, without re-deriving the geometry:
+///
+/// * [`ordinal`](Self::ordinal) — position in planning order, `0..n`. The
+///   OCCURRENCE IDENTITY: two windows whose text is byte-identical (a repeated
+///   paragraph) embed to the same vector, so nothing else distinguishes them.
+/// * [`byte_start`](Self::byte_start) / [`byte_end`](Self::byte_end) — the
+///   window's half-open range in UTF-8 bytes of the `text` that was passed in,
+///   `char`-aligned, exactly the chunk the planner cut. Slice the caller's own
+///   string with it ([`byte_range`](Self::byte_range)).
+/// * [`token_span`](Self::token_span) — the window's placement in TOKENS:
+///   `start()` is the running sum of the preceding windows' token counts (a
+///   position in the concatenated window token stream, not an index into `text`
+///   — under a non-zero overlap the repeated tokens are counted twice, which is
+///   the double weighting the overlap expresses), `len()` is this window's own
+///   token count including the [`SPECIAL_TOKENS_PER_WINDOW`] specials
+///   ([`token_count`](Self::token_count)), and `window()` is [`MAX_TOKENS`]. Its
+///   `coverage()` is the weight [`TextEmbedder::embed_long`] aggregates with.
+/// * [`embedding`](Self::embedding) — the unit-norm 384-d [`Embedding`] of that
+///   window's bytes alone, from one CoreML prediction.
+///
+/// This is not windit's `Windowed` (aliased there as `WindowEmbedding`, hence
+/// the name collision): that is a value plus a `Span`, and this adds the anchor
+/// into the caller's own text and the occurrence identity.
+/// [`TextEmbedder::embed_long`] builds windit's pairing from the embedding and
+/// the token span, and never sees the other two.
+///
+/// # No `PartialEq`
+///
+/// Deliberately, and for [`Embedding`]'s own reason: an ML model's f32 outputs
+/// are not bit-stable across runs, threads, or OSes, so `==` on a value carrying
+/// one is a trap. Compare the geometry field by field, and the vectors with
+/// [`Embedding::is_close`] / [`Embedding::is_close_cosine`]:
+///
+/// ```compile_fail,E0369
+/// # fn f(a: &coremlit::embeddings::granite::WindowEmbedding,
+/// #      b: &coremlit::embeddings::granite::WindowEmbedding) -> bool {
+/// a == b
+/// # }
+/// ```
+///
+/// For the same reason this type carries no `serde` impls: neither [`Embedding`]
+/// nor windit's `Span` has any, and a persisted window vector is a
+/// storage-format decision (fp16? quantized? which index?) that belongs to the
+/// consumer, not to this door.
+#[derive(Clone, Debug)]
+pub struct WindowEmbedding {
+  ordinal: usize,
+  byte_range: Range<usize>,
+  token_span: windit::plan::Span,
+  embedding: Embedding,
+}
+
+impl WindowEmbedding {
+  /// The window's position in planning order, `0..n` over the windows one call
+  /// returned — its occurrence identity.
+  ///
+  /// Two windows can hold the same bytes and the same vector (a document that
+  /// repeats a paragraph); the ordinal, with the byte range, is what keeps them
+  /// distinct.
+  ///
+  /// Deterministic for the same `text` and [`LongTextOptions`] replanned
+  /// against the same model artifact: chunking does not depend on whether the
+  /// separatorless fast lane's merge table was built (that is a performance
+  /// detail, pinned equal to the slow twin by the fast-vs-slow differential
+  /// gates), so the same inputs always plan to the same ordinals. A change to
+  /// either `text` or the options invalidates them — see
+  /// [`TextEmbedder::embed_windows`]'s note on what to persist alongside a
+  /// window. It is a planning POSITION, not a content hash: it carries no
+  /// information about what the window contains, and two different texts can
+  /// plan to the same ordinal sequence.
+  #[inline]
+  pub const fn ordinal(&self) -> usize {
+    self.ordinal
+  }
+
+  /// First byte of the window in the caller's `text`, a `char` boundary.
+  #[inline]
+  pub const fn byte_start(&self) -> usize {
+    self.byte_range.start
+  }
+
+  /// One past the window's last byte in the caller's `text`, a `char` boundary.
+  #[inline]
+  pub const fn byte_end(&self) -> usize {
+    self.byte_range.end
+  }
+
+  /// The window's half-open byte range in the caller's `text` — the form to
+  /// slice that same string with (`&text[w.byte_range()]`), which is why this
+  /// returns the range by value rather than the pair.
+  #[inline]
+  pub fn byte_range(&self) -> Range<usize> {
+    self.byte_range.clone()
+  }
+
+  /// The window's placement in the concatenated window token stream: `start()`
+  /// tokens before it, `len()` tokens of its own, padded to a `window()` of
+  /// [`MAX_TOKENS`] — the MODEL's fixed window, always, regardless of a smaller
+  /// [`WindowOptions::window`] the caller configured for chunking. So
+  /// `coverage()` (`len() / window()`) is relative to [`MAX_TOKENS`], not to a
+  /// smaller configured chunk budget: a chunk that completely fills a
+  /// 128-token [`WindowOptions`] still reports a coverage around `128 / 512`,
+  /// not `1.0`. Its `coverage()` is the weight [`TextEmbedder::embed_long`]
+  /// gives this window; that weighting is scale-invariant (windit's
+  /// `CoverageWeightedMean` divides through by the largest weight in the fold),
+  /// so using [`MAX_TOKENS`] rather than the configured `window()` as the
+  /// denominator does not change `embed_long`'s answer.
+  ///
+  /// Token positions, NOT byte offsets into `text` — use
+  /// [`byte_range`](Self::byte_range) to locate the window in the source.
+  #[inline]
+  pub const fn token_span(&self) -> windit::plan::Span {
+    self.token_span
+  }
+
+  /// The window's own token count, granite's [`SPECIAL_TOKENS_PER_WINDOW`]
+  /// specials included — `token_span().len()`, and at most [`MAX_TOKENS`].
+  #[inline]
+  pub const fn token_count(&self) -> usize {
+    self.token_span.len()
+  }
+
+  /// The unit-norm embedding of this window's bytes alone.
+  #[inline]
+  pub const fn embedding(&self) -> &Embedding {
+    &self.embedding
+  }
+
+  /// The embedding, moved out of the window — the only way to own it without a
+  /// clone.
+  #[must_use]
+  #[inline]
+  pub fn into_embedding(self) -> Embedding {
+    self.embedding
   }
 }
 
@@ -758,6 +946,26 @@ impl TextEmbedder {
   /// ([`LongTextOptions::max_input_bytes`], on [`Self::embed_long_with`], is the
   /// bound to set for untrusted input) (#118).
   ///
+  /// # Not a retrieval representation for sparse evidence
+  ///
+  /// This is a DOCUMENT-LEVEL representation — one vector standing for the whole
+  /// text — and averaging is what makes it one: a passage that answers a query
+  /// is weighted by its share of the document, so a long document whose evidence
+  /// sits in one window has that evidence diluted by every other window. #44
+  /// measured it on a 16-document adversarial corpus (English, Chinese, mixed
+  /// script, emoji; 513–8,192 true tokens; one relevant marker at the start,
+  /// middle, or end): `embed_long` scored Recall@1 37.5% / MRR 0.5195 / nDCG
+  /// 0.6274 — BELOW plain fixed-512 truncation (50.0%) — and 0/6 on the
+  /// end-marker cases, while taking the max over the SAME windows scored 100%.
+  /// (A purpose-built adversarial corpus, not a public benchmark: it rejects the
+  /// production claim for that workload; the 100% is not a model-quality score.)
+  ///
+  /// For retrieval, embed the windows and score them: [`Self::embed_windows`]
+  /// returns the same windows this call averages, each with its span in `text`,
+  /// so a consumer can take a max, a top-k, or a fusion over them and keep the
+  /// evidence span. Use `embed_long` for what it is — a whole-document summary
+  /// vector (clustering, near-duplicate detection, a coarse first stage).
+  ///
   /// # Errors
   /// As [`Self::embed_long_with`].
   pub fn embed_long(&self, text: &str) -> Result<Embedding> {
@@ -778,10 +986,13 @@ impl TextEmbedder {
   /// reattachment covers the tail windit drops, so no policy changes the chunk
   /// count or loses a byte.
   ///
-  /// The per-chunk token budget counts granite's special tokens (`[CLS]`/`[SEP]`,
-  /// +2), because both the length measurement and each chunk's embedding run
-  /// `encode(s, add_special_tokens = true)` — self-consistent by construction, so
-  /// the effective content budget is `window − 2`.
+  /// The per-chunk token budget counts granite's specials
+  /// ([`SPECIAL_TOKENS_PER_WINDOW`] — `<|startoftext|>` and `<|return|>`, not a
+  /// BERT `[CLS]`/`[SEP]` pair), because both the length measurement and each
+  /// chunk's embedding run `encode(s, add_special_tokens = true)` —
+  /// self-consistent by construction, so the effective content budget is
+  /// `window − `[`SPECIAL_TOKENS_PER_WINDOW`], and at the default full window
+  /// exactly [`CONTENT_TOKENS_PER_WINDOW`].
   ///
   /// With `overlap == 0` the chunks partition `text` (the first starts at byte 0,
   /// each begins where the previous ends, the last ends at `text.len()`); a
@@ -823,54 +1034,184 @@ impl TextEmbedder {
   /// plus any per-chunk tensor / prediction / output error (the same set
   /// [`Self::embed`] can raise).
   pub fn embed_long_with(&self, text: &str, opts: &LongTextOptions) -> Result<Embedding> {
+    let mut windows = self.embed_windows_with(text, opts)?;
+    // A single window is returned AS IT IS rather than routed through the
+    // one-window aggregation, to skip a fold over `windit::aggregate` and the
+    // second `Vec<Windowed<_>>` allocation just below — an optimization, not a
+    // behavior change: `single_window_is_the_bit_exact_identity` pins
+    // aggregating exactly one window under `CoverageWeightedMean` as the
+    // BIT-EXACT identity of its input (`assert_eq!` on every component). For one
+    // window the weight is `coverage / largest` = 1 exactly, the Neumaier fold
+    // over one term is exact, and windit's `l2_renorm` composed with
+    // `Embedding::from_unnormalized`'s `from_slice_normalizing` round-trips an
+    // already-unit vector exactly — so aggregating would have answered
+    // identically, not merely closely. After gap reattachment a single chunk
+    // always spans `[0, text.len())`, so this also runs the same `token_ids` ∘
+    // `embed_tokenized` path `embed` does on the same bytes;
+    // `single_window_text_matches_embed` asserts that within a tolerance, since
+    // separate CoreML predictions are not bit-stable with each other.
+    if windows.len() == 1 {
+      return Ok(
+        windows
+          .pop()
+          .expect("a one-element vector has a last element")
+          .into_embedding(),
+      );
+    }
+    // The coverage-weighted spherical mean over the SAME windows
+    // `embed_windows_with` just returned: `Span::coverage()` is `len / window`,
+    // so a window carrying more real tokens weighs more. windit's pairing is
+    // rebuilt here rather than carried through, because the byte anchor and the
+    // ordinal — the two things this door adds — are of no interest to the
+    // aggregator. This allocates a second `Vec` of `Windowed` (~1.6 KB/window: a
+    // 384-`f32` `Embedding` plus a `Span`), because the two types' layouts
+    // differ.
+    let windowed: Vec<_> = windows
+      .into_iter()
+      .map(|w| windit::windowed::Windowed::new(w.embedding, w.token_span))
+      .collect();
+    Ok(windit::aggregate::aggregate(
+      &windit::aggregate::CoverageWeightedMean,
+      &windowed,
+    )?)
+  }
+
+  /// Embeds arbitrarily long text ONE WINDOW AT A TIME: the same windows
+  /// [`Self::embed_long`] plans and averages, each returned with its own
+  /// unit-norm [`Embedding`] and its span in `text`. Equivalent to
+  /// `embed_windows_with(text, &LongTextOptions::new())`.
+  ///
+  /// This is the retrieval path. `embed_long` collapses these vectors into one
+  /// document representation, which dilutes localized evidence (#44, measured —
+  /// see [`Self::embed_long`]); scoring the windows keeps it, and each window
+  /// carries the byte range that produced it, so a hit points at its own
+  /// evidence in the caller's text.
+  ///
+  /// Text that fits a single window returns exactly one [`WindowEmbedding`],
+  /// spanning `[0, text.len())`, that runs the same `token_ids` ∘
+  /// `embed_tokenized` path as [`Self::embed`] on the same bytes; equality is
+  /// asserted with a tolerance in the tests (separate CoreML predictions are
+  /// not bit-stable with each other).
+  ///
+  /// # The contract a consumer pins
+  ///
+  /// Query and indexed windows must be embedded by the same model, tokenizer,
+  /// and pooling, or their cosines mean nothing. Everything that defines this
+  /// space is FIXED and enforced, not configured:
+  ///
+  /// * **Model** — `granite-embedding-97m-multilingual-r2` as converted at
+  ///   `FinDIT-Studio/embedkit-coreml` revision `a61241cb` (the revision
+  ///   `MODELS_LOCK` pins and `tests/granite/model_io.rs` checks per file).
+  /// * **Tokenizer** — the artifact's own [`TOKENIZER_FILE_NAME`], source
+  ///   revision `835ad14087e140460703cf0fae09f97d469d65c2`, SHA-256
+  ///   `4f2842…1582f`. Every constructor hashes the RAW bytes and REFUSES any
+  ///   other tokenizer, so query-side and index-side agreement is a
+  ///   construction-time guarantee rather than something a consumer must check.
+  /// * **Pooling** — prompt-free CLS: the graph emits `hidden_states[:, 0]`
+  ///   after the final LayerNorm, matching the checkpoint's own
+  ///   `Transformer → Pooling(cls) → Normalize` module chain (asserted against
+  ///   the pinned `1_Pooling/config.json` by `conversion/granite`). Feed RAW
+  ///   strings — granite r2's query/document prompts are empty; a task prefix
+  ///   would be embedded as text.
+  /// * **Normalization** — every [`Embedding`] is L2-normalized to unit norm in
+  ///   Rust (the graph emits the pre-norm vector), so a dot product IS the
+  ///   cosine.
+  /// * **Dimension** — [`EMBEDDING_DIM`], 384.
+  /// * **Window budget** — [`MAX_TOKENS`] tokens per prediction, of which
+  ///   [`SPECIAL_TOKENS_PER_WINDOW`] are the template's, leaving
+  ///   [`CONTENT_TOKENS_PER_WINDOW`] for the caller's text.
+  ///
+  /// The geometry is the one variable, and it is the caller's: pin the
+  /// [`LongTextOptions`] used at index time and reuse it, since a different
+  /// window or overlap cuts different windows from the same document. That
+  /// pinned value is exactly what a consumer must persist beside each window's
+  /// spans to make later use of them well-defined — [`LongTextOptions`]
+  /// (`LongTextOptions::new()` for this call) is `Copy + PartialEq + Eq`, and
+  /// serde-capable under the `serde` feature, so storing it beside a persisted
+  /// index is cheap and its identity is checkable at read time.
+  ///
+  /// # Errors
+  /// As [`Self::embed_windows_with`] (see there for exactly how its error set
+  /// relates to [`Self::embed_long_with`]'s). In particular `max_windows()`
+  /// bounds the returned `Vec` (it is the prediction cap), so this cannot
+  /// return more windows than that: it refuses with `TooManyWindows` rather
+  /// than truncating.
+  pub fn embed_windows(&self, text: &str) -> Result<Vec<WindowEmbedding>> {
+    self.embed_windows_with(text, &LongTextOptions::new())
+  }
+
+  /// [`Self::embed_windows`] with caller-controlled chunk geometry and an
+  /// optional input-size bound — the window-level twin of
+  /// [`Self::embed_long_with`], which the latter is now defined in terms of:
+  /// `embed_long_with` is the coverage-weighted spherical mean of these
+  /// embeddings over these spans (a lone window is returned unaggregated: it
+  /// runs the same `token_ids` ∘ `embed_tokenized` path as [`Self::embed`] on
+  /// the same bytes; equality is asserted with a tolerance in the tests).
+  ///
+  /// The geometry, the resource bounds, and the whole-text coverage guarantee
+  /// are [`Self::embed_long_with`]'s, unchanged: the windows jointly cover every
+  /// byte of `text` (with `overlap == 0` they partition it — the first starts at
+  /// byte 0, each starts where the previous ended, the last ends at
+  /// `text.len()`), each range is `char`-aligned, and each window re-tokenizes
+  /// to at most [`MAX_TOKENS`] ids.
+  ///
+  /// # Errors
+  /// As [`Self::embed_long_with`], minus the aggregation failures it alone can
+  /// raise (`NonFinite` from windit when the per-window embeddings cancel
+  /// exactly): the per-window vectors are handed back before any combination.
+  pub fn embed_windows_with(
+    &self,
+    text: &str,
+    opts: &LongTextOptions,
+  ) -> Result<Vec<WindowEmbedding>> {
     validate_long_input(text, opts)?;
     let wopts = opts.window_options();
-    let chunks = chunk_long(
+    let mut chunks = chunk_long(
       self.measuring_tokenizer()?,
       LazyTable::new(&self.merge_table, &self.tokenizer),
       text,
       &wopts,
     )?;
-    match chunks.len() {
-      // Only `""` chunks to nothing (`chunk_long` gives contentless nonempty
-      // text a single whole-input chunk); `embed` defines the empty-input
-      // contract, so delegate for its `EmptyText`.
-      0 => self.embed(text),
-      // After gap reattachment a single chunk always spans `[0, text.len())`, so
-      // this is `embed` on the same bytes — and skipping the one-window
-      // aggregation keeps it numerically identical rather than
-      // identical-up-to-an-f64-renormalization-rounding.
-      1 => {
-        let s = chunks[0].as_str(text).expect(
-          "chunk_long yields char-aligned boundaries (windit cuts, or 0/len from gap repair / the whole-input fallback)",
-        );
-        self.embed_tokenized(&self.token_ids(s)?)
-      }
-      _ => {
-        let mut windows = Vec::with_capacity(chunks.len());
-        // Cumulative token offset; informational only — aggregation reads
-        // coverage, not position. Under overlap the offsets overstate positions
-        // (overlapped tokens counted twice), which is exactly the double-weighting
-        // overlap is meant to express.
-        let mut offset = 0usize;
-        for chunk in &chunks {
-          let s = chunk.as_str(text).expect(
-            "chunk_long yields char-aligned boundaries (windit cuts, or 0/len from gap repair / the whole-input fallback)",
-          );
-          let ids = self.token_ids(s)?;
-          let embedding = self.embed_tokenized(&ids)?;
-          // `embed_tokenized` just proved `ids.len() <= MAX_TOKENS` (build_window's
-          // typed guard) and a chunk is never empty, so `Span::new` cannot panic.
-          let span = windit::plan::Span::new(offset, ids.len(), MAX_TOKENS);
-          windows.push(windit::windowed::Windowed::new(embedding, span));
-          offset += ids.len();
-        }
-        Ok(windit::aggregate::aggregate(
-          &windit::aggregate::CoverageWeightedMean,
-          &windows,
-        )?)
-      }
+    // Only `""` chunks to nothing — `chunk_long` already gives contentless
+    // NONEMPTY text a single whole-input chunk — and the window `""` would have
+    // had is that same whole-input one. Synthesizing it keeps ONE window body for
+    // every input rather than a branch: the loop's own `token_ids` refuses the
+    // empty string with `EmptyText`, which is `embed`'s empty-input contract
+    // raised by the very call `embed` itself makes. No window is fabricated —
+    // the refusal lands before any `Span`, which could not hold a zero-token
+    // one.
+    if chunks.is_empty() {
+      chunks.push(windit::split::Chunk::new(0, text.len()));
     }
+    let mut windows = Vec::with_capacity(chunks.len());
+    // Cumulative token offset. Aggregation reads coverage, not position, so for
+    // `embed_long` this is informational; for a consumer it is where the window
+    // sits in the concatenated window token stream. Under overlap the offsets
+    // overstate positions (overlapped tokens counted twice), which is exactly
+    // the double-weighting overlap is meant to express.
+    let mut offset = 0usize;
+    for (ordinal, chunk) in chunks.iter().enumerate() {
+      let s = chunk.as_str(text).expect(
+        "chunk_long yields char-aligned boundaries (windit cuts, or 0/len from gap repair / the whole-input fallback)",
+      );
+      let ids = self.token_ids(s)?;
+      let embedding = self.embed_tokenized(&ids)?;
+      // `Span::new` needs `0 < ids.len() <= MAX_TOKENS`. `embed_tokenized` just
+      // proved the upper bound (`build_window`'s typed guard). The lower one is
+      // the post-processor's: it brackets EVERY sequence it encodes with
+      // `<|startoftext|>`/`<|return|>`, so a returned `ids` is at least
+      // `SPECIAL_TOKENS_PER_WINDOW` long — and the one input that would encode
+      // to nothing, `""`, never reaches here, `token_ids` having refused it.
+      let token_span = windit::plan::Span::new(offset, ids.len(), MAX_TOKENS);
+      offset += ids.len();
+      windows.push(WindowEmbedding {
+        ordinal,
+        byte_range: chunk.start()..chunk.end(),
+        token_span,
+        embedding,
+      });
+    }
+    Ok(windows)
   }
 }
 

--- a/coremlit/src/embeddings/granite/tests.rs
+++ b/coremlit/src/embeddings/granite/tests.rs
@@ -2842,3 +2842,194 @@ fn a_small_probe_inside_a_long_word_never_builds_the_table() {
   );
   assert_eq!(fast, chunk_long_slow(&mt, &doc, &opts).expect("slow"));
 }
+
+// ── #160: the window-level contract (hermetic + the artifact's template) ─────
+
+/// [`WindowEmbedding`]'s accessors report exactly what was planned into it:
+/// the ordinal, both byte ends and the range they form, the token span with its
+/// count, and the embedding by reference and by value.
+///
+/// The type is a payload struct with private fields, so this is the only proof
+/// that the getters are wired to the right fields — a `byte_start`/`byte_end`
+/// swap or a `start()`/`len()` transposition inside `token_span` compiles.
+#[test]
+fn window_embedding_accessors_report_the_planned_geometry() {
+  let mut v = [0.0f32; EMBEDDING_DIM];
+  v[7] = 2.0;
+  let embedding = Embedding::from_slice_normalizing(&v).expect("unit vector");
+  let w = WindowEmbedding {
+    ordinal: 3,
+    byte_range: 17..42,
+    token_span: windit::plan::Span::new(1_024, 300, MAX_TOKENS),
+    embedding: embedding.clone(),
+  };
+  assert_eq!(w.ordinal(), 3);
+  assert_eq!(w.byte_start(), 17);
+  assert_eq!(w.byte_end(), 42);
+  assert_eq!(w.byte_range(), 17..42);
+  assert_eq!(
+    w.token_span(),
+    windit::plan::Span::new(1_024, 300, MAX_TOKENS)
+  );
+  assert_eq!(w.token_span().start(), 1_024);
+  assert_eq!(w.token_count(), 300);
+  assert_eq!(w.token_span().window(), MAX_TOKENS);
+  assert!(w.embedding().is_close(&embedding, 0.0), "by reference");
+  assert!(
+    w.clone().into_embedding().is_close(&embedding, 0.0),
+    "by value"
+  );
+  // The byte range is the form to slice the caller's own text with.
+  let text = "x".repeat(64);
+  assert_eq!(text[w.byte_range()].len(), 25);
+}
+
+/// [`CONTENT_TOKENS_PER_WINDOW`] is the real content budget of a
+/// [`MAX_TOKENS`]-wide window under a post-processor adding
+/// [`SPECIAL_TOKENS_PER_WINDOW`] tokens — MEASURED as the truncation boundary
+/// the `tokenizers` crate actually applies, not restated as arithmetic.
+///
+/// The fixture installs the artifact's overhead on a tiny vocabulary, so the
+/// boundary is exercisable without the 24 MB artifact, and its specials are id
+/// `0` against a content id of `1` — the content count is read off the ids
+/// rather than subtracted. Content up to the budget survives whole; one token
+/// past it is truncated away and the window still admits exactly the budget.
+/// What the artifact contributes — that its own overhead really is
+/// [`SPECIAL_TOKENS_PER_WINDOW`] — is
+/// `special_token_overhead_matches_the_pinned_template`.
+///
+/// `add_special_tokens = false` is deliberately NOT the control here: measured,
+/// `tokenizers` reserves the overhead only when it is going to add it, so a
+/// special-free encoding of the same text truncates at the full
+/// [`MAX_TOKENS`] and is two tokens longer, not equal.
+#[test]
+fn content_tokens_per_window_is_the_measured_truncation_budget() {
+  const CONTENT_ID: u32 = 1;
+
+  let bytes = tokenizer_bytes_with_special_overhead(SPECIAL_TOKENS_PER_WINDOW);
+  let tok = configured_tokenizer_from_bytes(&bytes).expect("the artifact's overhead configures");
+  for (content, kept) in [
+    (1, 1),
+    (CONTENT_TOKENS_PER_WINDOW - 1, CONTENT_TOKENS_PER_WINDOW - 1),
+    (CONTENT_TOKENS_PER_WINDOW, CONTENT_TOKENS_PER_WINDOW),
+    (CONTENT_TOKENS_PER_WINDOW + 1, CONTENT_TOKENS_PER_WINDOW),
+    (MAX_TOKENS * 2, CONTENT_TOKENS_PER_WINDOW),
+  ] {
+    let text = "a ".repeat(content);
+    let ids = tok.encode(text.as_str(), true).expect("encode");
+    let ids = ids.get_ids();
+    assert_eq!(
+      ids.iter().filter(|&&id| id == CONTENT_ID).count(),
+      kept,
+      "{content} content tokens through a {MAX_TOKENS}-token window"
+    );
+    assert!(
+      ids.len() <= MAX_TOKENS,
+      "{content} content tokens overran the window: {} ids",
+      ids.len()
+    );
+  }
+}
+
+/// [`SPECIAL_TOKENS_PER_WINDOW`] is MEASURED from the pinned artifact
+/// tokenizer, three independent ways, rather than asserted: the post-processor's
+/// own `added_tokens(false)` (the number `tokenizers` subtracts from the
+/// truncation length), the length of `encode("", true)` (the template applied to
+/// nothing), and the difference between encoding a text with and without
+/// specials. The ids are the `<|startoftext|> A <|return|>` bracket the
+/// artifact's `TemplateProcessing` declares.
+#[test]
+#[ignore = "requires the granite tokenizer.json staged beside the model bundle (EMBEDKIT_TEST_MODELS)"]
+fn special_token_overhead_matches_the_pinned_template() {
+  use tokenizers::PostProcessor;
+
+  let tok = configured_tokenizer_from_bytes(artifact_tokenizer_bytes()).expect("configure");
+  let post = tok
+    .get_post_processor()
+    .expect("the artifact declares a TemplateProcessing");
+  assert_eq!(
+    post.added_tokens(false),
+    SPECIAL_TOKENS_PER_WINDOW,
+    "the post-processor's single-sequence overhead"
+  );
+
+  let empty = tok.encode("", true).expect("encode the empty string");
+  assert_eq!(
+    empty.get_ids().len(),
+    SPECIAL_TOKENS_PER_WINDOW,
+    "the template applied to no content is the specials alone"
+  );
+  assert_eq!(
+    empty.get_ids(),
+    [contract::CLS_ID, contract::EOS_ID],
+    "the single-sequence template is <|startoftext|> A <|return|>"
+  );
+
+  let text = "hello world";
+  let with = tok.encode(text, true).expect("with specials");
+  let without = tok.encode(text, false).expect("without specials");
+  assert_eq!(
+    with.get_ids().len() - without.get_ids().len(),
+    SPECIAL_TOKENS_PER_WINDOW,
+    "the specials are the whole difference"
+  );
+  assert_eq!(with.get_ids().first(), Some(&contract::CLS_ID));
+  assert_eq!(with.get_ids().last(), Some(&contract::EOS_ID));
+
+  assert_eq!(
+    MAX_TOKENS - post.added_tokens(false),
+    CONTENT_TOKENS_PER_WINDOW,
+    "the artifact's own content budget"
+  );
+}
+
+// ── Cross-model review: the single-window aggregate identity (hermetic) ─────
+
+/// A tiny linear congruential generator (Knuth's MMIX 64-bit constants) for
+/// deterministic pseudo-random test data — no `rand` dependency, and enough
+/// entropy that the bit-exactness pin below is not vacuously true on an
+/// all-equal or arithmetic-sequence fixture.
+fn lcg_row(seed: u64) -> [f32; EMBEDDING_DIM] {
+  let mut state = seed;
+  std::array::from_fn(|_| {
+    state = state
+      .wrapping_mul(6_364_136_223_846_793_005)
+      .wrapping_add(1_442_695_040_888_963_407);
+    // The top 24 bits of each draw, mapped to (-1.0, 1.0): mixed signs, no
+    // near-zero components, plenty of entropy — never the all-zero vector
+    // `from_slice_normalizing` would refuse.
+    let top24 = (state >> 40) as u32;
+    (top24 as f32 / (1u32 << 24) as f32) * 2.0 - 1.0
+  })
+}
+
+/// Aggregating exactly one window is the BIT-EXACT identity of its input —
+/// pinning the TRUE reason `embed_long_with`'s short-circuit skips
+/// `windit::aggregate::aggregate` for a single window (an optimization, not a
+/// behavior change; a previous revision of that comment claimed an
+/// f64-rounding drift that measurement never found). Swept over four coverage
+/// values — `len` 1, 2, 511, and 512 out of `MAX_TOKENS` (near-zero, small,
+/// near-full, and exactly full) — because `WindowEmbedding::token_span`'s
+/// `Span::window()` is always `MAX_TOKENS`, so every one of these is a real
+/// coverage `embed_windows` can plan, not a hand-picked one.
+#[test]
+fn single_window_is_the_bit_exact_identity() {
+  for (i, &len) in [1usize, 2, 511, 512].iter().enumerate() {
+    let row = lcg_row(0x9E37_79B9_7F4A_7C15 ^ (i as u64 + 1));
+    let embedding = Embedding::from_slice_normalizing(&row).expect("normalize a random row");
+    let windowed = windit::windowed::Windowed::new(
+      embedding.clone(),
+      windit::plan::Span::new(0, len, MAX_TOKENS),
+    );
+    let agg = windit::aggregate::aggregate(
+      &windit::aggregate::CoverageWeightedMean,
+      std::slice::from_ref(&windowed),
+    )
+    .expect("aggregate a single window");
+    assert_eq!(
+      agg.as_slice(),
+      embedding.as_slice(),
+      "len={len} (coverage {len}/{MAX_TOKENS}): single-window aggregation must be bit-exact"
+    );
+  }
+}

--- a/coremlit/tests/granite/embed_windows.rs
+++ b/coremlit/tests/granite/embed_windows.rs
@@ -1,0 +1,419 @@
+//! `embed_windows` on the granite CoreML graph (model-gated): the window-level
+//! retrieval path of #160 — one embedding per planned window, its declared byte
+//! and token spans, its occurrence identity, and the identity that makes it the
+//! same pass `embed_long` runs.
+//!
+//! The chunk GEOMETRY is proven model-free in the in-lib granite suite
+//! (`src/embeddings/granite/tests.rs`), and `embed_long`'s own contracts in
+//! `tests/granite/embed_long.rs`. What only the graph can say is here: that the
+//! windows this door hands back are exactly the ones `embed_long` averages, and
+//! that its refusals are `embed_long`'s refusals. Model-gated tests are
+//! `#[ignore]` by default and run only with the granite model staged under
+//! `Models/embedkit-granite/` (or `EMBEDKIT_TEST_MODELS`).
+
+mod common;
+
+use coremlit::embeddings::granite::{
+  Error, LongTextOptions, MAX_TOKENS, SPECIAL_TOKENS_PER_WINDOW, TextEmbedder, WindowEmbedding,
+  WindowOptions,
+};
+
+fn embedder() -> TextEmbedder {
+  TextEmbedder::from_file(common::model_path()).unwrap_or_else(|e| panic!("load granite: {e}"))
+}
+
+/// A deterministic multi-paragraph document comfortably over several 512-token
+/// windows, so the window path exercises true multi-chunk planning.
+fn long_document() -> String {
+  (0..32)
+    .map(|p| {
+      (0..40)
+        .map(|w| format!("paragraph{p}word{w}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+    })
+    .collect::<Vec<_>>()
+    .join("\n\n")
+}
+
+/// One paragraph large enough to fill most of a window on its own, so a document
+/// built by repeating it plans one paragraph per window.
+fn wide_paragraph() -> String {
+  (0..150)
+    .map(|w| format!("lexeme{w}"))
+    .collect::<Vec<_>>()
+    .join(" ")
+}
+
+/// An INDEPENDENT coverage-weighted spherical mean, written from the declared
+/// contract rather than called through windit: `Σ coverage_i · v_i`, L2-normalized,
+/// accumulated in `f64`. `coverage` is `token_count / window`, read off the span
+/// this door published — so if the published spans stopped describing the windows
+/// `embed_long` weights, this reimplementation would stop reproducing it.
+///
+/// windit lifts its weights by `1 / max_j c_j` and sums with compensation; both
+/// are uniform positive scalings or rounding, which the final normalization
+/// removes, so the two agree to well inside [`TOL`].
+fn coverage_weighted_mean(windows: &[WindowEmbedding]) -> Vec<f32> {
+  assert!(!windows.is_empty(), "no windows to aggregate");
+  let dim = windows[0].embedding().as_slice().len();
+  let mut acc = vec![0.0f64; dim];
+  for w in windows {
+    #[expect(
+      clippy::cast_precision_loss,
+      reason = "token counts are <= 512; exact in f64"
+    )]
+    let coverage = w.token_count() as f64 / w.token_span().window() as f64;
+    for (a, v) in acc.iter_mut().zip(w.embedding().as_slice()) {
+      *a += coverage * f64::from(*v);
+    }
+  }
+  let norm = acc.iter().map(|x| x * x).sum::<f64>().sqrt();
+  assert!(norm > 0.0, "the window vectors cancelled exactly");
+  #[expect(clippy::cast_possible_truncation, reason = "the door's own f32 output")]
+  acc.iter().map(|x| (x / norm) as f32).collect()
+}
+
+/// Comparison tolerance for two f32 vectors that describe the same computation.
+/// Model f32 outputs are not bit-stable (why `Embedding: !PartialEq`), and the
+/// aggregate above is an independent f64 fold of them.
+const TOL: f32 = 1e-5;
+
+fn max_abs_delta(a: &[f32], b: &[f32]) -> f32 {
+  assert_eq!(a.len(), b.len(), "dimension mismatch");
+  a.iter()
+    .zip(b)
+    .map(|(x, y)| (x - y).abs())
+    .fold(0.0f32, f32::max)
+}
+
+/// The load-bearing identity of #160: `embed_long_with` IS the coverage-weighted
+/// mean of `embed_windows_with`'s embeddings over their published spans — for a
+/// many-window document, a text that fits one window, and contentless text, under
+/// both the default geometry and a small one that makes the coverages differ
+/// sharply between windows.
+///
+/// This is what makes the published span trustworthy: the weight a consumer can
+/// compute from `token_span()` is the weight `embed_long` actually applied. It is
+/// load-bearing against uniform weighting — replacing `coverage` above with `1.0`
+/// takes the multi-window deltas to ~1e-2, three orders past `TOL`.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn embed_long_is_the_coverage_weighted_mean_of_the_windows() {
+  let emb = embedder();
+  let doc = long_document();
+  let cases: [(&str, &str); 3] = [
+    ("multi-window", doc.as_str()),
+    (
+      "single-window",
+      "a compact sentence that fits comfortably inside one window",
+    ),
+    ("contentless", "   "),
+  ];
+  for (label, text) in cases {
+    for (geometry, opts) in [
+      ("default", LongTextOptions::new()),
+      ("window 64", LongTextOptions::from(WindowOptions::new(64))),
+    ] {
+      let windows = emb
+        .embed_windows_with(text, &opts)
+        .unwrap_or_else(|e| panic!("{label}/{geometry}: embed_windows_with: {e}"));
+      let pooled = emb
+        .embed_long_with(text, &opts)
+        .unwrap_or_else(|e| panic!("{label}/{geometry}: embed_long_with: {e}"));
+      let rebuilt = coverage_weighted_mean(&windows);
+      let delta = max_abs_delta(pooled.as_slice(), &rebuilt);
+      assert!(
+        delta <= TOL,
+        "{label}/{geometry}: embed_long is not the coverage-weighted mean of its \
+         {} windows (max |Δ| = {delta:e})",
+        windows.len()
+      );
+    }
+  }
+}
+
+/// The windows tile the caller's text in planning order: ordinals `0..n`, the
+/// first starting at byte 0, each starting where the previous ended, the last
+/// ending at `text.len()`, and every boundary on a `char` boundary — so
+/// `&text[w.byte_range()]` is the exact substring that produced the embedding.
+///
+/// (`overlap == 0` here, which is what makes the tiling a partition; a non-zero
+/// overlap covers the same bytes while repeating some.)
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn window_byte_ranges_tile_the_text_in_planning_order() {
+  let emb = embedder();
+  // Mixed script and multi-byte content, so a mis-aligned cut would be visible.
+  let doc = format!(
+    "{}\n\n{}\n\n{}",
+    long_document(),
+    "你好世界模型推理文本嵌入检索".repeat(200),
+    "naïve café — résumé ✅🇯🇵 ".repeat(200)
+  );
+  for (label, opts) in [
+    ("default", LongTextOptions::new()),
+    ("window 64", LongTextOptions::from(WindowOptions::new(64))),
+  ] {
+    let windows = emb
+      .embed_windows_with(&doc, &opts)
+      .unwrap_or_else(|e| panic!("{label}: embed_windows_with: {e}"));
+    assert!(
+      windows.len() > 1,
+      "{label}: the fixture must plan more than one window"
+    );
+    let mut cursor = 0usize;
+    for (i, w) in windows.iter().enumerate() {
+      assert_eq!(w.ordinal(), i, "{label}: ordinals are the planning order");
+      assert_eq!(
+        w.byte_start(),
+        cursor,
+        "{label}: window {i} does not start where window {} ended",
+        i.wrapping_sub(1)
+      );
+      assert!(
+        w.byte_end() > w.byte_start(),
+        "{label}: window {i} covers no bytes"
+      );
+      assert!(
+        doc.is_char_boundary(w.byte_start()) && doc.is_char_boundary(w.byte_end()),
+        "{label}: window {i} is not char-aligned"
+      );
+      assert!(
+        doc.get(w.byte_range()).is_some(),
+        "{label}: window {i} does not slice its own text"
+      );
+      assert_eq!(w.byte_range(), w.byte_start()..w.byte_end());
+      cursor = w.byte_end();
+    }
+    assert_eq!(
+      cursor,
+      doc.len(),
+      "{label}: the windows must cover the text"
+    );
+  }
+}
+
+/// The token spans are the windows' placement in the concatenated window token
+/// stream: `start()` is the running sum of the preceding windows' counts,
+/// `len()` is this window's own count (the specials included, so never below
+/// `SPECIAL_TOKENS_PER_WINDOW`) and never past `MAX_TOKENS`, and `window()` is
+/// `MAX_TOKENS` — the denominator of the coverage `embed_long` weights with.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn token_span_offsets_are_the_running_sum_of_the_token_counts() {
+  let emb = embedder();
+  let doc = long_document();
+  let windows = emb.embed_windows(&doc).expect("embed_windows");
+  assert!(
+    windows.len() > 1,
+    "the fixture must plan more than one window"
+  );
+  let mut offset = 0usize;
+  for w in &windows {
+    assert_eq!(
+      w.token_span().start(),
+      offset,
+      "window {} does not start at the running token sum",
+      w.ordinal()
+    );
+    assert_eq!(w.token_count(), w.token_span().len(), "len() is the count");
+    assert_eq!(w.token_span().window(), MAX_TOKENS, "the padded window");
+    assert!(
+      (SPECIAL_TOKENS_PER_WINDOW..=MAX_TOKENS).contains(&w.token_count()),
+      "window {} has {} tokens",
+      w.ordinal(),
+      w.token_count()
+    );
+    offset += w.token_count();
+  }
+}
+
+/// A document that repeats one paragraph plans byte-identical windows, and they
+/// stay DISTINCT: same text and (to within model f32 stability) the same vector,
+/// but different ordinals and different byte ranges. That is the occurrence
+/// identity a consumer attaches its own provenance to — nothing else separates
+/// the two.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn repeated_text_plans_distinct_windows_with_equal_embeddings() {
+  let emb = embedder();
+  let para = wide_paragraph();
+  let doc = [para.as_str(); 4].join("\n\n");
+  let windows = emb.embed_windows(&doc).expect("embed_windows");
+  let mut identical = 0usize;
+  for (i, a) in windows.iter().enumerate() {
+    for b in &windows[i + 1..] {
+      if doc[a.byte_range()] != doc[b.byte_range()] {
+        continue;
+      }
+      identical += 1;
+      assert_ne!(a.ordinal(), b.ordinal(), "identical text, same ordinal");
+      assert_ne!(a.byte_range(), b.byte_range(), "identical text, same range");
+      assert_eq!(
+        a.token_count(),
+        b.token_count(),
+        "identical text, same count"
+      );
+      let delta = max_abs_delta(a.embedding().as_slice(), b.embedding().as_slice());
+      assert!(
+        delta <= TOL,
+        "identical window text embedded differently (max |Δ| = {delta:e})"
+      );
+    }
+  }
+  assert!(
+    identical > 0,
+    "the fixture planned no two byte-identical windows: {:?}",
+    windows
+      .iter()
+      .map(|w| doc[w.byte_range()].len())
+      .collect::<Vec<_>>()
+  );
+}
+
+/// Contentless nonempty text is ONE window spanning the whole input, embedding
+/// to exactly what `embed` returns for it — the whole-input fallback chunk, the
+/// same `token_ids` ∘ `embed_tokenized` call on the same bytes.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn contentless_text_is_one_whole_input_window_matching_embed() {
+  let emb = embedder();
+  for text in ["   ", "\n\n\t \u{a0}"] {
+    let windows = emb
+      .embed_windows(text)
+      .unwrap_or_else(|e| panic!("embed_windows {text:?}: {e}"));
+    assert_eq!(windows.len(), 1, "{text:?}: one whole-input window");
+    let w = &windows[0];
+    assert_eq!(w.ordinal(), 0);
+    assert_eq!(w.byte_range(), 0..text.len(), "{text:?}: the whole input");
+    let direct = emb
+      .embed(text)
+      .unwrap_or_else(|e| panic!("embed {text:?}: {e}"));
+    let delta = max_abs_delta(w.embedding().as_slice(), direct.as_slice());
+    assert!(
+      delta <= TOL,
+      "{text:?}: the fallback window is not embed's own answer (max |Δ| = {delta:e})"
+    );
+  }
+}
+
+/// A text that fits one window is one window over `[0, text.len())`, and its
+/// embedding is `embed`'s — the equality `embed_long`'s single-window
+/// short-circuit rests on.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn single_window_text_is_one_window_matching_embed() {
+  let emb = embedder();
+  let text = "a compact sentence that fits comfortably inside one window";
+  let windows = emb.embed_windows(text).expect("embed_windows");
+  assert_eq!(windows.len(), 1);
+  assert_eq!(windows[0].byte_range(), 0..text.len());
+  let direct = emb.embed(text).expect("embed");
+  assert!(
+    max_abs_delta(windows[0].embedding().as_slice(), direct.as_slice()) <= TOL,
+    "the single window must be embed's own answer"
+  );
+  let pooled = emb.embed_long(text).expect("embed_long");
+  assert!(
+    max_abs_delta(pooled.as_slice(), direct.as_slice()) <= TOL,
+    "embed_long must still be embed on a single-window text"
+  );
+}
+
+/// `embed_windows` refuses exactly what `embed_long` refuses, with the same
+/// error and in the same order — they share one planning-and-prediction pass, so
+/// a caller can switch between them without re-learning the failure modes.
+///
+/// The cases walk the whole refusal set the two share: the empty string, the
+/// input-byte gate, the over-budget window, the prediction cap (twice — windit's
+/// own raise and the repaired-list re-check), and a contentless run past
+/// `MAX_TOKENS`.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn refusals_are_identical_to_embed_long() {
+  let emb = embedder();
+  let doc = long_document();
+  let big = "x".repeat(2 * 1024 * 1024);
+  let spaces = " ".repeat(100_000);
+  let cases: [(&str, &str, LongTextOptions); 6] = [
+    ("empty", "", LongTextOptions::new()),
+    (
+      "input too large",
+      big.as_str(),
+      LongTextOptions::new().with_max_input_bytes(1 << 10),
+    ),
+    (
+      "window over budget",
+      "any text",
+      LongTextOptions::from(WindowOptions::new(MAX_TOKENS + 1)),
+    ),
+    (
+      "cap zero",
+      "   ",
+      LongTextOptions::from(WindowOptions::new(MAX_TOKENS).with_max_windows(0)),
+    ),
+    (
+      "cap below the plan",
+      doc.as_str(),
+      LongTextOptions::from(WindowOptions::new(64).with_max_windows(2)),
+    ),
+    (
+      "contentless over budget",
+      spaces.as_str(),
+      LongTextOptions::new(),
+    ),
+  ];
+  for (label, text, opts) in cases {
+    let long = emb
+      .embed_long_with(text, &opts)
+      .err()
+      .unwrap_or_else(|| panic!("{label}: embed_long_with was expected to refuse"));
+    let windows = emb
+      .embed_windows_with(text, &opts)
+      .err()
+      .unwrap_or_else(|| panic!("{label}: embed_windows_with was expected to refuse"));
+    assert_eq!(
+      format!("{windows:?}"),
+      format!("{long:?}"),
+      "{label}: the two doors refuse differently"
+    );
+  }
+  // The empty string is `embed`'s own contract, named rather than only compared.
+  assert!(matches!(emb.embed_windows(""), Err(Error::EmptyText)));
+}
+
+/// `max_windows` is a bound on the returned windows, not a truncation: under a
+/// cap the plan fits, every window comes back; past it, the call refuses.
+#[test]
+#[ignore = "requires local granite model (EMBEDKIT_TEST_MODELS)"]
+fn max_windows_bounds_the_returned_windows() {
+  let emb = embedder();
+  let doc = long_document();
+  let geometry = WindowOptions::new(128);
+  let planned = emb
+    .embed_windows_with(&doc, &LongTextOptions::from(geometry))
+    .expect("uncapped")
+    .len();
+  assert!(planned > 2, "the fixture must plan several windows");
+  let at_cap = emb
+    .embed_windows_with(
+      &doc,
+      &LongTextOptions::from(geometry.with_max_windows(planned)),
+    )
+    .expect("a cap at the plan admits it");
+  assert_eq!(at_cap.len(), planned, "an exact cap returns every window");
+  let err = emb
+    .embed_windows_with(
+      &doc,
+      &LongTextOptions::from(geometry.with_max_windows(planned - 1)),
+    )
+    .unwrap_err();
+  assert!(
+    matches!(
+      err,
+      Error::Windowing(coremlit::embeddings::granite::error::WinditError::TooManyWindows { .. })
+    ),
+    "expected TooManyWindows, got {err:?}"
+  );
+}


### PR DESCRIPTION
Closes the API part of #160 (the two evaluation lines stay research under findit-studio/desktop#152).

**What.** `TextEmbedder::embed_windows(text)` / `embed_windows_with(text, &LongTextOptions)` return one `WindowEmbedding` per planned window: `ordinal()` (planning order — the occurrence identity), `byte_start()`/`byte_end()` (char-aligned offsets into the caller's text, exactly the chunk `chunk_long` planned), `token_span()`/`token_count()` (the same windit `Span` `embed_long` builds), `embedding()`/`into_embedding()`. `embed_long_with` is now literally the coverage-weighted mean of those windows over their spans — one planning-and-embedding pass shared by both, so they agree by construction; its outputs are unchanged (`granite_parity_embed` with its seeded mutation gates, `single_window_text_matches_embed`, the DropBelowMin geometry test all pass unmodified). Errors and the `max_windows` bound are identical to `embed_long_with`'s; `""` refuses with `EmptyText` as `embed` does.

**Contract facts a consumer pins.** `SPECIAL_TOKENS_PER_WINDOW = 2` and `CONTENT_TOKENS_PER_WINDOW = 510`, measured three ways on the pinned tokenizer (template `<|startoftext|> A <|return|>`; `added_tokens(false)`, `encode("", true)`, and the with/without-specials difference); pooling is the prompt-free CLS vector after the final LayerNorm, per `conversion/granite/README.md:145-146` and the conversion script's asserted `Transformer → Pooling(cls) → Normalize` chain; unit norm and 384-d from `Embedding`; tokenizer SHA from `contract`. `embed_windows`' doc cites them. `embed_long`'s doc now says what it is not for: a document-level representation that #44 measured losing localized evidence on sparse-evidence retrieval — score `embed_windows` for that. (Also corrected a pre-existing doc error naming the specials `[CLS]`/`[SEP]`.)

**Design points that measurement settled.** `WindowEmbedding` is `Clone + Debug` only: `Embedding` deliberately has no `PartialEq` (f32 model output is not bit-stable) and no serde, and windit's `Span` has no serde — a `compile_fail` doctest pins the absence of `==`. Under truncation, `encode(t, false)` is not "the same minus specials" (tokenizers reserves the overhead only when it will add it), so the budget test measures the truncation boundary by counting content ids.